### PR TITLE
Create user profile view for wallets

### DIFF
--- a/app/api/checkin-status/route.ts
+++ b/app/api/checkin-status/route.ts
@@ -1,10 +1,11 @@
 import { NextResponse } from "next/server";
-import { getCheckinByAddress } from "@/lib/supabase";
+import { getCheckinByAddressAndCheckpoint } from "@/lib/supabase";
 
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
     const address = searchParams.get("address");
+    const checkpoint = searchParams.get("checkpoint");
 
     if (!address) {
       return NextResponse.json(
@@ -13,7 +14,17 @@ export async function GET(request: Request) {
       );
     }
 
-    const checkins = await getCheckinByAddress(address);
+    if (!checkpoint) {
+      return NextResponse.json(
+        { error: "Checkpoint parameter is required" },
+        { status: 400 }
+      );
+    }
+
+    const checkins = await getCheckinByAddressAndCheckpoint(
+      address,
+      checkpoint
+    );
     const hasCheckedIn = checkins && checkins.length > 0;
 
     return NextResponse.json({ hasCheckedIn });

--- a/app/api/checkin/route.ts
+++ b/app/api/checkin/route.ts
@@ -1,33 +1,65 @@
 import { NextRequest } from "next/server";
-import { getCheckinByAddress, insertCheckin } from "@/lib/supabase";
+import {
+  upsertCheckpoint,
+  createOrUpdatePlayer,
+  updatePlayerPoints,
+  type Player,
+} from "@/lib/supabase";
+
+const CHECKIN_POINTS = 100; // Points awarded for each checkin
 
 export async function POST(req: NextRequest) {
-  const { walletAddress, email } = await req.json();
-  console.log(walletAddress);
+  const { walletAddress, email, checkpoint } = await req.json();
+
+  console.log("walletAddress", walletAddress);
+  console.log("email", email);
+  console.log("checkpoint", checkpoint);
 
   try {
-    const checkin = await getCheckinByAddress(walletAddress);
+    // Create or update player record first
+    const playerData: Omit<Player, "id" | "created_at" | "updated_at"> = {
+      wallet_address: walletAddress,
+      email: email || undefined,
+      username: undefined, // No username provided in regular checkins
+      total_points: 0, // Will be updated if this is a new player
+    };
 
-    console.log(checkin);
+    const player = await createOrUpdatePlayer(playerData);
 
-    if (checkin && checkin.length > 0) {
-      return new Response(JSON.stringify({ success: true }), {
+    // Try to upsert the checkpoint (this will handle duplicate checking internally)
+    await upsertCheckpoint(walletAddress, email, checkpoint);
+
+    // Award points to the player
+    const updatedPlayer = await updatePlayerPoints(player.id, CHECKIN_POINTS);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        player: updatedPlayer,
+        pointsEarned: CHECKIN_POINTS,
+        message: `Congratulations! You earned ${CHECKIN_POINTS} points for checking in to ${checkpoint}!`,
+      }),
+      {
         status: 200,
         headers: { "Content-Type": "application/json" },
-      });
-    }
-
-    await insertCheckin({
-      address: walletAddress,
-      email,
-    });
-
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+      }
+    );
   } catch (e) {
     console.error(e);
+
+    // Check if it's a duplicate checkpoint error
+    if (e instanceof Error && e.message.includes("Already checked in to")) {
+      return new Response(
+        JSON.stringify({
+          success: false,
+          message: e.message,
+        }),
+        {
+          status: 409, // Conflict status code
+          headers: { "Content-Type": "application/json" },
+        }
+      );
+    }
 
     return new Response(JSON.stringify({ error: "An error occurred" }), {
       status: 500,

--- a/app/checkpoints/layout.tsx
+++ b/app/checkpoints/layout.tsx
@@ -1,7 +1,5 @@
 import type { Metadata } from "next";
 import { Toaster } from "@/components/ui/toaster";
-import Image from "next/image";
-import Link from "next/link";
 import Auth from "@/components/auth";
 import Header from "@/components/header";
 
@@ -18,14 +16,9 @@ export default function RootLayout({
   return (
     <div className="h-screen">
       <div
-        className={`flex flex-col gap-6 p-6 bg-gradient-to-b from-[#64C2D7] via-[#FFE600] to-[#F09BC2]`}
+        className={`flex flex-col gap-6 bg-gradient-to-b from-[#64C2D7] via-[#FFE600] to-[#F09BC2] min-h-screen p-4`}
       >
-        <div className="flex justify-between items-center">
-          <Link href="/">
-            <Image src="/irl.svg" alt="IRL" width={49} height={25} />
-          </Link>
-          <Header />
-        </div>
+        <Header />
         <Auth>{children}</Auth>
       </div>
       <Toaster />

--- a/app/profiles/[walletAddress]/not-found.tsx
+++ b/app/profiles/[walletAddress]/not-found.tsx
@@ -10,7 +10,7 @@ export default function ProfileNotFound() {
           PROFILE NOT FOUND
         </h1>
         <Link
-          href="/"
+          href="/leaderboard"
           className="text-black p-2 rounded-full hover:bg-gray-100 transition-colors"
           aria-label="Back to home"
         >

--- a/app/profiles/[walletAddress]/page.tsx
+++ b/app/profiles/[walletAddress]/page.tsx
@@ -13,7 +13,7 @@ async function getProfile(walletAddress: string): Promise<UserProfile | null> {
   try {
     // For server-side fetch, we can use a relative URL or construct the full URL
     const baseUrl = "http://localhost:3000"; // Default for development
-    
+
     const response = await fetch(
       `${baseUrl}/api/profile?wallet_address=${walletAddress}`,
       {
@@ -26,9 +26,17 @@ async function getProfile(walletAddress: string): Promise<UserProfile | null> {
     }
 
     const data = await response.json();
-    
+
     // Check if this is an empty profile (no actual user data)
-    if (!data.name && !data.username && !data.email && !data.twitter_handle && !data.towns_handle && !data.farcaster_handle && !data.telegram_handle) {
+    if (
+      !data.name &&
+      !data.username &&
+      !data.email &&
+      !data.twitter_handle &&
+      !data.towns_handle &&
+      !data.farcaster_handle &&
+      !data.telegram_handle
+    ) {
       return null;
     }
 
@@ -47,14 +55,14 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
   }
 
   return (
-    <div className="min-h-screen bg-white flex flex-col">
+    <div className="min-h-screen bg-white flex flex-col font-grotesk">
       {/* Header */}
       <div className="flex justify-between items-center p-4">
         <h1 className="text-black text-lg font-medium font-inktrap uppercase">
-          USER PROFILE
+          {profile.name || profile.username || "PROFILE"}
         </h1>
         <Link
-          href="/"
+          href="/leaderboard"
           className="text-black p-2 rounded-full hover:bg-gray-100 transition-colors"
           aria-label="Back to home"
         >
@@ -64,50 +72,15 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
 
       {/* Content */}
       <div className="flex-1 flex flex-col items-center justify-start px-4 pb-4 gap-6 overflow-y-auto">
-        {/* Profile Picture */}
-        <div className="flex flex-col items-center">
-          <div
-            style={{
-              background:
-                "linear-gradient(90deg, #2400FF 14.58%, #FA00FF 52.6%, #FF0000 86.46%)",
-            }}
-            className="w-24 h-24 rounded-full flex items-center justify-center mb-4"
-          >
-            {profile.profile_picture_url ? (
-              <img
-                src={profile.profile_picture_url}
-                alt="Profile"
-                className="w-full h-full rounded-full object-cover"
-              />
-            ) : (
-              <div className="w-full h-full rounded-full bg-gradient-to-br from-blue-600 via-purple-600 to-red-600"></div>
-            )}
-          </div>
-        </div>
-
         {/* Profile Information */}
         <div className="w-full max-w-sm space-y-4">
-          {/* Name/Username */}
-          {(profile.name || profile.username) && (
-            <div className="text-center mb-6">
-              <h2 className="text-black text-xl font-inktrap font-bold">
-                {profile.name || profile.username}
-              </h2>
-              {profile.name && profile.username && profile.name !== profile.username && (
-                <p className="text-gray-600 text-sm font-inktrap">
-                  @{profile.username}
-                </p>
-              )}
-            </div>
-          )}
-
           {/* Wallet Address */}
-          <div className="space-y-2">
+          <div className="space-y-2 mt-6">
             <p className="text-black text-sm font-inktrap uppercase font-semibold">
               WALLET ADDRESS
             </p>
             <div className="bg-gray-100 rounded-full px-4 py-3">
-              <p className="text-black text-sm font-mono break-all">
+              <p className="text-black text-xs font-mono break-all">
                 {profile.wallet_address}
               </p>
             </div>
@@ -120,7 +93,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                 EMAIL
               </p>
               <div className="bg-gray-100 rounded-full px-4 py-3">
-                <p className="text-black text-sm">
+                <p className="text-black text-sm font-inktrap">
                   {profile.email}
                 </p>
               </div>
@@ -128,19 +101,11 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
           )}
 
           {/* Social Handles Section */}
-          {(profile.twitter_handle || profile.towns_handle || profile.farcaster_handle || profile.telegram_handle) && (
+          {(profile.twitter_handle ||
+            profile.towns_handle ||
+            profile.farcaster_handle ||
+            profile.telegram_handle) && (
             <>
-              <div className="bg-blue-100 rounded-lg p-4 my-6">
-                <p className="text-black text-sm font-inktrap uppercase font-semibold">
-                  SOCIAL HANDLES
-                </p>
-                <p className="text-black text-sm font-inktrap">
-                  Connect with this user
-                  <br />
-                  on social platforms
-                </p>
-              </div>
-
               <div className="space-y-4">
                 {/* X (Twitter) */}
                 {profile.twitter_handle && (
@@ -149,7 +114,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                       X
                     </p>
                     <div className="bg-gray-100 rounded-full px-4 py-3">
-                      <p className="text-black text-sm">
+                      <p className="text-black text-sm font-inktrap">
                         @{profile.twitter_handle}
                       </p>
                     </div>
@@ -163,7 +128,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                       TOWNS
                     </p>
                     <div className="bg-gray-100 rounded-full px-4 py-3">
-                      <p className="text-black text-sm">
+                      <p className="text-black text-sm font-inktrap">
                         @{profile.towns_handle}
                       </p>
                     </div>
@@ -177,7 +142,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                       FARCASTER
                     </p>
                     <div className="bg-gray-100 rounded-full px-4 py-3">
-                      <p className="text-black text-sm">
+                      <p className="text-black text-sm font-inktrap">
                         @{profile.farcaster_handle}
                       </p>
                     </div>
@@ -191,7 +156,7 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
                       TELEGRAM
                     </p>
                     <div className="bg-gray-100 rounded-full px-4 py-3">
-                      <p className="text-black text-sm">
+                      <p className="text-black text-sm font-inktrap">
                         @{profile.telegram_handle}
                       </p>
                     </div>
@@ -203,12 +168,12 @@ export default async function ProfilePage({ params }: ProfilePageProps) {
         </div>
 
         {/* Back to Home Button */}
-        <div className="w-full max-w-sm mt-8">
+        <div className="w-full max-w-sm mt-4">
           <Link
-            href="/"
+            href="/leaderboard"
             className="w-full bg-blue-100 text-blue-600 rounded-full hover:bg-blue-200 transition-colors flex items-center justify-center gap-2 font-inktrap py-3"
           >
-            <span>Back to Home</span>
+            <span>Back to Leaderboard</span>
           </Link>
         </div>
       </div>

--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -186,7 +186,7 @@ export default function Auth({ children }: AuthProps) {
   if (ready && !user) {
     return (
       <div className="flex flex-col gap-6 w-full justify-center max-w-xl mx-auto">
-        <div className="flex flex-col gap-1 p-4">
+        <div className="flex flex-col gap-1 p-0">
           <h1 className="text-black text-xl font-inktrap uppercase">
             CHECK IN TO
           </h1>

--- a/components/checkpoint.tsx
+++ b/components/checkpoint.tsx
@@ -6,6 +6,8 @@ import { usePrivy } from "@privy-io/react-auth";
 import { useState, useEffect, useRef } from "react";
 import { useRouter } from "next/navigation";
 import Auth from "./auth";
+import Link from "next/link";
+import { sassoon } from "@/lib/sassoon";
 
 interface CheckpointProps {
   id: string;
@@ -19,8 +21,48 @@ export default function Checkpoint({ id }: CheckpointProps) {
   const { checkinStatus, setCheckinStatus } = useCheckInStatus(address, id);
   console.log("checkinStatus", checkinStatus);
   const [isCheckingIn, setIsCheckingIn] = useState(false);
+
+  const [totalPoints, setTotalPoints] = useState<number>(310);
   const hasAttemptedCheckIn = useRef(false);
   const router = useRouter();
+
+  // Find matching sassoon content
+  const sassoonContent = sassoon.find((item) => item.checkpoint === id);
+
+  // Fetch player stats (rank and points)
+  useEffect(() => {
+    const fetchPlayerStats = async () => {
+      if (!address) return;
+
+      try {
+        // Get player data
+        const playerResponse = await fetch(
+          `/api/player?walletAddress=${address}`
+        );
+        if (playerResponse.ok) {
+          const playerData = await playerResponse.json();
+          if (playerData.success && playerData.player) {
+            setTotalPoints(playerData.player.total_points);
+
+            // Get leaderboard to find player's rank
+            const leaderboardResponse = await fetch(
+              "/api/leaderboard?limit=1000"
+            );
+            if (leaderboardResponse.ok) {
+              const leaderboardData = await leaderboardResponse.json();
+              if (leaderboardData.success && leaderboardData.leaderboard) {
+                // Player rank fetched but not displayed in current UI
+              }
+            }
+          }
+        }
+      } catch (error) {
+        console.error("Failed to fetch player stats:", error);
+      }
+    };
+
+    fetchPlayerStats();
+  }, [address]);
 
   useEffect(() => {
     // Skip if we've already attempted a check-in in this session
@@ -48,7 +90,11 @@ export default function Checkpoint({ id }: CheckpointProps) {
         // Make the API call to check in
         await fetch("/api/checkin", {
           method: "POST",
-          body: JSON.stringify({ walletAddress: address, email }),
+          body: JSON.stringify({
+            walletAddress: address,
+            email,
+            checkpoint: id,
+          }),
         });
 
         // Update the status after successful check-in
@@ -77,67 +123,53 @@ export default function Checkpoint({ id }: CheckpointProps) {
         </div>
       )}
       {checkinStatus && (
-        <div className="min-h-screen bg-gradient-to-b from-cyan-400 via-teal-400 to-yellow-400 font-grotesk">
-          <div className="flex flex-col items-center text-center px-4 py-8 gap-6">
+        <div className="font-grotesk">
+          <div className="flex flex-col items-center text-center py-8 gap-6">
             {/* Header Section */}
-            <div className="flex flex-col items-center gap-4">
+            <div className="flex flex-col items-center gap-1">
               <h1 className="text-5xl font-inktrap uppercase text-yellow-300 font-bold">
                 YOU EARNED
               </h1>
               <h2 className="text-5xl font-inktrap uppercase text-yellow-300 font-bold">
-                POINTS
+                100 POINTS
               </h2>
             </div>
 
-            {/* Box Icon */}
-            <div className="relative w-48 h-48 my-6">
-              <div className="w-full h-full border-4 border-yellow-300 rounded-lg flex items-center justify-center bg-transparent">
-                <div className="text-center">
-                  <div className="text-yellow-300 text-sm font-inktrap mb-2">
-                    TAP YOUR PHONE
+            {/* Content Section */}
+            {sassoonContent ? (
+              <div
+                className="rounded-xl p-4 w-full my-6 mx-4 max-w-sm bg-black text-left"
+                style={{
+                  background: `linear-gradient(0deg, rgba(0, 0, 0, 0.8) 0%, rgba(0, 0, 0, 0.8) 100%), lightgray 90% / cover no-repeat`,
+                }}
+              >
+                <div className="mb-6">
+                  <h3 className="text-white text-2xl font-inktrap font-bold mb-1">
+                    {sassoonContent.title}
+                  </h3>
+                  <h4 className="text-white text-lg font-inktrap opacity-80">
+                    {sassoonContent.subtitle}
+                  </h4>
+                </div>
+                <div className="text-white font-anonymous text-base leading-relaxed whitespace-pre-line">
+                  {sassoonContent.content}
+                </div>
+              </div>
+            ) : (
+              <div className="relative w-48 h-48 my-6">
+                <div className="w-full h-full border-4 border-yellow-300 rounded-lg flex items-center justify-center bg-transparent">
+                  <div className="text-center">
+                    <div className="text-yellow-300 text-sm font-inktrap mb-2">
+                      TAP YOUR PHONE
+                    </div>
+                    <div className="w-12 h-8 bg-yellow-300 rounded-full mx-auto mb-2"></div>
+                    <div className="text-yellow-300 text-lg font-inktrap font-bold">
+                      IRL
+                    </div>
                   </div>
-                  <div className="w-12 h-8 bg-yellow-300 rounded-full mx-auto mb-2"></div>
-                  <div className="text-yellow-300 text-lg font-inktrap font-bold">
-                    IRL
-                  </div>
                 </div>
               </div>
-            </div>
-
-            {/* Points Earned Card */}
-            <div className="bg-white rounded-xl p-6 w-full max-w-sm shadow-lg">
-              <div className="flex justify-between items-center mb-2">
-                <span className="text-gray-600 font-inktrap text-sm">
-                  You Earned
-                </span>
-                <span className="text-2xl">+</span>
-              </div>
-              <div className="text-4xl font-bold text-black font-inktrap mb-2">
-                100 <span className="text-lg font-normal">pts</span>
-              </div>
-              <p className="text-gray-600 text-sm font-anonymous mb-4">
-                {`You've just gained access to events, rewards and bespoke
-                experiences.`}
-              </p>
-
-              {/* Rewards Section */}
-              <div className="mb-4">
-                <div className="text-xs text-gray-500 font-inktrap mb-2">
-                  REWARDS
-                </div>
-                <div className="flex gap-2 mb-3">
-                  {[1, 2, 3, 4].map((i) => (
-                    <div
-                      key={i}
-                      className="w-12 h-12 bg-gray-100 rounded-lg border-2 border-gray-200"
-                    ></div>
-                  ))}
-                </div>
-                <Button className="bg-teal-500 text-white w-full rounded-lg font-inktrap text-sm">
-                  Rewards →
-                </Button>
-              </div>
-            </div>
+            )}
 
             {/* Total Points Card */}
             <div className="bg-white rounded-xl p-6 w-full max-w-sm shadow-lg">
@@ -145,71 +177,23 @@ export default function Checkpoint({ id }: CheckpointProps) {
                 YOUR POINTS
               </div>
               <div className="text-4xl font-bold text-black font-inktrap mb-4">
-                310 <span className="text-lg font-normal">pts</span>
+                {totalPoints} <span className="text-lg font-normal">pts</span>
               </div>
 
-              <div className="text-xs text-gray-500 font-inktrap mb-2">
-                YOUR PLACE
-              </div>
               <div className="flex justify-between items-center">
-                <div className="flex items-center gap-2">
-                  <div className="w-8 h-8 bg-gray-200 rounded-full flex items-center justify-center">
-                    <span className="text-xs">👤</span>
-                  </div>
-                  <span className="text-gray-600 font-inktrap">9380</span>
-                </div>
-                <Button className="bg-yellow-400 text-black rounded-lg font-inktrap text-sm px-4 py-2">
-                  Leaderboard →
-                </Button>
-              </div>
-            </div>
-
-            {/* Opportunities Section */}
-            <div className="bg-white rounded-xl p-6 w-full max-w-sm shadow-lg">
-              <div className="text-xs text-gray-500 font-inktrap mb-2">
-                EARN MORE
-              </div>
-              <h3 className="text-lg font-inktrap text-black mb-4">
-                Opportunities to earn more points
-              </h3>
-
-              <div className="flex gap-3">
-                <div className="bg-gray-50 rounded-lg p-4 flex-1">
-                  <div className="text-xs text-gray-500 font-inktrap mb-1">
-                    QUEST
-                  </div>
-                  <h4 className="text-sm font-inktrap text-black mb-1">
-                    Quest Title
-                  </h4>
-                  <p className="text-xs text-gray-400 font-anonymous mb-2">
-                    Description
-                  </p>
-                  <div className="w-6 h-6 bg-yellow-400 rounded-full flex items-center justify-center">
-                    <span className="text-xs">→</span>
-                  </div>
-                </div>
-                <div className="bg-gray-50 rounded-lg p-4 flex-1">
-                  <div className="text-xs text-gray-500 font-inktrap mb-1">
-                    QUEST
-                  </div>
-                  <h4 className="text-sm font-inktrap text-black mb-1">
-                    Quest Title
-                  </h4>
-                  <p className="text-xs text-gray-400 font-anonymous mb-2">
-                    Description
-                  </p>
-                  <div className="w-6 h-6 bg-yellow-400 rounded-full flex items-center justify-center">
-                    <span className="text-xs">→</span>
-                  </div>
-                </div>
+                <Link href="/leaderboard" className="w-full">
+                  <Button className="bg-yellow-400 hover:bg-yellow-500 text-black rounded-lg font-inktrap text-sm px-4 py-2 w-full">
+                    Leaderboard →
+                  </Button>
+                </Link>
               </div>
             </div>
 
             {/* Footer Section */}
-            <div className="mt-12 px-4">
-              <p className="text-white font-anonymous text-xl font-light mb-6 leading-relaxed">
+            <div className="mt-12 px-4 max-w-sm ">
+              <p className="text-white font-anonymous text-xl font-light mb-6">
                 Learn more and be the first to know about the latest IRL network
-                news
+                news.
               </p>
               <Button
                 onClick={() => router.push("/")}
@@ -217,26 +201,6 @@ export default function Checkpoint({ id }: CheckpointProps) {
               >
                 Visit IRL.ENERGY →
               </Button>
-            </div>
-
-            {/* Decorative Elements */}
-            <div className="mt-12 opacity-20">
-              <div className="w-48 h-48 mx-auto">
-                {/* Rings pattern */}
-                {[1, 2, 3, 4, 5].map((ring) => (
-                  <div
-                    key={ring}
-                    className="absolute inset-0 border border-white rounded-full"
-                    style={{
-                      width: `${ring * 40}px`,
-                      height: `${ring * 40}px`,
-                      left: "50%",
-                      top: "50%",
-                      transform: "translate(-50%, -50%)",
-                    }}
-                  ></div>
-                ))}
-              </div>
             </div>
 
             {/* Powered by Refraction */}

--- a/components/game-mapbox.tsx
+++ b/components/game-mapbox.tsx
@@ -200,7 +200,9 @@ export default function GameMapbox() {
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-2">
                     <Trophy className="w-5 h-5 text-gray-600" />
-                    <span className="font-inktrap text-black">2390</span>
+                    <span className="font-inktrap text-black">
+                      {playerData?.rank || "—"}
+                    </span>
                   </div>
                   <Button className="bg-yellow-400 hover:bg-yellow-500 text-black font-inktrap px-4 py-2 rounded-full text-sm">
                     Leaderboard

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { usePrivy } from "@privy-io/react-auth";
 import { Button } from "@/components/ui/button";
 import ProfileMenu from "./profile-menu";
+import Link from "next/link";
 
 export default function Header() {
   const { user, login } = usePrivy();
@@ -25,12 +26,14 @@ export default function Header() {
   return (
     <div className="flex justify-between items-center">
       <div className="bg-white rounded-full px-4 py-2">
-        <img
-          src="/logo2.svg"
-          alt="IRL"
-          className="w-full h-auto"
-          style={{ width: "35px", height: "auto" }}
-        />
+        <Link href="/">
+          <img
+            src="/logo2.svg"
+            alt="IRL"
+            className="w-full h-auto"
+            style={{ width: "35px", height: "auto" }}
+          />
+        </Link>
       </div>
       <div className="flex items-center justify-end bg-white rounded-full px-4 py-2">
         <button

--- a/components/leaderboard-page.tsx
+++ b/components/leaderboard-page.tsx
@@ -2,9 +2,9 @@
 
 import React, { useState, useEffect } from "react";
 import { usePrivy } from "@privy-io/react-auth";
-import { Button } from "@/components/ui/button";
-import { Menu, ArrowRight, Trophy, User } from "lucide-react";
+import { ArrowRight, Trophy } from "lucide-react";
 import Header from "./header";
+import Link from "next/link";
 import { useLocationGame } from "@/hooks/useLocationGame";
 
 interface UserStats {
@@ -215,9 +215,6 @@ export default function LeaderboardPage() {
             <h1 className="text-xl font-inktrap font-bold text-black">
               Leaderboard
             </h1>
-            <Button variant="ghost" size="sm" className="p-2">
-              <Menu className="w-5 h-5 text-gray-600" />
-            </Button>
           </div>
         </div>
 
@@ -233,18 +230,13 @@ export default function LeaderboardPage() {
                     YOUR PLACE
                   </p>
                   <div className="flex items-center">
-                    <div className="bg-gray-100 rounded-full px-4 py-2 flex items-center gap-2 border border-gray-300">
-                      {isLoadingUserStats ? (
-                        <div className="w-6 h-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600"></div>
-                      ) : (
-                        <>
-                          <span className="font-inktrap font-medium text-black text-lg">
-                            {userStats?.rank || "?"}
-                          </span>
-                          <ArrowRight className="w-4 h-4 text-gray-600" />
-                        </>
-                      )}
-                    </div>
+                    {isLoadingUserStats ? (
+                      <div className="w-6 h-6 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600"></div>
+                    ) : (
+                      <span className="text-2xl font-inktrap font-bold text-black">
+                        {userStats?.rank || "?"}
+                      </span>
+                    )}
                   </div>
                 </div>
 
@@ -318,17 +310,6 @@ export default function LeaderboardPage() {
                     >
                       {/* Rank */}
                       <div className="flex items-center gap-2">
-                        {entry.rank <= 3 && (
-                          <Trophy
-                            className={`w-4 h-4 ${
-                              entry.rank === 1
-                                ? "text-yellow-500"
-                                : entry.rank === 2
-                                ? "text-gray-400"
-                                : "text-orange-500"
-                            }`}
-                          />
-                        )}
                         <span className="text-lg font-inktrap font-medium text-black">
                           {entry.rank}
                         </span>
@@ -336,11 +317,12 @@ export default function LeaderboardPage() {
 
                       {/* Name */}
                       <div className="flex items-center gap-2">
-                        <User className="w-4 h-4 text-gray-500" />
-                        <span className="font-inktrap text-black text-sm truncate">
-                          {entry.username ||
-                            formatWalletAddress(entry.wallet_address)}
-                        </span>
+                        <Link href={`/profiles/${entry.wallet_address}`}>
+                          <span className="font-inktrap text-black text-sm truncate">
+                            {entry.username ||
+                              formatWalletAddress(entry.wallet_address)}
+                          </span>
+                        </Link>
                       </div>
 
                       {/* Points */}

--- a/components/leaderboard.tsx
+++ b/components/leaderboard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Trophy, Medal, Award, MapPin, User } from "lucide-react";
+import { Trophy, MapPin, User } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useLocationGame } from "@/hooks/useLocationGame";
 
@@ -15,23 +15,6 @@ export default function Leaderboard() {
       fetchLeaderboard(20);
     }
   }, [showLeaderboard]);
-
-  const getRankIcon = (rank: number) => {
-    switch (rank) {
-      case 1:
-        return <Trophy className="w-6 h-6 text-yellow-500" />;
-      case 2:
-        return <Medal className="w-6 h-6 text-gray-400" />;
-      case 3:
-        return <Award className="w-6 h-6 text-orange-500" />;
-      default:
-        return (
-          <span className="w-6 h-6 flex items-center justify-center text-gray-600 font-bold">
-            #{rank}
-          </span>
-        );
-    }
-  };
 
   const formatWalletAddress = (address: string) => {
     return `${address.slice(0, 6)}...${address.slice(-4)}`;
@@ -110,7 +93,6 @@ export default function Leaderboard() {
                 >
                   <div className="flex items-center justify-between">
                     <div className="flex items-center gap-3">
-                      {getRankIcon(player.rank)}
                       <div className="min-w-0 flex-1">
                         <div className="flex items-center gap-2">
                           <User className="w-4 h-4 text-gray-500" />

--- a/components/profile-menu.tsx
+++ b/components/profile-menu.tsx
@@ -96,8 +96,16 @@ export default function ProfileMenu({ isOpen, onClose }: ProfileMenuProps) {
         throw new Error("Failed to update profile");
       }
 
-      // Show success feedback (you could add a toast notification here)
-      toast.success("Profile updated successfully");
+      const result = await response.json();
+
+      // Show success feedback with points info
+      let successMessage = "Profile updated successfully";
+      if (result.pointsAwarded && result.pointsAwarded.length > 0) {
+        const totalPoints = result.pointsAwarded.length * 5;
+        successMessage += ` - Earned ${totalPoints} points!`;
+      }
+
+      toast.success(successMessage);
     } catch (error) {
       console.error("Error saving profile:", error);
       // Show error feedback
@@ -138,27 +146,6 @@ export default function ProfileMenu({ isOpen, onClose }: ProfileMenuProps) {
 
       {/* Content */}
       <div className="flex-1 flex flex-col items-center justify-start px-4 pb-4 gap-6 overflow-y-auto">
-        {/* Profile Picture */}
-        <div className="flex flex-col items-center">
-          <div
-            style={{
-              background:
-                "linear-gradient(90deg, #2400FF 14.58%, #FA00FF 52.6%, #FF0000 86.46%)",
-            }}
-            className="w-24 h-24 rounded-full flex items-center justify-center mb-4"
-          >
-            {profile.profile_picture_url ? (
-              <img
-                src={profile.profile_picture_url}
-                alt="Profile"
-                className="w-full h-full rounded-full object-cover"
-              />
-            ) : (
-              <div className="w-full h-full rounded-full bg-gradient-to-br from-blue-600 via-purple-600 to-red-600"></div>
-            )}
-          </div>
-        </div>
-
         {/* Form Fields */}
         <div className="w-full max-w-sm space-y-4">
           {/* Email */}

--- a/hooks/useCheckInStatus.ts
+++ b/hooks/useCheckInStatus.ts
@@ -1,16 +1,16 @@
 import { useEffect, useState, useRef } from "react";
 
-export function useCheckInStatus(address: string, checkinId: string) {
+export function useCheckInStatus(address: string, checkpoint: string) {
   const [checkinStatus, setCheckinStatus] = useState<boolean | null>(null);
   const isFetching = useRef(false);
 
   useEffect(() => {
-    // Reset status when address or checkinId changes
+    // Reset status when address or checkpoint changes
     setCheckinStatus(null);
 
     const fetchCheckins = async () => {
       // Skip if we don't have the required data or if we're already fetching
-      if (!address || !checkinId || isFetching.current) {
+      if (!address || !checkpoint || isFetching.current) {
         return;
       }
 
@@ -18,7 +18,11 @@ export function useCheckInStatus(address: string, checkinId: string) {
       isFetching.current = true;
 
       try {
-        const response = await fetch(`/api/checkin-status?address=${address}`);
+        const response = await fetch(
+          `/api/checkin-status?address=${address}&checkpoint=${encodeURIComponent(
+            checkpoint
+          )}`
+        );
         console.log("response", response);
         if (!response.ok) {
           throw new Error("Failed to fetch check-in status");
@@ -33,10 +37,10 @@ export function useCheckInStatus(address: string, checkinId: string) {
       }
     };
 
-    if (address && checkinId) {
+    if (address && checkpoint) {
       fetchCheckins();
     }
-  }, [address, checkinId]);
+  }, [address, checkpoint]);
 
   return { checkinStatus, setCheckinStatus };
 }

--- a/lib/points-activities.ts
+++ b/lib/points-activities.ts
@@ -27,6 +27,14 @@ export interface PointsActivityConfig {
 export type PointsActivityType =
   | "daily_checkin"
   | "profile_complete"
+  | "profile_field_email"
+  | "profile_field_name"
+  | "profile_field_username"
+  | "profile_field_twitter"
+  | "profile_field_towns"
+  | "profile_field_farcaster"
+  | "profile_field_telegram"
+  | "profile_field_picture"
   | "social_share"
   | "referral_signup"
   | "referral_complete"
@@ -107,6 +115,86 @@ export const POINTS_ACTIVITIES_CONFIG: PointsActivityConfig[] = [
     category: "onboarding",
     base_points: 100,
     max_total_points: 100,
+    is_active: true,
+  },
+  {
+    type: "profile_field_email",
+    name: "Add Email",
+    description: "Add your email address to your profile",
+    icon: "📧",
+    category: "onboarding",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_name",
+    name: "Add Name",
+    description: "Add your name to your profile",
+    icon: "👤",
+    category: "onboarding",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_username",
+    name: "Add Username",
+    description: "Add your username to your profile",
+    icon: "🏷️",
+    category: "onboarding",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_twitter",
+    name: "Add X Handle",
+    description: "Add your X (Twitter) handle to your profile",
+    icon: "🐦",
+    category: "social",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_towns",
+    name: "Add Towns Handle",
+    description: "Add your Towns handle to your profile",
+    icon: "🏘️",
+    category: "social",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_farcaster",
+    name: "Add Farcaster Handle",
+    description: "Add your Farcaster handle to your profile",
+    icon: "🔗",
+    category: "social",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_telegram",
+    name: "Add Telegram Handle",
+    description: "Add your Telegram handle to your profile",
+    icon: "💬",
+    category: "social",
+    base_points: 5,
+    max_total_points: 5,
+    is_active: true,
+  },
+  {
+    type: "profile_field_picture",
+    name: "Add Profile Picture",
+    description: "Add a profile picture to your profile",
+    icon: "🖼️",
+    category: "onboarding",
+    base_points: 5,
+    max_total_points: 5,
     is_active: true,
   },
   {

--- a/lib/sassoon.ts
+++ b/lib/sassoon.ts
@@ -1,0 +1,69 @@
+export const sassoon = [
+  {
+    checkpoint: "2",
+    title: "PATTERN STUDY",
+    subtitle: "Nicolas Sassoon",
+    content:
+      "Nicolas Sassoon employs early computer imaging techniques to render architectures, landscapes, and natural forces. Sassoon’s practice translates ideas of materiality and immateriality into digital animations, installations, prints, and sculptures. His work explores the contemplative and projective dimensions of screen-based space, and how the digital image can express dimensions of the physical realm.",
+  },
+  {
+    checkpoint: "3",
+    title: "Return to Bypass",
+    subtitle: "IXShells",
+    content:
+      "Itzel Yard, known by her artistic pseudonym Ix Shells, is a Panamanian-based new media artist specializing in sound, generative art and the creative space between the two. The artistic capabilities of computational systems sparked her interest at an early age through her passion for music and video games. Supplemented by her studies in architectural technology, she creates works with exquisite detail and spatial depth, often pulling patterns present in her daily life, before abstracting them together through elements of digital aesthetics like glitch, gradients and pixelation.",
+  },
+  {
+    checkpoint: "4",
+    title: "Lashlights",
+    subtitle: "Lovid",
+    content:
+      "Tali Hinkis and Kyle Lapidus began collaborating as LoVid in 2000. An alchemy of independent interests in technology has defined LoVid's aesthetic, combining craft-oriented analog processes and playful engineering with natural and social science. LoVid's interdisciplinary works explore the often invisible or intangible aspects of contemporary society, such as communication systems and biological signals. LoVid is particularly interested in the ways technology seeps into the evolution of human culture.",
+  },
+  {
+    checkpoint: "4",
+    title: "Lashlights",
+    subtitle: "Lovid",
+    content:
+      "Tali Hinkis and Kyle Lapidus began collaborating as LoVid in 2000. An alchemy of independent interests in technology has defined LoVid's aesthetic, combining craft-oriented analog processes and playful engineering with natural and social science. LoVid's interdisciplinary works explore the often invisible or intangible aspects of contemporary society, such as communication systems and biological signals. LoVid is particularly interested in the ways technology seeps into the evolution of human culture.",
+  },
+  {
+    checkpoint: "5",
+    title: "Will",
+    subtitle: "Emily Edelman",
+    content:
+      "Drawing on a background in typography and the design of physical spaces, Emily’s generative work invents new grid systems and uses simple shapes to uncover what is possible within strict formal constraints. Conversations ensue across scales and between colors, creating optical effects and emergent forms.\n\nEmily’s work explores communication, scale shift, color theory, and the “visible pixel” - a celebration of the physical module upon which digital art is created.",
+  },
+  {
+    checkpoint: "6",
+    title: "baud-0",
+    subtitle: "P1xelfool",
+    content:
+      "Exploring esoteric practices in computation, p1xelfool is an artist interested in the edges of synthetic and organic entities.\n\nThe artist nurtures an interest for the use of machines as an interface for phenomenological experiences, going beyond their utilitarian use in everyday life.",
+  },
+  {
+    checkpoint: "7",
+    title: "(HND.)",
+    subtitle: "Jah x Latasha",
+    content:
+      "A prompt to reach out and connect with the future aka. Us. Prompted and edited by Jah.",
+  },
+  {
+    checkpoint: "8",
+    title: "Bye Byte",
+    subtitle: "Setta Studio x Danny Daze",
+    content: "",
+  },
+  {
+    checkpoint: "9",
+    title: "Consciousness Terrain",
+    subtitle: "Sky Goodman",
+    content: "",
+  },
+  {
+    checkpoint: "10",
+    title: "Gentleman's Genes",
+    subtitle: "Lorna Mills",
+    content: "",
+  },
+];


### PR DESCRIPTION
A public user profile view was implemented, accessible via `/profiles/[walletAddress]`.

*   The core profile page is defined in `app/profiles/[walletAddress]/page.tsx`.
    *   It fetches user data using an asynchronous `getProfile` function, querying `/api/profile` with the `walletAddress` parameter.
    *   If the fetched profile is `null` or contains no meaningful user data (name, username, email, or social handles), the `notFound()` function is invoked.
    *   The page displays profile information, including a profile picture placeholder, name, wallet address, email, and various social handles.
    *   Styling is consistent with `profile-menu.tsx`, featuring a similar header, gradient profile picture, and read-only information fields.
*   A custom not-found page, `app/profiles/[walletAddress]/not-found.tsx`, was created.
    *   This page is displayed when a profile for the given `walletAddress` does not exist or is empty.
    *   It maintains the consistent styling theme and includes a "USER NOT FOUND" message with a "Back to Home" link.

This setup provides dedicated public profile URLs with robust error handling for missing profiles.