### PR TITLE
Fix points update after check-in

### DIFF
--- a/components/checkpoint.tsx
+++ b/components/checkpoint.tsx
@@ -76,8 +76,8 @@ export default function Checkpoint({ id }: CheckpointProps) {
         // If we get here, user is not checked in, so proceed with check-in
         setIsCheckingIn(true);
 
-        // Make the API call to check in
-        await fetch("/api/checkin", {
+        // Make the API call to check in and update points
+        const response = await fetch("/api/checkin", {
           method: "POST",
           body: JSON.stringify({
             walletAddress: address,
@@ -86,8 +86,13 @@ export default function Checkpoint({ id }: CheckpointProps) {
           }),
         });
 
-        // Update the status after successful check-in
-        setCheckinStatus(true);
+        if (response.ok) {
+          const result = await response.json();
+          setCheckinStatus(true);
+          if (result?.player?.total_points) {
+            setTotalPoints(result.player.total_points);
+          }
+        }
       } catch (error) {
         console.error("Failed to auto check-in:", error);
         // Reset the attempt flag on error so we can try again if needed

--- a/components/checkpoint.tsx
+++ b/components/checkpoint.tsx
@@ -89,7 +89,10 @@ export default function Checkpoint({ id }: CheckpointProps) {
         if (response.ok) {
           const result = await response.json();
           setCheckinStatus(true);
-          if (result?.player?.total_points) {
+          if (
+            result?.player &&
+            typeof result.player.total_points === "number"
+          ) {
             setTotalPoints(result.player.total_points);
           }
         }


### PR DESCRIPTION
## Summary
- update checkpoint screen to refresh user's points immediately after check-in

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685c8383960083318232fc72092af329