### PR TITLE
Fix screen height overflow

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -22,7 +22,7 @@ export default function RootLayout({
           rel="stylesheet"
         />
       </head>
-      <body>
+      <body className="min-h-dvh">
         <Providers>{children}</Providers>
         <Toaster />
       </body>

--- a/components/auth.tsx
+++ b/components/auth.tsx
@@ -88,7 +88,7 @@ export default function Auth({ children }: AuthProps) {
 
   if (!ready) {
     return (
-      <div className="flex justify-center items text-center w-full h-screen font-inktrap text-2xl pt-10">
+      <div className="flex items-center justify-center text-center w-full min-h-dvh font-inktrap text-2xl">
         Loading...
       </div>
     );
@@ -230,7 +230,7 @@ export default function Auth({ children }: AuthProps) {
                 backgroundSize: "cover",
                 backgroundPosition: "center",
               }}
-              className="flex flex-col gap-3 justify-between h-screen p-4 rounded-2xl overflow-hidden"
+              className="flex flex-col gap-3 justify-between h-[calc(100dvh-5rem)] p-4 rounded-2xl overflow-hidden"
             >
               <p
                 style={{ lineHeight: "40px" }}

--- a/components/checkpoint.tsx
+++ b/components/checkpoint.tsx
@@ -115,7 +115,7 @@ export default function Checkpoint({ id }: CheckpointProps) {
   return (
     <Auth>
       {!checkinStatus && (
-        <div className="flex justify-center items text-center w-full h-screen font-inktrap text-2xl pt-10">
+        <div className="flex items-center justify-center text-center w-full min-h-dvh font-inktrap text-2xl">
           Loading ...
         </div>
       )}

--- a/components/ikaro-auth.tsx
+++ b/components/ikaro-auth.tsx
@@ -13,7 +13,7 @@ export default function Auth({ children }: AuthProps) {
 
   if (!ready) {
     return (
-      <div className="flex justify-center items text-center w-full h-screen font-inktrap text-2xl pt-10">
+      <div className="flex items-center justify-center text-center w-full min-h-dvh font-inktrap text-2xl">
         Loading...
       </div>
     );


### PR DESCRIPTION
## Summary
- apply `min-h-dvh` to the body so every page expands to viewport height
- tweak auth and checkpoint loading states to use `min-h-dvh`
- ensure the onboarding card height accounts for padding

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686434001fcc833195745c278b7346ff