### PR TITLE
fix: structured Campaign Monitor logging for 404/debugging

### DIFF
--- a/app/api/player/route.ts
+++ b/app/api/player/route.ts
@@ -78,8 +78,15 @@ export async function POST(request: NextRequest) {
         await addCampaignMonitorSubscriber({ email });
       } catch (campaignMonitorError) {
         console.error(
-          'Failed to add subscriber to Campaign Monitor:',
-          campaignMonitorError
+          JSON.stringify({
+            source: 'api_player_post',
+            message: 'campaign_monitor_sync_exception',
+            walletAddressSuffix: walletAddress.slice(-8),
+            error:
+              campaignMonitorError instanceof Error
+                ? campaignMonitorError.message
+                : String(campaignMonitorError),
+          })
         );
       }
     }

--- a/lib/campaign-monitor/__tests__/subscribe.test.ts
+++ b/lib/campaign-monitor/__tests__/subscribe.test.ts
@@ -5,11 +5,15 @@ describe('addCampaignMonitorSubscriber', () => {
   const originalEnv = { ...process.env };
 
   beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
         ok: true,
         status: 201,
+        statusText: 'Created',
         text: async () => '"user@example.com"',
       })
     );
@@ -32,9 +36,18 @@ describe('addCampaignMonitorSubscriber', () => {
     expect(fetch).not.toHaveBeenCalled();
   });
 
+  it('no-ops when env is only whitespace', async () => {
+    process.env.CAMPAIGN_MONITOR_API_KEY = '   ';
+    process.env.CAMPAIGN_MONITOR_LIST_ID = '  \t';
+
+    await addCampaignMonitorSubscriber({ email: 'user@example.com' });
+
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
   it('POSTs to CreateSend with Basic auth and JSON body', async () => {
-    process.env.CAMPAIGN_MONITOR_API_KEY = 'test-api-key';
-    process.env.CAMPAIGN_MONITOR_LIST_ID = 'list-id-abc';
+    process.env.CAMPAIGN_MONITOR_API_KEY = '  test-api-key  ';
+    process.env.CAMPAIGN_MONITOR_LIST_ID = '  list-id-abc  ';
 
     await addCampaignMonitorSubscriber({
       email: 'user@example.com',

--- a/lib/campaign-monitor/subscribe.ts
+++ b/lib/campaign-monitor/subscribe.ts
@@ -10,9 +10,45 @@ export type AddCampaignMonitorSubscriberInput = {
 };
 
 function isConfigured(): boolean {
-  return Boolean(
-    process.env.CAMPAIGN_MONITOR_API_KEY && process.env.CAMPAIGN_MONITOR_LIST_ID
-  );
+  const key = process.env.CAMPAIGN_MONITOR_API_KEY?.trim();
+  const listId = process.env.CAMPAIGN_MONITOR_LIST_ID?.trim();
+  return Boolean(key && listId);
+}
+
+function redactEmailForLog(email: string): string {
+  const trimmed = email.trim();
+  const at = trimmed.lastIndexOf('@');
+  if (at <= 0 || at === trimmed.length - 1) {
+    return '(invalid-email)';
+  }
+  return `***@${trimmed.slice(at + 1)}`;
+}
+
+function redactListIdForLog(listId: string): string {
+  const s = listId.trim();
+  if (s.length <= 8) {
+    return '(short-id)';
+  }
+  return `${s.slice(0, 4)}…${s.slice(-4)} (len=${s.length})`;
+}
+
+function logCampaignMonitor(
+  level: 'info' | 'warn' | 'error',
+  message: string,
+  meta: Record<string, unknown>
+): void {
+  const line = JSON.stringify({
+    source: 'campaign_monitor',
+    message,
+    ...meta,
+  });
+  if (level === 'error') {
+    console.error(line);
+  } else if (level === 'warn') {
+    console.warn(line);
+  } else {
+    console.info(line);
+  }
 }
 
 /**
@@ -26,10 +62,11 @@ export async function addCampaignMonitorSubscriber(
     return;
   }
 
-  const apiKey = process.env.CAMPAIGN_MONITOR_API_KEY as string;
-  const listId = process.env.CAMPAIGN_MONITOR_LIST_ID as string;
+  const apiKey = process.env.CAMPAIGN_MONITOR_API_KEY!.trim();
+  const listId = process.env.CAMPAIGN_MONITOR_LIST_ID!.trim();
   const email = input.email.trim();
   if (!email) {
+    logCampaignMonitor('warn', 'campaign_monitor_skip_empty_email', {});
     return;
   }
 
@@ -41,20 +78,67 @@ export async function addCampaignMonitorSubscriber(
   const auth = Buffer.from(`${apiKey}:x`, 'utf8').toString('base64');
   const url = `${CREATESEND_API_BASE}/subscribers/${encodeURIComponent(listId)}.json`;
 
-  const res = await fetch(url, {
-    method: 'POST',
-    headers: {
-      Authorization: `Basic ${auth}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    },
-    body: JSON.stringify(body),
+  logCampaignMonitor('info', 'campaign_monitor_subscribe_request', {
+    email: redactEmailForLog(email),
+    listId: redactListIdForLog(listId),
+    apiKeyLen: apiKey.length,
+    endpointHost: 'api.createsend.com',
+    pathTemplate: '/api/v3.3/subscribers/{listId}.json',
   });
 
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${auth}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+  } catch (err) {
+    logCampaignMonitor('error', 'campaign_monitor_subscribe_network_error', {
+      email: redactEmailForLog(email),
+      listId: redactListIdForLog(listId),
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+
+  const responseText = await res.text();
+  let parsedBody: unknown;
+  try {
+    parsedBody = responseText ? JSON.parse(responseText) : null;
+  } catch {
+    parsedBody = responseText.slice(0, 500);
+  }
+
   if (!res.ok) {
-    const detail = await res.text();
+    const hint =
+      res.status === 404
+        ? '404 usually means wrong URL path or invalid list ID — confirm CAMPAIGN_MONITOR_LIST_ID matches List API ID in Campaign Monitor (Settings → list → bottom). Ensure no extra quotes/spaces in env.'
+        : res.status === 401
+          ? '401 means invalid API key or key not permitted for this list — confirm CAMPAIGN_MONITOR_API_KEY (Basic auth username per CM docs).'
+          : undefined;
+
+    logCampaignMonitor('error', 'campaign_monitor_subscribe_http_error', {
+      status: res.status,
+      statusText: res.statusText,
+      email: redactEmailForLog(email),
+      listId: redactListIdForLog(listId),
+      responseBody: parsedBody,
+      hint,
+    });
+
     throw new Error(
-      `Campaign Monitor subscriber API failed (${res.status}): ${detail}`
+      `Campaign Monitor subscriber API failed (${res.status}): ${responseText.slice(0, 300)}`
     );
   }
+
+  logCampaignMonitor('info', 'campaign_monitor_subscribe_ok', {
+    status: res.status,
+    email: redactEmailForLog(email),
+    listId: redactListIdForLog(listId),
+  });
 }


### PR DESCRIPTION
- Log JSON lines: request (redacted email, list id preview, api key length), success, HTTP errors with parsed body and 404/401 hints
- Trim env values; treat whitespace-only as unset
- Network errors logged before rethrow
- Route catch logs wallet suffix + error message as JSON
- Tests: mock console, whitespace env case