### PR TITLE
fix: checkpoint partner hero image 4:5 aspect ratio

### DIFF
--- a/components/auth/auth-wrapper.tsx
+++ b/components/auth/auth-wrapper.tsx
@@ -334,14 +334,14 @@ export default function AuthWrapper({
                   style={{
                     boxShadow: '0px 0px 100px 30px rgba(255,255,255,1)',
                     width: 208,
-                    height: 209,
+                    height: 260,
                   }}
                 >
                   <Image
                     src={partnerImageUrl}
                     alt={title}
                     width={208}
-                    height={209}
+                    height={260}
                     className="object-cover w-full h-full"
                   />
                 </div>

--- a/components/checkpoint/spend-checkpoint.tsx
+++ b/components/checkpoint/spend-checkpoint.tsx
@@ -5,7 +5,12 @@ import Image from 'next/image';
 import { usePrivy } from '@privy-io/react-auth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
-import type { Checkpoint, SpendItem, SpendRedemption, Player } from '@/lib/types';
+import type {
+  Checkpoint,
+  SpendItem,
+  SpendRedemption,
+  Player,
+} from '@/lib/types';
 
 type SpendCheckpointResponse = {
   checkpoint: Checkpoint;
@@ -93,7 +98,8 @@ export default function SpendCheckpoint({ checkpoint }: SpendCheckpointProps) {
       if (!response.ok) {
         throw new Error(responseData?.error || 'Failed to redeem');
       }
-      return (responseData.data || responseData) as RedeemSpendCheckpointResponse;
+      return (responseData.data ||
+        responseData) as RedeemSpendCheckpointResponse;
     },
     onSuccess: async () => {
       setSubmitError(null);
@@ -162,14 +168,14 @@ export default function SpendCheckpoint({ checkpoint }: SpendCheckpointProps) {
               style={{
                 boxShadow: '0px 0px 100px 30px rgba(255,255,255,1)',
                 width: 208,
-                height: 209,
+                height: 260,
               }}
             >
               <Image
                 src={checkpoint.partner_image_url}
                 alt={checkpoint.name}
                 width={208}
-                height={209}
+                height={260}
                 className="object-cover w-full h-full"
                 priority
               />
@@ -361,7 +367,8 @@ export default function SpendCheckpoint({ checkpoint }: SpendCheckpointProps) {
                   className="text-center text-xs"
                   style={{ color: `${textColor}CC` }}
                 >
-                  Balance after purchase: {pointsAfterRedeem.toLocaleString()} PTS
+                  Balance after purchase: {pointsAfterRedeem.toLocaleString()}{' '}
+                  PTS
                 </p>
               )}
             </>

--- a/components/checkpoint/unified-checkpoint.tsx
+++ b/components/checkpoint/unified-checkpoint.tsx
@@ -66,14 +66,14 @@ function CheckinSuccessView({
               style={{
                 boxShadow: '0px 0px 100px 30px rgba(255,255,255,1)',
                 width: 208,
-                height: 209,
+                height: 260,
               }}
             >
               <Image
                 src={checkpoint.partner_image_url}
                 alt={checkpoint.name}
                 width={208}
-                height={209}
+                height={260}
                 className="object-cover w-full h-full"
                 priority
               />
@@ -94,8 +94,7 @@ function CheckinSuccessView({
             className="text-[39px] leading-[0.95em] font-normal -tracking-[0.08em]"
             style={{ color: textColor }}
           >
-            Welcome To{' '}
-            {checkpoint.name}
+            Welcome To {checkpoint.name}
           </h2>
 
           <div className="flex items-end justify-between">
@@ -145,9 +144,7 @@ function CheckinSuccessView({
   );
 }
 
-function CheckinCheckpoint({
-  checkpoint,
-}: UnifiedCheckpointProps) {
+function CheckinCheckpoint({ checkpoint }: UnifiedCheckpointProps) {
   const { user } = usePrivy();
   const { createWallet } = useCreateWallet();
   const {
@@ -469,7 +466,9 @@ function CheckinCheckpoint({
   );
 }
 
-export default function UnifiedCheckpoint({ checkpoint }: UnifiedCheckpointProps) {
+export default function UnifiedCheckpoint({
+  checkpoint,
+}: UnifiedCheckpointProps) {
   if (checkpoint.checkpoint_mode === 'spend') {
     return <SpendCheckpoint checkpoint={checkpoint} />;
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Checkpoint partner images were shown in a ~1:1 frame (208×209). They are now **4:5** (208×260) so taller poster-style art displays correctly.

## Changes

- `components/auth/auth-wrapper.tsx` — branded login shell for `/c/[id]`
- `components/checkpoint/unified-checkpoint.tsx` — check-in success view
- `components/checkpoint/spend-checkpoint.tsx` — spend checkpoint flow

## Testing

- `yarn test components/checkpoint/unified-checkpoint.test.tsx --run`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://refractiondao.slack.com/archives/C087TCBRL90/p1776098653445659?thread_ts=1776098653.445659&cid=C087TCBRL90)

<div><a href="https://cursor.com/agents/bc-97339d4c-ab17-5c59-885c-5a1bbdc902e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-97339d4c-ab17-5c59-885c-5a1bbdc902e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

