### PR TITLE
fix: harden perk redemption dedupe

### DIFF
--- a/app/api/perks/redeem/__tests__/route.test.ts
+++ b/app/api/perks/redeem/__tests__/route.test.ts
@@ -373,6 +373,60 @@ describe('POST /api/perks/redeem', () => {
   });
 
   describe('Database Errors', () => {
+    it('should return 400 when insert loses a redemption race', async () => {
+      // Mock user with enough points
+      mockSingle.mockResolvedValueOnce({
+        data: { total_points: 500 },
+        error: null,
+      });
+      // Mock perk
+      mockSingle.mockResolvedValueOnce({
+        data: {
+          id: validPerkId,
+          points_threshold: 100,
+          type: 'discount',
+          location: null,
+        },
+        error: null,
+      });
+      // Mock no existing redemption
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { code: 'PGRST116', message: 'Not found' },
+      });
+      // Mock available code
+      mockSingle.mockResolvedValueOnce({
+        data: {
+          id: 'code-123',
+          code: 'SAVE50',
+          perk_id: validPerkId,
+          is_claimed: false,
+        },
+        error: null,
+      });
+      // Mock insert conflict from a concurrent request
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: '23505',
+          message: 'duplicate key value violates unique constraint',
+        },
+      });
+
+      const request = createRequest({
+        perkId: validPerkId,
+        walletAddress: validWallet,
+      });
+
+      const response = await POST(request);
+      const json = await response.json();
+
+      expect(response.status).toBe(400);
+      expect(json.success).toBe(false);
+      expect(json.error).toBe('Perk already redeemed');
+      expect(trackRewardClaimed).not.toHaveBeenCalled();
+    });
+
     it('should return 500 on user fetch error', async () => {
       mockSingle.mockResolvedValueOnce({
         data: null,

--- a/app/api/perks/redeem/route.ts
+++ b/app/api/perks/redeem/route.ts
@@ -7,6 +7,12 @@ import { setUserProperties as setUserPropertiesServer } from '@/lib/analytics/se
 
 export const dynamic = 'force-dynamic';
 
+const isDuplicateRedemptionError = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: string }).code === '23505';
+
 // POST /api/perks/redeem { perkId, walletAddress }
 export async function POST(request: NextRequest) {
   try {
@@ -72,7 +78,12 @@ export async function POST(request: NextRequest) {
       })
       .select(`*, perk_discount_codes ( code )`)
       .single();
-    if (error) throw error;
+    if (error) {
+      if (isDuplicateRedemptionError(error)) {
+        return apiError('Perk already redeemed', 400);
+      }
+      throw error;
+    }
 
     const distinctId = resolveServerIdentity({
       email: user.email || undefined,

--- a/database/add-unique-user-perk-redemptions.sql
+++ b/database/add-unique-user-perk-redemptions.sql
@@ -1,0 +1,32 @@
+-- Ensure one redemption per wallet/perk pair and release any duplicate-claimed codes.
+WITH ranked_redemptions AS (
+  SELECT
+    id,
+    discount_code_id,
+    user_wallet_address,
+    perk_id,
+    ROW_NUMBER() OVER (
+      PARTITION BY user_wallet_address, perk_id
+      ORDER BY redeemed_at ASC NULLS LAST, id ASC
+    ) AS redemption_rank
+  FROM user_perk_redemptions
+),
+duplicate_redemptions AS (
+  SELECT id, discount_code_id
+  FROM ranked_redemptions
+  WHERE redemption_rank > 1
+),
+released_codes AS (
+  UPDATE perk_discount_codes
+  SET
+    is_claimed = false,
+    claimed_by_wallet_address = NULL,
+    claimed_at = NULL
+  WHERE id IN (SELECT discount_code_id FROM duplicate_redemptions)
+  RETURNING id
+)
+DELETE FROM user_perk_redemptions
+WHERE id IN (SELECT id FROM duplicate_redemptions);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_user_perk_redemptions_wallet_perk_unique
+ON user_perk_redemptions(user_wallet_address, perk_id);

--- a/lib/db/__tests__/perks.test.ts
+++ b/lib/db/__tests__/perks.test.ts
@@ -1,48 +1,57 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
-import type { Perk, Player } from '@/lib/types'
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Perk, Player } from '@/lib/types';
 
 // Mock the supabase client - using any to avoid complex typing
-const mockSingle = vi.fn()
-const mockLimit = vi.fn(() => ({ single: mockSingle }))
-const mockOr = vi.fn<any>()
-const mockLte = vi.fn<any>(() => ({ or: mockOr }))
+const mockSingle = vi.fn();
+const mockLimit = vi.fn(() => ({ single: mockSingle }));
+const mockOr = vi.fn<any>();
+const mockLte = vi.fn<any>(() => ({ or: mockOr }));
 const mockEq = vi.fn<any>(() => ({
   single: mockSingle,
-  eq: vi.fn(() => ({ single: mockSingle, limit: mockLimit, lte: mockLte, or: mockOr })),
+  eq: vi.fn(() => ({
+    single: mockSingle,
+    limit: mockLimit,
+    lte: mockLte,
+    or: mockOr,
+  })),
   select: vi.fn(() => ({ single: mockSingle })),
   lte: mockLte,
   or: mockOr,
-}))
+}));
 const mockOrder = vi.fn<any>(() => ({
   eq: mockEq,
   or: mockOr,
-}))
+}));
 const mockSelect = vi.fn(() => ({
   single: mockSingle,
   eq: mockEq,
   order: mockOrder,
   lte: mockLte,
-}))
-const mockInsert = vi.fn(() => ({ select: vi.fn(() => ({ single: mockSingle })) }))
-const mockUpdate = vi.fn(() => ({ eq: vi.fn(() => ({ select: vi.fn(() => ({ single: mockSingle })) })) }))
-const mockDelete = vi.fn(() => ({ eq: mockEq }))
+}));
+const mockInsert = vi.fn(() => ({
+  select: vi.fn(() => ({ single: mockSingle })),
+}));
+const mockUpdate = vi.fn(() => ({
+  eq: vi.fn(() => ({ select: vi.fn(() => ({ single: mockSingle })) })),
+}));
+const mockDelete = vi.fn(() => ({ eq: mockEq }));
 const mockFrom = vi.fn(() => ({
   select: mockSelect,
   insert: mockInsert,
   update: mockUpdate,
   delete: mockDelete,
-}))
+}));
 
 vi.mock('@/lib/db/client', () => ({
   supabase: {
     from: () => mockFrom(),
   },
-}))
+}));
 
 // Mock getPlayerByWallet
 vi.mock('@/lib/db/players', () => ({
   getPlayerByWallet: vi.fn(),
-}))
+}));
 
 import {
   getAllPerks,
@@ -51,50 +60,83 @@ import {
   redeemPerk,
   createPerk,
   updatePerk,
-} from '../perks'
-import { getPlayerByWallet } from '../players'
+} from '../perks';
+import { getPlayerByWallet } from '../players';
 
 describe('Perks Database Module', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
-  })
+    vi.clearAllMocks();
+  });
 
   describe('getAllPerks', () => {
     it('should return all active perks respecting end_date', async () => {
       const mockPerks: Perk[] = [
-        { id: '1', title: 'Perk 1', description: 'Desc 1', points_threshold: 100, type: 'discount', is_active: true },
-        { id: '2', title: 'Perk 2', description: 'Desc 2', points_threshold: 200, type: 'exclusive', is_active: true },
-      ]
+        {
+          id: '1',
+          title: 'Perk 1',
+          description: 'Desc 1',
+          points_threshold: 100,
+          type: 'discount',
+          is_active: true,
+        },
+        {
+          id: '2',
+          title: 'Perk 2',
+          description: 'Desc 2',
+          points_threshold: 200,
+          type: 'exclusive',
+          is_active: true,
+        },
+      ];
 
-      mockOr.mockResolvedValueOnce({ data: mockPerks, error: null })
+      mockOr.mockResolvedValueOnce({ data: mockPerks, error: null });
 
-      const result = await getAllPerks(true)
+      const result = await getAllPerks(true);
 
-      expect(result).toEqual(mockPerks)
-      expect(mockFrom).toHaveBeenCalled()
-      expect(mockOrder).toHaveBeenCalledWith('created_at', { ascending: false })
-    })
+      expect(result).toEqual(mockPerks);
+      expect(mockFrom).toHaveBeenCalled();
+      expect(mockOrder).toHaveBeenCalledWith('created_at', {
+        ascending: false,
+      });
+    });
 
     it('should return all perks when activeOnly is false', async () => {
       const mockPerks: Perk[] = [
-        { id: '1', title: 'Perk 1', description: 'Desc 1', points_threshold: 100, type: 'discount', is_active: true },
-        { id: '2', title: 'Perk 2', description: 'Desc 2', points_threshold: 200, type: 'exclusive', is_active: false },
-      ]
+        {
+          id: '1',
+          title: 'Perk 1',
+          description: 'Desc 1',
+          points_threshold: 100,
+          type: 'discount',
+          is_active: true,
+        },
+        {
+          id: '2',
+          title: 'Perk 2',
+          description: 'Desc 2',
+          points_threshold: 200,
+          type: 'exclusive',
+          is_active: false,
+        },
+      ];
 
       // For activeOnly=false, the query goes directly to order() without eq/or
-      mockOrder.mockResolvedValueOnce({ data: mockPerks, error: null })
+      mockOrder.mockResolvedValueOnce({ data: mockPerks, error: null });
 
-      const result = await getAllPerks(false)
+      const result = await getAllPerks(false);
 
-      expect(result).toEqual(mockPerks)
-    })
+      expect(result).toEqual(mockPerks);
+    });
 
     it('should throw error on database failure', async () => {
-      mockOr.mockResolvedValueOnce({ data: null, error: { message: 'DB Error' } })
+      mockOr.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'DB Error' },
+      });
 
-      await expect(getAllPerks(true)).rejects.toEqual({ message: 'DB Error' })
-    })
-  })
+      await expect(getAllPerks(true)).rejects.toEqual({ message: 'DB Error' });
+    });
+  });
 
   describe('getPerkById', () => {
     it('should return perk when found', async () => {
@@ -105,28 +147,28 @@ describe('Perks Database Module', () => {
         points_threshold: 100,
         type: 'discount',
         is_active: true,
-      }
+      };
 
-      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null })
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
 
-      const result = await getPerkById('perk-123')
+      const result = await getPerkById('perk-123');
 
-      expect(result).toEqual(mockPerk)
-      expect(mockFrom).toHaveBeenCalled()
-    })
+      expect(result).toEqual(mockPerk);
+      expect(mockFrom).toHaveBeenCalled();
+    });
 
     it('should throw error when perk not found', async () => {
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { code: 'PGRST116', message: 'Not found' }
-      })
+        error: { code: 'PGRST116', message: 'Not found' },
+      });
 
       await expect(getPerkById('nonexistent')).rejects.toEqual({
         code: 'PGRST116',
-        message: 'Not found'
-      })
-    })
-  })
+        message: 'Not found',
+      });
+    });
+  });
 
   describe('getAvailablePerksForUser', () => {
     it('should filter by points threshold and exclude redeemed', async () => {
@@ -134,65 +176,79 @@ describe('Perks Database Module', () => {
         id: 1,
         wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
         total_points: 500,
-      }
+      };
 
       const mockPerks = [
         {
           id: '1',
           title: 'Affordable Perk',
           points_threshold: 100,
-          user_perk_redemptions: []
+          user_perk_redemptions: [],
         },
         {
           id: '2',
           title: 'Already Redeemed',
           points_threshold: 200,
-          user_perk_redemptions: [{ id: 'r1', user_wallet_address: '0x1234567890abcdef1234567890abcdef12345678' }]
+          user_perk_redemptions: [
+            {
+              id: 'r1',
+              user_wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+            },
+          ],
         },
-      ]
+      ];
 
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer)
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer);
       // getAvailablePerksForUser uses: .select().eq().lte().or()
-      mockOr.mockResolvedValueOnce({ data: mockPerks, error: null })
+      mockOr.mockResolvedValueOnce({ data: mockPerks, error: null });
 
-      const result = await getAvailablePerksForUser('0x1234567890abcdef1234567890abcdef12345678')
+      const result = await getAvailablePerksForUser(
+        '0x1234567890abcdef1234567890abcdef12345678'
+      );
 
       // Should only return the unredeemed perk
-      expect(result).toHaveLength(1)
-      expect(result[0].id).toBe('1')
-    })
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe('1');
+    });
 
     it('should return empty array when user has no points', async () => {
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(null)
-      mockOr.mockResolvedValueOnce({ data: [], error: null })
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(null);
+      mockOr.mockResolvedValueOnce({ data: [], error: null });
 
-      const result = await getAvailablePerksForUser('0x1234567890abcdef1234567890abcdef12345678')
+      const result = await getAvailablePerksForUser(
+        '0x1234567890abcdef1234567890abcdef12345678'
+      );
 
-      expect(result).toEqual([])
-    })
+      expect(result).toEqual([]);
+    });
 
     it('should throw error on database failure', async () => {
       vi.mocked(getPlayerByWallet).mockResolvedValueOnce({
         id: 1,
         wallet_address: '0x123',
-        total_points: 500
-      })
-      mockOr.mockResolvedValueOnce({ data: null, error: { message: 'DB Error' } })
+        total_points: 500,
+      });
+      mockOr.mockResolvedValueOnce({
+        data: null,
+        error: { message: 'DB Error' },
+      });
 
-      await expect(getAvailablePerksForUser('0x123')).rejects.toEqual({ message: 'DB Error' })
-    })
-  })
+      await expect(getAvailablePerksForUser('0x123')).rejects.toEqual({
+        message: 'DB Error',
+      });
+    });
+  });
 
   describe('redeemPerk', () => {
-    const mockWallet = '0x1234567890abcdef1234567890abcdef12345678'
-    const mockPerkId = 'perk-123'
+    const mockWallet = '0x1234567890abcdef1234567890abcdef12345678';
+    const mockPerkId = 'perk-123';
 
     it('should successfully redeem perk with available code', async () => {
       const mockPlayer: Player = {
         id: 1,
         wallet_address: mockWallet,
         total_points: 500,
-      }
+      };
 
       const mockPerk: Perk = {
         id: mockPerkId,
@@ -200,14 +256,14 @@ describe('Perks Database Module', () => {
         description: 'Desc',
         points_threshold: 100,
         type: 'discount',
-      }
+      };
 
       const mockCode = {
         id: 'code-123',
         code: 'DISCOUNT50',
         perk_id: mockPerkId,
         is_claimed: false,
-      }
+      };
 
       const mockRedemption = {
         id: 'redemption-123',
@@ -215,35 +271,35 @@ describe('Perks Database Module', () => {
         discount_code_id: 'code-123',
         user_wallet_address: mockWallet,
         perk_discount_codes: { code: 'DISCOUNT50' },
-      }
+      };
 
       // Mock getPlayerByWallet
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer)
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer);
 
       // Mock getPerkById (first single call)
-      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null })
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
 
       // Mock existing redemption check (second single call - returns null)
-      mockSingle.mockResolvedValueOnce({ data: null, error: null })
+      mockSingle.mockResolvedValueOnce({ data: null, error: null });
 
       // Mock available code lookup (third single call)
-      mockSingle.mockResolvedValueOnce({ data: mockCode, error: null })
+      mockSingle.mockResolvedValueOnce({ data: mockCode, error: null });
 
       // Mock redemption insert (fourth single call)
-      mockSingle.mockResolvedValueOnce({ data: mockRedemption, error: null })
+      mockSingle.mockResolvedValueOnce({ data: mockRedemption, error: null });
 
-      const result = await redeemPerk(mockPerkId, mockWallet)
+      const result = await redeemPerk(mockPerkId, mockWallet);
 
-      expect(result).toEqual(mockRedemption)
-      expect(result.perk_discount_codes?.code).toBe('DISCOUNT50')
-    })
+      expect(result).toEqual(mockRedemption);
+      expect(result.perk_discount_codes?.code).toBe('DISCOUNT50');
+    });
 
     it('should throw error for insufficient points', async () => {
       const mockPlayer: Player = {
         id: 1,
         wallet_address: mockWallet,
         total_points: 50, // Less than threshold
-      }
+      };
 
       const mockPerk: Perk = {
         id: mockPerkId,
@@ -251,14 +307,15 @@ describe('Perks Database Module', () => {
         description: 'Desc',
         points_threshold: 500, // More than user has
         type: 'exclusive',
-      }
+      };
 
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer)
-      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null })
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer);
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
 
-      await expect(redeemPerk(mockPerkId, mockWallet))
-        .rejects.toThrow('Insufficient points to redeem this perk')
-    })
+      await expect(redeemPerk(mockPerkId, mockWallet)).rejects.toThrow(
+        'Insufficient points to redeem this perk'
+      );
+    });
 
     it('should throw error when user not found', async () => {
       const mockPerk: Perk = {
@@ -267,21 +324,22 @@ describe('Perks Database Module', () => {
         description: 'Desc',
         points_threshold: 100,
         type: 'discount',
-      }
+      };
 
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(null)
-      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null })
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(null);
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
 
-      await expect(redeemPerk(mockPerkId, mockWallet))
-        .rejects.toThrow('Insufficient points to redeem this perk')
-    })
+      await expect(redeemPerk(mockPerkId, mockWallet)).rejects.toThrow(
+        'Insufficient points to redeem this perk'
+      );
+    });
 
     it('should throw error when already redeemed', async () => {
       const mockPlayer: Player = {
         id: 1,
         wallet_address: mockWallet,
         total_points: 500,
-      }
+      };
 
       const mockPerk: Perk = {
         id: mockPerkId,
@@ -289,28 +347,71 @@ describe('Perks Database Module', () => {
         description: 'Desc',
         points_threshold: 100,
         type: 'discount',
-      }
+      };
 
       const existingRedemption = {
         id: 'existing-redemption',
         perk_id: mockPerkId,
         user_wallet_address: mockWallet,
-      }
+      };
 
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer)
-      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null })
-      mockSingle.mockResolvedValueOnce({ data: existingRedemption, error: null })
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer);
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
+      mockSingle.mockResolvedValueOnce({
+        data: existingRedemption,
+        error: null,
+      });
 
-      await expect(redeemPerk(mockPerkId, mockWallet))
-        .rejects.toThrow('Perk already redeemed')
-    })
+      await expect(redeemPerk(mockPerkId, mockWallet)).rejects.toThrow(
+        'Perk already redeemed'
+      );
+    });
+
+    it('should throw already redeemed when insert loses a race', async () => {
+      const mockPlayer: Player = {
+        id: 1,
+        wallet_address: mockWallet,
+        total_points: 500,
+      };
+
+      const mockPerk: Perk = {
+        id: mockPerkId,
+        title: 'Test Perk',
+        description: 'Desc',
+        points_threshold: 100,
+        type: 'discount',
+      };
+
+      const mockCode = {
+        id: 'code-123',
+        code: 'DISCOUNT50',
+        perk_id: mockPerkId,
+        is_claimed: false,
+      };
+
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer);
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
+      mockSingle.mockResolvedValueOnce({ data: null, error: null });
+      mockSingle.mockResolvedValueOnce({ data: mockCode, error: null });
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: '23505',
+          message: 'duplicate key value violates unique constraint',
+        },
+      });
+
+      await expect(redeemPerk(mockPerkId, mockWallet)).rejects.toThrow(
+        'Perk already redeemed'
+      );
+    });
 
     it('should throw error when no codes available', async () => {
       const mockPlayer: Player = {
         id: 1,
         wallet_address: mockWallet,
         total_points: 500,
-      }
+      };
 
       const mockPerk: Perk = {
         id: mockPerkId,
@@ -318,17 +419,21 @@ describe('Perks Database Module', () => {
         description: 'Desc',
         points_threshold: 100,
         type: 'discount',
-      }
+      };
 
-      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer)
-      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null })
-      mockSingle.mockResolvedValueOnce({ data: null, error: null }) // No existing redemption
-      mockSingle.mockResolvedValueOnce({ data: null, error: { code: 'PGRST116' } }) // No available codes
+      vi.mocked(getPlayerByWallet).mockResolvedValueOnce(mockPlayer);
+      mockSingle.mockResolvedValueOnce({ data: mockPerk, error: null });
+      mockSingle.mockResolvedValueOnce({ data: null, error: null }); // No existing redemption
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { code: 'PGRST116' },
+      }); // No available codes
 
-      await expect(redeemPerk(mockPerkId, mockWallet))
-        .rejects.toThrow('No discount codes available for this perk')
-    })
-  })
+      await expect(redeemPerk(mockPerkId, mockWallet)).rejects.toThrow(
+        'No discount codes available for this perk'
+      );
+    });
+  });
 
   describe('createPerk', () => {
     it('should create a new perk', async () => {
@@ -338,36 +443,38 @@ describe('Perks Database Module', () => {
         points_threshold: 200,
         type: 'discount',
         is_active: true,
-      }
+      };
 
       const createdPerk = {
         ...newPerk,
         id: 'new-perk-123',
         created_at: '2024-01-01T00:00:00Z',
-      }
+      };
 
-      mockSingle.mockResolvedValueOnce({ data: createdPerk, error: null })
+      mockSingle.mockResolvedValueOnce({ data: createdPerk, error: null });
 
-      const result = await createPerk(newPerk)
+      const result = await createPerk(newPerk);
 
-      expect(result).toEqual(createdPerk)
-      expect(mockFrom).toHaveBeenCalled()
-    })
+      expect(result).toEqual(createdPerk);
+      expect(mockFrom).toHaveBeenCalled();
+    });
 
     it('should throw error on creation failure', async () => {
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { message: 'Insert failed' }
-      })
+        error: { message: 'Insert failed' },
+      });
 
-      await expect(createPerk({
-        title: 'Test',
-        description: 'Test',
-        points_threshold: 100,
-        type: 'discount',
-      })).rejects.toEqual({ message: 'Insert failed' })
-    })
-  })
+      await expect(
+        createPerk({
+          title: 'Test',
+          description: 'Test',
+          points_threshold: 100,
+          type: 'discount',
+        })
+      ).rejects.toEqual({ message: 'Insert failed' });
+    });
+  });
 
   describe('updatePerk', () => {
     it('should update an existing perk', async () => {
@@ -379,23 +486,24 @@ describe('Perks Database Module', () => {
         type: 'exclusive',
         is_active: true,
         updated_at: '2024-01-02T00:00:00Z',
-      }
+      };
 
-      mockSingle.mockResolvedValueOnce({ data: updatedPerk, error: null })
+      mockSingle.mockResolvedValueOnce({ data: updatedPerk, error: null });
 
-      const result = await updatePerk('perk-123', { title: 'Updated Perk' })
+      const result = await updatePerk('perk-123', { title: 'Updated Perk' });
 
-      expect(result).toEqual(updatedPerk)
-    })
+      expect(result).toEqual(updatedPerk);
+    });
 
     it('should throw error on update failure', async () => {
       mockSingle.mockResolvedValueOnce({
         data: null,
-        error: { message: 'Update failed' }
-      })
+        error: { message: 'Update failed' },
+      });
 
-      await expect(updatePerk('perk-123', { title: 'Test' }))
-        .rejects.toEqual({ message: 'Update failed' })
-    })
-  })
-})
+      await expect(updatePerk('perk-123', { title: 'Test' })).rejects.toEqual({
+        message: 'Update failed',
+      });
+    });
+  });
+});

--- a/lib/db/perks.ts
+++ b/lib/db/perks.ts
@@ -32,6 +32,12 @@ const DISCOUNT_CODE_COLUMNS = `
   is_universal
 `;
 
+const isDuplicateRedemptionError = (error: unknown) =>
+  typeof error === 'object' &&
+  error !== null &&
+  'code' in error &&
+  (error as { code?: string }).code === '23505';
+
 /**
  * Create a new perk
  */
@@ -203,7 +209,12 @@ export const redeemPerk = async (perkId: string, walletAddress: string) => {
     )
     .single();
 
-  if (error) throw error;
+  if (error) {
+    if (isDuplicateRedemptionError(error)) {
+      throw new Error('Perk already redeemed');
+    }
+    throw error;
+  }
   return data;
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a migration to enforce one `user_perk_redemptions` row per wallet/perk pair and clean up any existing duplicates before applying the unique index
- handle duplicate-key insert conflicts in the perk redemption API so concurrent requests return `Perk already redeemed` instead of tracking duplicate reward claims
- cover the race-condition path in the redemption route and shared perk DB helper tests

## Testing
- `yarn test app/api/perks/redeem/__tests__/route.test.ts lib/db/__tests__/perks.test.ts`
- [perk_redemption_tests.log](https://cursor.com/agents/bc-f2abcb74-cb71-43ea-bcf3-561734d7a3af/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fperk_redemption_tests.log)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2abcb74-cb71-43ea-bcf3-561734d7a3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2abcb74-cb71-43ea-bcf3-561734d7a3af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

