### PR TITLE
Restore plans/ folder removed in 423aef3

### DIFF
--- a/plans/dice-partnership-implementation.md
+++ b/plans/dice-partnership-implementation.md
@@ -1,0 +1,244 @@
+# DICE Implementation Plan
+
+## Goals
+
+- **Discovery**: browse/curate events via DICE **Collections** + broader **event listing API** access
+- **IRL check-ins at events/venues**: map DICE events to IRL locations/checkpoints, with clear curation + visibility controls.
+- **Ticket proof**: verify ticket ownership during check-in.
+- **Promotions**: support discounts/promos with attribution (ideally automated promo-code generation).
+
+## Non-goals (explicitly deferred)
+
+- Building a full in-app ticket checkout if the partnership only supports deep links.
+
+## Technical Details
+
+DICE's **Ticket Holders API (THAPI)** has been confirmed to support these technical requirements:
+
+- **API Endpoint**: GraphQL URL from `DICE_API_URL` (see `lib/dice/client.ts`)
+- **Authentication**: MIO-managed Bearer tokens
+- **Confirmed capabilities**: events, orders, ticket holders, tickets
+
+## Operation requirements
+
+- **Ticketing → IRL rewards**: IRL will build against DICE APIs to ingest ticket data and award points.
+- **Account linking**: email as the primary key
+- **Event discovery**: curated discovery can be supported via DICE Collections and/or the event listing API.
+- **Promos**: supported short term via bulk promo code exports, with potential API automation longer term.
+
+## THAPI Integration Details
+
+DICE's Ticket Holders API (THAPI) is a GraphQL API; the base URL is supplied via `DICE_API_URL` (see `lib/dice/client.ts`).
+
+### Authentication
+
+- Bearer token authentication via MIO-managed API tokens (DICE's internal back office)
+- Tokens are provisioned per partner account
+
+### Key GraphQL Queries
+
+**Fetch tickets for an event**:
+
+```graphql
+query GetEventTickets($eventId: ID!) {
+  node(id: $eventId) {
+    ... on Event {
+      id
+      name
+      startDatetime
+      tickets(first: 50) {
+        edges {
+          node {
+            id
+            ticketType {
+              id
+              name
+              description
+            }
+            holder {
+              id
+              firstName
+              lastName
+              email
+            }
+            claimedAt
+          }
+        }
+        pageInfo {
+          hasNextPage
+          endCursor
+        }
+      }
+    }
+  }
+}
+```
+
+**Query tickets by fan email**:
+
+```graphql
+query GetTicketsByEmail($email: String!) {
+  viewer {
+    tickets(first: 50, where: { fanEmail: { eq: $email } }) {
+      edges {
+        node {
+          id
+          ticketType {
+            name
+          }
+          holder {
+            email
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Query orders with purchase date filter**:
+
+```graphql
+query GetOrders($purchasedAfter: Datetime!) {
+  viewer {
+    orders(first: 50, where: { purchasedAt: { gte: $purchasedAfter } }) {
+      edges {
+        node {
+          id
+          purchasedAt
+          tickets {
+            holder {
+              email
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Workstreams + phases (incremental)
+
+### Phase 0 — Capability confirmation + operational alignment (parallel, week 0)
+
+Deliverable: answering the open questions below (listing scope, promos, identity model).
+
+- Confirm event listing access scope (refractions-only vs broader) and whether **Collections** are available.
+- Confirm promo-code generation API feasibility.
+- Identify the correct identity key(s): email, DICE user id, order id, ticket id.
+
+Acceptance criteria:
+
+- A single section (this doc) lists: endpoints, auth, rate limits, schemas, and confirmed identifiers.
+- Unknowns are explicitly tracked with an owner (DICE vs IRL) and a target date.
+
+### Phase 1 — Discovery (Collections + listing API) (1 week)
+
+Deliverable: IRL can browse a broader event set (within allowed scope) and/or curated collections.
+
+- Add server-only DICE discovery client + Zod schemas under `lib/dice/` (or `lib/dice.ts` if you prefer a single file).
+  - Treat protocol as TBD until confirmed (REST vs GraphQL).
+  - Typed upstream error handling: auth failures, 429/rate-limit, schema drift.
+- Add `app/api/dice/*` endpoints:
+  - `GET /api/dice/events` with filters (city, date range, tags/genres, pagination).
+  - `GET /api/dice/collections` and/or `GET /api/dice/collections/[id]` (if supported).
+  - `GET /api/dice/events/[id]` (details).
+- Add RSC-first UI pages (e.g. `app/events/*`) to browse DICE events/collections.
+- Cache discovery responses (revalidate) and provide friendly errors on rate limits.
+
+Acceptance criteria:
+
+- `GET /api/dice/events` returns stable pagination + deterministic ordering.
+- Rate limit errors surface as a user-friendly message and are observable in server logs.
+
+### Phase 2 — IRL curation + optional DB sync (1 week)
+
+Deliverable: curated set of DICE events appear as IRL "checkable" locations (with controls).
+
+Two viable approaches (choose per ops needs):
+
+- **Option A (DB sync + curation)**: periodic sync into Supabase `locations` (good for fast UX and operational curation).
+  - Keep minimal DICE columns: `dice_event_id`, `dice_event_state`, `dice_start_time`, `dice_end_time`.
+  - Use a cron route `/api/dice/sync` to upsert.
+- **Option B (no DB sync)**: discovery-only; check-in targets are created manually/curated in IRL.
+
+Recommendation: start with **Option A** if IRL wants operational control and fast map browsing.
+
+Acceptance criteria:
+
+- A DICE event can be selected/curated and becomes an IRL "checkable" entity with visibility controls.
+- Sync (if Option A) is idempotent (safe to re-run) and logs the upsert count + failures.
+
+### Phase 3 — Ticket proof at check-in (1 week)
+
+Deliverable: ticket-gated check-in for DICE events.
+
+- Integrate DICE THAPI GraphQL (Ticket Holders API) server-side.
+- Add identity linking:
+  - Primary key: **email** (IRL uses email-only linking)
+  - Store `players.dice_linked_email`
+  - Edge cases (e.g., Sign in with Apple email relay) to be handled during implementation
+- At check-in time, if `location.dice_event_id` exists:
+  - Query THAPI for ticket holder by email
+  - Verify ticket holder and valid ticket status
+  - Return clear errors for "not linked" and "no ticket"
+
+Acceptance criteria:
+
+- For a DICE-mapped location, check-in is blocked unless ticket proof succeeds.
+- Errors are deterministic and actionable (not linked / no ticket / upstream unavailable / rate limited).
+- All check-in attempts are auditable with identifiers (event id + player id + timestamp + outcome).
+
+### Phase 4 — Promotions / discounts (1 week)
+
+Deliverable: trackable discount campaigns.
+
+Two-phase approach (confirmed alignment):
+
+- **Short term**: bulk promo code exports (manual operational process)
+  - DICE provides promo codes via export
+  - IRL tracks redemptions and attribution manually
+- **Longer term**: potential API automation (to be explored)
+  - Generate codes programmatically per campaign/partner
+  - Constraints: expiry, max uses, eligible events
+  - Reporting fields to attribute redemptions to IRL
+
+Acceptance criteria:
+
+- A promo campaign can be created and attributed to IRL (manual export is sufficient for initial pilots).
+- Redemptions can be reconciled against DICE reporting fields (or a documented workaround if not available).
+
+## Clarifying questions (use in partner follow-ups)
+
+### A) Discovery (Collections + listing API)
+
+- What media fields are available (hero image, thumbnails, lineup/artist images)?
+- Rate limits (per minute/hour) and recommended caching strategy.
+- Do events include accurate venue coordinates, or must IRL geocode?
+
+### B) Ticket proof (ticket holders / orders)
+
+- Privacy constraints around fan emails (hashing, consent requirements)?
+- What constitutes a "valid ticket" (status values; transferred tickets; cancellations)?
+- Can IRL retrieve a stable ticket id/order id for audit logs?
+
+### C) Promotions / discounting
+
+- When will automated promo code generation API be available?
+- Constraints supported: per-event, per-collection, per-venue, start/end time, max uses, min spend?
+- What reporting is available (redemptions, revenue impact, attribution to IRL)?
+
+## Observability + operations (minimum requirements)
+
+- **Audit log**: store a record of ticket-proof checks with:
+  - `player_id`, `dice_event_id`, timestamp, outcome (success/failure reason)
+  - identifiers used (email), stored minimally and securely
+- **Backfill/replay**: a safe-to-re-run job (polling or import) that relies on idempotency rules above.
+- **Feature flags**: gate discovery scope, ticket proof, and promos.
+
+## Success criteria (definition of "working")
+
+- IRL can browse events/collections within allowed scope and curate what appears.
+- Ticket-gated check-in works reliably for DICE events.
+- Promo mechanism exists (API or manual) with clear attribution.

--- a/plans/irl-bridge-card.md
+++ b/plans/irl-bridge-card.md
@@ -1,0 +1,436 @@
+# IRL Bridge Card
+
+## Summary
+
+IRL should create a dedicated member card product powered by Bridge.
+
+The core idea is simple:
+
+- the card is the member's real-world identity inside the IRL ecosystem
+- the card is also the member's event spend instrument
+- the member logs into IRL on the web with Privy
+- the website becomes the place to see transactions, balance, rewards, and card status
+
+This makes the physical card the in-person surface and Privy the digital account layer.
+
+## Product Thesis
+
+An IRL member should not need to identify themselves in multiple different ways at an event.
+
+The cleanest experience is:
+
+- the member has one IRL card
+- that card is tied to exactly one IRL member profile
+- when the card is used, IRL knows which member it belongs to
+- IRL can attach spend, rewards, and event activity to that member automatically
+
+In person, the card is the identity.
+
+Online, the Privy account is the login.
+
+Together, they form one member account across real life and the web.
+
+## Recommendation
+
+Build a new product line called the **IRL Member Card**.
+
+The recommended first version is:
+
+- one Bridge card account per participating member
+- one linked IRL member record
+- one linked Privy-authenticated website account
+- one simple funding model for the pilot
+- one event cohort or one partner cohort to start
+
+The card should be treated as a first-class membership object, not just a payment method.
+
+## What the card is
+
+The IRL Member Card should represent four things at once:
+
+### 1. Identity in real life
+
+When a member presents or pays with the card at an event, IRL can recognize who they are by the linked card account.
+
+### 2. Spend instrument
+
+The card can be used anywhere that the program rules allow and the merchant accepts the network.
+
+### 3. Rewards trigger
+
+Card activity gives IRL a clean signal for points, perks, and event-linked rewards.
+
+### 4. Member status object
+
+The card can visually and operationally signal membership tier, pilot access, VIP status, or sponsor-backed perks.
+
+## What Privy does
+
+Privy remains the digital identity and account access layer.
+
+Members should use Privy to:
+
+- sign into the IRL website
+- link or confirm ownership of their member profile
+- view card transactions
+- see balance and rewards
+- freeze or unfreeze the card
+- manage support flows
+
+The card should not replace website login.
+
+Instead:
+
+- **Bridge card** = in-person identity and spend
+- **Privy login** = digital account access and account recovery
+
+## Canonical account model
+
+IRL should model the system like this:
+
+- one `privy_user_id`
+- one `irl_member_id`
+- one Bridge `customer_id`
+- one Bridge `card_account_id`
+
+The important product rule is:
+
+**A member card belongs to one member, and the website account for that member is accessed through Privy.**
+
+## Member experience
+
+### In real life
+
+The member:
+
+- receives an IRL card
+- uses it at the event or approved merchant
+- is automatically recognized through the linked card account
+- earns rewards without needing staff lookup
+
+### On the website
+
+The member signs in with Privy and sees:
+
+- card status
+- available balance
+- recent transactions
+- pending versus settled transactions
+- rewards earned from card activity
+- support actions such as freeze or lost-card reporting
+
+## The 3 strongest versions of the product
+
+### Option 1: Sponsored event card
+
+IRL or a sponsor funds the member card for a specific activation.
+
+Example:
+
+- a member is invited to an event
+- IRL issues the card before the event
+- the card is loaded with a fixed amount
+- the member spends with that card during the activation
+- the member logs in later with Privy to review transactions and rewards
+
+Why this is strong:
+
+- easiest pilot to control
+- strongest VIP or sponsor story
+- best way to prove the card can act as identity plus spend
+
+Tradeoffs:
+
+- IRL or the sponsor carries the funding burden
+- requires pre-event onboarding
+
+### Option 2: Reloadable member card
+
+The member has a persistent IRL card that can be funded and reused across events.
+
+Example:
+
+- member receives an IRL card once
+- member or IRL adds funds
+- member uses the same card across multiple events
+- member signs in with Privy to see a growing spend history and rewards history
+
+Why this is strong:
+
+- strongest long-term membership product
+- creates a durable spend graph tied to one member identity
+- makes the website more valuable over time
+
+Tradeoffs:
+
+- more balance-management UX
+- more support and reconciliation needs
+
+### Option 3: Hybrid member card
+
+The card is the primary member identity in person, but IRL can still support QR or web fallback for members who do not yet have the card.
+
+Example:
+
+- cardholders pay or identify with the card
+- non-cardholders use a QR or member code
+- both still log into the website with Privy
+
+Why this is strong:
+
+- smoother rollout
+- less pressure to onboard every member at once
+
+Tradeoffs:
+
+- two identity paths at the same time
+- more product complexity than a card-only model
+
+## Recommended v1
+
+Start with **Option 1: Sponsored event card**.
+
+This is the smallest version that clearly proves the product idea:
+
+- the card works as in-person identity
+- the card works as event spend
+- the website works as the account center
+- rewards are attached to the right member automatically
+
+## Recommended v1 flow
+
+1. Member is invited into the IRL card pilot
+2. Member signs into IRL with Privy
+3. IRL creates or links the member profile
+4. Member completes the required Bridge onboarding flow for cards
+5. IRL provisions the Bridge card for that member
+6. IRL funds the card for the pilot
+7. Member uses the card in person
+8. Bridge sends transaction events to IRL
+9. IRL maps those events to the member and applicable event rules
+10. Member logs into the website with Privy to see transactions, rewards, and card status
+
+## How Bridge fits
+
+Bridge should power:
+
+- customer onboarding for cards
+- card issuance
+- funding architecture
+- transaction events
+- freeze and unfreeze controls
+- secure reveal of card details when needed
+- optional mobile wallet provisioning later
+
+This is enough to support a real card-centered IRL product.
+
+## Funding choices
+
+Bridge supports multiple funding strategies. IRL should choose one per launch phase.
+
+### A. Card Wallet funding
+
+Each card has its own balance and funding instructions.
+
+Best for:
+
+- sponsored balances
+- simple event stipends
+- easy member understanding
+
+### B. Bridge Wallet funding
+
+The card spends from a Bridge-managed wallet associated with the member or program.
+
+Best for:
+
+- managed treasury flows
+- deeper wallet infrastructure later
+
+### C. Non-custodial funding
+
+The card pulls from an external wallet when used.
+
+Best for:
+
+- later crypto-native versions
+- advanced members only
+
+Not recommended for the first pilot.
+
+## Identity and attribution model
+
+The core benefit of the Bridge card is that it removes the need for staff to attach identity at checkout.
+
+IRL should treat the card account as the primary in-person identifier.
+
+When a transaction is received from Bridge, IRL should:
+
+- map the `card_account_id` to the member
+- determine whether the spend matches an active event or campaign
+- issue points or perks based on the matching rules
+- store the transaction in the member ledger shown on the website
+
+## Website requirements
+
+The website should be the member control panel for the card.
+
+### 1. Privy sign-in
+
+Members must be able to access the card account experience using Privy authentication.
+
+### 2. Card overview
+
+Members should see:
+
+- card status
+- last 4 digits
+- available balance
+- funding source label
+
+### 3. Transaction history
+
+Members should see:
+
+- pending transactions
+- settled transactions
+- merchant details available from Bridge
+- event attribution where applicable
+
+### 4. Rewards history
+
+Members should see:
+
+- points earned from card activity
+- reward status
+- any skipped or ineligible transactions with a simple explanation
+
+### 5. Card controls
+
+Members should be able to:
+
+- freeze the card
+- unfreeze the card
+- report lost or stolen status
+
+### 6. Support and recovery
+
+Members should have a clear path for:
+
+- support contact
+- replacement card flow
+- onboarding status issues
+
+## Event experience requirements
+
+In person, the product should feel simple.
+
+The card should support:
+
+- spend at approved venues or merchants
+- automatic attribution back to the member
+- optional event-specific bonuses
+- no mandatory staff lookup for standard spend flows
+
+If IRL wants non-spend identity uses later, the card can also carry:
+
+- printed member ID
+- visual tier marker
+- QR code for check-in or support
+
+## Data model requirements
+
+IRL should store and maintain:
+
+- `privy_user_id`
+- `irl_member_id`
+- `bridge_customer_id`
+- `bridge_card_account_id`
+- card status
+- non-sensitive card metadata
+- balance snapshots if needed for UI
+- transaction ledger
+- rewards ledger
+
+IRL should not expose sensitive card details directly from its own backend if Bridge provides a secure reveal flow.
+
+## Operations requirements
+
+IRL needs internal tooling for:
+
+- member-to-card linking
+- onboarding status tracking
+- funding status tracking
+- transaction reconciliation
+- reward issuance review
+- card support actions
+
+## Constraints to design around
+
+- card issuance requires Bridge customer onboarding and card eligibility
+- card approval timing matters, so instant mass issuance on event day is risky
+- Bridge currently supports one card account per customer
+- each card is tied to a specific currency and chain at creation
+- real-time authorization exists but adds latency risk and should stay out of v1
+- mobile wallet provisioning is useful later but should not be required for the first launch
+
+## What IRL should not build first
+
+- a full POS product
+- custom real-time authorization logic
+- broad merchant settlement tooling
+- same-day venue card issuance at scale
+- complex disputes and chargeback operations
+- multiple overlapping funding models in the first pilot
+
+## Rollout plan
+
+### Phase 1: prove the member card
+
+- select a small pilot cohort
+- onboard members through Privy plus Bridge card onboarding
+- issue cards before the event
+- fund the cards
+- capture transactions
+- show those transactions on the website
+- issue points automatically
+
+### Phase 2: make the website account useful
+
+- improve transaction history
+- improve rewards visibility
+- add card controls
+- add support tooling
+
+### Phase 3: make the card reusable
+
+- support repeat events
+- support persistent balances or reloads
+- expand partner programs
+
+### Phase 4: deepen the card product
+
+- virtual card support
+- mobile wallet provisioning
+- more advanced funding models
+- richer event and sponsor policies
+
+## Open questions
+
+- Should the first card be physical, virtual, or both?
+- Should the first pilot be fully sponsor-funded or partly member-funded?
+- Should points be issued on authorization or settlement?
+- How restrictive should event attribution rules be?
+- Does IRL want the card to carry printed QR or visible member metadata for non-payment identity uses?
+
+## Decision
+
+Create a separate product plan around a **Bridge-powered IRL Member Card**.
+
+The product should treat:
+
+- the **card** as the member's real-world identity and spend instrument
+- **Privy** as the member's website login and account access layer
+- the **website** as the place to review card transactions, rewards, balance, and card controls
+
+That is the clearest way to make the card feel central to IRL membership.

--- a/plans/irl-spend.md
+++ b/plans/irl-spend.md
@@ -1,0 +1,256 @@
+# IRL Spend
+
+## Summary
+
+IRL needs a simple way for people to make purchases at events and immediately receive points tied to that purchase.
+
+The first version should prove that IRL can support a real in-person transaction loop from checkout through rewards. The goal is not to build a full payments platform yet. The goal is to make one event work cleanly end-to-end.
+
+## Objective
+
+Make paying with IRL feel simple and real at a live event.
+
+A user should be able to identify themselves, complete a purchase in person, and instantly receive points, with the transaction tied to the correct event.
+
+## What We’re Building
+
+A lightweight in-person spend flow inside IRL that includes:
+
+- a clear Pay with IRL experience
+- a staff-friendly checkout flow
+- instant payment confirmation
+- instant points issuance
+- event-linked transaction tracking
+- a simple dashboard to review transactions
+
+## Core Idea
+
+In v1, Pay with IRL does not need to mean stablecoin-only checkout.
+
+It should mean:
+
+- the user is recognized through IRL
+- the payment is tied to their IRL account
+- the purchase is tied to the event
+- points are issued immediately after payment
+- staff can process transactions without confusion
+
+## Goals
+
+- Process one full event end-to-end using IRL spend
+- Make checkout easy enough that most payments do not require staff help
+- Attach every purchase to an event
+- Issue points automatically after successful payment
+- Give operators a basic way to track transactions during and after the event
+
+## Success Metrics
+
+- 1 full event processed end-to-end
+- 75%+ of payments complete without staff help
+- 100+ transactions processed cleanly
+- Every successful payment tied to an event
+- Every successful payment either issues points or logs a clear reason why it did not
+
+## Partner Roles
+
+### Stripe
+
+V1 uses **Stripe Terminal** for card-present payments at the event. Stripe handles authorization and settlement; IRL handles identity, checkout sessions, rewards, and event-scoped records. The handoff between products is defined in **How payment works (v1)**.
+
+### Privy
+
+Privy is the identity and wallet layer.
+
+Privy should help make the experience feel seamless for users by handling login, account identity, and wallet readiness. Even if v1 is not stablecoin-first, Privy sets IRL up for a future where wallet-based spend, balances, and onchain rewards are a natural extension of the product.
+
+### Bridge
+
+Bridge is the future balance and stablecoin infrastructure layer.
+
+Bridge does not need to sit in the critical path for the first event flow, but it is important as IRL expands toward stablecoin-based spending, stored balances, treasury movement, and payment infrastructure behind the scenes.
+
+### Tempo
+
+Tempo is the future event payments and programmable rewards layer.
+
+Tempo is an interesting opportunity because it can help IRL explore a more crypto-native version of event payments over time. It should not block the first spend launch, but it can become part of how IRL handles things like onchain receipts, payment-linked rewards, and more programmable event transaction mechanics later on.
+
+## How payment works (v1)
+
+Stripe Terminal is designed to sit inside an existing POS workflow. Responsibilities split like this:
+
+- **IRL** — User identification, checkout session state, post-payment confirmation, points issuance, and logging the transaction against the event.
+- **Stripe Terminal** — Collecting the in-person card payment (the physical reader flow your staff already uses alongside the register).
+
+End-to-end: IRL identifies the attendee and creates the checkout session; Terminal runs the card payment; when Terminal succeeds, IRL confirms the purchase, issues points, and records the event-linked transaction.
+
+Venues do not need to replace their full POS to use IRL spend. In v1, IRL can run as a focused event checkout for specific lines—door sales, drink tickets, merch, VIP purchases, and similar—with **Stripe Terminal** covering the in-person card step alongside whatever register system they already use.
+
+## v1 Scope
+
+### In Scope
+
+- one live event spend flow
+- one simple purchase flow, starting with something like a Drink Ticket
+- a user identification step before payment
+- a payment confirmation screen
+- instant points issuance after successful payment
+- event ID attached to every transaction
+- a basic transaction dashboard inside IRL
+- Stripe Terminal for card-present payment in the first version
+
+### Out of Scope
+
+- full stablecoin-native checkout
+- a broad merchant platform
+- advanced inventory management
+- complex refund tooling
+- multi-event operational tooling beyond what is needed for launch
+- deep Bridge or Tempo integration in the first live flow
+
+## User Experience
+
+### For the attendee
+
+The attendee opens IRL and uses Pay with IRL to identify themselves at checkout.
+
+They should be able to:
+
+- show a QR or member code
+- complete a purchase quickly
+- see confirmation that payment worked
+- receive points immediately
+
+### For staff
+
+Staff should be able to:
+
+- attach the correct user in IRL before charging
+- run Terminal payment with confidence and read clear success or failure in IRL
+- retry or recover easily if something goes wrong
+
+### For operators
+
+Operators should be able to:
+
+- view all event transactions in one place
+- see who paid, what they bought, and whether points were issued
+- confirm the event processed cleanly
+
+## Recommended v1 Flow
+
+1. The user presents their IRL member QR at checkout
+2. Staff uses the IRL admin / POS screen on a phone or tablet to scan the QR or enter a short member code manually
+3. IRL looks up the user, attaches them to the active event, and creates the checkout session
+4. Staff selects the item and starts payment in IRL
+5. IRL creates the Stripe payment session and connects to **Stripe Terminal**
+6. The customer pays on the Stripe Terminal reader
+7. On success, IRL shows confirmation, issues points, and logs the sale to the event
+
+**Rule:** Finish member lookup, event attachment, and checkout session (steps 1–3) before staff starts payment (step 4 onward) so attribution and rewards stay correct.
+
+## Product Requirements
+
+### 1. Pay with IRL
+
+IRL needs a simple user-facing payment identity screen.
+
+This should let the user present:
+
+- a QR code or member code
+- their IRL identity for checkout
+- optionally their points balance or rewards context
+
+### 2. Checkout Flow
+
+IRL needs a staff-facing checkout flow for live events.
+
+This should support:
+
+- attaching a user to a transaction
+- selecting the item or offer
+- handing off to **Stripe Terminal** for the card read, then reflecting the result in IRL
+- showing success or failure clearly
+
+### 3. Confirmation
+
+After payment succeeds, IRL should show a clear confirmation state.
+
+This should include:
+
+- that payment was successful
+- what was purchased
+- the event context
+- points earned
+
+### 4. Instant Points
+
+Successful payments should trigger points automatically.
+
+This should feel immediate and reliable.
+
+### 5. Event Attribution
+
+Every transaction should be tied to an event.
+
+This is a core requirement for reporting, analytics, and partner value.
+
+### 6. Transaction Dashboard
+
+IRL should have a simple dashboard for event transactions.
+
+This should show:
+
+- transaction list
+- payment status
+- user
+- event
+- points issued
+
+## Rollout Plan
+
+### Phase 1
+
+Ship one real event flow:
+
+- one event
+- one checkout experience
+- one or a few simple products
+- instant points
+- transaction dashboard
+- Stripe Terminal at the venue
+
+### Phase 2
+
+Improve the operating experience:
+
+- more products
+- better retry flows
+- cleaner staff tooling
+- better reporting
+
+### Phase 3
+
+Expand payment depth:
+
+- stored balance
+- stablecoin spend
+- deeper wallet experiences through Privy
+- balance and settlement infrastructure through Bridge
+- more programmable event payment and rewards mechanics through Tempo
+
+## Open Questions
+
+- Is the first live use case just Drink Ticket, or do we need multiple products?
+- Should confirmation appear on the attendee device, the staff device, or both?
+- How should spend-based points be calculated?
+- Do we need refunds for v1?
+- How much transaction detail is needed in the first dashboard?
+
+## Decision
+
+Launch v1 as a tight loop: identify the user in IRL → item and session in IRL → pay on **Stripe Terminal** → IRL confirms, issues points, and logs the transaction to the event.
+
+**Privy** supports identity and wallet readiness. **Bridge** and **Tempo** guide later phases (balances, stablecoin spend, programmable event payments), not the first live Terminal loop.
+
+That is the smallest version of IRL spend that proves the concept in the real world.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Commit `423aef3` removed the root `plans/` directory (three markdown planning docs). This branch restores those files from the parent of that commit.

## Note on DICE plan

The restored `plans/dice-partnership-implementation.md` contained the live DICE GraphQL endpoint URL inline. The pre-commit secret scanner blocks that pattern (it matches `DICE_API_URL`). Those two spots now point to `DICE_API_URL` and `lib/dice/client.ts` instead of embedding the URL, so the plans stay accurate without checking in a sensitive value.

## Files

- `plans/dice-partnership-implementation.md`
- `plans/irl-bridge-card.md`
- `plans/irl-spend.md`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-153b4d46-ebc6-45b4-bcc6-6c9cb8b7dee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-153b4d46-ebc6-45b4-bcc6-6c9cb8b7dee1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

