### PR TITLE
feat: apply paper texture to all city guide template images

### DIFF
--- a/app/city-guides/template/page.tsx
+++ b/app/city-guides/template/page.tsx
@@ -1,11 +1,11 @@
 import type { Metadata } from 'next';
-import Image from 'next/image';
 import Link from 'next/link';
 
 import { CityGuideArticleNav } from '@/components/city-guides/city-guide-article-nav';
 import { CityGuideArticleDescription } from '@/components/city-guides/city-guide-article-description';
 import { CityGuideArticleHeroImage } from '@/components/city-guides/city-guide-article-hero-image';
 import { CityGuideLocationCard } from '@/components/city-guides/city-guide-location-card';
+import { CityGuideTexturedImage } from '@/components/city-guides/city-guide-textured-image';
 import { CityGuideArticleMetaRow } from '@/components/city-guides/city-guide-article-meta-row';
 import { CityGuideArticleTitle } from '@/components/city-guides/city-guide-article-title';
 import { getMichailStanglBerlinGuideListLocations } from '@/lib/db/location-lists';
@@ -124,14 +124,13 @@ export default async function CityGuideTemplatePage() {
             <h2 className="title3 flex h-[54px] w-full max-w-[361px] shrink-0 items-center text-[#171717]">
               {TEMPLATE_GUIDE_MAP.heading}
             </h2>
-            <div className="relative h-[361px] w-full max-w-[361px] shrink-0 overflow-hidden">
-              <Image
+            <div className="h-[361px] w-full max-w-[361px] shrink-0 overflow-hidden">
+              <CityGuideTexturedImage
                 src={TEMPLATE_GUIDE_MAP.imageSrc}
                 alt={TEMPLATE_GUIDE_MAP.imageAlt}
-                fill
-                className="object-cover object-center"
                 sizes="361px"
-                priority={false}
+                containerClassName="h-full w-full"
+                textureOpacity={0.34}
               />
             </div>
           </section>

--- a/components/city-guides/city-guide-article-hero-image.tsx
+++ b/components/city-guides/city-guide-article-hero-image.tsx
@@ -1,8 +1,8 @@
-import Image from 'next/image';
-
 import { cn } from '@/lib/utils';
-
-const DEFAULT_TEXTURE_SRC = '/city-guides/paper-texture.jpg';
+import {
+  CityGuideTexturedImage,
+  DEFAULT_PAPER_TEXTURE_SRC,
+} from '@/components/city-guides/city-guide-textured-image';
 
 export interface CityGuideArticleHeroImageProps {
   src: string;
@@ -26,46 +26,23 @@ export interface CityGuideArticleHeroImageProps {
 export function CityGuideArticleHeroImage({
   src,
   alt,
-  textureSrc = DEFAULT_TEXTURE_SRC,
+  textureSrc = DEFAULT_PAPER_TEXTURE_SRC,
   textureOpacity = 0.38,
   textureBlendMode = 'lighten',
   className,
 }: CityGuideArticleHeroImageProps) {
   return (
-    <div
-      className={cn(
-        'relative h-[361px] w-full max-w-[361px] overflow-hidden',
-        className
-      )}
-    >
-      <Image
-        src={src}
-        alt={alt}
-        fill
-        priority
-        className="object-cover object-center"
-        sizes="361px"
-      />
-      {textureSrc ? (
-        <div
-          className="pointer-events-none absolute left-1/2 top-1/2 z-[1] h-[412px] w-[412px] -translate-x-1/2 -translate-y-1/2"
-          aria-hidden
-        >
-          <Image
-            src={textureSrc}
-            alt=""
-            fill
-            className={cn(
-              'object-cover',
-              textureBlendMode === 'lighten'
-                ? 'mix-blend-lighten'
-                : 'mix-blend-soft-light'
-            )}
-            style={{ opacity: textureOpacity }}
-            sizes="412px"
-          />
-        </div>
-      ) : null}
-    </div>
+    <CityGuideTexturedImage
+      src={src}
+      alt={alt}
+      sizes="361px"
+      priority
+      containerClassName={cn('h-[361px] w-full max-w-[361px]', className)}
+      textureSrc={textureSrc}
+      textureOpacity={textureOpacity}
+      textureBlendMode={textureBlendMode}
+      textureClassName="left-1/2 top-1/2 h-[412px] w-[412px] -translate-x-1/2 -translate-y-1/2"
+      textureSizes="412px"
+    />
   );
 }

--- a/components/city-guides/city-guide-location-card.tsx
+++ b/components/city-guides/city-guide-location-card.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 
+import { CityGuideTexturedImage } from '@/components/city-guides/city-guide-textured-image';
 import { cn } from '@/lib/utils';
 
 export interface CityGuideLocationCardProps {
@@ -34,14 +35,14 @@ export function CityGuideLocationCard({
       )}
       aria-label={`Location: ${name}`}
     >
-      <div className="relative h-[345px] w-full max-w-[361px] shrink-0 overflow-hidden bg-neutral-200">
+      <div className="h-[345px] w-full max-w-[361px] shrink-0 overflow-hidden bg-neutral-200">
         {imageSrc ? (
-          <Image
+          <CityGuideTexturedImage
             src={imageSrc}
             alt={imageAlt}
-            fill
-            className="object-cover object-center"
             sizes="361px"
+            containerClassName="h-full w-full"
+            textureOpacity={0.32}
           />
         ) : null}
       </div>

--- a/components/city-guides/city-guide-textured-image.tsx
+++ b/components/city-guides/city-guide-textured-image.tsx
@@ -1,0 +1,78 @@
+import Image from 'next/image';
+
+import { cn } from '@/lib/utils';
+
+export const DEFAULT_PAPER_TEXTURE_SRC = '/city-guides/paper-texture.jpg';
+
+export interface CityGuideTexturedImageProps {
+  src: string;
+  alt: string;
+  sizes: string;
+  priority?: boolean;
+  containerClassName?: string;
+  className?: string;
+  /** Paper grit overlay; set `null` to disable. */
+  textureSrc?: string | null;
+  /** Texture layer opacity (0–1). @default 0.38 */
+  textureOpacity?: number;
+  /**
+   * `lighten` matches design spec but bright paper can hide the photo — pair with lower `textureOpacity`.
+   * `soft-light` keeps grit stronger at higher opacity. @default lighten
+   */
+  textureBlendMode?: 'lighten' | 'soft-light';
+  textureClassName?: string;
+  textureSizes?: string;
+}
+
+/**
+ * Base image with optional paper texture overlay for city guide visuals.
+ */
+export function CityGuideTexturedImage({
+  src,
+  alt,
+  sizes,
+  priority = false,
+  containerClassName,
+  className,
+  textureSrc = DEFAULT_PAPER_TEXTURE_SRC,
+  textureOpacity = 0.38,
+  textureBlendMode = 'lighten',
+  textureClassName,
+  textureSizes,
+}: CityGuideTexturedImageProps) {
+  return (
+    <div className={cn('relative overflow-hidden', containerClassName)}>
+      <Image
+        src={src}
+        alt={alt}
+        fill
+        priority={priority}
+        className={cn('object-cover object-center', className)}
+        sizes={sizes}
+      />
+      {textureSrc ? (
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-0 z-[1]',
+            textureClassName
+          )}
+          aria-hidden
+        >
+          <Image
+            src={textureSrc}
+            alt=""
+            fill
+            className={cn(
+              'object-cover',
+              textureBlendMode === 'lighten'
+                ? 'mix-blend-lighten'
+                : 'mix-blend-soft-light'
+            )}
+            style={{ opacity: textureOpacity }}
+            sizes={textureSizes ?? sizes}
+          />
+        </div>
+      ) : null}
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- apply paper texture overlay to all image surfaces used by `/city-guides/template`
- extract reusable `CityGuideTexturedImage` component for consistent texture behavior
- refactor hero image component to use the shared textured image wrapper
- apply texture overlay to the in-guide map image and each location card photo

## Testing
- `yarn build` (passed before your follow-up instruction to skip further verification)

## Notes
- followed your latest instruction to skip manual verification and not create a video artifact
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9ddabab5-e89a-4dde-bae1-b88c158e45dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ddabab5-e89a-4dde-bae1-b88c158e45dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

