### PR TITLE
Spend pilot: spend experiences schema, admin API, and configuration UI

### DIFF
--- a/app/admin/spend-experiences/form-state.ts
+++ b/app/admin/spend-experiences/form-state.ts
@@ -1,0 +1,61 @@
+import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+
+export type SpendExperienceFormState = {
+  title: string;
+  description: string;
+  event_id: string;
+  status: SpendExperienceStatus;
+  points_to_usdc_rate: string;
+  max_usdc_per_user: string;
+  treasury_wallet_address: string;
+  receiving_wallet_address: string;
+  start_time_local: string;
+  end_time_local: string;
+};
+
+export function isoToDatetimeLocalValue(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function datetimeLocalToIso(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function defaultWindow(): { start: string; end: string } {
+  const start = new Date();
+  const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export function experienceToForm(e: SpendExperience): SpendExperienceFormState {
+  return {
+    title: e.title,
+    description: e.description ?? '',
+    event_id: e.event_id ?? '',
+    status: e.status,
+    points_to_usdc_rate: String(e.points_to_usdc_rate),
+    max_usdc_per_user: String(e.max_usdc_per_user),
+    treasury_wallet_address: e.treasury_wallet_address,
+    receiving_wallet_address: e.receiving_wallet_address,
+    start_time_local: isoToDatetimeLocalValue(e.start_time),
+    end_time_local: isoToDatetimeLocalValue(e.end_time),
+  };
+}
+
+export function emptySpendExperienceForm(): SpendExperienceFormState {
+  const { start, end } = defaultWindow();
+  return {
+    title: '',
+    description: '',
+    event_id: '',
+    status: 'draft',
+    points_to_usdc_rate: '1000',
+    max_usdc_per_user: '5',
+    treasury_wallet_address: '',
+    receiving_wallet_address: '',
+    start_time_local: isoToDatetimeLocalValue(start),
+    end_time_local: isoToDatetimeLocalValue(end),
+  };
+}

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -4,81 +4,19 @@ import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
 import { toast } from 'sonner';
-import { Loader2, Pencil, Plus } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
+import type { SpendExperience } from '@/lib/types';
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@/components/ui/select';
-import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+  datetimeLocalToIso,
+  emptySpendExperienceForm,
+  experienceToForm,
+  type SpendExperienceFormState,
+} from './form-state';
+import { SpendExperienceFormPanel } from './spend-experience-form-panel';
+import { SpendExperienceList } from './spend-experience-list';
 
 const QUERY_KEY = ['admin-spend-experiences'] as const;
-
-function isoToDatetimeLocalValue(iso: string): string {
-  const d = new Date(iso);
-  const pad = (n: number) => String(n).padStart(2, '0');
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
-}
-
-function datetimeLocalToIso(value: string): string {
-  return new Date(value).toISOString();
-}
-
-function defaultWindow(): { start: string; end: string } {
-  const start = new Date();
-  const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
-  return { start: start.toISOString(), end: end.toISOString() };
-}
-
-type FormState = {
-  title: string;
-  description: string;
-  event_id: string;
-  status: SpendExperienceStatus;
-  points_to_usdc_rate: string;
-  max_usdc_per_user: string;
-  treasury_wallet_address: string;
-  receiving_wallet_address: string;
-  start_time_local: string;
-  end_time_local: string;
-};
-
-function experienceToForm(e: SpendExperience): FormState {
-  return {
-    title: e.title,
-    description: e.description ?? '',
-    event_id: e.event_id ?? '',
-    status: e.status,
-    points_to_usdc_rate: String(e.points_to_usdc_rate),
-    max_usdc_per_user: String(e.max_usdc_per_user),
-    treasury_wallet_address: e.treasury_wallet_address,
-    receiving_wallet_address: e.receiving_wallet_address,
-    start_time_local: isoToDatetimeLocalValue(e.start_time),
-    end_time_local: isoToDatetimeLocalValue(e.end_time),
-  };
-}
-
-function emptyForm(): FormState {
-  const { start, end } = defaultWindow();
-  return {
-    title: '',
-    description: '',
-    event_id: '',
-    status: 'draft',
-    points_to_usdc_rate: '1000',
-    max_usdc_per_user: '5',
-    treasury_wallet_address: '',
-    receiving_wallet_address: '',
-    start_time_local: isoToDatetimeLocalValue(start),
-    end_time_local: isoToDatetimeLocalValue(end),
-  };
-}
 
 export default function AdminSpendExperiencesPage() {
   const { user, login } = usePrivy();
@@ -87,7 +25,9 @@ export default function AdminSpendExperiencesPage() {
   const [adminLoading, setAdminLoading] = useState(true);
   const [panelOpen, setPanelOpen] = useState(false);
   const [editing, setEditing] = useState<SpendExperience | null>(null);
-  const [form, setForm] = useState<FormState>(emptyForm);
+  const [form, setForm] = useState<SpendExperienceFormState>(
+    emptySpendExperienceForm
+  );
 
   const checkAdminStatus = useCallback(async () => {
     if (!user?.email?.address) return false;
@@ -144,6 +84,11 @@ export default function AdminSpendExperiencesPage() {
     enabled: !!isAdmin && !!adminEmail,
   });
 
+  const closePanel = useCallback(() => {
+    setPanelOpen(false);
+    setEditing(null);
+  }, []);
+
   const saveMutation = useMutation({
     mutationFn: async () => {
       const payload = {
@@ -189,22 +134,22 @@ export default function AdminSpendExperiencesPage() {
       );
       setPanelOpen(false);
       setEditing(null);
-      setForm(emptyForm());
+      setForm(emptySpendExperienceForm());
     },
     onError: (e: Error) => toast.error(e.message),
   });
 
-  const openCreate = () => {
+  const openCreate = useCallback(() => {
     setEditing(null);
-    setForm(emptyForm());
+    setForm(emptySpendExperienceForm());
     setPanelOpen(true);
-  };
+  }, []);
 
-  const openEdit = (e: SpendExperience) => {
+  const openEdit = useCallback((e: SpendExperience) => {
     setEditing(e);
     setForm(experienceToForm(e));
     setPanelOpen(true);
-  };
+  }, []);
 
   if (adminLoading) {
     return (
@@ -241,279 +186,22 @@ export default function AdminSpendExperiencesPage() {
 
   return (
     <div className="mx-auto max-w-3xl p-6 font-grotesk">
-      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
-        <div>
-          <h1 className="text-2xl font-semibold text-[#171717]">
-            Spend experiences
-          </h1>
-          <p className="mt-1 text-sm text-neutral-600">
-            Pilot defaults: 1000 points = $1 USDC, max $5 per user (adjust per
-            experience).
-          </p>
-        </div>
-        <Button
-          type="button"
-          onClick={openCreate}
-          className="gap-1 bg-black text-white hover:bg-black/85"
-        >
-          <Plus className="size-4" />
-          New experience
-        </Button>
-      </div>
+      <SpendExperienceList
+        experiences={spendExperiences}
+        isLoading={isLoading}
+        onNew={openCreate}
+        onEdit={openEdit}
+      />
 
-      {isLoading ? (
-        <div className="flex justify-center py-12">
-          <Loader2 className="size-8 animate-spin text-neutral-500" />
-        </div>
-      ) : spendExperiences.length === 0 ? (
-        <p className="text-neutral-600">No spend experiences yet.</p>
-      ) : (
-        <ul className="divide-y divide-neutral-200 rounded-lg border border-neutral-200 bg-white">
-          {spendExperiences.map((exp) => (
-            <li
-              key={exp.id}
-              className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
-            >
-              <div className="min-w-0 flex-1">
-                <div className="font-medium text-[#171717]">{exp.title}</div>
-                <div className="text-sm text-neutral-500">
-                  <span className="capitalize">{exp.status}</span>
-                  {' · '}
-                  {exp.points_to_usdc_rate} pts / $1 · max $
-                  {exp.max_usdc_per_user} USDC
-                </div>
-                <div className="mt-0.5 font-mono text-xs text-blue-600">
-                  /spend/{exp.id}
-                </div>
-              </div>
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
-                className="shrink-0 gap-1"
-                onClick={() => openEdit(exp)}
-              >
-                <Pencil className="size-3.5" />
-                Edit
-              </Button>
-            </li>
-          ))}
-        </ul>
-      )}
-
-      {panelOpen && (
-        <div className="fixed inset-0 z-50 flex justify-end">
-          <button
-            type="button"
-            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
-            aria-label="Close panel"
-            onClick={() => {
-              setPanelOpen(false);
-              setEditing(null);
-            }}
-          />
-          <div className="relative flex h-full w-full max-w-lg flex-col bg-white shadow-2xl">
-            <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
-              <h2 className="text-lg font-semibold text-[#171717]">
-                {editing ? 'Edit spend experience' : 'New spend experience'}
-              </h2>
-              <button
-                type="button"
-                className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100"
-                onClick={() => {
-                  setPanelOpen(false);
-                  setEditing(null);
-                }}
-              >
-                ×
-              </button>
-            </div>
-            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
-              <div className="space-y-2">
-                <Label htmlFor="se-title">Title</Label>
-                <Input
-                  id="se-title"
-                  value={form.title}
-                  onChange={(ev) =>
-                    setForm((f) => ({ ...f, title: ev.target.value }))
-                  }
-                  placeholder="e.g. Spring launch pilot"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="se-desc">Description</Label>
-                <Textarea
-                  id="se-desc"
-                  className="min-h-[88px]"
-                  value={form.description}
-                  onChange={(ev) =>
-                    setForm((f) => ({ ...f, description: ev.target.value }))
-                  }
-                  placeholder="Shown in the spend flow"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="se-event">Event ID (optional)</Label>
-                <Input
-                  id="se-event"
-                  value={form.event_id}
-                  onChange={(ev) =>
-                    setForm((f) => ({ ...f, event_id: ev.target.value }))
-                  }
-                  placeholder="External event id if linked"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>Status</Label>
-                <Select
-                  value={form.status}
-                  onValueChange={(v) =>
-                    setForm((f) => ({
-                      ...f,
-                      status: v as SpendExperienceStatus,
-                    }))
-                  }
-                >
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="draft">Draft</SelectItem>
-                    <SelectItem value="active">Active</SelectItem>
-                    <SelectItem value="ended">Ended</SelectItem>
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="se-rate">Points per $1 USDC</Label>
-                  <Input
-                    id="se-rate"
-                    type="number"
-                    min={1}
-                    step={1}
-                    value={form.points_to_usdc_rate}
-                    onChange={(ev) =>
-                      setForm((f) => ({
-                        ...f,
-                        points_to_usdc_rate: ev.target.value,
-                      }))
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="se-max">Max USDC per user</Label>
-                  <Input
-                    id="se-max"
-                    type="number"
-                    min={0}
-                    step="any"
-                    value={form.max_usdc_per_user}
-                    onChange={(ev) =>
-                      setForm((f) => ({
-                        ...f,
-                        max_usdc_per_user: ev.target.value,
-                      }))
-                    }
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="se-treasury">
-                  Treasury wallet (funds users)
-                </Label>
-                <Input
-                  id="se-treasury"
-                  className="font-mono text-sm"
-                  value={form.treasury_wallet_address}
-                  onChange={(ev) =>
-                    setForm((f) => ({
-                      ...f,
-                      treasury_wallet_address: ev.target.value,
-                    }))
-                  }
-                  placeholder="0x…"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="se-receive">
-                  Receiving wallet (event / IRL)
-                </Label>
-                <Input
-                  id="se-receive"
-                  className="font-mono text-sm"
-                  value={form.receiving_wallet_address}
-                  onChange={(ev) =>
-                    setForm((f) => ({
-                      ...f,
-                      receiving_wallet_address: ev.target.value,
-                    }))
-                  }
-                  placeholder="0x…"
-                />
-              </div>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <div className="space-y-2">
-                  <Label htmlFor="se-start">Start (local)</Label>
-                  <Input
-                    id="se-start"
-                    type="datetime-local"
-                    value={form.start_time_local}
-                    onChange={(ev) =>
-                      setForm((f) => ({
-                        ...f,
-                        start_time_local: ev.target.value,
-                      }))
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="se-end">End (local)</Label>
-                  <Input
-                    id="se-end"
-                    type="datetime-local"
-                    value={form.end_time_local}
-                    onChange={(ev) =>
-                      setForm((f) => ({
-                        ...f,
-                        end_time_local: ev.target.value,
-                      }))
-                    }
-                  />
-                </div>
-              </div>
-            </div>
-            <div className="flex justify-end gap-2 border-t border-neutral-200 bg-neutral-50 px-5 py-4">
-              <Button
-                type="button"
-                variant="outline"
-                onClick={() => {
-                  setPanelOpen(false);
-                  setEditing(null);
-                }}
-              >
-                Cancel
-              </Button>
-              <Button
-                type="button"
-                disabled={saveMutation.isPending}
-                onClick={() => saveMutation.mutate()}
-              >
-                {saveMutation.isPending ? (
-                  <>
-                    <Loader2 className="mr-2 size-4 animate-spin" />
-                    Saving…
-                  </>
-                ) : editing ? (
-                  'Save changes'
-                ) : (
-                  'Create'
-                )}
-              </Button>
-            </div>
-          </div>
-        </div>
-      )}
+      <SpendExperienceFormPanel
+        open={panelOpen}
+        editing={editing}
+        form={form}
+        setForm={setForm}
+        isSaving={saveMutation.isPending}
+        onClose={closePanel}
+        onSubmit={saveMutation.mutate}
+      />
     </div>
   );
 }

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -1,0 +1,519 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePrivy } from '@privy-io/react-auth';
+import { toast } from 'sonner';
+import { Loader2, Pencil, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+
+const QUERY_KEY = ['admin-spend-experiences'] as const;
+
+function isoToDatetimeLocalValue(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+function datetimeLocalToIso(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function defaultWindow(): { start: string; end: string } {
+  const start = new Date();
+  const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+type FormState = {
+  title: string;
+  description: string;
+  event_id: string;
+  status: SpendExperienceStatus;
+  points_to_usdc_rate: string;
+  max_usdc_per_user: string;
+  treasury_wallet_address: string;
+  receiving_wallet_address: string;
+  start_time_local: string;
+  end_time_local: string;
+};
+
+function experienceToForm(e: SpendExperience): FormState {
+  return {
+    title: e.title,
+    description: e.description ?? '',
+    event_id: e.event_id ?? '',
+    status: e.status,
+    points_to_usdc_rate: String(e.points_to_usdc_rate),
+    max_usdc_per_user: String(e.max_usdc_per_user),
+    treasury_wallet_address: e.treasury_wallet_address,
+    receiving_wallet_address: e.receiving_wallet_address,
+    start_time_local: isoToDatetimeLocalValue(e.start_time),
+    end_time_local: isoToDatetimeLocalValue(e.end_time),
+  };
+}
+
+function emptyForm(): FormState {
+  const { start, end } = defaultWindow();
+  return {
+    title: '',
+    description: '',
+    event_id: '',
+    status: 'draft',
+    points_to_usdc_rate: '1000',
+    max_usdc_per_user: '5',
+    treasury_wallet_address: '',
+    receiving_wallet_address: '',
+    start_time_local: isoToDatetimeLocalValue(start),
+    end_time_local: isoToDatetimeLocalValue(end),
+  };
+}
+
+export default function AdminSpendExperiencesPage() {
+  const { user, login } = usePrivy();
+  const queryClient = useQueryClient();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [adminLoading, setAdminLoading] = useState(true);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [editing, setEditing] = useState<SpendExperience | null>(null);
+  const [form, setForm] = useState<FormState>(emptyForm);
+
+  const checkAdminStatus = useCallback(async () => {
+    if (!user?.email?.address) return false;
+    try {
+      const response = await fetch('/api/admin/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email.address }),
+      });
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return data.isAdmin;
+    } catch {
+      return false;
+    }
+  }, [user?.email?.address]);
+
+  useEffect(() => {
+    const verify = async () => {
+      if (user?.email?.address) {
+        setIsAdmin(await checkAdminStatus());
+        setAdminLoading(false);
+      } else if (user === null) {
+        setIsAdmin(false);
+        setAdminLoading(false);
+      }
+    };
+    void verify();
+  }, [user, checkAdminStatus]);
+
+  const adminEmail = user?.email?.address || '';
+
+  const headers = useMemo(
+    () => ({
+      'Content-Type': 'application/json',
+      'x-user-email': adminEmail,
+    }),
+    [adminEmail]
+  );
+
+  const { data: spendExperiences = [], isLoading } = useQuery<
+    SpendExperience[]
+  >({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const response = await fetch('/api/admin/spend-experiences', {
+        headers: { 'x-user-email': adminEmail },
+      });
+      if (!response.ok) throw new Error('Failed to load spend experiences');
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return data.spendExperiences ?? [];
+    },
+    enabled: !!isAdmin && !!adminEmail,
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: async () => {
+      const payload = {
+        title: form.title.trim(),
+        description: form.description.trim() || null,
+        event_id: form.event_id.trim() || null,
+        status: form.status,
+        points_to_usdc_rate: Number(form.points_to_usdc_rate),
+        max_usdc_per_user: Number(form.max_usdc_per_user),
+        treasury_wallet_address: form.treasury_wallet_address.trim(),
+        receiving_wallet_address: form.receiving_wallet_address.trim(),
+        start_time: datetimeLocalToIso(form.start_time_local),
+        end_time: datetimeLocalToIso(form.end_time_local),
+      };
+
+      if (editing) {
+        const response = await fetch(
+          `/api/admin/spend-experiences/${encodeURIComponent(editing.id)}`,
+          { method: 'PATCH', headers, body: JSON.stringify(payload) }
+        );
+        const j = await response.json().catch(() => ({}));
+        if (!response.ok) {
+          throw new Error(j.error || j.message || 'Update failed');
+        }
+        return j.data?.spendExperience ?? j.spendExperience;
+      }
+
+      const response = await fetch('/api/admin/spend-experiences', {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(payload),
+      });
+      const j = await response.json().catch(() => ({}));
+      if (!response.ok) {
+        throw new Error(j.error || j.message || 'Create failed');
+      }
+      return j.data?.spendExperience ?? j.spendExperience;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+      toast.success(
+        editing ? 'Spend experience updated' : 'Spend experience created'
+      );
+      setPanelOpen(false);
+      setEditing(null);
+      setForm(emptyForm());
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const openCreate = () => {
+    setEditing(null);
+    setForm(emptyForm());
+    setPanelOpen(true);
+  };
+
+  const openEdit = (e: SpendExperience) => {
+    setEditing(e);
+    setForm(experienceToForm(e));
+    setPanelOpen(true);
+  };
+
+  if (adminLoading) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center p-8">
+        <Loader2 className="size-8 animate-spin text-neutral-500" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto max-w-lg p-8">
+        <h1 className="mb-4 text-xl font-semibold">Spend experiences</h1>
+        <p className="mb-4 text-neutral-600">
+          Sign in to configure the spend pilot.
+        </p>
+        <Button type="button" onClick={() => login()}>
+          Log in
+        </Button>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto max-w-lg p-8">
+        <h1 className="mb-4 text-xl font-semibold">Unauthorized</h1>
+        <p className="text-neutral-600">
+          Your account cannot access this admin page.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mx-auto max-w-3xl p-6 font-grotesk">
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-[#171717]">
+            Spend experiences
+          </h1>
+          <p className="mt-1 text-sm text-neutral-600">
+            Pilot defaults: 1000 points = $1 USDC, max $5 per user (adjust per
+            experience).
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={openCreate}
+          className="gap-1 bg-black text-white hover:bg-black/85"
+        >
+          <Plus className="size-4" />
+          New experience
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="size-8 animate-spin text-neutral-500" />
+        </div>
+      ) : spendExperiences.length === 0 ? (
+        <p className="text-neutral-600">No spend experiences yet.</p>
+      ) : (
+        <ul className="divide-y divide-neutral-200 rounded-lg border border-neutral-200 bg-white">
+          {spendExperiences.map((exp) => (
+            <li
+              key={exp.id}
+              className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="font-medium text-[#171717]">{exp.title}</div>
+                <div className="text-sm text-neutral-500">
+                  <span className="capitalize">{exp.status}</span>
+                  {' · '}
+                  {exp.points_to_usdc_rate} pts / $1 · max $
+                  {exp.max_usdc_per_user} USDC
+                </div>
+                <div className="mt-0.5 font-mono text-xs text-blue-600">
+                  /spend/{exp.id}
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 gap-1"
+                onClick={() => openEdit(exp)}
+              >
+                <Pencil className="size-3.5" />
+                Edit
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {panelOpen && (
+        <div className="fixed inset-0 z-50 flex justify-end">
+          <button
+            type="button"
+            className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+            aria-label="Close panel"
+            onClick={() => {
+              setPanelOpen(false);
+              setEditing(null);
+            }}
+          />
+          <div className="relative flex h-full w-full max-w-lg flex-col bg-white shadow-2xl">
+            <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
+              <h2 className="text-lg font-semibold text-[#171717]">
+                {editing ? 'Edit spend experience' : 'New spend experience'}
+              </h2>
+              <button
+                type="button"
+                className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100"
+                onClick={() => {
+                  setPanelOpen(false);
+                  setEditing(null);
+                }}
+              >
+                ×
+              </button>
+            </div>
+            <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+              <div className="space-y-2">
+                <Label htmlFor="se-title">Title</Label>
+                <Input
+                  id="se-title"
+                  value={form.title}
+                  onChange={(ev) =>
+                    setForm((f) => ({ ...f, title: ev.target.value }))
+                  }
+                  placeholder="e.g. Spring launch pilot"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="se-desc">Description</Label>
+                <Textarea
+                  id="se-desc"
+                  className="min-h-[88px]"
+                  value={form.description}
+                  onChange={(ev) =>
+                    setForm((f) => ({ ...f, description: ev.target.value }))
+                  }
+                  placeholder="Shown in the spend flow"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="se-event">Event ID (optional)</Label>
+                <Input
+                  id="se-event"
+                  value={form.event_id}
+                  onChange={(ev) =>
+                    setForm((f) => ({ ...f, event_id: ev.target.value }))
+                  }
+                  placeholder="External event id if linked"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label>Status</Label>
+                <Select
+                  value={form.status}
+                  onValueChange={(v) =>
+                    setForm((f) => ({
+                      ...f,
+                      status: v as SpendExperienceStatus,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="draft">Draft</SelectItem>
+                    <SelectItem value="active">Active</SelectItem>
+                    <SelectItem value="ended">Ended</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="se-rate">Points per $1 USDC</Label>
+                  <Input
+                    id="se-rate"
+                    type="number"
+                    min={1}
+                    step={1}
+                    value={form.points_to_usdc_rate}
+                    onChange={(ev) =>
+                      setForm((f) => ({
+                        ...f,
+                        points_to_usdc_rate: ev.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="se-max">Max USDC per user</Label>
+                  <Input
+                    id="se-max"
+                    type="number"
+                    min={0}
+                    step="any"
+                    value={form.max_usdc_per_user}
+                    onChange={(ev) =>
+                      setForm((f) => ({
+                        ...f,
+                        max_usdc_per_user: ev.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="se-treasury">
+                  Treasury wallet (funds users)
+                </Label>
+                <Input
+                  id="se-treasury"
+                  className="font-mono text-sm"
+                  value={form.treasury_wallet_address}
+                  onChange={(ev) =>
+                    setForm((f) => ({
+                      ...f,
+                      treasury_wallet_address: ev.target.value,
+                    }))
+                  }
+                  placeholder="0x…"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="se-receive">
+                  Receiving wallet (event / IRL)
+                </Label>
+                <Input
+                  id="se-receive"
+                  className="font-mono text-sm"
+                  value={form.receiving_wallet_address}
+                  onChange={(ev) =>
+                    setForm((f) => ({
+                      ...f,
+                      receiving_wallet_address: ev.target.value,
+                    }))
+                  }
+                  placeholder="0x…"
+                />
+              </div>
+              <div className="grid gap-4 sm:grid-cols-2">
+                <div className="space-y-2">
+                  <Label htmlFor="se-start">Start (local)</Label>
+                  <Input
+                    id="se-start"
+                    type="datetime-local"
+                    value={form.start_time_local}
+                    onChange={(ev) =>
+                      setForm((f) => ({
+                        ...f,
+                        start_time_local: ev.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="se-end">End (local)</Label>
+                  <Input
+                    id="se-end"
+                    type="datetime-local"
+                    value={form.end_time_local}
+                    onChange={(ev) =>
+                      setForm((f) => ({
+                        ...f,
+                        end_time_local: ev.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+            </div>
+            <div className="flex justify-end gap-2 border-t border-neutral-200 bg-neutral-50 px-5 py-4">
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => {
+                  setPanelOpen(false);
+                  setEditing(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                type="button"
+                disabled={saveMutation.isPending}
+                onClick={() => saveMutation.mutate()}
+              >
+                {saveMutation.isPending ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    Saving…
+                  </>
+                ) : editing ? (
+                  'Save changes'
+                ) : (
+                  'Create'
+                )}
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/spend-experiences/spend-experience-form-panel.tsx
+++ b/app/admin/spend-experiences/spend-experience-form-panel.tsx
@@ -1,0 +1,242 @@
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+import type { SpendExperienceFormState } from './form-state';
+
+export type SpendExperienceFormPanelProps = {
+  open: boolean;
+  editing: SpendExperience | null;
+  form: SpendExperienceFormState;
+  setForm: Dispatch<SetStateAction<SpendExperienceFormState>>;
+  isSaving: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+};
+
+function panelTitle(editing: SpendExperience | null): string {
+  if (editing) return 'Edit spend experience';
+  return 'New spend experience';
+}
+
+function submitButtonContent(
+  isSaving: boolean,
+  editing: SpendExperience | null
+): ReactNode {
+  if (isSaving) {
+    return (
+      <>
+        <Loader2 className="mr-2 size-4 animate-spin" />
+        Saving…
+      </>
+    );
+  }
+  if (editing) return 'Save changes';
+  return 'Create';
+}
+
+export function SpendExperienceFormPanel({
+  open,
+  editing,
+  form,
+  setForm,
+  isSaving,
+  onClose,
+  onSubmit,
+}: SpendExperienceFormPanelProps) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        aria-label="Close panel"
+        onClick={onClose}
+      />
+      <div className="relative flex h-full w-full max-w-lg flex-col bg-white shadow-2xl">
+        <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4">
+          <h2 className="text-lg font-semibold text-[#171717]">
+            {panelTitle(editing)}
+          </h2>
+          <button
+            type="button"
+            className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="se-title">Title</Label>
+            <Input
+              id="se-title"
+              value={form.title}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, title: ev.target.value }))
+              }
+              placeholder="e.g. Spring launch pilot"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="se-desc">Description</Label>
+            <Textarea
+              id="se-desc"
+              className="min-h-[88px]"
+              value={form.description}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, description: ev.target.value }))
+              }
+              placeholder="Shown in the spend flow"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="se-event">Event ID (optional)</Label>
+            <Input
+              id="se-event"
+              value={form.event_id}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, event_id: ev.target.value }))
+              }
+              placeholder="External event id if linked"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Status</Label>
+            <Select
+              value={form.status}
+              onValueChange={(v) =>
+                setForm((f) => ({
+                  ...f,
+                  status: v as SpendExperienceStatus,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="draft">Draft</SelectItem>
+                <SelectItem value="active">Active</SelectItem>
+                <SelectItem value="ended">Ended</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="se-rate">Points per $1 USDC</Label>
+              <Input
+                id="se-rate"
+                type="number"
+                min={1}
+                step={1}
+                value={form.points_to_usdc_rate}
+                onChange={(ev) =>
+                  setForm((f) => ({
+                    ...f,
+                    points_to_usdc_rate: ev.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="se-max">Max USDC per user</Label>
+              <Input
+                id="se-max"
+                type="number"
+                min={0}
+                step="any"
+                value={form.max_usdc_per_user}
+                onChange={(ev) =>
+                  setForm((f) => ({
+                    ...f,
+                    max_usdc_per_user: ev.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="se-treasury">Treasury wallet (funds users)</Label>
+            <Input
+              id="se-treasury"
+              className="font-mono text-sm"
+              value={form.treasury_wallet_address}
+              onChange={(ev) =>
+                setForm((f) => ({
+                  ...f,
+                  treasury_wallet_address: ev.target.value,
+                }))
+              }
+              placeholder="0x…"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="se-receive">Receiving wallet (event / IRL)</Label>
+            <Input
+              id="se-receive"
+              className="font-mono text-sm"
+              value={form.receiving_wallet_address}
+              onChange={(ev) =>
+                setForm((f) => ({
+                  ...f,
+                  receiving_wallet_address: ev.target.value,
+                }))
+              }
+              placeholder="0x…"
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="se-start">Start (local)</Label>
+              <Input
+                id="se-start"
+                type="datetime-local"
+                value={form.start_time_local}
+                onChange={(ev) =>
+                  setForm((f) => ({
+                    ...f,
+                    start_time_local: ev.target.value,
+                  }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="se-end">End (local)</Label>
+              <Input
+                id="se-end"
+                type="datetime-local"
+                value={form.end_time_local}
+                onChange={(ev) =>
+                  setForm((f) => ({
+                    ...f,
+                    end_time_local: ev.target.value,
+                  }))
+                }
+              />
+            </div>
+          </div>
+        </div>
+        <div className="flex justify-end gap-2 border-t border-neutral-200 bg-neutral-50 px-5 py-4">
+          <Button type="button" variant="outline" onClick={onClose}>
+            Cancel
+          </Button>
+          <Button type="button" disabled={isSaving} onClick={() => onSubmit()}>
+            {submitButtonContent(isSaving, editing)}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/admin/spend-experiences/spend-experience-list.tsx
+++ b/app/admin/spend-experiences/spend-experience-list.tsx
@@ -1,0 +1,81 @@
+import { Loader2, Pencil, Plus } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { SpendExperience } from '@/lib/types';
+
+export type SpendExperienceListProps = {
+  experiences: SpendExperience[];
+  isLoading: boolean;
+  onNew: () => void;
+  onEdit: (exp: SpendExperience) => void;
+};
+
+export function SpendExperienceList({
+  experiences,
+  isLoading,
+  onNew,
+  onEdit,
+}: SpendExperienceListProps) {
+  return (
+    <>
+      <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
+        <div>
+          <h1 className="text-2xl font-semibold text-[#171717]">
+            Spend experiences
+          </h1>
+          <p className="mt-1 text-sm text-neutral-600">
+            Pilot defaults: 1000 points = $1 USDC, max $5 per user (adjust per
+            experience).
+          </p>
+        </div>
+        <Button
+          type="button"
+          onClick={onNew}
+          className="gap-1 bg-black text-white hover:bg-black/85"
+        >
+          <Plus className="size-4" />
+          New experience
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12">
+          <Loader2 className="size-8 animate-spin text-neutral-500" />
+        </div>
+      ) : experiences.length === 0 ? (
+        <p className="text-neutral-600">No spend experiences yet.</p>
+      ) : (
+        <ul className="divide-y divide-neutral-200 rounded-lg border border-neutral-200 bg-white">
+          {experiences.map((exp) => (
+            <li
+              key={exp.id}
+              className="flex flex-wrap items-center justify-between gap-3 px-4 py-3"
+            >
+              <div className="min-w-0 flex-1">
+                <div className="font-medium text-[#171717]">{exp.title}</div>
+                <div className="text-sm text-neutral-500">
+                  <span className="capitalize">{exp.status}</span>
+                  {' · '}
+                  {exp.points_to_usdc_rate} pts / $1 · max $
+                  {exp.max_usdc_per_user} USDC
+                </div>
+                <div className="mt-0.5 font-mono text-xs text-blue-600">
+                  /spend/{exp.id}
+                </div>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="shrink-0 gap-1"
+                onClick={() => onEdit(exp)}
+              >
+                <Pencil className="size-3.5" />
+                Edit
+              </Button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </>
+  );
+}

--- a/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockGetSpendExperienceById = vi.fn();
+const mockUpdateSpendExperience = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/spend-experiences', () => ({
+  getSpendExperienceById: (...args: unknown[]) =>
+    mockGetSpendExperienceById(...args),
+  updateSpendExperience: (...args: unknown[]) =>
+    mockUpdateSpendExperience(...args),
+}));
+
+import { PATCH } from '../route';
+
+const existing = {
+  id: 'exp-1',
+  title: 'Old',
+  description: null,
+  event_id: null,
+  status: 'draft' as const,
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  start_time: '2026-05-01T12:00:00.000Z',
+  end_time: '2026-05-08T12:00:00.000Z',
+  created_by: 'a@b.com',
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+};
+
+function patchRequest(body: Record<string, unknown>, email?: string) {
+  const headers = new Headers();
+  headers.set('Content-Type', 'application/json');
+  if (email) headers.set('x-user-email', email);
+  return new NextRequest(
+    'http://localhost:3000/api/admin/spend-experiences/exp-1',
+    { method: 'PATCH', headers, body: JSON.stringify(body) }
+  );
+}
+
+describe('PATCH /api/admin/spend-experiences/[experienceId]', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await PATCH(patchRequest({ title: 'x' }, 'u@v.com'), {
+      params: { experienceId: 'exp-1' },
+    });
+    expect(res.status).toBe(403);
+    expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when experience missing', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(null);
+
+    const res = await PATCH(patchRequest({ title: 'x' }, 'admin@example.com'), {
+      params: { experienceId: 'missing' },
+    });
+    const j = await res.json();
+    expect(res.status).toBe(404);
+    expect(j.success).toBe(false);
+    expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when merged window is invalid', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(existing);
+
+    const res = await PATCH(
+      patchRequest(
+        { start_time: '2026-06-10T12:00:00.000Z' },
+        'admin@example.com'
+      ),
+      { params: { experienceId: 'exp-1' } }
+    );
+    const j = await res.json();
+    expect(res.status).toBe(400);
+    expect(j.success).toBe(false);
+    expect(j.error).toContain('end_time');
+    expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/spend-experiences/[experienceId]/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server';
+import {
+  getSpendExperienceById,
+  updateSpendExperience,
+} from '@/lib/db/spend-experiences';
+import { updateSpendExperienceRequestSchema } from '@/lib/schemas/spend-experience';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+interface RouteParams {
+  params: { experienceId: string };
+}
+
+/** PATCH /api/admin/spend-experiences/{experienceId} */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const existing = await getSpendExperienceById(params.experienceId);
+    if (!existing) {
+      return apiError('Spend experience not found', 404);
+    }
+
+    const raw = await request.json();
+    const validation = updateSpendExperienceRequestSchema.safeParse(raw);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+
+    const nextStart = validation.data.start_time ?? existing.start_time;
+    const nextEnd = validation.data.end_time ?? existing.end_time;
+    if (new Date(nextEnd) <= new Date(nextStart)) {
+      return apiError('end_time must be after start_time', 400);
+    }
+
+    const spendExperience = await updateSpendExperience(
+      params.experienceId,
+      validation.data
+    );
+
+    return apiSuccess(
+      { spendExperience },
+      'Spend experience updated successfully'
+    );
+  } catch (error) {
+    console.error('Error updating spend experience:', error);
+    return apiError('Failed to update spend experience', 500);
+  }
+}

--- a/app/api/admin/spend-experiences/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/__tests__/route.test.ts
@@ -1,0 +1,132 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockListSpendExperiences = vi.fn();
+const mockCreateSpendExperience = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/spend-experiences', () => ({
+  listSpendExperiences: (...args: unknown[]) =>
+    mockListSpendExperiences(...args),
+  createSpendExperience: (...args: unknown[]) =>
+    mockCreateSpendExperience(...args),
+}));
+
+import { GET, POST } from '../route';
+
+function jsonRequest(
+  method: 'GET' | 'POST',
+  body?: Record<string, unknown>,
+  emailHeader?: string
+): NextRequest {
+  const headers = new Headers();
+  if (emailHeader) headers.set('x-user-email', emailHeader);
+  if (body) headers.set('Content-Type', 'application/json');
+  return new NextRequest('http://localhost:3000/api/admin/spend-experiences', {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe('GET /api/admin/spend-experiences', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await GET(jsonRequest('GET', undefined, 'user@example.com'));
+    const j = await res.json();
+    expect(res.status).toBe(403);
+    expect(j.success).toBe(false);
+    expect(mockListSpendExperiences).not.toHaveBeenCalled();
+  });
+
+  it('returns list for admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockListSpendExperiences.mockResolvedValue([
+      {
+        id: 'uuid-1',
+        title: 'Test',
+        description: null,
+        event_id: null,
+        status: 'draft',
+        points_to_usdc_rate: 1000,
+        max_usdc_per_user: 5,
+        treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+        receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+        start_time: '2026-05-01T00:00:00Z',
+        end_time: '2026-05-02T00:00:00Z',
+        created_by: 'admin@example.com',
+        created_at: '2026-04-01T00:00:00Z',
+        updated_at: '2026-04-01T00:00:00Z',
+      },
+    ]);
+
+    const res = await GET(jsonRequest('GET', undefined, 'admin@example.com'));
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.success).toBe(true);
+    expect(j.data.spendExperiences).toHaveLength(1);
+  });
+});
+
+describe('POST /api/admin/spend-experiences', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 400 on validation failure', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+
+    const res = await POST(
+      jsonRequest(
+        'POST',
+        {
+          title: '',
+          points_to_usdc_rate: 1000,
+          max_usdc_per_user: 5,
+          treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+          receiving_wallet_address:
+            '0x2222222222222222222222222222222222222222',
+          start_time: '2026-05-01T12:00:00.000Z',
+          end_time: '2026-05-08T12:00:00.000Z',
+        },
+        'admin@example.com'
+      )
+    );
+    const j = await res.json();
+    expect(res.status).toBe(400);
+    expect(j.success).toBe(false);
+    expect(mockCreateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await POST(
+      jsonRequest(
+        'POST',
+        {
+          title: 'Ok',
+          points_to_usdc_rate: 1000,
+          max_usdc_per_user: 5,
+          treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+          receiving_wallet_address:
+            '0x2222222222222222222222222222222222222222',
+          start_time: '2026-05-01T12:00:00.000Z',
+          end_time: '2026-05-08T12:00:00.000Z',
+        },
+        'x@y.com'
+      )
+    );
+    expect(res.status).toBe(403);
+    expect(mockCreateSpendExperience).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/spend-experiences/route.ts
+++ b/app/api/admin/spend-experiences/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest } from 'next/server';
+import {
+  createSpendExperience,
+  listSpendExperiences,
+} from '@/lib/db/spend-experiences';
+import { createSpendExperienceRequestSchema } from '@/lib/schemas/spend-experience';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+/** GET /api/admin/spend-experiences */
+export async function GET(request: NextRequest) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const spendExperiences = await listSpendExperiences();
+    return apiSuccess({ spendExperiences });
+  } catch (error) {
+    console.error('Error listing spend experiences:', error);
+    return apiError('Failed to fetch spend experiences', 500);
+  }
+}
+
+/** POST /api/admin/spend-experiences */
+export async function POST(request: NextRequest) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const body = await request.json();
+    const validation = createSpendExperienceRequestSchema.safeParse(body);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+
+    const adminEmail = adminCheck.user?.email || undefined;
+    const spendExperience = await createSpendExperience({
+      ...validation.data,
+      created_by: adminEmail ?? null,
+    });
+
+    return apiSuccess(
+      { spendExperience },
+      'Spend experience created successfully'
+    );
+  } catch (error) {
+    console.error('Error creating spend experience:', error);
+    return apiError('Failed to create spend experience', 500);
+  }
+}

--- a/database/spend-experiences-schema.sql
+++ b/database/spend-experiences-schema.sql
@@ -1,0 +1,69 @@
+-- Spend pilot: admin-configured spend experiences (IRL Spend Pilot PRD §7)
+-- Apply after core tables exist. Optional event_id links to external Dice event ids (text).
+
+CREATE EXTENSION IF NOT EXISTS pgcrypto;
+
+CREATE TABLE IF NOT EXISTS spend_experiences (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title VARCHAR(255) NOT NULL,
+    description TEXT,
+    event_id TEXT,
+    status VARCHAR(20) NOT NULL DEFAULT 'draft'
+        CHECK (status IN ('draft', 'active', 'ended')),
+    -- Points required per 1 USDC (e.g. 1000 => 1000 points = $1 USDC)
+    points_to_usdc_rate NUMERIC(24, 8) NOT NULL
+        CHECK (points_to_usdc_rate > 0),
+    max_usdc_per_user NUMERIC(24, 8) NOT NULL
+        CHECK (max_usdc_per_user > 0),
+    treasury_wallet_address TEXT NOT NULL,
+    receiving_wallet_address TEXT NOT NULL,
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    created_by VARCHAR(255),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT spend_experiences_time_window CHECK (end_time > start_time)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spend_experiences_status
+    ON spend_experiences (status);
+
+CREATE INDEX IF NOT EXISTS idx_spend_experiences_active_window
+    ON spend_experiences (start_time, end_time)
+    WHERE status = 'active';
+
+CREATE INDEX IF NOT EXISTS idx_spend_experiences_event_id
+    ON spend_experiences (event_id)
+    WHERE event_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS idx_spend_experiences_created_at
+    ON spend_experiences (created_at DESC);
+
+COMMENT ON TABLE spend_experiences IS 'Admin spend pilot configuration: conversion rate, caps, wallets, active window.';
+
+CREATE OR REPLACE FUNCTION update_spend_experiences_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS spend_experiences_updated_at_trigger ON spend_experiences;
+CREATE TRIGGER spend_experiences_updated_at_trigger
+    BEFORE UPDATE ON spend_experiences
+    FOR EACH ROW
+    EXECUTE FUNCTION update_spend_experiences_updated_at();
+
+ALTER TABLE spend_experiences ENABLE ROW LEVEL SECURITY;
+
+-- Authenticated product flows can read active experiences; service role bypasses RLS.
+CREATE POLICY "Allow public read of active spend experiences"
+    ON spend_experiences
+    FOR SELECT
+    USING (status = 'active');
+
+CREATE POLICY "Allow service role full access spend experiences"
+    ON spend_experiences
+    USING (true)
+    WITH CHECK (true);

--- a/lib/db/spend-experiences.ts
+++ b/lib/db/spend-experiences.ts
@@ -1,0 +1,173 @@
+import { supabase } from './client';
+import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+
+const SPEND_EXPERIENCE_COLUMNS = `
+  id,
+  title,
+  description,
+  event_id,
+  status,
+  points_to_usdc_rate,
+  max_usdc_per_user,
+  treasury_wallet_address,
+  receiving_wallet_address,
+  start_time,
+  end_time,
+  created_by,
+  created_at,
+  updated_at
+`;
+
+const toNumber = (value: unknown): number => {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+};
+
+const normalizeRow = (row: Record<string, unknown>): SpendExperience => ({
+  id: String(row.id),
+  title: String(row.title),
+  description: row.description == null ? null : String(row.description),
+  event_id: row.event_id == null ? null : String(row.event_id),
+  status: row.status as SpendExperienceStatus,
+  points_to_usdc_rate: toNumber(row.points_to_usdc_rate),
+  max_usdc_per_user: toNumber(row.max_usdc_per_user),
+  treasury_wallet_address: String(row.treasury_wallet_address),
+  receiving_wallet_address: String(row.receiving_wallet_address),
+  start_time: String(row.start_time),
+  end_time: String(row.end_time),
+  created_by: row.created_by == null ? null : String(row.created_by),
+  created_at: String(row.created_at),
+  updated_at: String(row.updated_at),
+});
+
+export async function listSpendExperiences(): Promise<SpendExperience[]> {
+  const { data, error } = await supabase
+    .from('spend_experiences')
+    .select(SPEND_EXPERIENCE_COLUMNS)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error('listSpendExperiences error:', error);
+    throw new Error(error.message || 'Failed to list spend experiences');
+  }
+
+  return (data || []).map((row) =>
+    normalizeRow(row as Record<string, unknown>)
+  );
+}
+
+export type CreateSpendExperienceInput = {
+  title: string;
+  description?: string | null;
+  event_id?: string | null;
+  status: SpendExperienceStatus;
+  points_to_usdc_rate: number;
+  max_usdc_per_user: number;
+  treasury_wallet_address: string;
+  receiving_wallet_address: string;
+  start_time: string;
+  end_time: string;
+  created_by?: string | null;
+};
+
+export async function createSpendExperience(
+  input: CreateSpendExperienceInput
+): Promise<SpendExperience> {
+  const insertRow = {
+    title: input.title,
+    description: input.description ?? null,
+    event_id: input.event_id ?? null,
+    status: input.status,
+    points_to_usdc_rate: input.points_to_usdc_rate,
+    max_usdc_per_user: input.max_usdc_per_user,
+    treasury_wallet_address: input.treasury_wallet_address,
+    receiving_wallet_address: input.receiving_wallet_address,
+    start_time: input.start_time,
+    end_time: input.end_time,
+    created_by: input.created_by ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from('spend_experiences')
+    .insert(insertRow)
+    .select(SPEND_EXPERIENCE_COLUMNS)
+    .single();
+
+  if (error) {
+    console.error('createSpendExperience error:', error);
+    throw new Error(error.message || 'Failed to create spend experience');
+  }
+
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export type UpdateSpendExperienceInput = Partial<{
+  title: string;
+  description: string | null;
+  event_id: string | null;
+  status: SpendExperienceStatus;
+  points_to_usdc_rate: number;
+  max_usdc_per_user: number;
+  treasury_wallet_address: string;
+  receiving_wallet_address: string;
+  start_time: string;
+  end_time: string;
+}>;
+
+export async function getSpendExperienceById(
+  id: string
+): Promise<SpendExperience | null> {
+  const { data, error } = await supabase
+    .from('spend_experiences')
+    .select(SPEND_EXPERIENCE_COLUMNS)
+    .eq('id', id)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendExperienceById error:', error);
+    throw new Error(error.message || 'Failed to load spend experience');
+  }
+
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function updateSpendExperience(
+  id: string,
+  updates: UpdateSpendExperienceInput
+): Promise<SpendExperience> {
+  const patch: Record<string, unknown> = {};
+  if (updates.title !== undefined) patch.title = updates.title;
+  if (updates.description !== undefined)
+    patch.description = updates.description;
+  if (updates.event_id !== undefined) patch.event_id = updates.event_id;
+  if (updates.status !== undefined) patch.status = updates.status;
+  if (updates.points_to_usdc_rate !== undefined)
+    patch.points_to_usdc_rate = updates.points_to_usdc_rate;
+  if (updates.max_usdc_per_user !== undefined)
+    patch.max_usdc_per_user = updates.max_usdc_per_user;
+  if (updates.treasury_wallet_address !== undefined)
+    patch.treasury_wallet_address = updates.treasury_wallet_address;
+  if (updates.receiving_wallet_address !== undefined)
+    patch.receiving_wallet_address = updates.receiving_wallet_address;
+  if (updates.start_time !== undefined) patch.start_time = updates.start_time;
+  if (updates.end_time !== undefined) patch.end_time = updates.end_time;
+
+  const { data, error } = await supabase
+    .from('spend_experiences')
+    .update(patch)
+    .eq('id', id)
+    .select(SPEND_EXPERIENCE_COLUMNS)
+    .single();
+
+  if (error) {
+    console.error('updateSpendExperience error:', error);
+    throw new Error(error.message || 'Failed to update spend experience');
+  }
+
+  return normalizeRow(data as Record<string, unknown>);
+}

--- a/lib/db/spend-experiences.ts
+++ b/lib/db/spend-experiences.ts
@@ -167,6 +167,9 @@ export async function updateSpendExperience(
   updates: UpdateSpendExperienceInput
 ): Promise<SpendExperience> {
   const patch = buildSpendExperiencePatch(updates);
+  if (Object.keys(patch).length === 0) {
+    throw new Error('No fields to update');
+  }
 
   const { data, error } = await supabase
     .from('spend_experiences')

--- a/lib/db/spend-experiences.ts
+++ b/lib/db/spend-experiences.ts
@@ -118,6 +118,32 @@ export type UpdateSpendExperienceInput = Partial<{
   end_time: string;
 }>;
 
+const UPDATE_SPEND_EXPERIENCE_KEYS: (keyof UpdateSpendExperienceInput)[] = [
+  'title',
+  'description',
+  'event_id',
+  'status',
+  'points_to_usdc_rate',
+  'max_usdc_per_user',
+  'treasury_wallet_address',
+  'receiving_wallet_address',
+  'start_time',
+  'end_time',
+];
+
+function buildSpendExperiencePatch(
+  updates: UpdateSpendExperienceInput
+): Record<string, unknown> {
+  const patch: Record<string, unknown> = {};
+  for (const key of UPDATE_SPEND_EXPERIENCE_KEYS) {
+    const value = updates[key];
+    if (value !== undefined) {
+      patch[key] = value;
+    }
+  }
+  return patch;
+}
+
 export async function getSpendExperienceById(
   id: string
 ): Promise<SpendExperience | null> {
@@ -140,22 +166,7 @@ export async function updateSpendExperience(
   id: string,
   updates: UpdateSpendExperienceInput
 ): Promise<SpendExperience> {
-  const patch: Record<string, unknown> = {};
-  if (updates.title !== undefined) patch.title = updates.title;
-  if (updates.description !== undefined)
-    patch.description = updates.description;
-  if (updates.event_id !== undefined) patch.event_id = updates.event_id;
-  if (updates.status !== undefined) patch.status = updates.status;
-  if (updates.points_to_usdc_rate !== undefined)
-    patch.points_to_usdc_rate = updates.points_to_usdc_rate;
-  if (updates.max_usdc_per_user !== undefined)
-    patch.max_usdc_per_user = updates.max_usdc_per_user;
-  if (updates.treasury_wallet_address !== undefined)
-    patch.treasury_wallet_address = updates.treasury_wallet_address;
-  if (updates.receiving_wallet_address !== undefined)
-    patch.receiving_wallet_address = updates.receiving_wallet_address;
-  if (updates.start_time !== undefined) patch.start_time = updates.start_time;
-  if (updates.end_time !== undefined) patch.end_time = updates.end_time;
+  const patch = buildSpendExperiencePatch(updates);
 
   const { data, error } = await supabase
     .from('spend_experiences')

--- a/lib/schemas/__tests__/spend-experience.test.ts
+++ b/lib/schemas/__tests__/spend-experience.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createSpendExperienceRequestSchema,
+  updateSpendExperienceRequestSchema,
+} from '../spend-experience';
+
+const validBase = {
+  title: 'Pilot',
+  description: null,
+  event_id: null,
+  status: 'draft' as const,
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  start_time: '2026-05-01T12:00:00.000Z',
+  end_time: '2026-05-08T12:00:00.000Z',
+};
+
+describe('createSpendExperienceRequestSchema', () => {
+  it('accepts valid payload', () => {
+    const r = createSpendExperienceRequestSchema.safeParse(validBase);
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects invalid treasury address', () => {
+    const r = createSpendExperienceRequestSchema.safeParse({
+      ...validBase,
+      treasury_wallet_address: 'not-an-address',
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects end before start', () => {
+    const r = createSpendExperienceRequestSchema.safeParse({
+      ...validBase,
+      start_time: '2026-05-08T12:00:00.000Z',
+      end_time: '2026-05-01T12:00:00.000Z',
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('updateSpendExperienceRequestSchema', () => {
+  it('rejects empty patch', () => {
+    const r = updateSpendExperienceRequestSchema.safeParse({});
+    expect(r.success).toBe(false);
+  });
+
+  it('accepts partial update', () => {
+    const r = updateSpendExperienceRequestSchema.safeParse({ title: 'x' });
+    expect(r.success).toBe(true);
+  });
+});

--- a/lib/schemas/spend-experience.ts
+++ b/lib/schemas/spend-experience.ts
@@ -1,0 +1,53 @@
+import { z } from 'zod';
+import { walletAddressSchema } from './player';
+
+export const spendExperienceStatusSchema = z.enum(['draft', 'active', 'ended']);
+
+/**
+ * Points per 1 USDC (e.g. 1000 = 1000 IRL points for $1 USDC).
+ */
+export const createSpendExperienceRequestSchema = z
+  .object({
+    title: z.string().min(1).max(255),
+    description: z.string().max(5000).optional().nullable(),
+    event_id: z.string().min(1).max(256).optional().nullable(),
+    status: spendExperienceStatusSchema.default('draft'),
+    points_to_usdc_rate: z.coerce.number().positive().max(1e15),
+    max_usdc_per_user: z.coerce.number().positive().max(1e9),
+    treasury_wallet_address: walletAddressSchema,
+    receiving_wallet_address: walletAddressSchema,
+    start_time: z.string().datetime({ offset: true }),
+    end_time: z.string().datetime({ offset: true }),
+  })
+  .refine((data) => new Date(data.end_time) > new Date(data.start_time), {
+    message: 'end_time must be after start_time',
+    path: ['end_time'],
+  });
+
+export const updateSpendExperienceRequestSchema = z
+  .object({
+    title: z.string().min(1).max(255).optional(),
+    description: z.string().max(5000).optional().nullable(),
+    event_id: z.string().min(1).max(256).optional().nullable(),
+    status: spendExperienceStatusSchema.optional(),
+    points_to_usdc_rate: z.coerce.number().positive().max(1e15).optional(),
+    max_usdc_per_user: z.coerce.number().positive().max(1e9).optional(),
+    treasury_wallet_address: walletAddressSchema.optional(),
+    receiving_wallet_address: walletAddressSchema.optional(),
+    start_time: z.string().datetime({ offset: true }).optional(),
+    end_time: z.string().datetime({ offset: true }).optional(),
+  })
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required',
+  })
+  .superRefine((data, ctx) => {
+    if (data.start_time !== undefined && data.end_time !== undefined) {
+      if (new Date(data.end_time) <= new Date(data.start_time)) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: 'end_time must be after start_time',
+          path: ['end_time'],
+        });
+      }
+    }
+  });

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -264,3 +264,25 @@ export type Checkpoint = {
   created_at?: string;
   updated_at?: string;
 };
+
+export type SpendExperienceStatus = 'draft' | 'active' | 'ended';
+
+/**
+ * Admin-configured spend pilot experience (points → USDC conversion window).
+ */
+export type SpendExperience = {
+  id: string;
+  title: string;
+  description: string | null;
+  event_id: string | null;
+  status: SpendExperienceStatus;
+  points_to_usdc_rate: number;
+  max_usdc_per_user: number;
+  treasury_wallet_address: string;
+  receiving_wallet_address: string;
+  start_time: string;
+  end_time: string;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes https://github.com/hurley87/refraction/issues/504

## Summary

- Adds `database/spend-experiences-schema.sql` for the `spend_experiences` table (PRD §7): title, description, optional `event_id`, `status` (`draft` | `active` | `ended`), `points_to_usdc_rate` (points per $1 USDC), `max_usdc_per_user`, treasury/receiving addresses, `start_time` / `end_time`, audit fields, indexes, RLS (public read for `active` only; service role full access), and `updated_at` trigger.
- Admin APIs: `GET` / `POST` `/api/admin/spend-experiences`, `PATCH` `/api/admin/spend-experiences/{experienceId}` using `requireAdmin`, `apiSuccess` / `apiError` / `apiValidationError`, and Zod schemas in `lib/schemas/spend-experience.ts`. DB helpers in `lib/db/spend-experiences.ts`.
- Admin UI at `/admin/spend-experiences`: list experiences, create/edit in a slide-over (defaults 1000 pts / $1, max $5). UI split into `form-state.ts`, `spend-experience-list.tsx`, and `spend-experience-form-panel.tsx` for clarity; `updateSpendExperience` builds the Supabase patch via a single keyed loop.
- Tests: Zod validation (`lib/schemas/__tests__/spend-experience.test.ts`) and route tests for auth, validation, and merged window checks.

## Notes

- Apply the SQL file in Supabase (or your migration pipeline) before using the UI in a real environment.
- `points_to_usdc_rate` is stored as **IRL points required per 1 USDC** (e.g. `1000` = 1000 points per $1), matching the pilot default wording in the issue.

## Verification

- `yarn vitest run app/api/admin/spend-experiences lib/schemas/__tests__/spend-experience.test.ts`
- `yarn build`
- `yarn lint` (existing repo warnings only)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-83ceb543-8cb4-45f1-abf4-7c03312f31ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-83ceb543-8cb4-45f1-abf4-7c03312f31ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

