### PR TITLE
Spend pilot: conversion confirm API, atomic deduction, treasury USDC (#507)

### DIFF
--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyWallet = vi.fn();
+const mockGetPrivyUserId = vi.fn();
+const mockGetSpendContext = vi.fn();
+const mockRunConfirm = vi.fn();
+const mockResolve = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+  verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
+}));
+
+vi.mock('@/lib/spend-conversion-confirm', () => ({
+  getSpendContextOr404: (...a: unknown[]) => mockGetSpendContext(...a),
+  runSpendConversionConfirm: (...a: unknown[]) => mockRunConfirm(...a),
+}));
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: (...a: unknown[]) => mockResolve(...a),
+}));
+
+import { POST } from '../route';
+
+const session = {
+  id: 'sess-1',
+  spend_experience_id: 'exp-1',
+  user_id: 'privy-1',
+  wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  status: 'created' as const,
+  qr_token_hash: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  expires_at: '2026-01-02T00:00:00.000Z',
+  completed_at: null,
+};
+
+const spendExperience = {
+  id: 'exp-1',
+  title: 'Event',
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+} as const;
+
+describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns 401 when wallet ownership fails', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: false,
+      error: 'Unauthorized',
+    });
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/conversion/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns success payload when conversion succeeds', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: true,
+      userId: 'privy-1',
+    });
+    mockGetPrivyUserId.mockResolvedValue('privy-1');
+    mockGetSpendContext.mockResolvedValue({
+      session,
+      spendExperience,
+      usdcAmount: 5,
+      pointsRequired: 5000,
+    });
+    mockResolve.mockReturnValue('distinct-1');
+    mockRunConfirm.mockResolvedValue({
+      ok: true,
+      pointConversion: {
+        id: 'conv-1',
+        spend_experience_id: spendExperience.id,
+        spend_session_id: session.id,
+        user_id: 'privy-1',
+        points_deducted: 5000,
+        usdc_amount: 5,
+        status: 'funded',
+        treasury_wallet_address: spendExperience.treasury_wallet_address,
+        user_wallet_address: session.wallet_address,
+        funding_tx_hash: '0xabc',
+        idempotency_key: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        completed_at: '2026-01-01T00:00:01.000Z',
+        failed_reason: null,
+      },
+      session: { ...session, status: 'conversion_complete' as const },
+      resumed: false,
+    });
+
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/conversion/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: session.wallet_address,
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as {
+      success: boolean;
+      data: { pointConversion: { status: string } };
+    };
+    expect(json.success).toBe(true);
+    expect(json.data.pointConversion.status).toBe('funded');
+  });
+});

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
+import { resolveServerIdentity } from '@/lib/analytics/server';
+import {
+  getSpendContextOr404,
+  runSpendConversionConfirm,
+} from '@/lib/spend-conversion-confirm';
+import { spendConversionConfirmBodySchema } from '@/lib/schemas/spend-session';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { sessionId: string } };
+
+/**
+ * POST /api/spend-sessions/{sessionId}/conversion/confirm
+ * Atomically deducts points, creates point conversion, sends treasury USDC to the user wallet (PRD §11).
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return apiError('Missing session id', 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  const parsed = spendConversionConfirmBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return apiValidationError(parsed.error);
+  }
+
+  const walletAddress = parsed.data.walletAddress.trim();
+  const normalizedWallet = walletAddress.toLowerCase();
+
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return apiError(auth.error ?? 'Unauthorized', 401);
+  }
+
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return apiError('Unauthorized', 401);
+  }
+
+  const ctx = await getSpendContextOr404(sessionId);
+  if ('error' in ctx) {
+    return apiError(ctx.error.error, ctx.error.httpStatus);
+  }
+
+  const { session, spendExperience, usdcAmount, pointsRequired } = ctx;
+
+  if (session.user_id !== auth.userId) {
+    return apiError('Forbidden', 403);
+  }
+
+  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
+    return apiError('Wallet does not match this session', 400);
+  }
+
+  const distinctId = resolveServerIdentity({
+    privyUserId: auth.userId,
+    walletAddress: normalizedWallet,
+  });
+
+  try {
+    const result = await runSpendConversionConfirm({
+      session,
+      spendExperience,
+      normalizedWallet,
+      authUserId: auth.userId,
+      distinctId,
+      usdcAmount,
+      pointsRequired,
+    });
+
+    if (!result.ok) {
+      return apiError(result.error, result.httpStatus);
+    }
+
+    return apiSuccess({
+      pointConversion: result.pointConversion,
+      session: {
+        id: result.session.id,
+        status: result.session.status,
+        expires_at: result.session.expires_at,
+      },
+      spendExperience: {
+        id: spendExperience.id,
+        title: spendExperience.title,
+        pointsRequired,
+        usdcAmount,
+      },
+      resumed: result.resumed,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Failed to confirm conversion';
+    console.error('POST conversion confirm:', e);
+    return apiError(msg, 500);
+  }
+}

--- a/database/spend-conversion-confirm-atomic.sql
+++ b/database/spend-conversion-confirm-atomic.sql
@@ -1,0 +1,212 @@
+-- Atomic spend pilot conversion: lock session + player, deduct points, insert point_conversions (`points_deducted`).
+-- Retries: if a conversion row already exists for the session, returns it without deducting again.
+
+CREATE OR REPLACE FUNCTION confirm_spend_conversion_atomic(
+  p_spend_session_id UUID,
+  p_user_id TEXT,
+  p_wallet_address TEXT,
+  p_spend_experience_id UUID,
+  p_points_to_deduct INTEGER,
+  p_usdc_amount NUMERIC(24, 8),
+  p_treasury_wallet_address TEXT,
+  p_user_wallet_address TEXT
+) RETURNS TABLE (
+  outcome TEXT,
+  conversion_id UUID,
+  player_total_points INTEGER
+) AS $$
+DECLARE
+  v_session spend_sessions%ROWTYPE;
+  v_existing_id UUID;
+  v_player_id BIGINT;
+  v_player_total INTEGER;
+  v_funded_exists BOOLEAN;
+BEGIN
+  IF p_points_to_deduct IS NULL OR p_points_to_deduct <= 0 THEN
+    RAISE EXCEPTION 'Invalid points amount';
+  END IF;
+
+  IF p_usdc_amount IS NULL OR p_usdc_amount <= 0 THEN
+    RAISE EXCEPTION 'Invalid USDC amount';
+  END IF;
+
+  SELECT *
+  INTO v_session
+  FROM spend_sessions
+  WHERE id = p_spend_session_id
+  FOR UPDATE;
+
+  IF v_session.id IS NULL THEN
+    RAISE EXCEPTION 'Spend session not found';
+  END IF;
+
+  IF v_session.user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Session does not belong to this user';
+  END IF;
+
+  IF lower(trim(v_session.wallet_address)) IS DISTINCT FROM lower(trim(p_wallet_address)) THEN
+    RAISE EXCEPTION 'Wallet does not match this session';
+  END IF;
+
+  IF v_session.spend_experience_id IS DISTINCT FROM p_spend_experience_id THEN
+    RAISE EXCEPTION 'Spend experience mismatch';
+  END IF;
+
+  SELECT pc.id
+  INTO v_existing_id
+  FROM point_conversions pc
+  WHERE pc.spend_session_id = p_spend_session_id
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL THEN
+    SELECT COALESCE(total_points, 0)::INTEGER
+    INTO v_player_total
+    FROM players
+    WHERE lower(trim(wallet_address)) = lower(trim(p_wallet_address));
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Player not found';
+    END IF;
+
+    RETURN QUERY SELECT 'already_exists'::TEXT, v_existing_id, v_player_total;
+    RETURN;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM point_conversions pc
+    WHERE pc.spend_experience_id = p_spend_experience_id
+      AND pc.user_id = p_user_id
+      AND pc.status = 'funded'
+  )
+  INTO v_funded_exists;
+
+  IF v_funded_exists THEN
+    RAISE EXCEPTION 'Already converted for this spend experience';
+  END IF;
+
+  SELECT id, COALESCE(total_points, 0)::INTEGER
+  INTO v_player_id, v_player_total
+  FROM players
+  WHERE lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found';
+  END IF;
+
+  IF v_player_total < p_points_to_deduct THEN
+    RAISE EXCEPTION 'Insufficient points';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) - p_points_to_deduct,
+      updated_at = NOW()
+  WHERE id = v_player_id
+  RETURNING total_points::INTEGER INTO v_player_total;
+
+  INSERT INTO point_conversions (
+    spend_experience_id,
+    spend_session_id,
+    user_id,
+    points_deducted,
+    usdc_amount,
+    status,
+    treasury_wallet_address,
+    user_wallet_address
+  )
+  VALUES (
+    p_spend_experience_id,
+    p_spend_session_id,
+    p_user_id,
+    p_points_to_deduct,
+    p_usdc_amount,
+    'points_deducted',
+    p_treasury_wallet_address,
+    p_user_wallet_address
+  )
+  RETURNING id INTO v_existing_id;
+
+  RETURN QUERY SELECT 'created'::TEXT, v_existing_id, v_player_total;
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE EXCEPTION 'Conversion already in progress';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION confirm_spend_conversion_atomic IS
+  'Spend pilot: atomically deduct points and create point_conversions row (pending). Idempotent per session if row exists.';
+
+-- Refund points and mark conversion failed (e.g. on-chain USDC send failed). Only when status is still `pending`.
+CREATE OR REPLACE FUNCTION refund_spend_conversion_on_funding_failure(
+  p_conversion_id UUID,
+  p_user_id TEXT,
+  p_spend_session_id UUID,
+  p_points_to_refund INTEGER,
+  p_failed_reason TEXT
+) RETURNS VOID AS $$
+DECLARE
+  v_status VARCHAR(32);
+  v_session TEXT;
+  v_user TEXT;
+  v_points NUMERIC(24, 8);
+  v_player_id BIGINT;
+BEGIN
+  IF p_points_to_refund IS NULL OR p_points_to_refund <= 0 THEN
+    RAISE EXCEPTION 'Invalid refund amount';
+  END IF;
+
+  SELECT status, user_id, spend_session_id, points_deducted
+  INTO v_status, v_user, v_session, v_points
+  FROM point_conversions
+  WHERE id = p_conversion_id
+  FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'Conversion not found';
+  END IF;
+
+  IF v_user IS DISTINCT FROM p_user_id OR v_session::TEXT IS DISTINCT FROM p_spend_session_id::TEXT THEN
+    RAISE EXCEPTION 'Conversion mismatch';
+  END IF;
+
+  IF v_status IS DISTINCT FROM 'points_deducted' THEN
+    RAISE EXCEPTION 'Conversion is not in points_deducted state';
+  END IF;
+
+  IF v_points::INTEGER IS DISTINCT FROM p_points_to_refund THEN
+    RAISE EXCEPTION 'Points amount mismatch';
+  END IF;
+
+  SELECT id
+  INTO v_player_id
+  FROM players
+  WHERE lower(trim(wallet_address)) = (
+    SELECT lower(trim(wallet_address)) FROM spend_sessions WHERE id = p_spend_session_id
+  )
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found for session';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) + p_points_to_refund,
+      updated_at = NOW()
+  WHERE id = v_player_id;
+
+  UPDATE point_conversions
+  SET
+    status = 'failed',
+    failed_reason = left(
+      COALESCE(p_failed_reason, 'funding_transaction_failed'),
+      256
+    ),
+    completed_at = NOW()
+  WHERE id = p_conversion_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION refund_spend_conversion_on_funding_failure IS
+  'Reverses a pending spend conversion: restores points to the user and marks the conversion as failed (PRD: rollback on funding failure / race).';

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -43,6 +43,9 @@ export const ANALYTICS_EVENTS = {
   SPEND_CONVERSION_PREVIEWED: 'spend_conversion_previewed',
   SPEND_USER_ALREADY_CONVERTED: 'spend_user_already_converted',
   SPEND_TREASURY_INSUFFICIENT_FUNDS: 'spend_treasury_insufficient_funds',
+  SPEND_CONVERSION_CONFIRMED: 'spend_conversion_confirmed',
+  SPEND_CONVERSION_COMPLETED: 'spend_conversion_completed',
+  SPEND_CONVERSION_FAILED: 'spend_conversion_failed',
 } as const;
 
 export type AnalyticsEventName =

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -299,3 +299,32 @@ export function trackSpendTreasuryInsufficientFunds(
     properties
   );
 }
+
+export function trackSpendConversionConfirmed(
+  distinctId: string,
+  properties: SpendPilotConversionEventProperties
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPEND_CONVERSION_CONFIRMED,
+    properties
+  );
+}
+
+export function trackSpendConversionCompleted(
+  distinctId: string,
+  properties: SpendPilotConversionEventProperties
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPEND_CONVERSION_COMPLETED,
+    properties
+  );
+}
+
+export function trackSpendConversionFailed(
+  distinctId: string,
+  properties: SpendPilotConversionEventProperties
+): void {
+  trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_CONVERSION_FAILED, properties);
+}

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -123,4 +123,9 @@ export interface SpendPilotConversionEventProperties {
   usdc_amount: number;
   status: string;
   error_reason?: string;
+  /** Point conversion row */
+  point_conversion_id?: string;
+  spend_session_id?: string;
+  /** On-chain USDC funding tx */
+  funding_tx_hash?: string | null;
 }

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -208,3 +208,129 @@ export async function createOrGetSpendSession(
   console.error('createOrGetSpendSession error:', insertError);
   throw new Error(insertError?.message || 'Failed to create spend session');
 }
+
+export type ConfirmSpendConversionRpcResult = {
+  outcome: 'created' | 'already_exists';
+  conversionId: string;
+  playerTotalPoints: number;
+};
+
+/**
+ * Atomically deduct points and create `point_conversions` (status `points_deducted`), or return existing
+ * conversion for the session. Requires `confirm_spend_conversion_atomic` in the database.
+ */
+export async function confirmSpendConversionAtomic(input: {
+  spendSessionId: string;
+  userId: string;
+  walletAddress: string;
+  spendExperienceId: string;
+  pointsToDeduct: number;
+  usdcAmount: number;
+  treasuryWalletAddress: string;
+  userWalletAddress: string;
+}): Promise<ConfirmSpendConversionRpcResult> {
+  const { data, error } = await supabase.rpc(
+    'confirm_spend_conversion_atomic',
+    {
+      p_spend_session_id: input.spendSessionId,
+      p_user_id: input.userId,
+      p_wallet_address: input.walletAddress,
+      p_spend_experience_id: input.spendExperienceId,
+      p_points_to_deduct: input.pointsToDeduct,
+      p_usdc_amount: input.usdcAmount,
+      p_treasury_wallet_address: input.treasuryWalletAddress,
+      p_user_wallet_address: input.userWalletAddress,
+    }
+  );
+
+  if (error) {
+    throw new Error(error.message || 'confirm_spend_conversion_atomic failed');
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  const outcome = row?.outcome as string | undefined;
+  const conversionId = row?.conversion_id as string | undefined;
+  const playerTotalPoints = row?.player_total_points;
+
+  if (
+    (outcome !== 'created' && outcome !== 'already_exists') ||
+    !conversionId ||
+    typeof playerTotalPoints !== 'number'
+  ) {
+    throw new Error(
+      'Unexpected RPC response from confirm_spend_conversion_atomic'
+    );
+  }
+
+  return {
+    outcome,
+    conversionId,
+    playerTotalPoints,
+  };
+}
+
+export async function updatePointConversionFields(
+  conversionId: string,
+  patch: Partial<
+    Pick<
+      PointConversion,
+      'status' | 'funding_tx_hash' | 'completed_at' | 'failed_reason'
+    >
+  >
+): Promise<PointConversion> {
+  const { data, error } = await supabase
+    .from('point_conversions')
+    .update(patch)
+    .eq('id', conversionId)
+    .select(CONVERSION_COLS)
+    .single();
+
+  if (error || !data) {
+    console.error('updatePointConversionFields:', error);
+    throw new Error(error?.message || 'Failed to update point conversion');
+  }
+  return rowToConversion(data as Record<string, unknown>);
+}
+
+export async function updateSpendSessionStatus(
+  sessionId: string,
+  status: SpendSessionStatus
+): Promise<void> {
+  const { error } = await supabase
+    .from('spend_sessions')
+    .update({ status })
+    .eq('id', sessionId);
+
+  if (error) {
+    console.error('updateSpendSessionStatus:', error);
+    throw new Error(error.message || 'Failed to update spend session');
+  }
+}
+
+/**
+ * If USDC transfer fails after points were deducted, refund points and mark conversion `failed`.
+ */
+export async function refundSpendConversionOnFundingFailure(input: {
+  conversionId: string;
+  userId: string;
+  spendSessionId: string;
+  pointsToRefund: number;
+  failedReason: string;
+}): Promise<void> {
+  const { error } = await supabase.rpc(
+    'refund_spend_conversion_on_funding_failure',
+    {
+      p_conversion_id: input.conversionId,
+      p_user_id: input.userId,
+      p_spend_session_id: input.spendSessionId,
+      p_points_to_refund: input.pointsToRefund,
+      p_failed_reason: input.failedReason,
+    }
+  );
+
+  if (error) {
+    throw new Error(
+      error.message || 'refund_spend_conversion_on_funding_failure failed'
+    );
+  }
+}

--- a/lib/schemas/spend-session.ts
+++ b/lib/schemas/spend-session.ts
@@ -27,3 +27,17 @@ export const spendConversionPreviewBodySchema = z.object({
 export type SpendConversionPreviewBody = z.infer<
   typeof spendConversionPreviewBodySchema
 >;
+
+/** POST /api/spend-sessions/{sessionId}/conversion/confirm */
+export const spendConversionConfirmBodySchema = z.object({
+  walletAddress: z
+    .string()
+    .min(1, 'walletAddress is required')
+    .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
+      message: 'walletAddress must be a valid EVM address',
+    }),
+});
+
+export type SpendConversionConfirmBody = z.infer<
+  typeof spendConversionConfirmBodySchema
+>;

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -1,0 +1,603 @@
+import { checkAndTrackTierProgression } from '@/lib/tier-progression';
+import { getPlayerByWallet } from '@/lib/db/players';
+import {
+  confirmSpendConversionAtomic,
+  getPointConversionBySessionId,
+  getSpendSessionById,
+  refundSpendConversionOnFundingFailure,
+  updatePointConversionFields,
+  updateSpendSessionStatus,
+} from '@/lib/db/spend-sessions';
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
+import {
+  computeConversionAmounts,
+  fetchTreasuryUsdcBalanceSafe,
+  loadSpendEligibilityForSession,
+} from '@/lib/spend-conversion-preview';
+import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
+import { getServerWalletAddress } from '@/lib/spend-treasury-usdc-transfer';
+import {
+  submitTreasuryUsdcTransfer,
+  waitForTreasuryTxReceipt,
+} from '@/lib/spend-treasury-usdc-transfer';
+import type {
+  PointConversion,
+  SpendExperience,
+  SpendSession,
+} from '@/lib/types';
+import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
+import {
+  resolveServerIdentity,
+  trackSpendConversionCompleted,
+  trackSpendConversionConfirmed,
+  trackSpendConversionFailed,
+  trackSpendTreasuryInsufficientFunds,
+} from '@/lib/analytics/server';
+import type { SpendPilotConversionEventProperties } from '@/lib/analytics/types';
+
+const RESUMABLE: PointConversion['status'][] = [
+  'points_deducted',
+  'funding_pending',
+];
+
+type ConfirmContext = {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  normalizedWallet: string;
+  authUserId: string;
+  distinctId: string;
+  usdcAmount: number;
+  pointsRequired: number;
+};
+
+function assertServerTreasuryMatchesExperience(
+  experience: SpendExperience
+):
+  | { ok: true; serverAddress: `0x${string}` }
+  | { ok: false; userMessage: string } {
+  const serverAddress = getServerWalletAddress();
+  if (!serverAddress) {
+    return { ok: false, userMessage: 'Conversion is temporarily unavailable.' };
+  }
+  const expected = experience.treasury_wallet_address.trim().toLowerCase();
+  const actual = serverAddress.toLowerCase();
+  if (expected !== actual) {
+    console.error(
+      'Treasury address mismatch: experience expects',
+      expected,
+      'server key derives',
+      actual
+    );
+    return {
+      ok: false,
+      userMessage:
+        'Conversion is not configured correctly. Please contact support.',
+    };
+  }
+  return { ok: true, serverAddress };
+}
+
+/**
+ * After successful conversion funding, set session to `conversion_complete` (PRD §11).
+ */
+async function markSessionAfterFunding(sessionId: string): Promise<void> {
+  await updateSpendSessionStatus(sessionId, 'conversion_complete');
+}
+
+export type SpendConversionConfirmResult =
+  | {
+      ok: true;
+      pointConversion: PointConversion;
+      session: SpendSession;
+      resumed: boolean;
+    }
+  | {
+      ok: false;
+      httpStatus: 400 | 401 | 403 | 404 | 409 | 500;
+      error: string;
+    };
+
+/**
+ * Core confirm / resume logic for spend pilot (used by API route and tests).
+ */
+export async function runSpendConversionConfirm(
+  input: ConfirmContext
+): Promise<SpendConversionConfirmResult> {
+  const { session, spendExperience, normalizedWallet, authUserId, distinctId } =
+    input;
+  const { usdcAmount, pointsRequired } = input;
+  const now = new Date();
+
+  const baseAnalytics: SpendPilotConversionEventProperties = {
+    spend_experience_id: spendExperience.id,
+    event_id: spendExperience.event_id,
+    user_id: authUserId,
+    wallet_address: normalizedWallet,
+    points_amount: pointsRequired,
+    usdc_amount: usdcAmount,
+    status: 'confirm',
+  };
+
+  let pointConversion = await getPointConversionBySessionId(session.id);
+
+  if (
+    pointConversion?.status === 'funded' ||
+    pointConversion?.status === 'failed'
+  ) {
+    if (pointConversion.status === 'funded') {
+      await markSessionAfterFunding(session.id);
+    }
+    const freshSession = await getSpendSessionById(session.id);
+    return {
+      ok: true,
+      pointConversion,
+      session: freshSession ?? session,
+      resumed: true,
+    };
+  }
+
+  if (pointConversion && RESUMABLE.includes(pointConversion.status)) {
+    const fundResult = await fundOrResumeUsdc({
+      pointConversion,
+      session,
+      spendExperience,
+      normalizedWallet,
+      usdcAmount,
+      distinctId,
+      baseAnalytics,
+    });
+    if (fundResult.error) {
+      return fundResult.error;
+    }
+    pointConversion = fundResult.conversion;
+    return {
+      ok: true,
+      pointConversion,
+      session: (await getSpendSessionById(session.id)) ?? session,
+      resumed: true,
+    };
+  }
+
+  const player = await getPlayerByWallet(normalizedWallet);
+  const preRpcPoints = player != null ? Number(player.total_points ?? 0) : 0;
+
+  if (now > new Date(session.expires_at)) {
+    return { ok: false, httpStatus: 400, error: 'This session has expired.' };
+  }
+
+  const openGate = assertSpendExperienceOpenForSessions(spendExperience, now);
+  if (!openGate.ok) {
+    return { ok: false, httpStatus: 400, error: openGate.error };
+  }
+
+  const eligibility = await loadSpendEligibilityForSession({
+    session,
+    spendExperience,
+    now,
+  });
+
+  if (eligibility.status === 'treasury_insufficient') {
+    trackSpendTreasuryInsufficientFunds(distinctId, {
+      ...baseAnalytics,
+      status: 'treasury_insufficient',
+      error_reason: 'treasury_insufficient',
+    });
+  }
+
+  if (eligibility.status !== 'eligible') {
+    return {
+      ok: false,
+      httpStatus: 400,
+      error: eligibility.message,
+    };
+  }
+
+  const bal = await fetchTreasuryUsdcBalanceSafe(
+    spendExperience.treasury_wallet_address
+  );
+  if (bal === null || bal < usdcAmount) {
+    trackSpendTreasuryInsufficientFunds(distinctId, {
+      ...baseAnalytics,
+      status: 'treasury_insufficient',
+      error_reason: 'treasury_insufficient_at_confirm',
+    });
+    return {
+      ok: false,
+      httpStatus: 400,
+      error: SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient,
+    };
+  }
+
+  const treasuryCheck = assertServerTreasuryMatchesExperience(spendExperience);
+  if (!treasuryCheck.ok) {
+    return {
+      ok: false,
+      httpStatus: 500,
+      error: treasuryCheck.userMessage,
+    };
+  }
+
+  if (!isEvmAddress(session.wallet_address.trim())) {
+    return {
+      ok: false,
+      httpStatus: 400,
+      error: 'Invalid wallet for this session.',
+    };
+  }
+
+  const recipient = session.wallet_address.trim() as `0x${string}`;
+
+  let rpc: Awaited<ReturnType<typeof confirmSpendConversionAtomic>>;
+  try {
+    rpc = await confirmSpendConversionAtomic({
+      spendSessionId: session.id,
+      userId: authUserId,
+      walletAddress: normalizedWallet,
+      spendExperienceId: spendExperience.id,
+      pointsToDeduct: pointsRequired,
+      usdcAmount,
+      treasuryWalletAddress: spendExperience.treasury_wallet_address,
+      userWalletAddress: session.wallet_address,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    if (msg.includes('Already converted for this spend experience')) {
+      return {
+        ok: false,
+        httpStatus: 409,
+        error: 'You have already completed a conversion for this event.',
+      };
+    }
+    if (
+      msg.includes('Insufficient points') ||
+      msg.includes('Player not found')
+    ) {
+      return { ok: false, httpStatus: 400, error: msg };
+    }
+    if (
+      msg.includes('PGRST202') ||
+      msg.includes('confirm_spend_conversion_atomic')
+    ) {
+      return {
+        ok: false,
+        httpStatus: 500,
+        error:
+          'Points conversion is not available yet. Please try again later.',
+      };
+    }
+    throw e;
+  }
+
+  let conv = (await getPointConversionBySessionId(session.id))!;
+  const previousPoints = preRpcPoints;
+  const newPoints = rpc.playerTotalPoints;
+
+  if (rpc.outcome === 'created') {
+    void checkAndTrackTierProgression(
+      resolveServerIdentity({
+        privyUserId: authUserId,
+        walletAddress: normalizedWallet,
+      }),
+      previousPoints,
+      newPoints
+    );
+
+    const confirmedProps = {
+      ...baseAnalytics,
+      point_conversion_id: conv.id,
+      spend_session_id: session.id,
+      status: 'points_deducted',
+    };
+    trackSpendConversionConfirmed(distinctId, confirmedProps);
+    await updateSpendSessionStatus(session.id, 'conversion_pending');
+  }
+
+  const userRecipient =
+    spendExperience.treasury_wallet_address.trim().toLowerCase() ===
+    recipient.toLowerCase()
+      ? (normalizedWallet as `0x${string}`)
+      : recipient;
+
+  const sub = await submitTreasuryUsdcTransfer({
+    recipientAddress: userRecipient,
+    usdcAmount,
+  });
+
+  if (!sub.ok) {
+    const failReason = sub.error.slice(0, 256);
+    try {
+      await refundSpendConversionOnFundingFailure({
+        conversionId: conv.id,
+        userId: authUserId,
+        spendSessionId: session.id,
+        pointsToRefund: pointsRequired,
+        failedReason: failReason,
+      });
+    } catch (refundErr) {
+      console.error('refund after funding failure:', refundErr);
+    }
+    const failedConv =
+      (await getPointConversionBySessionId(session.id)) ?? conv;
+    trackSpendConversionFailed(distinctId, {
+      ...baseAnalytics,
+      point_conversion_id: failedConv.id,
+      spend_session_id: session.id,
+      status: 'failed',
+      error_reason: `funding_submission_failed: ${failReason}`,
+    });
+
+    if (failedConv.user_id === authUserId) {
+      const distinct = resolveServerIdentity({
+        privyUserId: authUserId,
+        walletAddress: normalizedWallet,
+      });
+      void checkAndTrackTierProgression(
+        distinct,
+        newPoints,
+        newPoints + pointsRequired
+      );
+    }
+
+    return {
+      ok: false,
+      httpStatus: 400,
+      error: 'USDC transfer could not be sent. Your points have been restored.',
+    };
+  }
+
+  const txHash = sub.txHash;
+  conv = await updatePointConversionFields(conv.id, {
+    status: 'funding_pending',
+    funding_tx_hash: txHash,
+  });
+  await updateSpendSessionStatus(session.id, 'conversion_pending');
+
+  try {
+    await waitForTreasuryTxReceipt(txHash);
+  } catch (waitErr) {
+    const wmsg =
+      waitErr instanceof Error ? waitErr.message : 'receipt wait failed';
+    try {
+      await refundSpendConversionOnFundingFailure({
+        conversionId: conv.id,
+        userId: authUserId,
+        spendSessionId: session.id,
+        pointsToRefund: pointsRequired,
+        failedReason: wmsg.slice(0, 200),
+      });
+    } catch (refundErr) {
+      console.error('refund after wait failure:', refundErr);
+    }
+    const after = (await getPointConversionBySessionId(session.id)) ?? conv;
+    trackSpendConversionFailed(distinctId, {
+      ...baseAnalytics,
+      point_conversion_id: after.id,
+      spend_session_id: session.id,
+      status: 'failed',
+      error_reason: `funding_receipt_timeout: ${wmsg}`,
+    });
+
+    if (after.user_id === authUserId) {
+      const distinct = resolveServerIdentity({
+        privyUserId: authUserId,
+        walletAddress: normalizedWallet,
+      });
+      void checkAndTrackTierProgression(
+        distinct,
+        newPoints,
+        newPoints + pointsRequired
+      );
+    }
+    return {
+      ok: false,
+      httpStatus: 400,
+      error:
+        'The funding transaction could not be confirmed. Your points have been restored.',
+    };
+  }
+
+  const completed = await updatePointConversionFields(conv.id, {
+    status: 'funded',
+    completed_at: new Date().toISOString(),
+  });
+  await markSessionAfterFunding(session.id);
+  trackSpendConversionCompleted(distinctId, {
+    ...baseAnalytics,
+    point_conversion_id: completed.id,
+    spend_session_id: session.id,
+    status: 'funded',
+    funding_tx_hash: txHash,
+  });
+
+  return {
+    ok: true,
+    pointConversion: completed,
+    session: (await getSpendSessionById(session.id)) ?? session,
+    resumed: rpc.outcome === 'already_exists',
+  };
+}
+
+async function fundOrResumeUsdc(input: {
+  pointConversion: PointConversion;
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  normalizedWallet: string;
+  usdcAmount: number;
+  distinctId: string;
+  baseAnalytics: SpendPilotConversionEventProperties;
+}): Promise<
+  | { conversion: PointConversion; error: null }
+  | { error: SpendConversionConfirmResult; conversion?: never }
+> {
+  const {
+    pointConversion,
+    session,
+    spendExperience,
+    normalizedWallet,
+    usdcAmount,
+    distinctId,
+    baseAnalytics,
+  } = input;
+
+  const tre = assertServerTreasuryMatchesExperience(spendExperience);
+  if (!tre.ok) {
+    return {
+      error: {
+        ok: false,
+        httpStatus: 500,
+        error: tre.userMessage,
+      },
+    };
+  }
+
+  let conv = pointConversion;
+  if (conv.status === 'points_deducted' && !conv.funding_tx_hash) {
+    const recipient = session.wallet_address.trim() as `0x${string}`;
+    const userRecipient =
+      spendExperience.treasury_wallet_address.trim().toLowerCase() ===
+      recipient.toLowerCase()
+        ? (normalizedWallet as `0x${string}`)
+        : recipient;
+
+    const sub = await submitTreasuryUsdcTransfer({
+      recipientAddress: userRecipient,
+      usdcAmount,
+    });
+    if (!sub.ok) {
+      const fail = sub.error.slice(0, 256);
+      try {
+        await refundSpendConversionOnFundingFailure({
+          conversionId: conv.id,
+          userId: conv.user_id,
+          spendSessionId: session.id,
+          pointsToRefund: Math.ceil(Number(conv.points_deducted)),
+          failedReason: fail,
+        });
+      } catch (e) {
+        console.error('resume refund failed:', e);
+      }
+      trackSpendConversionFailed(distinctId, {
+        ...baseAnalytics,
+        point_conversion_id: conv.id,
+        spend_session_id: session.id,
+        status: 'failed',
+        error_reason: 'funding_submission_failed',
+      });
+
+      const p = await getPlayerByWallet(normalizedWallet);
+      if (p) {
+        const cur = Number(p.total_points ?? 0);
+        void checkAndTrackTierProgression(
+          resolveServerIdentity({ walletAddress: normalizedWallet }),
+          cur,
+          cur + Math.ceil(Number(conv.points_deducted))
+        );
+      }
+      return {
+        error: {
+          ok: false,
+          httpStatus: 400,
+          error:
+            'USDC transfer could not be sent. Your points have been restored.',
+        },
+      };
+    }
+    const txHash = sub.txHash;
+    conv = await updatePointConversionFields(conv.id, {
+      status: 'funding_pending',
+      funding_tx_hash: txHash,
+    });
+    await updateSpendSessionStatus(session.id, 'conversion_pending');
+  }
+
+  const hash = (conv.funding_tx_hash ?? null) as `0x${string}` | null;
+  if (!hash) {
+    return {
+      error: {
+        ok: false,
+        httpStatus: 500,
+        error: 'Missing funding transaction',
+      } as SpendConversionConfirmResult,
+    };
+  }
+
+  try {
+    await waitForTreasuryTxReceipt(hash);
+  } catch (e) {
+    const wmsg = e instanceof Error ? e.message : 'receipt error';
+    try {
+      await refundSpendConversionOnFundingFailure({
+        conversionId: conv.id,
+        userId: conv.user_id,
+        spendSessionId: session.id,
+        pointsToRefund: Math.ceil(Number(conv.points_deducted)),
+        failedReason: wmsg.slice(0, 200),
+      });
+    } catch (r) {
+      console.error('resume wait refund:', r);
+    }
+    return {
+      error: {
+        ok: false,
+        httpStatus: 400,
+        error:
+          'The funding transaction could not be confirmed. Your points have been restored.',
+      },
+    };
+  }
+
+  const done = await updatePointConversionFields(conv.id, {
+    status: 'funded',
+    completed_at: new Date().toISOString(),
+  });
+  await markSessionAfterFunding(session.id);
+  trackSpendConversionCompleted(distinctId, {
+    ...baseAnalytics,
+    point_conversion_id: done.id,
+    spend_session_id: session.id,
+    status: 'funded',
+    funding_tx_hash: hash,
+  });
+
+  return { conversion: done, error: null };
+}
+
+/**
+ * Fetches experience by session; returns 404 if missing.
+ */
+export async function getSpendContextOr404(sessionId: string): Promise<
+  | {
+      session: SpendSession;
+      spendExperience: SpendExperience;
+      usdcAmount: number;
+      pointsRequired: number;
+    }
+  | {
+      error: { httpStatus: 400 | 401 | 403 | 404 | 409 | 500; error: string };
+    }
+> {
+  const session = await getSpendSessionById(sessionId);
+  if (!session) {
+    return {
+      error: {
+        httpStatus: 404,
+        error: 'Spend session not found',
+      },
+    };
+  }
+  const spendExperience = await getSpendExperienceById(
+    session.spend_experience_id
+  );
+  if (!spendExperience) {
+    return {
+      error: {
+        httpStatus: 404,
+        error: 'Spend experience not found',
+      },
+    };
+  }
+  const { usdcAmount, pointsRequired } =
+    computeConversionAmounts(spendExperience);
+  return { session, spendExperience, usdcAmount, pointsRequired };
+}

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -16,8 +16,8 @@ import {
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
 import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
-import { getServerWalletAddress } from '@/lib/spend-treasury-usdc-transfer';
 import {
+  getServerWalletAddress,
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
 } from '@/lib/spend-treasury-usdc-transfer';
@@ -76,6 +76,51 @@ function assertServerTreasuryMatchesExperience(
     };
   }
   return { ok: true, serverAddress };
+}
+
+/**
+ * Treasury-funded USDC goes to the session embedded wallet. If session wallet equals treasury
+ * (misconfiguration), fall back to the normalized embedded address from auth.
+ */
+function recipientUsdcAddressForSpendTransfer(params: {
+  treasuryWalletAddress: string;
+  sessionWalletTrimmed: string;
+  normalizedWalletLower: string;
+}): `0x${string}` {
+  const treasuryLower = params.treasuryWalletAddress.trim().toLowerCase();
+  const sessionLower = params.sessionWalletTrimmed.toLowerCase();
+  if (treasuryLower === sessionLower) {
+    return params.normalizedWalletLower as `0x${string}`;
+  }
+  return params.sessionWalletTrimmed as `0x${string}`;
+}
+
+function restoreTierAfterRefund(params: {
+  authUserId: string;
+  normalizedWallet: string;
+  balanceAfterDeduction: number;
+  pointsRestored: number;
+}): void {
+  void checkAndTrackTierProgression(
+    resolveServerIdentity({
+      privyUserId: params.authUserId,
+      walletAddress: params.normalizedWallet,
+    }),
+    params.balanceAfterDeduction,
+    params.balanceAfterDeduction + params.pointsRestored
+  );
+}
+
+function restoreTierAfterRefundResumeOnlyWallet(params: {
+  normalizedWallet: string;
+  balanceNow: number;
+  pointsRestored: number;
+}): void {
+  void checkAndTrackTierProgression(
+    resolveServerIdentity({ walletAddress: params.normalizedWallet }),
+    params.balanceNow,
+    params.balanceNow + params.pointsRestored
+  );
 }
 
 /**
@@ -226,7 +271,11 @@ export async function runSpendConversionConfirm(
     };
   }
 
-  const recipient = session.wallet_address.trim() as `0x${string}`;
+  const userRecipient = recipientUsdcAddressForSpendTransfer({
+    treasuryWalletAddress: spendExperience.treasury_wallet_address,
+    sessionWalletTrimmed: session.wallet_address.trim(),
+    normalizedWalletLower: normalizedWallet,
+  });
 
   let rpc: Awaited<ReturnType<typeof confirmSpendConversionAtomic>>;
   try {
@@ -293,12 +342,6 @@ export async function runSpendConversionConfirm(
     await updateSpendSessionStatus(session.id, 'conversion_pending');
   }
 
-  const userRecipient =
-    spendExperience.treasury_wallet_address.trim().toLowerCase() ===
-    recipient.toLowerCase()
-      ? (normalizedWallet as `0x${string}`)
-      : recipient;
-
   const sub = await submitTreasuryUsdcTransfer({
     recipientAddress: userRecipient,
     usdcAmount,
@@ -328,15 +371,12 @@ export async function runSpendConversionConfirm(
     });
 
     if (failedConv.user_id === authUserId) {
-      const distinct = resolveServerIdentity({
-        privyUserId: authUserId,
-        walletAddress: normalizedWallet,
+      restoreTierAfterRefund({
+        authUserId,
+        normalizedWallet,
+        balanceAfterDeduction: newPoints,
+        pointsRestored: pointsRequired,
       });
-      void checkAndTrackTierProgression(
-        distinct,
-        newPoints,
-        newPoints + pointsRequired
-      );
     }
 
     return {
@@ -379,15 +419,12 @@ export async function runSpendConversionConfirm(
     });
 
     if (after.user_id === authUserId) {
-      const distinct = resolveServerIdentity({
-        privyUserId: authUserId,
-        walletAddress: normalizedWallet,
+      restoreTierAfterRefund({
+        authUserId,
+        normalizedWallet,
+        balanceAfterDeduction: newPoints,
+        pointsRestored: pointsRequired,
       });
-      void checkAndTrackTierProgression(
-        distinct,
-        newPoints,
-        newPoints + pointsRequired
-      );
     }
     return {
       ok: false,
@@ -453,12 +490,11 @@ async function fundOrResumeUsdc(input: {
 
   let conv = pointConversion;
   if (conv.status === 'points_deducted' && !conv.funding_tx_hash) {
-    const recipient = session.wallet_address.trim() as `0x${string}`;
-    const userRecipient =
-      spendExperience.treasury_wallet_address.trim().toLowerCase() ===
-      recipient.toLowerCase()
-        ? (normalizedWallet as `0x${string}`)
-        : recipient;
+    const userRecipient = recipientUsdcAddressForSpendTransfer({
+      treasuryWalletAddress: spendExperience.treasury_wallet_address,
+      sessionWalletTrimmed: session.wallet_address.trim(),
+      normalizedWalletLower: normalizedWallet,
+    });
 
     const sub = await submitTreasuryUsdcTransfer({
       recipientAddress: userRecipient,
@@ -488,11 +524,12 @@ async function fundOrResumeUsdc(input: {
       const p = await getPlayerByWallet(normalizedWallet);
       if (p) {
         const cur = Number(p.total_points ?? 0);
-        void checkAndTrackTierProgression(
-          resolveServerIdentity({ walletAddress: normalizedWallet }),
-          cur,
-          cur + Math.ceil(Number(conv.points_deducted))
-        );
+        const refunded = Math.ceil(Number(conv.points_deducted));
+        restoreTierAfterRefundResumeOnlyWallet({
+          normalizedWallet,
+          balanceNow: cur,
+          pointsRestored: refunded,
+        });
       }
       return {
         error: {

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -1,0 +1,101 @@
+import {
+  createPublicClient,
+  createWalletClient,
+  erc20Abi,
+  http,
+  parseUnits,
+} from 'viem';
+import { privateKeyToAccount } from 'viem/accounts';
+import { getServerPrivateKey } from '@/lib/server-private-key';
+import {
+  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+  POSTER_CHECKOUT_CHAIN,
+} from '@/lib/walletconnect-poster-direct-usdc';
+
+export type TreasuryUsdcSubmitResult =
+  | { ok: true; txHash: `0x${string}` }
+  | { ok: false; error: string };
+
+/**
+ * Submits a USDC transfer on Base from the server wallet; returns the tx hash immediately
+ * so the caller can persist it before awaiting confirmation.
+ */
+export async function submitTreasuryUsdcTransfer(params: {
+  recipientAddress: `0x${string}`;
+  /** Human-readable USDC amount (6 decimals). */
+  usdcAmount: number;
+}): Promise<TreasuryUsdcSubmitResult> {
+  const rpcUrl = process.env.NEXT_PUBLIC_BASE_RPC?.trim();
+  if (!rpcUrl) {
+    return { ok: false, error: 'RPC not configured' };
+  }
+
+  const pk = getServerPrivateKey();
+  if (!pk) {
+    return { ok: false, error: 'Server wallet not configured' };
+  }
+
+  const trimmedPk = pk.startsWith('0x') ? pk : `0x${pk}`;
+  let account;
+  try {
+    account = privateKeyToAccount(trimmedPk as `0x${string}`);
+  } catch {
+    return { ok: false, error: 'Invalid server wallet key' };
+  }
+
+  const transport = http(rpcUrl);
+  const walletClient = createWalletClient({
+    account,
+    chain: POSTER_CHECKOUT_CHAIN,
+    transport,
+  });
+
+  const rawAmount = parseUnits(params.usdcAmount.toFixed(6), 6);
+
+  try {
+    const hash = await walletClient.writeContract({
+      account,
+      address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+      abi: erc20Abi,
+      functionName: 'transfer',
+      args: [params.recipientAddress, rawAmount],
+      chain: POSTER_CHECKOUT_CHAIN,
+    });
+    return { ok: true, txHash: hash };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'USDC transfer failed';
+    console.error('submitTreasuryUsdcTransfer:', e);
+    return { ok: false, error: msg };
+  }
+}
+
+export async function waitForTreasuryTxReceipt(
+  txHash: `0x${string}`
+): Promise<void> {
+  const rpcUrl = process.env.NEXT_PUBLIC_BASE_RPC?.trim();
+  if (!rpcUrl) {
+    throw new Error('RPC not configured');
+  }
+  const publicClient = createPublicClient({
+    chain: POSTER_CHECKOUT_CHAIN,
+    transport: http(rpcUrl),
+  });
+  await publicClient.waitForTransactionReceipt({
+    hash: txHash,
+    timeout: 120_000,
+  });
+}
+
+/**
+ * Address derived from `SERVER_WALLET_PRIVATE_KEY` / `SERVER_PRIVATE_KEY`, or null if missing/invalid.
+ */
+export function getServerWalletAddress(): `0x${string}` | null {
+  const pk = getServerPrivateKey();
+  if (!pk) return null;
+  const trimmed = pk.startsWith('0x') ? pk : `0x${pk}`;
+  try {
+    return privateKeyToAccount(trimmed as `0x${string}`).address;
+  } catch {
+    return null;
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **`POST /api/spend-sessions/{sessionId}/conversion/confirm`** for [issue #507](https://github.com/hurley87/refraction/issues/507): Privy-authenticated conversion confirmation with atomic points deduction, treasury balance re-check, Base USDC funding from the server wallet, idempotent retries, Mixpanel events, and refund-on-funding-failure behavior.

## What changed

- **API route** `app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts` — same auth pattern as conversion preview (wallet ownership + Bearer token).
- **Orchestration** `lib/spend-conversion-confirm.ts` — eligibility + on-chain treasury balance check before deduction; resumes `points_deducted` / `funding_pending`; updates session status through the PRD flow.
- **DB** `database/spend-conversion-confirm-atomic.sql` — `confirm_spend_conversion_atomic` (lock session + player, deduct points, insert `point_conversions` with status `points_deducted`) and `refund_spend_conversion_on_funding_failure` when funding fails after deduction.
- **Chain** `lib/spend-treasury-usdc-transfer.ts` — viem ERC-20 transfer on Base using official USDC from `lib/walletconnect-poster-direct-usdc.ts` and `SERVER_WALLET_PRIVATE_KEY` / `SERVER_PRIVATE_KEY`.
- **Analytics** — `spend_conversion_confirmed`, `spend_conversion_completed`, `spend_conversion_failed` (plus optional props on conversion events).

## Ops / configuration

- Apply **`database/spend-conversion-confirm-atomic.sql`** to Supabase before relying on production conversion.
- **`SERVER_WALLET_PRIVATE_KEY`** must derive the same address as **`treasury_wallet_address`** on the spend experience (otherwise confirm returns a configuration error).
- **`NEXT_PUBLIC_BASE_RPC`** required for reads and writes.

## Race / insufficient treasury

- Treasury USDC is re-read immediately before the atomic RPC; if insufficient, **no points are deducted**.
- If balance drops **after** deduction but **before** a successful send, the refund RPC restores points and sets conversion `failed` with `failed_reason`.

## Tests

- `app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts`
- `yarn build` passes.

Closes #507 when merged (unblocks follow-on payment work).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dc4195db-8a70-41fb-a796-5d9ba4f0927e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dc4195db-8a70-41fb-a796-5d9ba4f0927e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

