### PR TITLE
Spend pilot: USDC payment confirm, receipt, and analytics (#508)

### DIFF
--- a/app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyWallet = vi.fn();
+const mockGetPrivyUserId = vi.fn();
+const mockGetCtx = vi.fn();
+const mockRunConfirm = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
+  getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+}));
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: () => 'distinct-1',
+}));
+
+vi.mock('@/lib/spend-payment-confirm', () => ({
+  getSpendPaymentContextOr404: (...a: unknown[]) => mockGetCtx(...a),
+  runSpendPaymentConfirm: (...a: unknown[]) => mockRunConfirm(...a),
+}));
+
+import { POST } from '../route';
+
+const spendTx = {
+  id: 'tx-1',
+  spend_experience_id: 'exp-1',
+  spend_session_id: 'sess-1',
+  user_id: 'privy-1',
+  usdc_amount: 5,
+  from_wallet_address: '0xabc',
+  to_wallet_address: '0xdef',
+  status: 'confirmed' as const,
+  payment_tx_hash: '0x' + '1'.repeat(64),
+  idempotency_key: 'k',
+  created_at: '2026-01-01T00:00:00.000Z',
+  completed_at: '2026-01-01T00:00:01.000Z',
+  failed_reason: null,
+};
+
+describe('POST /api/spend-sessions/[sessionId]/payment/confirm', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyWallet.mockResolvedValue({ authorized: true, userId: 'privy-1' });
+    mockGetPrivyUserId.mockResolvedValue('privy-1');
+    mockGetCtx.mockResolvedValue({
+      session: {
+        id: 'sess-1',
+        user_id: 'privy-1',
+        wallet_address: '0xabcdef0123456789012345678901234567890abc',
+      },
+      spendExperience: { id: 'exp-1' },
+      usdcAmount: 5,
+    });
+    mockRunConfirm.mockResolvedValue({
+      ok: true,
+      spendTransaction: spendTx,
+      session: {
+        id: 'sess-1',
+        status: 'payment_complete',
+        expires_at: '2026-01-02T00:00:00.000Z',
+        completed_at: '2026-01-01T00:00:01.000Z',
+      },
+      resumed: false,
+    });
+  });
+
+  it('returns 200 with spend transaction on success', async () => {
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/payment/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: '0xAbCdEf0123456789012345678901234567890aBc',
+          paymentTxHash: '0x' + 'a'.repeat(64),
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.data.spendTransaction.id).toBe('tx-1');
+    expect(j.data.session.status).toBe('payment_complete');
+  });
+
+  it('returns 400 for invalid paymentTxHash', async () => {
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/payment/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: '0xAbCdEf0123456789012345678901234567890aBc',
+          paymentTxHash: 'not-a-hash',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
+import { resolveServerIdentity } from '@/lib/analytics/server';
+import {
+  getSpendPaymentContextOr404,
+  runSpendPaymentConfirm,
+} from '@/lib/spend-payment-confirm';
+import { spendPaymentConfirmBodySchema } from '@/lib/schemas/spend-session';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { sessionId: string } };
+
+/**
+ * POST /api/spend-sessions/{sessionId}/payment/confirm
+ * Verifies on-chain Base USDC transfer from the session wallet to the experience receiving wallet.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return apiError('Missing session id', 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  const parsed = spendPaymentConfirmBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return apiValidationError(parsed.error);
+  }
+
+  const walletAddress = parsed.data.walletAddress.trim();
+  const normalizedWallet = walletAddress.toLowerCase();
+  const paymentTxHash = parsed.data.paymentTxHash.trim();
+
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return apiError(auth.error ?? 'Unauthorized', 401);
+  }
+
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return apiError('Unauthorized', 401);
+  }
+
+  const ctx = await getSpendPaymentContextOr404(sessionId);
+  if ('error' in ctx) {
+    return apiError(ctx.error, ctx.httpStatus);
+  }
+
+  const { session, spendExperience, usdcAmount } = ctx;
+
+  if (session.user_id !== auth.userId) {
+    return apiError('Forbidden', 403);
+  }
+
+  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
+    return apiError('Wallet does not match this session', 400);
+  }
+
+  const distinctId = resolveServerIdentity({
+    privyUserId: auth.userId,
+    walletAddress: normalizedWallet,
+  });
+
+  try {
+    const result = await runSpendPaymentConfirm({
+      session,
+      spendExperience,
+      normalizedWallet,
+      authUserId: auth.userId,
+      distinctId,
+      paymentTxHash,
+      usdcAmount,
+    });
+
+    if (!result.ok) {
+      return apiError(result.error, result.httpStatus);
+    }
+
+    return apiSuccess({
+      spendTransaction: result.spendTransaction,
+      session: {
+        id: result.session.id,
+        status: result.session.status,
+        expires_at: result.session.expires_at,
+        completed_at: result.session.completed_at,
+      },
+      resumed: result.resumed,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Failed to confirm payment';
+    console.error('POST payment confirm:', e);
+    return apiError(msg, 500);
+  }
+}

--- a/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
@@ -14,6 +14,7 @@ vi.mock('@/lib/api/privy', () => ({
 vi.mock('@/lib/db/spend-sessions', () => ({
   getSpendSessionById: (...a: unknown[]) => mockGetSession(...a),
   getPointConversionBySessionId: (...a: unknown[]) => mockGetConversion(...a),
+  getSpendTransactionBySessionId: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/db/spend-experiences', () => ({
@@ -23,6 +24,11 @@ vi.mock('@/lib/db/spend-experiences', () => ({
 vi.mock('@/lib/spend-conversion-preview', () => ({
   loadSpendEligibilityForSession: (...a: unknown[]) =>
     mockLoadEligibility(...a),
+}));
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: () => 'distinct-1',
+  trackSpendReceiptViewed: vi.fn(),
 }));
 
 import { GET } from '../route';

--- a/app/api/spend-sessions/[sessionId]/receipt/route.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/route.ts
@@ -3,10 +3,15 @@ import { getPrivyUserIdFromRequest } from '@/lib/api/privy';
 import {
   getSpendSessionById,
   getPointConversionBySessionId,
+  getSpendTransactionBySessionId,
 } from '@/lib/db/spend-sessions';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { apiSuccess, apiError } from '@/lib/api/response';
 import { loadSpendEligibilityForSession } from '@/lib/spend-conversion-preview';
+import {
+  resolveServerIdentity,
+  trackSpendReceiptViewed,
+} from '@/lib/analytics/server';
 
 export const dynamic = 'force-dynamic';
 
@@ -36,10 +41,12 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return apiError('Forbidden', 403);
   }
 
-  const [spendExperience, pointConversion] = await Promise.all([
-    getSpendExperienceById(session.spend_experience_id),
-    getPointConversionBySessionId(sessionId),
-  ]);
+  const [spendExperience, pointConversion, spendTransaction] =
+    await Promise.all([
+      getSpendExperienceById(session.spend_experience_id),
+      getPointConversionBySessionId(sessionId),
+      getSpendTransactionBySessionId(sessionId),
+    ]);
 
   if (!spendExperience) {
     return apiError('Spend experience not found', 404);
@@ -51,10 +58,29 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       spendExperience,
     });
 
+    const distinctId = resolveServerIdentity({
+      privyUserId: userId,
+      walletAddress: session.wallet_address.toLowerCase(),
+    });
+    trackSpendReceiptViewed(distinctId, {
+      spend_experience_id: spendExperience.id,
+      event_id: spendExperience.event_id,
+      user_id: userId,
+      wallet_address: session.wallet_address.toLowerCase(),
+      points_amount: pointConversion?.points_deducted ?? 0,
+      usdc_amount: pointConversion?.usdc_amount ?? 0,
+      status: session.status,
+      spend_session_id: session.id,
+      point_conversion_id: pointConversion?.id,
+      spend_transaction_id: spendTransaction?.id,
+      payment_tx_hash: spendTransaction?.payment_tx_hash ?? null,
+    });
+
     return apiSuccess({
       session,
       spendExperience,
       pointConversion,
+      spendTransaction,
       eligibility,
     });
   } catch (e) {

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -135,6 +135,17 @@ function toEvmHexAddress(value: string | undefined): `0x${string}` | null {
   return value && isEvmAddress(value) ? (value as `0x${string}`) : null;
 }
 
+function eligibilityToneClass(status: SpendEligibilityStatus): string {
+  if (
+    status === 'eligible' ||
+    status === 'ready_for_payment' ||
+    status === 'payment_complete'
+  ) {
+    return 'text-sm text-emerald-800';
+  }
+  return 'text-sm text-amber-900';
+}
+
 /**
  * Spend pilot: opens from QR at `/spend/{experienceId}`; creates/returns a session when authed.
  */
@@ -148,16 +159,15 @@ export function SpendExperiencePage({
   const walletAddress = user?.wallet?.address;
   const [trackedScan, setTrackedScan] = useState(false);
 
-  const address = walletAddress;
   const evmWallet = useMemo(() => {
-    if (!address) return null;
-    const lower = address.toLowerCase();
+    if (!walletAddress) return null;
+    const lower = walletAddress.toLowerCase();
     return (
       wallets.find((w) => w.address.toLowerCase() === lower) ??
       wallets[0] ??
       null
     );
-  }, [address, wallets]);
+  }, [walletAddress, wallets]);
 
   const {
     data: sessionPayload,
@@ -281,7 +291,7 @@ export function SpendExperiencePage({
   });
 
   const sendUsdcPayment = useCallback(async () => {
-    if (!address || !evmWallet || !previewPayload?.eligibility.preview) {
+    if (!walletAddress || !evmWallet || !previewPayload?.eligibility.preview) {
       toast.error('Wallet not ready');
       return;
     }
@@ -308,7 +318,7 @@ export function SpendExperiencePage({
           method: 'eth_sendTransaction',
           params: [
             {
-              from: address,
+              from: walletAddress,
               to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
               data,
             },
@@ -323,7 +333,7 @@ export function SpendExperiencePage({
       const msg = e instanceof Error ? e.message : String(e);
       toast.error(msg);
     }
-  }, [address, evmWallet, previewPayload, paymentMutation]);
+  }, [walletAddress, evmWallet, previewPayload, paymentMutation]);
 
   useEffect(() => {
     const fireScan = async () => {
@@ -369,6 +379,8 @@ export function SpendExperiencePage({
     isEvmAddress(preview.receivingWalletAddress);
 
   const receiptSession = receiptPayload?.session ?? session;
+  const receiptConversion = receiptPayload?.pointConversion;
+  const receiptPaymentHash = receiptPayload?.spendTransaction?.payment_tx_hash;
 
   const displayReceipt =
     elig?.status === 'payment_complete' || sessionStatus === 'payment_complete';
@@ -477,15 +489,7 @@ export function SpendExperiencePage({
                     </div>
                   )}
 
-                  <p
-                    className={
-                      elig.status === 'eligible' ||
-                      elig.status === 'ready_for_payment' ||
-                      elig.status === 'payment_complete'
-                        ? 'text-sm text-emerald-800'
-                        : 'text-sm text-amber-900'
-                    }
-                  >
+                  <p className={eligibilityToneClass(elig.status)}>
                     {elig.message}
                   </p>
 
@@ -518,7 +522,7 @@ export function SpendExperiencePage({
                           Pay with USDC…
                         </>
                       ) : (
-                        `Send $${preview!.usdcAmount.toFixed(2)} USDC on Base`
+                        `Send $${preview.usdcAmount.toFixed(2)} USDC on Base`
                       )}
                     </Button>
                   )}
@@ -533,7 +537,7 @@ export function SpendExperiencePage({
                         <span className="font-medium">
                           $
                           {(
-                            receiptPayload?.pointConversion?.usdc_amount ??
+                            receiptConversion?.usdc_amount ??
                             preview?.usdcAmount ??
                             0
                           ).toFixed(2)}{' '}
@@ -544,7 +548,7 @@ export function SpendExperiencePage({
                         <span className="text-neutral-600">Points used</span>
                         <span className="font-medium">
                           {Number(
-                            receiptPayload?.pointConversion?.points_deducted ??
+                            receiptConversion?.points_deducted ??
                               preview?.pointsRequired ??
                               0
                           ).toLocaleString()}
@@ -556,12 +560,9 @@ export function SpendExperiencePage({
                           {receiptSession?.id}
                         </p>
                       </div>
-                      {(receiptPayload?.spendTransaction?.payment_tx_hash ??
-                        null) && (
+                      {receiptPaymentHash && (
                         <a
-                          href={basescanUrl(
-                            receiptPayload!.spendTransaction!.payment_tx_hash!
-                          )}
+                          href={basescanUrl(receiptPaymentHash)}
                           target="_blank"
                           rel="noreferrer"
                           className="inline-flex items-center gap-1 text-sm font-medium text-emerald-900 underline"

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -1,18 +1,31 @@
 'use client';
 
-import { useEffect, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { usePrivy } from '@privy-io/react-auth';
-import { Loader2 } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePrivy, useWallets } from '@privy-io/react-auth';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
-import type { SpendExperience, SpendSession } from '@/lib/types';
+import type {
+  PointConversion,
+  SpendExperience,
+  SpendSession,
+  SpendTransaction,
+} from '@/lib/types';
 import { initMixpanel, trackEvent } from '@/lib/analytics';
 import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
-import { apiClient } from '@/lib/api/client';
+import { apiClient, ApiError } from '@/lib/api/client';
 import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
+import {
+  encodeUsdcTransferData,
+  isEvmAddress,
+  POSTER_CHECKOUT_CHAIN_ID,
+  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+} from '@/lib/walletconnect-poster-direct-usdc';
+import type { BrowserProvider } from '@/lib/walletconnect-pay/sign-wallet-rpc-action';
 
 type SpendExperiencePageProps = {
   experienceId: string;
@@ -42,11 +55,64 @@ type ConversionPreviewResponse = {
   session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
 };
 
-/** POST with Bearer token + `{ walletAddress }` body (session + preview APIs). */
+type ConversionConfirmResponse = {
+  pointConversion: PointConversion;
+  session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
+  spendExperience: {
+    id: string;
+    title: string;
+    pointsRequired: number;
+    usdcAmount: number;
+  };
+  resumed: boolean;
+};
+
+type PaymentConfirmResponse = {
+  spendTransaction: SpendTransaction;
+  session: Pick<SpendSession, 'id' | 'status' | 'expires_at' | 'completed_at'>;
+  resumed: boolean;
+};
+
+type ReceiptResponse = {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  pointConversion: PointConversion | null;
+  spendTransaction: SpendTransaction | null;
+  eligibility: ConversionPreviewResponse['eligibility'];
+};
+
+const WALLET_STEP_TIMEOUT_MS = 180_000;
+
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> {
+  return new Promise((resolve, reject) => {
+    const id = window.setTimeout(() => {
+      reject(
+        new Error(
+          `${label} timed out. Check your wallet or network, then try again.`
+        )
+      );
+    }, ms);
+    promise
+      .then((v) => {
+        clearTimeout(id);
+        resolve(v);
+      })
+      .catch((e) => {
+        clearTimeout(id);
+        reject(e);
+      });
+  });
+}
+
+/** POST with Bearer token + JSON body. */
 async function spendAuthedPost<T>(
   token: string,
-  walletAddress: string,
-  path: string
+  path: string,
+  body: Record<string, unknown>
 ): Promise<T> {
   return apiClient<T>(path, {
     method: 'POST',
@@ -54,8 +120,19 @@ async function spendAuthedPost<T>(
       Authorization: `Bearer ${token}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ walletAddress }),
+    body: JSON.stringify(body),
   });
+}
+
+async function spendAuthedGet<T>(token: string, path: string): Promise<T> {
+  return apiClient<T>(path, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+function toEvmHexAddress(value: string | undefined): `0x${string}` | null {
+  return value && isEvmAddress(value) ? (value as `0x${string}`) : null;
 }
 
 /**
@@ -66,8 +143,21 @@ export function SpendExperiencePage({
   initialExperience,
 }: SpendExperiencePageProps) {
   const { user, login, getAccessToken } = usePrivy();
+  const { wallets } = useWallets();
+  const queryClient = useQueryClient();
   const walletAddress = user?.wallet?.address;
   const [trackedScan, setTrackedScan] = useState(false);
+
+  const address = walletAddress;
+  const evmWallet = useMemo(() => {
+    if (!address) return null;
+    const lower = address.toLowerCase();
+    return (
+      wallets.find((w) => w.address.toLowerCase() === lower) ??
+      wallets[0] ??
+      null
+    );
+  }, [address, wallets]);
 
   const {
     data: sessionPayload,
@@ -82,8 +172,8 @@ export function SpendExperiencePage({
       }
       return spendAuthedPost<SessionResponse>(
         token,
-        walletAddress,
-        `/api/spend-experiences/${experienceId}/sessions`
+        `/api/spend-experiences/${experienceId}/sessions`,
+        { walletAddress }
       );
     },
     enabled: Boolean(user && walletAddress),
@@ -106,13 +196,134 @@ export function SpendExperiencePage({
       }
       return spendAuthedPost<ConversionPreviewResponse>(
         token,
-        walletAddress,
-        `/api/spend-sessions/${sessionId}/conversion/preview`
+        `/api/spend-sessions/${sessionId}/conversion/preview`,
+        { walletAddress }
       );
     },
     enabled: Boolean(user && walletAddress && sessionId && !isFetching),
     retry: false,
   });
+
+  const sessionStatus = previewPayload?.session?.status;
+
+  const { data: receiptPayload } = useQuery({
+    queryKey: ['spend-receipt', sessionId, user?.id, walletAddress] as const,
+    queryFn: async () => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress || !sessionId) {
+        throw new Error('Missing auth or session');
+      }
+      return spendAuthedGet<ReceiptResponse>(
+        token,
+        `/api/spend-sessions/${sessionId}/receipt`
+      );
+    },
+    enabled: Boolean(
+      user && walletAddress && sessionId && sessionStatus === 'payment_complete'
+    ),
+    retry: false,
+  });
+
+  const invalidateSpendQueries = useCallback(async () => {
+    await queryClient.invalidateQueries({
+      queryKey: ['spend-conversion-preview', sessionId],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: ['spend-session', experienceId],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: ['spend-receipt', sessionId],
+    });
+  }, [queryClient, sessionId, experienceId]);
+
+  const conversionMutation = useMutation({
+    mutationFn: async () => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress || !sessionId) {
+        throw new Error('Missing auth or session');
+      }
+      return spendAuthedPost<ConversionConfirmResponse>(
+        token,
+        `/api/spend-sessions/${sessionId}/conversion/confirm`,
+        { walletAddress }
+      );
+    },
+    onSuccess: async () => {
+      toast.success('USDC is on the way to your wallet.');
+      await invalidateSpendQueries();
+    },
+    onError: (e) => {
+      const msg = e instanceof ApiError ? e.message : String(e);
+      toast.error(msg);
+    },
+  });
+
+  const paymentMutation = useMutation({
+    mutationFn: async (paymentTxHash: string) => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress || !sessionId) {
+        throw new Error('Missing auth or session');
+      }
+      return spendAuthedPost<PaymentConfirmResponse>(
+        token,
+        `/api/spend-sessions/${sessionId}/payment/confirm`,
+        { walletAddress, paymentTxHash }
+      );
+    },
+    onSuccess: async () => {
+      toast.success('Payment recorded. Thank you!');
+      await invalidateSpendQueries();
+    },
+    onError: (e) => {
+      const msg = e instanceof ApiError ? e.message : String(e);
+      toast.error(msg);
+    },
+  });
+
+  const sendUsdcPayment = useCallback(async () => {
+    if (!address || !evmWallet || !previewPayload?.eligibility.preview) {
+      toast.error('Wallet not ready');
+      return;
+    }
+    const preview = previewPayload.eligibility.preview;
+    const recipient = toEvmHexAddress(preview.receivingWalletAddress);
+    if (!recipient) {
+      toast.error('Invalid receiving wallet');
+      return;
+    }
+
+    try {
+      await withTimeout(
+        evmWallet.switchChain(POSTER_CHECKOUT_CHAIN_ID),
+        WALLET_STEP_TIMEOUT_MS,
+        'Switching to Base in your wallet'
+      );
+      const provider = await evmWallet.getEthereumProvider();
+      if (!provider) {
+        throw new Error('Could not connect to your wallet');
+      }
+      const data = encodeUsdcTransferData(recipient, preview.usdcAmount);
+      const hash = await withTimeout(
+        (provider as unknown as BrowserProvider).request({
+          method: 'eth_sendTransaction',
+          params: [
+            {
+              from: address,
+              to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+              data,
+            },
+          ],
+        }) as Promise<string>,
+        WALLET_STEP_TIMEOUT_MS,
+        'Confirm the USDC payment in your wallet'
+      );
+      const txHash = typeof hash === 'string' ? hash : String(hash);
+      await paymentMutation.mutateAsync(txHash);
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      toast.error(msg);
+    }
+  }, [address, evmWallet, previewPayload, paymentMutation]);
 
   useEffect(() => {
     const fireScan = async () => {
@@ -145,6 +356,25 @@ export function SpendExperiencePage({
   const preview = elig?.preview;
   const showSessionError = user && walletAddress && sessionError;
   const showWalletBlock = user && !walletAddress;
+
+  const showConvert =
+    elig?.status === 'eligible' &&
+    preview &&
+    (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
+
+  const showPay =
+    (elig?.status === 'ready_for_payment' ||
+      elig?.status === 'payment_failed') &&
+    preview &&
+    isEvmAddress(preview.receivingWalletAddress);
+
+  const receiptSession = receiptPayload?.session ?? session;
+
+  const displayReceipt =
+    elig?.status === 'payment_complete' || sessionStatus === 'payment_complete';
+
+  const basescanUrl = (hash: string) =>
+    `https://basescan.org/tx/${hash.trim()}`;
 
   return (
     <div className="container mx-auto max-w-lg p-6">
@@ -238,7 +468,7 @@ export function SpendExperiencePage({
                       )}
                       <div className="border-t border-neutral-100 pt-2">
                         <p className="text-xs text-neutral-500">
-                          Pay to (IRL / event)
+                          Event wallet (USDC on Base)
                         </p>
                         <p className="break-all font-mono text-xs text-[#171717]">
                           {preview.receivingWalletAddress}
@@ -249,13 +479,99 @@ export function SpendExperiencePage({
 
                   <p
                     className={
-                      elig.status === 'eligible'
+                      elig.status === 'eligible' ||
+                      elig.status === 'ready_for_payment' ||
+                      elig.status === 'payment_complete'
                         ? 'text-sm text-emerald-800'
                         : 'text-sm text-amber-900'
                     }
                   >
                     {elig.message}
                   </p>
+
+                  {showConvert && (
+                    <Button
+                      className="w-full"
+                      disabled={conversionMutation.isPending}
+                      onClick={() => conversionMutation.mutate()}
+                    >
+                      {conversionMutation.isPending ? (
+                        <>
+                          <Loader2 className="mr-2 size-4 animate-spin" />
+                          Converting…
+                        </>
+                      ) : (
+                        'Convert points to USDC'
+                      )}
+                    </Button>
+                  )}
+
+                  {showPay && (
+                    <Button
+                      className="w-full"
+                      disabled={paymentMutation.isPending}
+                      onClick={() => void sendUsdcPayment()}
+                    >
+                      {paymentMutation.isPending ? (
+                        <>
+                          <Loader2 className="mr-2 size-4 animate-spin" />
+                          Pay with USDC…
+                        </>
+                      ) : (
+                        `Send $${preview!.usdcAmount.toFixed(2)} USDC on Base`
+                      )}
+                    </Button>
+                  )}
+
+                  {displayReceipt && (
+                    <div className="space-y-3 rounded-lg border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-[#171717]">
+                      <p className="font-semibold text-emerald-900">
+                        Payment complete
+                      </p>
+                      <div className="flex justify-between gap-2">
+                        <span className="text-neutral-600">Amount</span>
+                        <span className="font-medium">
+                          $
+                          {(
+                            receiptPayload?.pointConversion?.usdc_amount ??
+                            preview?.usdcAmount ??
+                            0
+                          ).toFixed(2)}{' '}
+                          USDC
+                        </span>
+                      </div>
+                      <div className="flex justify-between gap-2">
+                        <span className="text-neutral-600">Points used</span>
+                        <span className="font-medium">
+                          {Number(
+                            receiptPayload?.pointConversion?.points_deducted ??
+                              preview?.pointsRequired ??
+                              0
+                          ).toLocaleString()}
+                        </span>
+                      </div>
+                      <div>
+                        <p className="text-xs text-neutral-600">Session</p>
+                        <p className="break-all font-mono text-xs">
+                          {receiptSession?.id}
+                        </p>
+                      </div>
+                      {(receiptPayload?.spendTransaction?.payment_tx_hash ??
+                        null) && (
+                        <a
+                          href={basescanUrl(
+                            receiptPayload!.spendTransaction!.payment_tx_hash!
+                          )}
+                          target="_blank"
+                          rel="noreferrer"
+                          className="inline-flex items-center gap-1 text-sm font-medium text-emerald-900 underline"
+                        >
+                          View payment on BaseScan
+                          <ExternalLink className="size-3.5" />
+                        </a>
+                      )}
+                    </div>
+                  )}
                 </div>
               )}
             </>

--- a/database/spend-transactions-one-per-session.sql
+++ b/database/spend-transactions-one-per-session.sql
@@ -1,0 +1,7 @@
+-- Enforce at most one spend_transaction row per session (idempotent payment / retries).
+-- Safe to apply after spend-pilot-sessions-ledger.sql; drops redundant partial unique if present.
+
+DROP INDEX IF EXISTS idx_spend_transactions_one_confirmed_per_session;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spend_transactions_session_unique
+    ON spend_transactions (spend_session_id);

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -46,6 +46,10 @@ export const ANALYTICS_EVENTS = {
   SPEND_CONVERSION_CONFIRMED: 'spend_conversion_confirmed',
   SPEND_CONVERSION_COMPLETED: 'spend_conversion_completed',
   SPEND_CONVERSION_FAILED: 'spend_conversion_failed',
+  SPEND_PAYMENT_CONFIRMED: 'spend_payment_confirmed',
+  SPEND_PAYMENT_COMPLETED: 'spend_payment_completed',
+  SPEND_PAYMENT_FAILED: 'spend_payment_failed',
+  SPEND_RECEIPT_VIEWED: 'spend_receipt_viewed',
 } as const;
 
 export type AnalyticsEventName =

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -13,6 +13,7 @@ import type {
   CityMilestoneProperties,
   SpendPilotSessionEventProperties,
   SpendPilotConversionEventProperties,
+  SpendPilotPaymentEventProperties,
 } from './types';
 import { ANALYTICS_EVENTS } from './events';
 import { resolveDistinctId, type IdentityInput } from './identity';
@@ -327,4 +328,32 @@ export function trackSpendConversionFailed(
   properties: SpendPilotConversionEventProperties
 ): void {
   trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_CONVERSION_FAILED, properties);
+}
+
+export function trackSpendPaymentConfirmed(
+  distinctId: string,
+  properties: SpendPilotPaymentEventProperties
+): void {
+  trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_PAYMENT_CONFIRMED, properties);
+}
+
+export function trackSpendPaymentCompleted(
+  distinctId: string,
+  properties: SpendPilotPaymentEventProperties
+): void {
+  trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_PAYMENT_COMPLETED, properties);
+}
+
+export function trackSpendPaymentFailed(
+  distinctId: string,
+  properties: SpendPilotPaymentEventProperties
+): void {
+  trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_PAYMENT_FAILED, properties);
+}
+
+export function trackSpendReceiptViewed(
+  distinctId: string,
+  properties: SpendPilotPaymentEventProperties
+): void {
+  trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_RECEIPT_VIEWED, properties);
 }

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -129,3 +129,19 @@ export interface SpendPilotConversionEventProperties {
   /** On-chain USDC funding tx */
   funding_tx_hash?: string | null;
 }
+
+/** Spend pilot: user payment to receiving wallet (PRD §13). */
+export interface SpendPilotPaymentEventProperties {
+  spend_experience_id: string;
+  event_id?: string | null;
+  user_id: string;
+  wallet_address: string;
+  points_amount: number;
+  usdc_amount: number;
+  status: string;
+  error_reason?: string;
+  spend_session_id?: string;
+  point_conversion_id?: string;
+  spend_transaction_id?: string;
+  payment_tx_hash?: string | null;
+}

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -5,6 +5,7 @@ import type {
   SpendExperience,
   SpendSession,
   SpendSessionStatus,
+  SpendTransaction,
 } from '@/lib/types';
 
 const SESSION_COLS = `
@@ -36,6 +37,22 @@ const CONVERSION_COLS = `
   failed_reason
 `;
 
+const SPEND_TX_COLS = `
+  id,
+  spend_experience_id,
+  spend_session_id,
+  user_id,
+  usdc_amount,
+  from_wallet_address,
+  to_wallet_address,
+  status,
+  payment_tx_hash,
+  idempotency_key,
+  created_at,
+  completed_at,
+  failed_reason
+`;
+
 function toNum(v: unknown): number {
   if (typeof v === 'number' && !Number.isNaN(v)) return v;
   if (typeof v === 'string') {
@@ -56,6 +73,26 @@ function rowToSession(row: Record<string, unknown>): SpendSession {
     created_at: String(row.created_at),
     expires_at: String(row.expires_at),
     completed_at: row.completed_at == null ? null : String(row.completed_at),
+  };
+}
+
+function rowToSpendTransaction(row: Record<string, unknown>): SpendTransaction {
+  return {
+    id: String(row.id),
+    spend_experience_id: String(row.spend_experience_id),
+    spend_session_id: String(row.spend_session_id),
+    user_id: String(row.user_id),
+    usdc_amount: toNum(row.usdc_amount),
+    from_wallet_address: String(row.from_wallet_address),
+    to_wallet_address: String(row.to_wallet_address),
+    status: row.status as SpendTransaction['status'],
+    payment_tx_hash:
+      row.payment_tx_hash == null ? null : String(row.payment_tx_hash),
+    idempotency_key:
+      row.idempotency_key == null ? null : String(row.idempotency_key),
+    created_at: String(row.created_at),
+    completed_at: row.completed_at == null ? null : String(row.completed_at),
+    failed_reason: row.failed_reason == null ? null : String(row.failed_reason),
   };
 }
 
@@ -95,6 +132,23 @@ export async function getSpendSessionById(
   }
   if (!data) return null;
   return rowToSession(data as Record<string, unknown>);
+}
+
+export async function getSpendTransactionBySessionId(
+  sessionId: string
+): Promise<SpendTransaction | null> {
+  const { data, error } = await supabase
+    .from('spend_transactions')
+    .select(SPEND_TX_COLS)
+    .eq('spend_session_id', sessionId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendTransactionBySessionId error:', error);
+    throw new Error(error.message || 'Failed to load spend transaction');
+  }
+  if (!data) return null;
+  return rowToSpendTransaction(data as Record<string, unknown>);
 }
 
 export async function getPointConversionBySessionId(
@@ -294,17 +348,118 @@ export async function updatePointConversionFields(
 
 export async function updateSpendSessionStatus(
   sessionId: string,
-  status: SpendSessionStatus
+  status: SpendSessionStatus,
+  extra?: { completed_at?: string | null }
 ): Promise<void> {
+  const patch: { status: SpendSessionStatus; completed_at?: string | null } = {
+    status,
+  };
+  if (extra?.completed_at !== undefined) {
+    patch.completed_at = extra.completed_at;
+  }
   const { error } = await supabase
     .from('spend_sessions')
-    .update({ status })
+    .update(patch)
     .eq('id', sessionId);
 
   if (error) {
     console.error('updateSpendSessionStatus:', error);
     throw new Error(error.message || 'Failed to update spend session');
   }
+}
+
+export async function insertSpendTransactionSubmitted(input: {
+  spendExperienceId: string;
+  spendSessionId: string;
+  userId: string;
+  usdcAmount: number;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  paymentTxHash: string;
+}): Promise<SpendTransaction | 'session_duplicate'> {
+  const idempotencyKey = `spend_payment:${input.spendSessionId}`;
+  const row = {
+    spend_experience_id: input.spendExperienceId,
+    spend_session_id: input.spendSessionId,
+    user_id: input.userId,
+    usdc_amount: input.usdcAmount,
+    from_wallet_address: input.fromWalletAddress,
+    to_wallet_address: input.toWalletAddress,
+    status: 'submitted' as const,
+    payment_tx_hash: input.paymentTxHash,
+    idempotency_key: idempotencyKey,
+  };
+
+  const { data, error } = await supabase
+    .from('spend_transactions')
+    .insert(row)
+    .select(SPEND_TX_COLS)
+    .single();
+
+  if (!error && data) {
+    return rowToSpendTransaction(data as Record<string, unknown>);
+  }
+
+  if (
+    error?.code === '23505' ||
+    error?.message?.toLowerCase().includes('duplicate')
+  ) {
+    return 'session_duplicate';
+  }
+
+  console.error('insertSpendTransactionSubmitted:', error);
+  throw new Error(error?.message || 'Failed to record spend transaction');
+}
+
+export async function updateSpendTransactionFields(
+  spendTransactionId: string,
+  patch: Partial<
+    Pick<
+      SpendTransaction,
+      'status' | 'payment_tx_hash' | 'completed_at' | 'failed_reason'
+    >
+  >
+): Promise<SpendTransaction> {
+  const { data, error } = await supabase
+    .from('spend_transactions')
+    .update(patch)
+    .eq('id', spendTransactionId)
+    .select(SPEND_TX_COLS)
+    .single();
+
+  if (error || !data) {
+    console.error('updateSpendTransactionFields:', error);
+    throw new Error(error?.message || 'Failed to update spend transaction');
+  }
+  return rowToSpendTransaction(data as Record<string, unknown>);
+}
+
+/**
+ * Atomically moves a row from `submitted` → `confirmed` when still submitted (idempotent under concurrency).
+ * Returns the updated row, or null if no row matched (already confirmed or wrong state).
+ */
+export async function confirmSpendTransactionIfSubmitted(
+  spendTransactionId: string
+): Promise<SpendTransaction | null> {
+  const completedAt = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('spend_transactions')
+    .update({
+      status: 'confirmed',
+      completed_at: completedAt,
+      failed_reason: null,
+    })
+    .eq('id', spendTransactionId)
+    .eq('status', 'submitted')
+    .select(SPEND_TX_COLS)
+    .maybeSingle();
+
+  if (error) {
+    console.error('confirmSpendTransactionIfSubmitted:', error);
+    throw new Error(error.message || 'Failed to confirm spend transaction');
+  }
+  if (!data) return null;
+  return rowToSpendTransaction(data as Record<string, unknown>);
 }
 
 /**

--- a/lib/schemas/spend-session.ts
+++ b/lib/schemas/spend-session.ts
@@ -1,13 +1,15 @@
 import { z } from 'zod';
 
+const evmAddressField = z
+  .string()
+  .min(1, 'walletAddress is required')
+  .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
+    message: 'walletAddress must be a valid EVM address',
+  });
+
 /** POST /api/spend-experiences/{experienceId}/sessions */
 export const createSpendSessionBodySchema = z.object({
-  walletAddress: z
-    .string()
-    .min(1, 'walletAddress is required')
-    .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
-      message: 'walletAddress must be a valid EVM address',
-    }),
+  walletAddress: evmAddressField,
 });
 
 export type CreateSpendSessionBody = z.infer<
@@ -16,12 +18,7 @@ export type CreateSpendSessionBody = z.infer<
 
 /** POST /api/spend-sessions/{sessionId}/conversion/preview */
 export const spendConversionPreviewBodySchema = z.object({
-  walletAddress: z
-    .string()
-    .min(1, 'walletAddress is required')
-    .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
-      message: 'walletAddress must be a valid EVM address',
-    }),
+  walletAddress: evmAddressField,
 });
 
 export type SpendConversionPreviewBody = z.infer<
@@ -30,14 +27,24 @@ export type SpendConversionPreviewBody = z.infer<
 
 /** POST /api/spend-sessions/{sessionId}/conversion/confirm */
 export const spendConversionConfirmBodySchema = z.object({
-  walletAddress: z
-    .string()
-    .min(1, 'walletAddress is required')
-    .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
-      message: 'walletAddress must be a valid EVM address',
-    }),
+  walletAddress: evmAddressField,
 });
 
 export type SpendConversionConfirmBody = z.infer<
   typeof spendConversionConfirmBodySchema
+>;
+
+/** POST /api/spend-sessions/{sessionId}/payment/confirm */
+export const spendPaymentConfirmBodySchema = z.object({
+  walletAddress: evmAddressField,
+  paymentTxHash: z
+    .string()
+    .min(1, 'paymentTxHash is required')
+    .refine((s) => /^0x[a-fA-F0-9]{64}$/.test(s.trim()), {
+      message: 'paymentTxHash must be a 32-byte hex hash with 0x prefix',
+    }),
+});
+
+export type SpendPaymentConfirmBody = z.infer<
+  typeof spendPaymentConfirmBodySchema
 >;

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -57,6 +57,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendExperience: exp(),
       player: player(6000),
       pointConversion: null,
+      spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 10,
       now,
@@ -72,6 +73,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendExperience: exp(),
       player: player(100),
       pointConversion: null,
+      spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 100,
       now,
@@ -85,6 +87,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendExperience: exp(),
       player: player(6000),
       pointConversion: null,
+      spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 2,
       now,
@@ -114,10 +117,85 @@ describe('buildSpendEligibilityPreview', () => {
       spendExperience: exp(),
       player: player(6000),
       pointConversion: null,
+      spendTransaction: null,
       fundedConversionForOtherSession: funded,
       treasuryUsdcBalance: 100,
       now,
     });
     expect(r.status).toBe('already_converted');
+  });
+
+  it('returns ready_for_payment when conversion funded and no spend tx', () => {
+    const conv: PointConversion = {
+      id: 'c1',
+      spend_experience_id: 'e1',
+      spend_session_id: 's1',
+      user_id: 'u1',
+      points_deducted: 5000,
+      usdc_amount: 5,
+      status: 'funded',
+      treasury_wallet_address: '0x1',
+      user_wallet_address: '0x3',
+      funding_tx_hash: '0xabc',
+      idempotency_key: null,
+      created_at: '',
+      completed_at: '',
+      failed_reason: null,
+    };
+    const r = buildSpendEligibilityPreview({
+      session: sess({ status: 'conversion_complete' }),
+      spendExperience: exp(),
+      player: player(1000),
+      pointConversion: conv,
+      spendTransaction: null,
+      fundedConversionForOtherSession: null,
+      treasuryUsdcBalance: 100,
+      now,
+    });
+    expect(r.status).toBe('ready_for_payment');
+  });
+
+  it('returns payment_complete when spend transaction confirmed', () => {
+    const conv: PointConversion = {
+      id: 'c1',
+      spend_experience_id: 'e1',
+      spend_session_id: 's1',
+      user_id: 'u1',
+      points_deducted: 5000,
+      usdc_amount: 5,
+      status: 'funded',
+      treasury_wallet_address: '0x1',
+      user_wallet_address: '0x3',
+      funding_tx_hash: '0xabc',
+      idempotency_key: null,
+      created_at: '',
+      completed_at: '',
+      failed_reason: null,
+    };
+    const r = buildSpendEligibilityPreview({
+      session: sess({ status: 'payment_complete' }),
+      spendExperience: exp(),
+      player: player(1000),
+      pointConversion: conv,
+      spendTransaction: {
+        id: 't1',
+        spend_experience_id: 'e1',
+        spend_session_id: 's1',
+        user_id: 'u1',
+        usdc_amount: 5,
+        from_wallet_address: '0x3',
+        to_wallet_address: '0x2',
+        status: 'confirmed',
+        payment_tx_hash: '0x' + 'a'.repeat(64),
+        idempotency_key: 'k',
+        created_at: '',
+        completed_at: '',
+        failed_reason: null,
+      },
+      fundedConversionForOtherSession: null,
+      treasuryUsdcBalance: 100,
+      now,
+    });
+    expect(r.status).toBe('payment_complete');
   });
 });

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -12,11 +12,13 @@ import type {
   Player,
   SpendExperience,
   SpendSession,
+  SpendTransaction,
 } from '@/lib/types';
 import { getPlayerByWallet } from '@/lib/db/players';
 import {
   getFundedPointConversionForUserExperience,
   getPointConversionBySessionId,
+  getSpendTransactionBySessionId,
 } from '@/lib/db/spend-sessions';
 
 export type { SpendEligibilityStatus } from '@/lib/spend-eligibility-messages';
@@ -48,6 +50,7 @@ type BuildPreviewInput = {
   spendExperience: SpendExperience;
   player: Player | null;
   pointConversion: PointConversion | null;
+  spendTransaction: SpendTransaction | null;
   /** Funded conversion for same user+experience on a different session (one per user). */
   fundedConversionForOtherSession: PointConversion | null;
   treasuryUsdcBalance: number | null;
@@ -78,6 +81,7 @@ export function buildSpendEligibilityPreview(
     spendExperience,
     player,
     pointConversion,
+    spendTransaction,
     fundedConversionForOtherSession,
     treasuryUsdcBalance,
     now,
@@ -113,10 +117,35 @@ export function buildSpendEligibilityPreview(
     };
   }
 
-  if (fundedConversionForOtherSession || pointConversion?.status === 'funded') {
+  if (fundedConversionForOtherSession) {
     return {
       status: 'already_converted',
       message: SPEND_ELIGIBILITY_MESSAGES.already_converted,
+      preview: basePreview(),
+    };
+  }
+
+  if (pointConversion?.status === 'funded') {
+    if (
+      spendTransaction?.status === 'confirmed' ||
+      session.status === 'payment_complete'
+    ) {
+      return {
+        status: 'payment_complete',
+        message: SPEND_ELIGIBILITY_MESSAGES.payment_complete,
+        preview: basePreview(),
+      };
+    }
+    if (spendTransaction?.status === 'failed') {
+      return {
+        status: 'payment_failed',
+        message: SPEND_ELIGIBILITY_MESSAGES.payment_failed,
+        preview: basePreview(),
+      };
+    }
+    return {
+      status: 'ready_for_payment',
+      message: SPEND_ELIGIBILITY_MESSAGES.ready_for_payment,
       preview: basePreview(),
     };
   }
@@ -188,7 +217,7 @@ export async function loadSpendEligibilityForSession(
   const session = input.session;
   const spendExperience = input.spendExperience;
 
-  const [player, pointConversion, fundedOther, treasuryUsdcBalance] =
+  const [player, pointConversion, fundedOther, treasuryUsdcBalance, spendTx] =
     await Promise.all([
       getPlayerByWallet(session.wallet_address),
       getPointConversionBySessionId(session.id),
@@ -197,6 +226,7 @@ export async function loadSpendEligibilityForSession(
         session.user_id
       ),
       fetchTreasuryUsdcBalanceSafe(spendExperience.treasury_wallet_address),
+      getSpendTransactionBySessionId(session.id),
     ]);
 
   return buildSpendEligibilityPreview({
@@ -204,6 +234,7 @@ export async function loadSpendEligibilityForSession(
     spendExperience,
     player,
     pointConversion,
+    spendTransaction: spendTx,
     fundedConversionForOtherSession:
       fundedOther && fundedOther.spend_session_id !== session.id
         ? fundedOther

--- a/lib/spend-eligibility-messages.ts
+++ b/lib/spend-eligibility-messages.ts
@@ -9,7 +9,10 @@ export type SpendEligibilityStatus =
   | 'experience_inactive'
   | 'session_expired'
   | 'treasury_insufficient'
-  | 'wallet_unavailable';
+  | 'wallet_unavailable'
+  | 'ready_for_payment'
+  | 'payment_failed'
+  | 'payment_complete';
 
 export const SPEND_ELIGIBILITY_MESSAGES: Record<
   SpendEligibilityStatus,
@@ -27,4 +30,10 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
     'The event wallet is temporarily out of USDC. Please try again later or ask an event host.',
   wallet_unavailable:
     'Wallet unavailable. Add or connect your embedded wallet in your profile.',
+  ready_for_payment:
+    'Your points were converted to USDC. Send payment to the event wallet below to finish.',
+  payment_failed:
+    'Your last payment could not be verified on-chain. You can try sending payment again.',
+  payment_complete:
+    'Your USDC payment was received. You are all set for this event.',
 };

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -1,0 +1,368 @@
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import {
+  getPointConversionBySessionId,
+  getSpendSessionById,
+  getSpendTransactionBySessionId,
+  insertSpendTransactionSubmitted,
+  updateSpendSessionStatus,
+  updateSpendTransactionFields,
+  confirmSpendTransactionIfSubmitted,
+} from '@/lib/db/spend-sessions';
+import { computeConversionAmounts } from '@/lib/spend-conversion-preview';
+import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
+import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
+import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
+import type {
+  SpendExperience,
+  SpendSession,
+  SpendTransaction,
+} from '@/lib/types';
+import {
+  trackSpendPaymentCompleted,
+  trackSpendPaymentConfirmed,
+  trackSpendPaymentFailed,
+} from '@/lib/analytics/server';
+import type { SpendPilotPaymentEventProperties } from '@/lib/analytics/types';
+
+function normalizeTxHash(raw: string): `0x${string}` | null {
+  const t = raw.trim();
+  if (!/^0x[a-fA-F0-9]{64}$/.test(t)) return null;
+  return t as `0x${string}`;
+}
+
+/** HTTP statuses allowed by `apiError` for spend pilot routes. */
+export type SpendPilotApiHttpStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
+
+export async function getSpendPaymentContextOr404(sessionId: string): Promise<
+  | {
+      session: SpendSession;
+      spendExperience: SpendExperience;
+      usdcAmount: number;
+    }
+  | { error: string; httpStatus: SpendPilotApiHttpStatus }
+> {
+  const session = await getSpendSessionById(sessionId);
+  if (!session) {
+    return { error: 'Spend session not found', httpStatus: 404 };
+  }
+  const spendExperience = await getSpendExperienceById(
+    session.spend_experience_id
+  );
+  if (!spendExperience) {
+    return { error: 'Spend experience not found', httpStatus: 404 };
+  }
+  const { usdcAmount } = computeConversionAmounts(spendExperience);
+  return { session, spendExperience, usdcAmount };
+}
+
+export type SpendPaymentConfirmResult =
+  | {
+      ok: true;
+      spendTransaction: SpendTransaction;
+      session: SpendSession;
+      resumed: boolean;
+    }
+  | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
+
+async function finalizeSuccess(params: {
+  spendTransactionId: string;
+  sessionId: string;
+  distinctId: string;
+  analytics: SpendPilotPaymentEventProperties;
+}): Promise<boolean> {
+  const confirmed = await confirmSpendTransactionIfSubmitted(
+    params.spendTransactionId
+  );
+  if (!confirmed) {
+    return false;
+  }
+  await updateSpendSessionStatus(params.sessionId, 'payment_complete', {
+    completed_at: confirmed.completed_at,
+  });
+  trackSpendPaymentCompleted(params.distinctId, {
+    ...params.analytics,
+    status: 'confirmed',
+    payment_tx_hash: params.analytics.payment_tx_hash,
+  });
+  return true;
+}
+
+async function finalizeFailure(params: {
+  spendTransactionId: string;
+  sessionId: string;
+  distinctId: string;
+  analytics: SpendPilotPaymentEventProperties;
+  reason: string;
+}): Promise<void> {
+  const completedAt = new Date().toISOString();
+  await updateSpendTransactionFields(params.spendTransactionId, {
+    status: 'failed',
+    completed_at: completedAt,
+    failed_reason: params.reason,
+  });
+  await updateSpendSessionStatus(params.sessionId, 'payment_pending');
+  trackSpendPaymentFailed(params.distinctId, {
+    ...params.analytics,
+    status: 'failed',
+    error_reason: params.reason,
+    payment_tx_hash: params.analytics.payment_tx_hash,
+  });
+}
+
+/**
+ * Records and verifies a user USDC payment to the experience receiving wallet (PRD §9, §11).
+ */
+export async function runSpendPaymentConfirm(input: {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  normalizedWallet: string;
+  authUserId: string;
+  distinctId: string;
+  paymentTxHash: string;
+  usdcAmount: number;
+}): Promise<SpendPaymentConfirmResult> {
+  const { session, spendExperience, normalizedWallet, authUserId, distinctId } =
+    input;
+  const txHash = normalizeTxHash(input.paymentTxHash);
+  if (!txHash) {
+    return { ok: false, error: 'Invalid paymentTxHash', httpStatus: 400 };
+  }
+
+  if (session.user_id !== authUserId) {
+    return { ok: false, error: 'Forbidden', httpStatus: 403 };
+  }
+
+  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
+    return {
+      ok: false,
+      error: 'Wallet does not match this session',
+      httpStatus: 400,
+    };
+  }
+
+  const now = new Date();
+  if (now > new Date(session.expires_at)) {
+    return { ok: false, error: 'Spend session expired', httpStatus: 400 };
+  }
+
+  const openGate = assertSpendExperienceOpenForSessions(spendExperience, now);
+  if (!openGate.ok) {
+    return {
+      ok: false,
+      error: 'Spend experience is not active',
+      httpStatus: 400,
+    };
+  }
+
+  const pointConversion = await getPointConversionBySessionId(session.id);
+  if (!pointConversion || pointConversion.status !== 'funded') {
+    return {
+      ok: false,
+      error: 'Conversion must be completed before payment',
+      httpStatus: 400,
+    };
+  }
+
+  const receiving = spendExperience.receiving_wallet_address.trim();
+  if (!isEvmAddress(receiving)) {
+    return {
+      ok: false,
+      error: 'Invalid receiving wallet configuration',
+      httpStatus: 500,
+    };
+  }
+
+  const fromAddr = normalizedWallet as `0x${string}`;
+  const toAddr = receiving as `0x${string}`;
+  const usdcAmount = input.usdcAmount;
+
+  const baseAnalytics: SpendPilotPaymentEventProperties = {
+    spend_experience_id: spendExperience.id,
+    event_id: spendExperience.event_id,
+    user_id: authUserId,
+    wallet_address: normalizedWallet,
+    points_amount: pointConversion.points_deducted,
+    usdc_amount: usdcAmount,
+    status: 'submitted',
+    spend_session_id: session.id,
+    point_conversion_id: pointConversion.id,
+    payment_tx_hash: txHash,
+  };
+
+  if (
+    session.status !== 'conversion_complete' &&
+    session.status !== 'payment_pending'
+  ) {
+    if (session.status === 'payment_complete') {
+      const existing = await getSpendTransactionBySessionId(session.id);
+      if (existing?.status === 'confirmed') {
+        return {
+          ok: true,
+          spendTransaction: existing,
+          session: { ...session, status: 'payment_complete' },
+          resumed: true,
+        };
+      }
+    }
+    return {
+      ok: false,
+      error: 'Session is not ready for payment',
+      httpStatus: 400,
+    };
+  }
+
+  let spendTx = await getSpendTransactionBySessionId(session.id);
+
+  if (spendTx?.status === 'confirmed') {
+    const fresh = await getSpendSessionById(session.id);
+    return {
+      ok: true,
+      spendTransaction: spendTx,
+      session: fresh ?? { ...session, status: 'payment_complete' },
+      resumed: true,
+    };
+  }
+
+  if (spendTx?.status === 'submitted') {
+    const existingHash = spendTx.payment_tx_hash?.toLowerCase() ?? '';
+    if (existingHash && existingHash !== txHash.toLowerCase()) {
+      return {
+        ok: false,
+        error: 'A different payment is already in progress for this session',
+        httpStatus: 409,
+      };
+    }
+  }
+
+  if (spendTx?.status === 'failed') {
+    await updateSpendTransactionFields(spendTx.id, {
+      status: 'submitted',
+      payment_tx_hash: txHash,
+      failed_reason: null,
+      completed_at: null,
+    });
+    spendTx = await getSpendTransactionBySessionId(session.id);
+  }
+
+  let resumed = false;
+  if (!spendTx) {
+    const inserted = await insertSpendTransactionSubmitted({
+      spendExperienceId: spendExperience.id,
+      spendSessionId: session.id,
+      userId: authUserId,
+      usdcAmount,
+      fromWalletAddress: normalizedWallet,
+      toWalletAddress: receiving.toLowerCase(),
+      paymentTxHash: txHash,
+    });
+
+    if (inserted === 'session_duplicate') {
+      spendTx = await getSpendTransactionBySessionId(session.id);
+      resumed = true;
+    } else {
+      spendTx = inserted;
+    }
+  }
+
+  if (!spendTx) {
+    return {
+      ok: false,
+      error: 'Failed to load payment record',
+      httpStatus: 500,
+    };
+  }
+
+  if (
+    spendTx.status === 'submitted' &&
+    spendTx.payment_tx_hash?.toLowerCase() !== txHash.toLowerCase()
+  ) {
+    return {
+      ok: false,
+      error: 'A different payment is already in progress for this session',
+      httpStatus: 409,
+    };
+  }
+
+  if (spendTx.status === 'pending') {
+    await updateSpendTransactionFields(spendTx.id, {
+      status: 'submitted',
+      payment_tx_hash: txHash,
+    });
+    spendTx = await getSpendTransactionBySessionId(session.id);
+    if (!spendTx) {
+      return {
+        ok: false,
+        error: 'Failed to load payment record',
+        httpStatus: 500,
+      };
+    }
+  }
+
+  const idempotentResubmit =
+    spendTx.status === 'submitted' &&
+    spendTx.payment_tx_hash?.toLowerCase() === txHash.toLowerCase();
+
+  if (!idempotentResubmit) {
+    trackSpendPaymentConfirmed(distinctId, {
+      ...baseAnalytics,
+      spend_transaction_id: spendTx.id,
+    });
+  }
+
+  await updateSpendSessionStatus(session.id, 'payment_pending');
+
+  const verify = await verifySpendUsdcPaymentTx({
+    txHash,
+    expectedFrom: fromAddr,
+    expectedTo: toAddr,
+    expectedUsdcAmount: usdcAmount,
+  });
+
+  if (!verify.ok) {
+    await finalizeFailure({
+      spendTransactionId: spendTx.id,
+      sessionId: session.id,
+      distinctId,
+      analytics: { ...baseAnalytics, spend_transaction_id: spendTx.id },
+      reason: verify.reason,
+    });
+    return {
+      ok: false,
+      error:
+        'Payment could not be verified on-chain. If funds left your wallet, contact support with your transaction hash.',
+      httpStatus: 400,
+    };
+  }
+
+  const didWinRace = await finalizeSuccess({
+    spendTransactionId: spendTx.id,
+    sessionId: session.id,
+    distinctId,
+    analytics: { ...baseAnalytics, spend_transaction_id: spendTx.id },
+  });
+
+  const [updatedTx, freshSession] = await Promise.all([
+    getSpendTransactionBySessionId(session.id),
+    getSpendSessionById(session.id),
+  ]);
+
+  if (!didWinRace && updatedTx?.status === 'confirmed') {
+    return {
+      ok: true,
+      spendTransaction: updatedTx,
+      session: freshSession ?? { ...session, status: 'payment_complete' },
+      resumed: true,
+    };
+  }
+
+  return {
+    ok: true,
+    spendTransaction: updatedTx ?? spendTx,
+    session: freshSession ?? {
+      ...session,
+      status: 'payment_complete',
+      completed_at: new Date().toISOString(),
+    },
+    resumed: resumed || idempotentResubmit,
+  };
+}

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -30,6 +30,16 @@ function normalizeTxHash(raw: string): `0x${string}` | null {
   return t as `0x${string}`;
 }
 
+/** Submitted row already bound to another tx hash (idempotent resubmit uses same hash). */
+function submittedPaymentHashConflicts(
+  spendTx: SpendTransaction,
+  requestedHashLower: string
+): boolean {
+  if (spendTx.status !== 'submitted') return false;
+  const existing = (spendTx.payment_tx_hash ?? '').toLowerCase();
+  return existing.length > 0 && existing !== requestedHashLower;
+}
+
 /** HTTP statuses allowed by `apiError` for spend pilot routes. */
 export type SpendPilotApiHttpStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
 
@@ -63,6 +73,12 @@ export type SpendPaymentConfirmResult =
       resumed: boolean;
     }
   | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
+
+const PAYMENT_HASH_CONFLICT: SpendPaymentConfirmResult = {
+  ok: false,
+  error: 'A different payment is already in progress for this session',
+  httpStatus: 409,
+};
 
 async function finalizeSuccess(params: {
   spendTransactionId: string;
@@ -175,6 +191,7 @@ export async function runSpendPaymentConfirm(input: {
   const fromAddr = normalizedWallet as `0x${string}`;
   const toAddr = receiving as `0x${string}`;
   const usdcAmount = input.usdcAmount;
+  const requestedHashLower = txHash.toLowerCase();
 
   const baseAnalytics: SpendPilotPaymentEventProperties = {
     spend_experience_id: spendExperience.id,
@@ -223,15 +240,8 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  if (spendTx?.status === 'submitted') {
-    const existingHash = spendTx.payment_tx_hash?.toLowerCase() ?? '';
-    if (existingHash && existingHash !== txHash.toLowerCase()) {
-      return {
-        ok: false,
-        error: 'A different payment is already in progress for this session',
-        httpStatus: 409,
-      };
-    }
+  if (spendTx && submittedPaymentHashConflicts(spendTx, requestedHashLower)) {
+    return PAYMENT_HASH_CONFLICT;
   }
 
   if (spendTx?.status === 'failed') {
@@ -272,15 +282,8 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  if (
-    spendTx.status === 'submitted' &&
-    spendTx.payment_tx_hash?.toLowerCase() !== txHash.toLowerCase()
-  ) {
-    return {
-      ok: false,
-      error: 'A different payment is already in progress for this session',
-      httpStatus: 409,
-    };
+  if (submittedPaymentHashConflicts(spendTx, requestedHashLower)) {
+    return PAYMENT_HASH_CONFLICT;
   }
 
   if (spendTx.status === 'pending') {
@@ -298,11 +301,11 @@ export async function runSpendPaymentConfirm(input: {
     }
   }
 
-  const idempotentResubmit =
+  const isSameSubmittedHash =
     spendTx.status === 'submitted' &&
-    spendTx.payment_tx_hash?.toLowerCase() === txHash.toLowerCase();
+    (spendTx.payment_tx_hash ?? '').toLowerCase() === requestedHashLower;
 
-  if (!idempotentResubmit) {
+  if (!isSameSubmittedHash) {
     trackSpendPaymentConfirmed(distinctId, {
       ...baseAnalytics,
       spend_transaction_id: spendTx.id,
@@ -363,6 +366,6 @@ export async function runSpendPaymentConfirm(input: {
       status: 'payment_complete',
       completed_at: new Date().toISOString(),
     },
-    resumed: resumed || idempotentResubmit,
+    resumed: resumed || isSameSubmittedHash,
   };
 }

--- a/lib/spend-payment-verify.ts
+++ b/lib/spend-payment-verify.ts
@@ -52,12 +52,10 @@ export async function verifySpendUsdcPaymentTx(params: {
   const expectedRaw = parseUnits(params.expectedUsdcAmount.toFixed(6), 6);
   const fromLower = params.expectedFrom.toLowerCase();
   const toLower = params.expectedTo.toLowerCase();
+  const usdcLower = POSTER_CHECKOUT_USDC_ADDRESS_BASE.toLowerCase();
 
   for (const log of receipt.logs) {
-    if (
-      log.address.toLowerCase() !==
-      POSTER_CHECKOUT_USDC_ADDRESS_BASE.toLowerCase()
-    ) {
+    if (log.address.toLowerCase() !== usdcLower) {
       continue;
     }
     try {

--- a/lib/spend-payment-verify.ts
+++ b/lib/spend-payment-verify.ts
@@ -1,0 +1,88 @@
+import {
+  createPublicClient,
+  decodeEventLog,
+  erc20Abi,
+  http,
+  parseUnits,
+} from 'viem';
+import {
+  POSTER_CHECKOUT_CHAIN,
+  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+} from '@/lib/walletconnect-poster-direct-usdc';
+
+export type SpendPaymentTxVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+/**
+ * Confirms a Base USDC transfer receipt: success, token, from, to, and amount (6 decimals).
+ */
+export async function verifySpendUsdcPaymentTx(params: {
+  txHash: `0x${string}`;
+  expectedFrom: `0x${string}`;
+  expectedTo: `0x${string}`;
+  /** Human-readable USDC (must match on-chain 6-decimal amount). */
+  expectedUsdcAmount: number;
+}): Promise<SpendPaymentTxVerifyResult> {
+  const rpcUrl = process.env.NEXT_PUBLIC_BASE_RPC?.trim();
+  if (!rpcUrl) {
+    return { ok: false, reason: 'RPC not configured' };
+  }
+
+  const publicClient = createPublicClient({
+    chain: POSTER_CHECKOUT_CHAIN,
+    transport: http(rpcUrl),
+  });
+
+  let receipt;
+  try {
+    receipt = await publicClient.waitForTransactionReceipt({
+      hash: params.txHash,
+      timeout: 120_000,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'receipt wait failed';
+    return { ok: false, reason: msg };
+  }
+
+  if (receipt.status !== 'success') {
+    return { ok: false, reason: 'transaction_reverted' };
+  }
+
+  const expectedRaw = parseUnits(params.expectedUsdcAmount.toFixed(6), 6);
+  const fromLower = params.expectedFrom.toLowerCase();
+  const toLower = params.expectedTo.toLowerCase();
+
+  for (const log of receipt.logs) {
+    if (
+      log.address.toLowerCase() !==
+      POSTER_CHECKOUT_USDC_ADDRESS_BASE.toLowerCase()
+    ) {
+      continue;
+    }
+    try {
+      const decoded = decodeEventLog({
+        abi: erc20Abi,
+        data: log.data,
+        topics: log.topics,
+      });
+      if (decoded.eventName !== 'Transfer') continue;
+      const args = decoded.args as {
+        from: `0x${string}`;
+        to: `0x${string}`;
+        value: bigint;
+      };
+      if (
+        args.from.toLowerCase() === fromLower &&
+        args.to.toLowerCase() === toLower &&
+        args.value === expectedRaw
+      ) {
+        return { ok: true };
+      }
+    } catch {
+      // not a Transfer on USDC ABI
+    }
+  }
+
+  return { ok: false, reason: 'no_matching_usdc_transfer' };
+}

--- a/lib/walletconnect-poster-direct-usdc.ts
+++ b/lib/walletconnect-poster-direct-usdc.ts
@@ -5,12 +5,12 @@ import {
   formatUnits,
   http,
   parseUnits,
-} from "viem";
-import { base } from "viem/chains";
+} from 'viem';
+import { base } from 'viem/chains';
 
 /** Official USDC on Base mainnet (same chain as Privy `supportedChains` in providers). */
 export const POSTER_CHECKOUT_USDC_ADDRESS_BASE =
-  "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as const;
+  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913' as const;
 
 export const POSTER_CHECKOUT_CHAIN = base;
 export const POSTER_CHECKOUT_CHAIN_ID = base.id;
@@ -28,10 +28,19 @@ export function isEvmAddress(value: string): boolean {
 export function encodePosterUsdcTransferData(
   recipient: `0x${string}`
 ): `0x${string}` {
+  return encodeUsdcTransferData(recipient, 1);
+}
+
+/** ERC-20 `transfer` calldata for USDC (6 decimals) on Base. */
+export function encodeUsdcTransferData(
+  recipient: `0x${string}`,
+  /** Human-readable USDC amount (e.g. 5.25). */
+  usdcAmount: number
+): `0x${string}` {
   return encodeFunctionData({
     abi: erc20Abi,
-    functionName: "transfer",
-    args: [recipient, parseUnits("1", 6)],
+    functionName: 'transfer',
+    args: [recipient, parseUnits(usdcAmount.toFixed(6), 6)],
   });
 }
 
@@ -49,7 +58,7 @@ export async function fetchUsdcBalanceOnBase(
   const raw = await client.readContract({
     address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
     abi: erc20Abi,
-    functionName: "balanceOf",
+    functionName: 'balanceOf',
     args: [walletAddress],
   });
   return parseFloat(formatUnits(raw, 6));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements [GitHub issue #508](https://github.com/hurley87/refraction/issues/508): after funded conversion, users can send Base USDC from their embedded wallet to the experience `receiving_wallet_address`, submit the tx hash for server verification, and see a success receipt. Adds Mixpanel events from PRD §13 and tightens idempotency with a DB migration.

## Changes

- **API:** `POST /api/spend-sessions/{sessionId}/payment/confirm` — validates Privy + wallet ownership, verifies on-chain USDC `Transfer` (from session wallet → receiving wallet, exact 6-decimal amount), updates `spend_transactions` (`pending`/`submitted` → `confirmed`/`failed`) and `spend_sessions` (`payment_pending` / `payment_complete`).
- **Receipt:** `GET /api/spend-sessions/{sessionId}/receipt` now includes `spendTransaction` and emits `spend_receipt_viewed` server-side.
- **Analytics:** `spend_payment_confirmed`, `spend_payment_completed`, `spend_payment_failed`, `spend_receipt_viewed` in `lib/analytics/events.ts` + `server.ts` + types.
- **UI:** `components/spend/spend-experience-page.tsx` — convert button, Base USDC send via `eth_sendTransaction` (same pattern as walletconnect poster), payment confirm, receipt card with BaseScan link.
- **Eligibility:** New statuses `ready_for_payment`, `payment_failed`, `payment_complete` so funded conversion is not mislabeled as “already converted.”
- **DB:** `database/spend-transactions-one-per-session.sql` — unique index on `spend_transactions(spend_session_id)` (drops partial unique that only covered `confirmed`). **Apply this migration in Supabase** for idempotent one-row-per-session semantics.
- **Helpers:** `encodeUsdcTransferData` for variable amounts; `lib/spend-payment-verify.ts` for receipt parsing.

A follow-up commit refactors payment confirm (shared hash-conflict helper) and tidies the spend experience page without behavior changes.

## Testing

- `yarn vitest run lib/spend-conversion-preview.test.ts app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts`
- `yarn build`

## Note

Depends on conversion/funding flow (#507) being deployed; payment confirm requires `point_conversions.status === 'funded'` and `NEXT_PUBLIC_BASE_RPC` for on-chain verification.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-59b9391a-a546-4517-a29e-a7902a2cb08a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-59b9391a-a546-4517-a29e-a7902a2cb08a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

