### PR TITLE
Spend pilot: admin activity + treasury monitoring (#509)

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -70,6 +70,77 @@ function baseScanTxUrl(hash: string): string {
   return `https://basescan.org/tx/${h}`;
 }
 
+function TxHashShortLink({
+  hash,
+  className,
+}: {
+  hash: string;
+  className?: string;
+}) {
+  return (
+    <a
+      href={baseScanTxUrl(hash)}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={
+        className ??
+        'inline-flex items-center gap-0.5 text-blue-700 hover:underline'
+      }
+    >
+      {shortenAddr(hash)}
+      <ExternalLink className="size-3" />
+    </a>
+  );
+}
+
+function SessionConversionCell({
+  conversion,
+}: {
+  conversion: PointConversion | null;
+}) {
+  if (!conversion) {
+    return <span className="text-neutral-400">—</span>;
+  }
+  return (
+    <>
+      <div>{conversion.status}</div>
+      <div className="text-neutral-600">{fmtUsdc(conversion.usdc_amount)}</div>
+      {conversion.funding_tx_hash && (
+        <a
+          href={baseScanTxUrl(conversion.funding_tx_hash)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Tx
+        </a>
+      )}
+    </>
+  );
+}
+
+function SessionPaymentCell({ payment }: { payment: SpendTransaction | null }) {
+  if (!payment) {
+    return <span className="text-neutral-400">—</span>;
+  }
+  return (
+    <>
+      <div>{payment.status}</div>
+      <div className="text-neutral-600">{fmtUsdc(payment.usdc_amount)}</div>
+      {payment.payment_tx_hash && (
+        <a
+          href={baseScanTxUrl(payment.payment_tx_hash)}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="text-blue-600 hover:underline"
+        >
+          Tx
+        </a>
+      )}
+    </>
+  );
+}
+
 export default function SpendExperienceDetailPage() {
   const params = useParams<{ experienceId: string }>();
   const experienceId = params.experienceId;
@@ -204,8 +275,14 @@ export default function SpendExperienceDetailPage() {
   }
 
   const exp = experienceQuery.data;
-  const totals = activityQuery.data?.totals;
-  const mixpanelUrl = activityQuery.data?.mixpanelInsightUrl;
+  const activityData = activityQuery.data;
+  const treasuryData = treasuryQuery.data;
+  const totals = activityData?.totals;
+  const mixpanelUrl = activityData?.mixpanelInsightUrl;
+  const ledgerTotalsSuffix =
+    treasuryData && treasuryData.ledgerTotals.admin_recovery_usdc > 0
+      ? ` · admin_recovery ${fmtUsdc(treasuryData.ledgerTotals.admin_recovery_usdc)}`
+      : '';
 
   return (
     <div className="mx-auto max-w-4xl p-6 font-grotesk">
@@ -237,7 +314,7 @@ export default function SpendExperienceDetailPage() {
               variant="outline"
               size="sm"
               className="gap-1"
-              onClick={() => refetchAll()}
+              onClick={refetchAll}
               disabled={
                 activityQuery.isFetching ||
                 treasuryQuery.isFetching ||
@@ -267,7 +344,7 @@ export default function SpendExperienceDetailPage() {
         </p>
       )}
 
-      {totals && treasuryQuery.data && (
+      {totals && treasuryData && (
         <section className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-lg border border-neutral-200 bg-white p-4">
             <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
@@ -298,42 +375,40 @@ export default function SpendExperienceDetailPage() {
               Treasury USDC (live)
             </div>
             <div className="mt-1 text-2xl font-semibold tabular-nums">
-              {fmtUsdc(treasuryQuery.data.treasuryUsdcBalance)}
+              {fmtUsdc(treasuryData.treasuryUsdcBalance)}
             </div>
           </div>
         </section>
       )}
 
-      {treasuryQuery.data && (
+      {treasuryData && (
         <section className="mb-8 rounded-lg border border-neutral-200 bg-white p-5">
           <h2 className="text-lg font-semibold text-[#171717]">Treasury</h2>
           <div className="mt-3 grid gap-4 text-sm sm:grid-cols-2">
             <div>
               <div className="text-neutral-500">Treasury wallet</div>
               <code className="mt-0.5 block break-all text-xs text-neutral-800">
-                {treasuryQuery.data.treasuryWalletAddress}
+                {treasuryData.treasuryWalletAddress}
               </code>
             </div>
             <div>
               <div className="text-neutral-500">Receiving (event) wallet</div>
               <code className="mt-0.5 block break-all text-xs text-neutral-800">
-                {treasuryQuery.data.receivingWalletAddress}
+                {treasuryData.receivingWalletAddress}
               </code>
             </div>
           </div>
-          {treasuryQuery.data.ledger.length > 0 && (
+          {treasuryData.ledger.length > 0 && (
             <div className="mt-4 border-t border-neutral-100 pt-4">
               <div className="text-xs text-neutral-500">
                 Ledger totals (optional audit rows): fund_user{' '}
-                {fmtUsdc(treasuryQuery.data.ledgerTotals.fund_user_usdc)} ·
+                {fmtUsdc(treasuryData.ledgerTotals.fund_user_usdc)} ·
                 receive_payment{' '}
-                {fmtUsdc(treasuryQuery.data.ledgerTotals.receive_payment_usdc)}
-                {treasuryQuery.data.ledgerTotals.admin_recovery_usdc > 0
-                  ? ` · admin_recovery ${fmtUsdc(treasuryQuery.data.ledgerTotals.admin_recovery_usdc)}`
-                  : ''}
+                {fmtUsdc(treasuryData.ledgerTotals.receive_payment_usdc)}
+                {ledgerTotalsSuffix}
               </div>
               <ul className="mt-3 max-h-48 overflow-auto text-xs">
-                {treasuryQuery.data.ledger.slice(0, 50).map((row) => (
+                {treasuryData.ledger.slice(0, 50).map((row) => (
                   <li
                     key={row.id}
                     className="flex flex-wrap items-baseline justify-between gap-2 border-b border-neutral-50 py-1.5 last:border-0"
@@ -343,15 +418,10 @@ export default function SpendExperienceDetailPage() {
                       {fmtUsdc(row.amount)}
                     </span>
                     {row.tx_hash ? (
-                      <a
-                        href={baseScanTxUrl(row.tx_hash)}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                      <TxHashShortLink
+                        hash={row.tx_hash}
                         className="inline-flex items-center gap-0.5 font-mono text-blue-600 hover:underline"
-                      >
-                        {shortenAddr(row.tx_hash)}
-                        <ExternalLink className="size-3" />
-                      </a>
+                      />
                     ) : (
                       <span className="text-neutral-400">—</span>
                     )}
@@ -378,9 +448,9 @@ export default function SpendExperienceDetailPage() {
         </p>
       )}
 
-      {activityQuery.data &&
-        (activityQuery.data.failedConversions.length > 0 ||
-          activityQuery.data.failedPayments.length > 0) && (
+      {activityData &&
+        (activityData.failedConversions.length > 0 ||
+          activityData.failedPayments.length > 0) && (
           <section className="mb-8 rounded-lg border border-red-200 bg-red-50/80 p-5">
             <h2 className="text-lg font-semibold text-red-900">
               Failed transactions
@@ -390,13 +460,13 @@ export default function SpendExperienceDetailPage() {
               full detail.
             </p>
             <div className="mt-4 grid gap-6 md:grid-cols-2">
-              {activityQuery.data.failedConversions.length > 0 && (
+              {activityData.failedConversions.length > 0 && (
                 <div>
                   <h3 className="text-sm font-medium text-red-900">
-                    Conversions ({activityQuery.data.failedConversions.length})
+                    Conversions ({activityData.failedConversions.length})
                   </h3>
                   <ul className="mt-2 space-y-2 text-xs">
-                    {activityQuery.data.failedConversions.map((c) => (
+                    {activityData.failedConversions.map((c) => (
                       <li
                         key={c.id}
                         className="rounded border border-red-100 bg-white/80 p-2"
@@ -408,28 +478,22 @@ export default function SpendExperienceDetailPage() {
                           {c.failed_reason ?? 'Unknown'}
                         </div>
                         {c.funding_tx_hash && (
-                          <a
-                            href={baseScanTxUrl(c.funding_tx_hash)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="mt-1 inline-flex items-center gap-0.5 text-blue-700 hover:underline"
-                          >
-                            {shortenAddr(c.funding_tx_hash)}
-                            <ExternalLink className="size-3" />
-                          </a>
+                          <div className="mt-1">
+                            <TxHashShortLink hash={c.funding_tx_hash} />
+                          </div>
                         )}
                       </li>
                     ))}
                   </ul>
                 </div>
               )}
-              {activityQuery.data.failedPayments.length > 0 && (
+              {activityData.failedPayments.length > 0 && (
                 <div>
                   <h3 className="text-sm font-medium text-red-900">
-                    Payments ({activityQuery.data.failedPayments.length})
+                    Payments ({activityData.failedPayments.length})
                   </h3>
                   <ul className="mt-2 space-y-2 text-xs">
-                    {activityQuery.data.failedPayments.map((p) => (
+                    {activityData.failedPayments.map((p) => (
                       <li
                         key={p.id}
                         className="rounded border border-red-100 bg-white/80 p-2"
@@ -441,15 +505,9 @@ export default function SpendExperienceDetailPage() {
                           {p.failed_reason ?? 'Unknown'}
                         </div>
                         {p.payment_tx_hash && (
-                          <a
-                            href={baseScanTxUrl(p.payment_tx_hash)}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="mt-1 inline-flex items-center gap-0.5 text-blue-700 hover:underline"
-                          >
-                            {shortenAddr(p.payment_tx_hash)}
-                            <ExternalLink className="size-3" />
-                          </a>
+                          <div className="mt-1">
+                            <TxHashShortLink hash={p.payment_tx_hash} />
+                          </div>
                         )}
                       </li>
                     ))}
@@ -460,11 +518,11 @@ export default function SpendExperienceDetailPage() {
           </section>
         )}
 
-      {activityQuery.data && (
+      {activityData && (
         <section className="rounded-lg border border-neutral-200 bg-white">
           <div className="border-b border-neutral-100 px-4 py-3">
             <h2 className="font-semibold text-[#171717]">
-              Recent sessions ({activityQuery.data.sessions.length} shown)
+              Recent sessions ({activityData.sessions.length} shown)
             </h2>
             <p className="text-xs text-neutral-500">
               Newest first. Conversion and payment rows when present.
@@ -481,7 +539,7 @@ export default function SpendExperienceDetailPage() {
                 </tr>
               </thead>
               <tbody>
-                {activityQuery.data.sessions.map(
+                {activityData.sessions.map(
                   ({ session, conversion, payment }) => (
                     <tr
                       key={session.id}
@@ -497,48 +555,10 @@ export default function SpendExperienceDetailPage() {
                         {session.status.replace(/_/g, ' ')}
                       </td>
                       <td className="px-3 py-2 align-top text-xs">
-                        {conversion ? (
-                          <>
-                            <div>{conversion.status}</div>
-                            <div className="text-neutral-600">
-                              {fmtUsdc(conversion.usdc_amount)}
-                            </div>
-                            {conversion.funding_tx_hash && (
-                              <a
-                                href={baseScanTxUrl(conversion.funding_tx_hash)}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline"
-                              >
-                                Tx
-                              </a>
-                            )}
-                          </>
-                        ) : (
-                          <span className="text-neutral-400">—</span>
-                        )}
+                        <SessionConversionCell conversion={conversion} />
                       </td>
                       <td className="px-3 py-2 align-top text-xs">
-                        {payment ? (
-                          <>
-                            <div>{payment.status}</div>
-                            <div className="text-neutral-600">
-                              {fmtUsdc(payment.usdc_amount)}
-                            </div>
-                            {payment.payment_tx_hash && (
-                              <a
-                                href={baseScanTxUrl(payment.payment_tx_hash)}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="text-blue-600 hover:underline"
-                              >
-                                Tx
-                              </a>
-                            )}
-                          </>
-                        ) : (
-                          <span className="text-neutral-400">—</span>
-                        )}
+                        <SessionPaymentCell payment={payment} />
                       </td>
                     </tr>
                   )

--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -1,0 +1,553 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useQuery } from '@tanstack/react-query';
+import { usePrivy } from '@privy-io/react-auth';
+import { Loader2, ArrowLeft, ExternalLink, RefreshCw } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type {
+  PointConversion,
+  SpendExperience,
+  SpendSession,
+  SpendTransaction,
+  TreasuryTransaction,
+} from '@/lib/types';
+
+type ActivityTotals = {
+  usersConverted: number;
+  totalUsdcDistributed: number;
+  totalUsdcReceivedAtEventWallet: number;
+  spendSessionsCount: number;
+};
+
+type ActivitySessionRow = {
+  session: SpendSession;
+  conversion: PointConversion | null;
+  payment: SpendTransaction | null;
+};
+
+type ActivityPayload = {
+  spendExperienceId: string;
+  totals: ActivityTotals;
+  sessions: ActivitySessionRow[];
+  failedConversions: PointConversion[];
+  failedPayments: SpendTransaction[];
+  mixpanelInsightUrl?: string;
+};
+
+type TreasuryPayload = {
+  spendExperienceId: string;
+  treasuryWalletAddress: string;
+  receivingWalletAddress: string;
+  treasuryUsdcBalance: number | null;
+  ledger: TreasuryTransaction[];
+  ledgerTotals: {
+    fund_user_usdc: number;
+    receive_payment_usdc: number;
+    admin_recovery_usdc: number;
+  };
+};
+
+function fmtUsdc(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return '—';
+  const rounded = Math.round(n * 1e6) / 1e6;
+  return `$${rounded.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  })}`;
+}
+
+function shortenAddr(a: string): string {
+  const t = a.trim();
+  if (t.length < 14) return t;
+  return `${t.slice(0, 6)}…${t.slice(-4)}`;
+}
+
+function baseScanTxUrl(hash: string): string {
+  const h = hash.trim().toLowerCase();
+  return `https://basescan.org/tx/${h}`;
+}
+
+export default function SpendExperienceDetailPage() {
+  const params = useParams<{ experienceId: string }>();
+  const experienceId = params.experienceId;
+  const { user, login } = usePrivy();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [adminLoading, setAdminLoading] = useState(true);
+
+  const checkAdminStatus = useCallback(async () => {
+    if (!user?.email?.address) return false;
+    try {
+      const response = await fetch('/api/admin/auth', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email: user.email.address }),
+      });
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return data.isAdmin;
+    } catch {
+      return false;
+    }
+  }, [user?.email?.address]);
+
+  useEffect(() => {
+    const verify = async () => {
+      if (user?.email?.address) {
+        setIsAdmin(await checkAdminStatus());
+        setAdminLoading(false);
+      } else if (user === null) {
+        setIsAdmin(false);
+        setAdminLoading(false);
+      }
+    };
+    void verify();
+  }, [user, checkAdminStatus]);
+
+  const adminEmail = user?.email?.address || '';
+
+  const headers = useMemo(
+    () => ({
+      'Content-Type': 'application/json',
+      'x-user-email': adminEmail,
+    }),
+    [adminEmail]
+  );
+
+  const experienceQuery = useQuery<SpendExperience>({
+    queryKey: ['admin-spend-experience', experienceId, adminEmail],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/admin/spend-experiences/${experienceId}`,
+        { headers }
+      );
+      if (!response.ok) throw new Error('Failed to load experience');
+      const j = await response.json();
+      const exp = (j.data?.spendExperience ?? j.spendExperience) as
+        | SpendExperience
+        | undefined;
+      if (!exp) throw new Error('Missing experience');
+      return exp;
+    },
+    enabled: Boolean(experienceId && isAdmin && adminEmail),
+  });
+
+  const activityQuery = useQuery<ActivityPayload>({
+    queryKey: ['admin-spend-activity', experienceId, adminEmail],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/admin/spend-experiences/${experienceId}/activity`,
+        { headers }
+      );
+      if (!response.ok) throw new Error('Failed to load activity');
+      const j = await response.json();
+      const data = j.data ?? j;
+      return data as ActivityPayload;
+    },
+    enabled: Boolean(experienceId && isAdmin && adminEmail),
+  });
+
+  const treasuryQuery = useQuery<TreasuryPayload>({
+    queryKey: ['admin-spend-treasury', experienceId, adminEmail],
+    queryFn: async () => {
+      const response = await fetch(
+        `/api/admin/spend-experiences/${experienceId}/treasury`,
+        { headers }
+      );
+      if (!response.ok) throw new Error('Failed to load treasury');
+      const j = await response.json();
+      const data = j.data ?? j;
+      return data as TreasuryPayload;
+    },
+    enabled: Boolean(experienceId && isAdmin && adminEmail),
+  });
+
+  const refetchAll = useCallback(() => {
+    void experienceQuery.refetch();
+    void activityQuery.refetch();
+    void treasuryQuery.refetch();
+  }, [experienceQuery, activityQuery, treasuryQuery]);
+
+  if (adminLoading || (user && isAdmin === null)) {
+    return (
+      <div className="flex min-h-[40vh] items-center justify-center">
+        <Loader2 className="size-8 animate-spin text-neutral-500" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <p className="mb-4 text-neutral-700">Sign in to view activity.</p>
+        <Button onClick={login} className="w-full">
+          Log in
+        </Button>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="mx-auto max-w-md p-6">
+        <p className="text-red-600">You do not have access to this page.</p>
+        <Link
+          href="/admin/spend-experiences"
+          className="mt-4 inline-block text-sm text-blue-600 hover:underline"
+        >
+          Back to spend experiences
+        </Link>
+      </div>
+    );
+  }
+
+  const exp = experienceQuery.data;
+  const totals = activityQuery.data?.totals;
+  const mixpanelUrl = activityQuery.data?.mixpanelInsightUrl;
+
+  return (
+    <div className="mx-auto max-w-4xl p-6 font-grotesk">
+      <div className="mb-6 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <Link
+            href="/admin/spend-experiences"
+            className="mb-3 inline-flex items-center gap-1 text-sm text-blue-600 hover:underline"
+          >
+            <ArrowLeft className="size-4" />
+            Back to list
+          </Link>
+          <h1 className="text-2xl font-semibold text-[#171717]">
+            {exp?.title ?? 'Spend experience'}
+          </h1>
+          {exp?.description && (
+            <p className="mt-1 max-w-2xl text-sm text-neutral-600">
+              {exp.description}
+            </p>
+          )}
+          <div className="mt-2 flex flex-wrap gap-2">
+            <Button variant="outline" size="sm" asChild>
+              <Link href={`/admin/spend-experiences/${experienceId}/qr`}>
+                QR code
+              </Link>
+            </Button>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1"
+              onClick={() => refetchAll()}
+              disabled={
+                activityQuery.isFetching ||
+                treasuryQuery.isFetching ||
+                experienceQuery.isFetching
+              }
+            >
+              <RefreshCw className="size-3.5" />
+              Refresh
+            </Button>
+          </div>
+        </div>
+      </div>
+
+      {(experienceQuery.isLoading ||
+        activityQuery.isLoading ||
+        treasuryQuery.isLoading) && (
+        <div className="flex justify-center py-12">
+          <Loader2 className="size-8 animate-spin text-neutral-500" />
+        </div>
+      )}
+
+      {(experienceQuery.error ||
+        activityQuery.error ||
+        treasuryQuery.error) && (
+        <p className="text-red-600">
+          Could not load monitoring data. Try refresh.
+        </p>
+      )}
+
+      {totals && treasuryQuery.data && (
+        <section className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+          <div className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              Users converted
+            </div>
+            <div className="mt-1 text-2xl font-semibold tabular-nums">
+              {totals.usersConverted}
+            </div>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              USDC distributed
+            </div>
+            <div className="mt-1 text-2xl font-semibold tabular-nums">
+              {fmtUsdc(totals.totalUsdcDistributed)}
+            </div>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              USDC at event wallet
+            </div>
+            <div className="mt-1 text-2xl font-semibold tabular-nums">
+              {fmtUsdc(totals.totalUsdcReceivedAtEventWallet)}
+            </div>
+          </div>
+          <div className="rounded-lg border border-neutral-200 bg-white p-4">
+            <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+              Treasury USDC (live)
+            </div>
+            <div className="mt-1 text-2xl font-semibold tabular-nums">
+              {fmtUsdc(treasuryQuery.data.treasuryUsdcBalance)}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {treasuryQuery.data && (
+        <section className="mb-8 rounded-lg border border-neutral-200 bg-white p-5">
+          <h2 className="text-lg font-semibold text-[#171717]">Treasury</h2>
+          <div className="mt-3 grid gap-4 text-sm sm:grid-cols-2">
+            <div>
+              <div className="text-neutral-500">Treasury wallet</div>
+              <code className="mt-0.5 block break-all text-xs text-neutral-800">
+                {treasuryQuery.data.treasuryWalletAddress}
+              </code>
+            </div>
+            <div>
+              <div className="text-neutral-500">Receiving (event) wallet</div>
+              <code className="mt-0.5 block break-all text-xs text-neutral-800">
+                {treasuryQuery.data.receivingWalletAddress}
+              </code>
+            </div>
+          </div>
+          {treasuryQuery.data.ledger.length > 0 && (
+            <div className="mt-4 border-t border-neutral-100 pt-4">
+              <div className="text-xs text-neutral-500">
+                Ledger totals (optional audit rows): fund_user{' '}
+                {fmtUsdc(treasuryQuery.data.ledgerTotals.fund_user_usdc)} ·
+                receive_payment{' '}
+                {fmtUsdc(treasuryQuery.data.ledgerTotals.receive_payment_usdc)}
+                {treasuryQuery.data.ledgerTotals.admin_recovery_usdc > 0
+                  ? ` · admin_recovery ${fmtUsdc(treasuryQuery.data.ledgerTotals.admin_recovery_usdc)}`
+                  : ''}
+              </div>
+              <ul className="mt-3 max-h-48 overflow-auto text-xs">
+                {treasuryQuery.data.ledger.slice(0, 50).map((row) => (
+                  <li
+                    key={row.id}
+                    className="flex flex-wrap items-baseline justify-between gap-2 border-b border-neutral-50 py-1.5 last:border-0"
+                  >
+                    <span className="text-neutral-600">
+                      {row.transaction_type.replace(/_/g, ' ')} ·{' '}
+                      {fmtUsdc(row.amount)}
+                    </span>
+                    {row.tx_hash ? (
+                      <a
+                        href={baseScanTxUrl(row.tx_hash)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-0.5 font-mono text-blue-600 hover:underline"
+                      >
+                        {shortenAddr(row.tx_hash)}
+                        <ExternalLink className="size-3" />
+                      </a>
+                    ) : (
+                      <span className="text-neutral-400">—</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </section>
+      )}
+
+      {mixpanelUrl && (
+        <p className="mb-6 text-sm text-neutral-600">
+          <a
+            href={mixpanelUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 text-blue-600 hover:underline"
+          >
+            Open Mixpanel events
+            <ExternalLink className="size-3.5" />
+          </a>{' '}
+          for deeper funnels (token is project id).
+        </p>
+      )}
+
+      {activityQuery.data &&
+        (activityQuery.data.failedConversions.length > 0 ||
+          activityQuery.data.failedPayments.length > 0) && (
+          <section className="mb-8 rounded-lg border border-red-200 bg-red-50/80 p-5">
+            <h2 className="text-lg font-semibold text-red-900">
+              Failed transactions
+            </h2>
+            <p className="mt-1 text-sm text-red-800/90">
+              Reasons are truncated server-side; use tx hashes on BaseScan for
+              full detail.
+            </p>
+            <div className="mt-4 grid gap-6 md:grid-cols-2">
+              {activityQuery.data.failedConversions.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-red-900">
+                    Conversions ({activityQuery.data.failedConversions.length})
+                  </h3>
+                  <ul className="mt-2 space-y-2 text-xs">
+                    {activityQuery.data.failedConversions.map((c) => (
+                      <li
+                        key={c.id}
+                        className="rounded border border-red-100 bg-white/80 p-2"
+                      >
+                        <div className="font-mono text-[11px] text-neutral-600">
+                          session {shortenAddr(c.spend_session_id)}
+                        </div>
+                        <div className="mt-1 text-neutral-800">
+                          {c.failed_reason ?? 'Unknown'}
+                        </div>
+                        {c.funding_tx_hash && (
+                          <a
+                            href={baseScanTxUrl(c.funding_tx_hash)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 inline-flex items-center gap-0.5 text-blue-700 hover:underline"
+                          >
+                            {shortenAddr(c.funding_tx_hash)}
+                            <ExternalLink className="size-3" />
+                          </a>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+              {activityQuery.data.failedPayments.length > 0 && (
+                <div>
+                  <h3 className="text-sm font-medium text-red-900">
+                    Payments ({activityQuery.data.failedPayments.length})
+                  </h3>
+                  <ul className="mt-2 space-y-2 text-xs">
+                    {activityQuery.data.failedPayments.map((p) => (
+                      <li
+                        key={p.id}
+                        className="rounded border border-red-100 bg-white/80 p-2"
+                      >
+                        <div className="font-mono text-[11px] text-neutral-600">
+                          session {shortenAddr(p.spend_session_id)}
+                        </div>
+                        <div className="mt-1 text-neutral-800">
+                          {p.failed_reason ?? 'Unknown'}
+                        </div>
+                        {p.payment_tx_hash && (
+                          <a
+                            href={baseScanTxUrl(p.payment_tx_hash)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="mt-1 inline-flex items-center gap-0.5 text-blue-700 hover:underline"
+                          >
+                            {shortenAddr(p.payment_tx_hash)}
+                            <ExternalLink className="size-3" />
+                          </a>
+                        )}
+                      </li>
+                    ))}
+                  </ul>
+                </div>
+              )}
+            </div>
+          </section>
+        )}
+
+      {activityQuery.data && (
+        <section className="rounded-lg border border-neutral-200 bg-white">
+          <div className="border-b border-neutral-100 px-4 py-3">
+            <h2 className="font-semibold text-[#171717]">
+              Recent sessions ({activityQuery.data.sessions.length} shown)
+            </h2>
+            <p className="text-xs text-neutral-500">
+              Newest first. Conversion and payment rows when present.
+            </p>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[640px] text-left text-sm">
+              <thead className="border-b border-neutral-100 bg-neutral-50/80 text-xs uppercase text-neutral-500">
+                <tr>
+                  <th className="px-3 py-2 font-medium">Session</th>
+                  <th className="px-3 py-2 font-medium">Status</th>
+                  <th className="px-3 py-2 font-medium">Conversion</th>
+                  <th className="px-3 py-2 font-medium">Payment</th>
+                </tr>
+              </thead>
+              <tbody>
+                {activityQuery.data.sessions.map(
+                  ({ session, conversion, payment }) => (
+                    <tr
+                      key={session.id}
+                      className="border-b border-neutral-50 last:border-0"
+                    >
+                      <td className="px-3 py-2 align-top font-mono text-xs">
+                        <div>{shortenAddr(session.id)}</div>
+                        <div className="text-neutral-400">
+                          {shortenAddr(session.wallet_address)}
+                        </div>
+                      </td>
+                      <td className="px-3 py-2 align-top capitalize">
+                        {session.status.replace(/_/g, ' ')}
+                      </td>
+                      <td className="px-3 py-2 align-top text-xs">
+                        {conversion ? (
+                          <>
+                            <div>{conversion.status}</div>
+                            <div className="text-neutral-600">
+                              {fmtUsdc(conversion.usdc_amount)}
+                            </div>
+                            {conversion.funding_tx_hash && (
+                              <a
+                                href={baseScanTxUrl(conversion.funding_tx_hash)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline"
+                              >
+                                Tx
+                              </a>
+                            )}
+                          </>
+                        ) : (
+                          <span className="text-neutral-400">—</span>
+                        )}
+                      </td>
+                      <td className="px-3 py-2 align-top text-xs">
+                        {payment ? (
+                          <>
+                            <div>{payment.status}</div>
+                            <div className="text-neutral-600">
+                              {fmtUsdc(payment.usdc_amount)}
+                            </div>
+                            {payment.payment_tx_hash && (
+                              <a
+                                href={baseScanTxUrl(payment.payment_tx_hash)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="text-blue-600 hover:underline"
+                              >
+                                Tx
+                              </a>
+                            )}
+                          </>
+                        ) : (
+                          <span className="text-neutral-400">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  )
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/app/admin/spend-experiences/spend-experience-list.tsx
+++ b/app/admin/spend-experiences/spend-experience-list.tsx
@@ -64,6 +64,11 @@ export function SpendExperienceList({
                 </div>
               </div>
               <div className="flex shrink-0 flex-wrap gap-2">
+                <Button type="button" variant="outline" size="sm" asChild>
+                  <Link href={`/admin/spend-experiences/${exp.id}`}>
+                    Activity
+                  </Link>
+                </Button>
                 <Button
                   type="button"
                   variant="outline"

--- a/app/api/admin/spend-experiences/[experienceId]/activity/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/activity/__tests__/route.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockGetSpendExperienceById = vi.fn();
+const mockGetTotals = vi.fn();
+const mockListActivity = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/spend-experiences', () => ({
+  getSpendExperienceById: (...args: unknown[]) =>
+    mockGetSpendExperienceById(...args),
+}));
+
+vi.mock('@/lib/db/spend-admin', () => ({
+  getSpendPilotAdminTotals: (...args: unknown[]) => mockGetTotals(...args),
+  listSpendPilotActivityForExperience: (...args: unknown[]) =>
+    mockListActivity(...args),
+}));
+
+import { GET } from '../route';
+
+const experience = {
+  id: 'exp-1',
+  title: 'Pilot',
+  description: null,
+  event_id: null,
+  status: 'active' as const,
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  start_time: '2026-05-01T12:00:00.000Z',
+  end_time: '2026-05-08T12:00:00.000Z',
+  created_by: 'a@b.com',
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+};
+
+describe('GET /api/admin/spend-experiences/[experienceId]/activity', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv('NEXT_PUBLIC_MIXPANEL_TOKEN', 'proj-token');
+  });
+
+  it('returns totals and activity when admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(experience);
+    mockGetTotals.mockResolvedValue({
+      usersConverted: 2,
+      totalUsdcDistributed: 10,
+      totalUsdcReceivedAtEventWallet: 8,
+      spendSessionsCount: 5,
+    });
+    mockListActivity.mockResolvedValue({
+      sessions: [],
+      failedConversions: [],
+      failedPayments: [],
+    });
+
+    const headers = new Headers();
+    headers.set('x-user-email', 'admin@example.com');
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/activity',
+      { method: 'GET', headers }
+    );
+    const res = await GET(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(j.data.totals.usersConverted).toBe(2);
+    expect(j.data.mixpanelInsightUrl).toContain('proj-token');
+  });
+
+  it('returns 404 when experience missing', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(null);
+
+    const headers = new Headers();
+    headers.set('x-user-email', 'admin@example.com');
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/missing/activity',
+      { method: 'GET', headers }
+    );
+    const res = await GET(req, { params: { experienceId: 'missing' } });
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/admin/spend-experiences/[experienceId]/activity/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/activity/route.ts
@@ -1,0 +1,52 @@
+import { NextRequest } from 'next/server';
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import {
+  getSpendPilotAdminTotals,
+  listSpendPilotActivityForExperience,
+} from '@/lib/db/spend-admin';
+import { apiSuccess, apiError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+interface RouteParams {
+  params: { experienceId: string };
+}
+
+/**
+ * GET /api/admin/spend-experiences/{experienceId}/activity
+ * Sessions (recent), failed conversion/payment rows, and aggregate totals (PRD §12).
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(_request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const experience = await getSpendExperienceById(params.experienceId);
+    if (!experience) {
+      return apiError('Spend experience not found', 404);
+    }
+
+    const [totals, activity] = await Promise.all([
+      getSpendPilotAdminTotals(experience.id),
+      listSpendPilotActivityForExperience(experience.id),
+    ]);
+
+    const mixpanelProjectId = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN?.trim();
+    const mixpanelInsightUrl = mixpanelProjectId
+      ? `https://mixpanel.com/project/${encodeURIComponent(mixpanelProjectId)}/view/events`
+      : undefined;
+
+    return apiSuccess({
+      spendExperienceId: experience.id,
+      totals,
+      sessions: activity.sessions,
+      failedConversions: activity.failedConversions,
+      failedPayments: activity.failedPayments,
+      mixpanelInsightUrl,
+    });
+  } catch (error) {
+    console.error('admin spend activity:', error);
+    return apiError('Failed to load spend activity', 500);
+  }
+}

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockGetSpendExperienceById = vi.fn();
+const mockFetchBalance = vi.fn();
+const mockListLedger = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/spend-experiences', () => ({
+  getSpendExperienceById: (...args: unknown[]) =>
+    mockGetSpendExperienceById(...args),
+}));
+
+vi.mock('@/lib/spend-conversion-preview', () => ({
+  fetchTreasuryUsdcBalanceSafe: (...args: unknown[]) =>
+    mockFetchBalance(...args),
+}));
+
+vi.mock('@/lib/db/treasury-transactions', () => ({
+  listTreasuryTransactionsForExperience: (...args: unknown[]) =>
+    mockListLedger(...args),
+}));
+
+import { GET } from '../route';
+
+const experience = {
+  id: 'exp-1',
+  title: 'Pilot',
+  description: null,
+  event_id: null,
+  status: 'active' as const,
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  start_time: '2026-05-01T12:00:00.000Z',
+  end_time: '2026-05-08T12:00:00.000Z',
+  created_by: 'a@b.com',
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+};
+
+describe('GET /api/admin/spend-experiences/[experienceId]/treasury', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns balance and ledger totals', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(experience);
+    mockFetchBalance.mockResolvedValue(123.45);
+    mockListLedger.mockResolvedValue([
+      {
+        id: 't1',
+        spend_experience_id: 'exp-1',
+        transaction_type: 'fund_user',
+        amount: 5,
+        from_wallet_address: '0x11',
+        to_wallet_address: '0xaa',
+        tx_hash: '0xabc',
+        status: 'confirmed',
+        created_at: '2026-04-01T00:00:00Z',
+      },
+    ]);
+
+    const headers = new Headers();
+    headers.set('x-user-email', 'admin@example.com');
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury',
+      { method: 'GET', headers }
+    );
+    const res = await GET(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(j.data.treasuryUsdcBalance).toBe(123.45);
+    expect(j.data.ledgerTotals.fund_user_usdc).toBe(5);
+  });
+});

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
@@ -1,0 +1,65 @@
+import { NextRequest } from 'next/server';
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import { fetchTreasuryUsdcBalanceSafe } from '@/lib/spend-conversion-preview';
+import { listTreasuryTransactionsForExperience } from '@/lib/db/treasury-transactions';
+import { apiSuccess, apiError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+interface RouteParams {
+  params: { experienceId: string };
+}
+
+function sumLedgerAmount(
+  rows: { transaction_type: string; amount: number }[],
+  type: string
+): number {
+  let s = 0;
+  for (const r of rows) {
+    if (r.transaction_type === type && Number.isFinite(r.amount)) {
+      s += r.amount;
+    }
+  }
+  return s;
+}
+
+/**
+ * GET /api/admin/spend-experiences/{experienceId}/treasury
+ * Treasury + receiving addresses, live USDC balance, optional ledger (PRD §12).
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(_request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const experience = await getSpendExperienceById(params.experienceId);
+    if (!experience) {
+      return apiError('Spend experience not found', 404);
+    }
+
+    const treasuryWalletAddress = experience.treasury_wallet_address.trim();
+    const receivingWalletAddress = experience.receiving_wallet_address.trim();
+
+    const [treasuryUsdcBalance, ledger] = await Promise.all([
+      fetchTreasuryUsdcBalanceSafe(treasuryWalletAddress),
+      listTreasuryTransactionsForExperience(experience.id),
+    ]);
+
+    return apiSuccess({
+      spendExperienceId: experience.id,
+      treasuryWalletAddress,
+      receivingWalletAddress,
+      treasuryUsdcBalance,
+      ledger,
+      ledgerTotals: {
+        fund_user_usdc: sumLedgerAmount(ledger, 'fund_user'),
+        receive_payment_usdc: sumLedgerAmount(ledger, 'receive_payment'),
+        admin_recovery_usdc: sumLedgerAmount(ledger, 'admin_recovery'),
+      },
+    });
+  } catch (error) {
+    console.error('admin spend treasury:', error);
+    return apiError('Failed to load treasury', 500);
+  }
+}

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
@@ -4,22 +4,29 @@ import { fetchTreasuryUsdcBalanceSafe } from '@/lib/spend-conversion-preview';
 import { listTreasuryTransactionsForExperience } from '@/lib/db/treasury-transactions';
 import { apiSuccess, apiError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
+import type { TreasuryTransaction } from '@/lib/types';
 
 interface RouteParams {
   params: { experienceId: string };
 }
 
-function sumLedgerAmount(
-  rows: { transaction_type: string; amount: number }[],
-  type: string
-): number {
-  let s = 0;
+function ledgerTotalsFromRows(rows: TreasuryTransaction[]): {
+  fund_user_usdc: number;
+  receive_payment_usdc: number;
+  admin_recovery_usdc: number;
+} {
+  let fund_user_usdc = 0;
+  let receive_payment_usdc = 0;
+  let admin_recovery_usdc = 0;
   for (const r of rows) {
-    if (r.transaction_type === type && Number.isFinite(r.amount)) {
-      s += r.amount;
-    }
+    if (!Number.isFinite(r.amount)) continue;
+    if (r.transaction_type === 'fund_user') fund_user_usdc += r.amount;
+    else if (r.transaction_type === 'receive_payment')
+      receive_payment_usdc += r.amount;
+    else if (r.transaction_type === 'admin_recovery')
+      admin_recovery_usdc += r.amount;
   }
-  return s;
+  return { fund_user_usdc, receive_payment_usdc, admin_recovery_usdc };
 }
 
 /**
@@ -46,17 +53,15 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       listTreasuryTransactionsForExperience(experience.id),
     ]);
 
+    const ledgerTotals = ledgerTotalsFromRows(ledger);
+
     return apiSuccess({
       spendExperienceId: experience.id,
       treasuryWalletAddress,
       receivingWalletAddress,
       treasuryUsdcBalance,
       ledger,
-      ledgerTotals: {
-        fund_user_usdc: sumLedgerAmount(ledger, 'fund_user'),
-        receive_payment_usdc: sumLedgerAmount(ledger, 'receive_payment'),
-        admin_recovery_usdc: sumLedgerAmount(ledger, 'admin_recovery'),
-      },
+      ledgerTotals,
     });
   } catch (error) {
     console.error('admin spend treasury:', error);

--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -166,16 +166,16 @@ export async function getSpendPilotAdminTotals(
 
   const fundedRows = fundedAgg.data ?? [];
   const userIds = new Set(fundedRows.map((r) => String(r.user_id)));
-  let totalUsdcDistributed = 0;
-  for (const r of fundedRows) {
-    totalUsdcDistributed += toNum(r.usdc_amount);
-  }
+  const totalUsdcDistributed = fundedRows.reduce<number>(
+    (sum, r) => sum + toNum(r.usdc_amount),
+    0
+  );
 
   const paymentRows = confirmedPaymentsAgg.data ?? [];
-  let totalUsdcReceivedAtEventWallet = 0;
-  for (const r of paymentRows) {
-    totalUsdcReceivedAtEventWallet += toNum(r.usdc_amount);
-  }
+  const totalUsdcReceivedAtEventWallet = paymentRows.reduce<number>(
+    (sum, r) => sum + toNum(r.usdc_amount),
+    0
+  );
 
   return {
     usersConverted: userIds.size,

--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -1,0 +1,310 @@
+import { supabase } from './client';
+import type {
+  PointConversion,
+  SpendSession,
+  SpendTransaction,
+} from '@/lib/types';
+
+const SESSION_COLS = `
+  id,
+  spend_experience_id,
+  user_id,
+  wallet_address,
+  status,
+  qr_token_hash,
+  created_at,
+  expires_at,
+  completed_at
+`;
+
+const CONVERSION_COLS = `
+  id,
+  spend_experience_id,
+  spend_session_id,
+  user_id,
+  points_deducted,
+  usdc_amount,
+  status,
+  treasury_wallet_address,
+  user_wallet_address,
+  funding_tx_hash,
+  idempotency_key,
+  created_at,
+  completed_at,
+  failed_reason
+`;
+
+const SPEND_TX_COLS = `
+  id,
+  spend_experience_id,
+  spend_session_id,
+  user_id,
+  usdc_amount,
+  from_wallet_address,
+  to_wallet_address,
+  status,
+  payment_tx_hash,
+  idempotency_key,
+  created_at,
+  completed_at,
+  failed_reason
+`;
+
+function toNum(v: unknown): number {
+  if (typeof v === 'number' && !Number.isNaN(v)) return v;
+  if (typeof v === 'string') {
+    const n = Number(v);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+}
+
+function rowToSession(row: Record<string, unknown>): SpendSession {
+  return {
+    id: String(row.id),
+    spend_experience_id: String(row.spend_experience_id),
+    user_id: String(row.user_id),
+    wallet_address: String(row.wallet_address),
+    status: row.status as SpendSession['status'],
+    qr_token_hash: row.qr_token_hash == null ? null : String(row.qr_token_hash),
+    created_at: String(row.created_at),
+    expires_at: String(row.expires_at),
+    completed_at: row.completed_at == null ? null : String(row.completed_at),
+  };
+}
+
+function rowToSpendTransaction(row: Record<string, unknown>): SpendTransaction {
+  return {
+    id: String(row.id),
+    spend_experience_id: String(row.spend_experience_id),
+    spend_session_id: String(row.spend_session_id),
+    user_id: String(row.user_id),
+    usdc_amount: toNum(row.usdc_amount),
+    from_wallet_address: String(row.from_wallet_address),
+    to_wallet_address: String(row.to_wallet_address),
+    status: row.status as SpendTransaction['status'],
+    payment_tx_hash:
+      row.payment_tx_hash == null ? null : String(row.payment_tx_hash),
+    idempotency_key:
+      row.idempotency_key == null ? null : String(row.idempotency_key),
+    created_at: String(row.created_at),
+    completed_at: row.completed_at == null ? null : String(row.completed_at),
+    failed_reason: row.failed_reason == null ? null : String(row.failed_reason),
+  };
+}
+
+function rowToConversion(row: Record<string, unknown>): PointConversion {
+  return {
+    id: String(row.id),
+    spend_experience_id: String(row.spend_experience_id),
+    spend_session_id: String(row.spend_session_id),
+    user_id: String(row.user_id),
+    points_deducted: toNum(row.points_deducted),
+    usdc_amount: toNum(row.usdc_amount),
+    status: row.status as PointConversion['status'],
+    treasury_wallet_address: String(row.treasury_wallet_address),
+    user_wallet_address: String(row.user_wallet_address),
+    funding_tx_hash:
+      row.funding_tx_hash == null ? null : String(row.funding_tx_hash),
+    idempotency_key:
+      row.idempotency_key == null ? null : String(row.idempotency_key),
+    created_at: String(row.created_at),
+    completed_at: row.completed_at == null ? null : String(row.completed_at),
+    failed_reason: row.failed_reason == null ? null : String(row.failed_reason),
+  };
+}
+
+export type SpendPilotAdminTotals = {
+  /** Distinct users with status `funded` conversion */
+  usersConverted: number;
+  totalUsdcDistributed: number;
+  totalUsdcReceivedAtEventWallet: number;
+  spendSessionsCount: number;
+};
+
+export async function getSpendPilotAdminTotals(
+  spendExperienceId: string
+): Promise<SpendPilotAdminTotals> {
+  const [fundedAgg, confirmedPaymentsAgg, sessionsCountRes] = await Promise.all(
+    [
+      supabase
+        .from('point_conversions')
+        .select('user_id, usdc_amount')
+        .eq('spend_experience_id', spendExperienceId)
+        .eq('status', 'funded'),
+      supabase
+        .from('spend_transactions')
+        .select('usdc_amount')
+        .eq('spend_experience_id', spendExperienceId)
+        .eq('status', 'confirmed'),
+      supabase
+        .from('spend_sessions')
+        .select('id', { count: 'exact', head: true })
+        .eq('spend_experience_id', spendExperienceId),
+    ]
+  );
+
+  if (fundedAgg.error) {
+    console.error('getSpendPilotAdminTotals funded:', fundedAgg.error);
+    throw new Error(fundedAgg.error.message || 'Failed to sum conversions');
+  }
+  if (confirmedPaymentsAgg.error) {
+    console.error(
+      'getSpendPilotAdminTotals payments:',
+      confirmedPaymentsAgg.error
+    );
+    throw new Error(
+      confirmedPaymentsAgg.error.message || 'Failed to sum payments'
+    );
+  }
+  if (sessionsCountRes.error) {
+    console.error('getSpendPilotAdminTotals sessions:', sessionsCountRes.error);
+    throw new Error(
+      sessionsCountRes.error.message || 'Failed to count sessions'
+    );
+  }
+
+  const fundedRows = fundedAgg.data ?? [];
+  const userIds = new Set(fundedRows.map((r) => String(r.user_id)));
+  let totalUsdcDistributed = 0;
+  for (const r of fundedRows) {
+    totalUsdcDistributed += toNum(r.usdc_amount);
+  }
+
+  const paymentRows = confirmedPaymentsAgg.data ?? [];
+  let totalUsdcReceivedAtEventWallet = 0;
+  for (const r of paymentRows) {
+    totalUsdcReceivedAtEventWallet += toNum(r.usdc_amount);
+  }
+
+  return {
+    usersConverted: userIds.size,
+    totalUsdcDistributed,
+    totalUsdcReceivedAtEventWallet,
+    spendSessionsCount: sessionsCountRes.count ?? 0,
+  };
+}
+
+const ACTIVITY_SESSION_LIMIT = 200;
+const FAILED_LIMIT = 100;
+
+export type SpendPilotSessionActivityRow = {
+  session: SpendSession;
+  conversion: PointConversion | null;
+  payment: SpendTransaction | null;
+};
+
+export async function listSpendPilotActivityForExperience(
+  spendExperienceId: string
+): Promise<{
+  sessions: SpendPilotSessionActivityRow[];
+  failedConversions: PointConversion[];
+  failedPayments: SpendTransaction[];
+}> {
+  const { data: sessionRows, error: sessErr } = await supabase
+    .from('spend_sessions')
+    .select(SESSION_COLS)
+    .eq('spend_experience_id', spendExperienceId)
+    .order('created_at', { ascending: false })
+    .limit(ACTIVITY_SESSION_LIMIT);
+
+  if (sessErr) {
+    console.error('listSpendPilotActivityForExperience sessions:', sessErr);
+    throw new Error(sessErr.message || 'Failed to load sessions');
+  }
+
+  const sessions = (sessionRows ?? []).map((row) =>
+    rowToSession(row as Record<string, unknown>)
+  );
+  const sessionIds = sessions.map((s) => s.id);
+
+  const conversionsBySession = new Map<string, PointConversion>();
+  const paymentsBySession = new Map<string, SpendTransaction>();
+
+  if (sessionIds.length > 0) {
+    const [convRes, payRes] = await Promise.all([
+      supabase
+        .from('point_conversions')
+        .select(CONVERSION_COLS)
+        .eq('spend_experience_id', spendExperienceId)
+        .in('spend_session_id', sessionIds),
+      supabase
+        .from('spend_transactions')
+        .select(SPEND_TX_COLS)
+        .eq('spend_experience_id', spendExperienceId)
+        .in('spend_session_id', sessionIds),
+    ]);
+
+    if (convRes.error) {
+      console.error('listSpendPilotActivityForExperience conv:', convRes.error);
+      throw new Error(convRes.error.message || 'Failed to load conversions');
+    }
+    if (payRes.error) {
+      console.error('listSpendPilotActivityForExperience pay:', payRes.error);
+      throw new Error(payRes.error.message || 'Failed to load payments');
+    }
+
+    for (const row of convRes.data ?? []) {
+      const c = rowToConversion(row as Record<string, unknown>);
+      conversionsBySession.set(c.spend_session_id, c);
+    }
+    for (const row of payRes.data ?? []) {
+      const p = rowToSpendTransaction(row as Record<string, unknown>);
+      paymentsBySession.set(p.spend_session_id, p);
+    }
+  }
+
+  const activitySessions: SpendPilotSessionActivityRow[] = sessions.map(
+    (session) => ({
+      session,
+      conversion: conversionsBySession.get(session.id) ?? null,
+      payment: paymentsBySession.get(session.id) ?? null,
+    })
+  );
+
+  const [failedConvRes, failedPayRes] = await Promise.all([
+    supabase
+      .from('point_conversions')
+      .select(CONVERSION_COLS)
+      .eq('spend_experience_id', spendExperienceId)
+      .eq('status', 'failed')
+      .order('created_at', { ascending: false })
+      .limit(FAILED_LIMIT),
+    supabase
+      .from('spend_transactions')
+      .select(SPEND_TX_COLS)
+      .eq('spend_experience_id', spendExperienceId)
+      .eq('status', 'failed')
+      .order('created_at', { ascending: false })
+      .limit(FAILED_LIMIT),
+  ]);
+
+  if (failedConvRes.error) {
+    console.error(
+      'listSpendPilotActivityForExperience failed conv:',
+      failedConvRes.error
+    );
+    throw new Error(
+      failedConvRes.error.message || 'Failed to load failed conversions'
+    );
+  }
+  if (failedPayRes.error) {
+    console.error(
+      'listSpendPilotActivityForExperience failed pay:',
+      failedPayRes.error
+    );
+    throw new Error(
+      failedPayRes.error.message || 'Failed to load failed payments'
+    );
+  }
+
+  return {
+    sessions: activitySessions,
+    failedConversions: (failedConvRes.data ?? []).map((row) =>
+      rowToConversion(row as Record<string, unknown>)
+    ),
+    failedPayments: (failedPayRes.data ?? []).map((row) =>
+      rowToSpendTransaction(row as Record<string, unknown>)
+    ),
+  };
+}

--- a/lib/db/treasury-transactions.ts
+++ b/lib/db/treasury-transactions.ts
@@ -1,0 +1,125 @@
+import { supabase } from './client';
+import type { TreasuryTransaction } from '@/lib/types';
+
+const TREASURY_COLS = `
+  id,
+  spend_experience_id,
+  transaction_type,
+  amount,
+  from_wallet_address,
+  to_wallet_address,
+  tx_hash,
+  status,
+  created_at
+`;
+
+function rowToTreasury(row: Record<string, unknown>): TreasuryTransaction {
+  return {
+    id: String(row.id),
+    spend_experience_id:
+      row.spend_experience_id == null ? null : String(row.spend_experience_id),
+    transaction_type:
+      row.transaction_type as TreasuryTransaction['transaction_type'],
+    amount:
+      typeof row.amount === 'number' ? row.amount : Number(row.amount ?? NaN),
+    from_wallet_address:
+      row.from_wallet_address == null ? null : String(row.from_wallet_address),
+    to_wallet_address:
+      row.to_wallet_address == null ? null : String(row.to_wallet_address),
+    tx_hash: row.tx_hash == null ? null : String(row.tx_hash),
+    status: row.status as TreasuryTransaction['status'],
+    created_at: String(row.created_at),
+  };
+}
+
+/**
+ * Optional audit row for treasury → user USDC (matches `point_conversions.funding_tx_hash` when confirmed).
+ */
+export async function insertTreasuryFundUserLedgerIfAbsent(input: {
+  spendExperienceId: string;
+  amount: number;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  txHash: string;
+}): Promise<void> {
+  const txLower = input.txHash.trim().toLowerCase();
+  const { data: existing } = await supabase
+    .from('treasury_transactions')
+    .select('id')
+    .eq('spend_experience_id', input.spendExperienceId)
+    .eq('transaction_type', 'fund_user')
+    .eq('tx_hash', txLower)
+    .maybeSingle();
+
+  if (existing) return;
+
+  const { error } = await supabase.from('treasury_transactions').insert({
+    spend_experience_id: input.spendExperienceId,
+    transaction_type: 'fund_user',
+    amount: input.amount,
+    from_wallet_address: input.fromWalletAddress.trim().toLowerCase(),
+    to_wallet_address: input.toWalletAddress.trim().toLowerCase(),
+    tx_hash: txLower,
+    status: 'confirmed',
+  });
+
+  if (error) {
+    console.error('insertTreasuryFundUserLedgerIfAbsent:', error);
+  }
+}
+
+/**
+ * Optional audit row for user → receiving wallet USDC (matches `spend_transactions.payment_tx_hash` when confirmed).
+ */
+export async function insertTreasuryReceivePaymentLedgerIfAbsent(input: {
+  spendExperienceId: string;
+  amount: number;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  txHash: string;
+}): Promise<void> {
+  const txLower = input.txHash.trim().toLowerCase();
+  const { data: existing } = await supabase
+    .from('treasury_transactions')
+    .select('id')
+    .eq('spend_experience_id', input.spendExperienceId)
+    .eq('transaction_type', 'receive_payment')
+    .eq('tx_hash', txLower)
+    .maybeSingle();
+
+  if (existing) return;
+
+  const { error } = await supabase.from('treasury_transactions').insert({
+    spend_experience_id: input.spendExperienceId,
+    transaction_type: 'receive_payment',
+    amount: input.amount,
+    from_wallet_address: input.fromWalletAddress.trim().toLowerCase(),
+    to_wallet_address: input.toWalletAddress.trim().toLowerCase(),
+    tx_hash: txLower,
+    status: 'confirmed',
+  });
+
+  if (error) {
+    console.error('insertTreasuryReceivePaymentLedgerIfAbsent:', error);
+  }
+}
+
+export async function listTreasuryTransactionsForExperience(
+  spendExperienceId: string,
+  limit = 500
+): Promise<TreasuryTransaction[]> {
+  const { data, error } = await supabase
+    .from('treasury_transactions')
+    .select(TREASURY_COLS)
+    .eq('spend_experience_id', spendExperienceId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.error('listTreasuryTransactionsForExperience:', error);
+    throw new Error(error.message || 'Failed to load treasury ledger');
+  }
+  return (data ?? []).map((row) =>
+    rowToTreasury(row as Record<string, unknown>)
+  );
+}

--- a/lib/db/treasury-transactions.ts
+++ b/lib/db/treasury-transactions.ts
@@ -32,76 +32,82 @@ function rowToTreasury(row: Record<string, unknown>): TreasuryTransaction {
   };
 }
 
-/**
- * Optional audit row for treasury → user USDC (matches `point_conversions.funding_tx_hash` when confirmed).
- */
-export async function insertTreasuryFundUserLedgerIfAbsent(input: {
+type TreasuryLedgerInsertType = Extract<
+  TreasuryTransaction['transaction_type'],
+  'fund_user' | 'receive_payment'
+>;
+
+async function insertTreasuryLedgerRowIfAbsent(params: {
   spendExperienceId: string;
+  transactionType: TreasuryLedgerInsertType;
   amount: number;
   fromWalletAddress: string;
   toWalletAddress: string;
   txHash: string;
 }): Promise<void> {
-  const txLower = input.txHash.trim().toLowerCase();
+  const txLower = params.txHash.trim().toLowerCase();
   const { data: existing } = await supabase
     .from('treasury_transactions')
     .select('id')
-    .eq('spend_experience_id', input.spendExperienceId)
-    .eq('transaction_type', 'fund_user')
+    .eq('spend_experience_id', params.spendExperienceId)
+    .eq('transaction_type', params.transactionType)
     .eq('tx_hash', txLower)
     .maybeSingle();
 
   if (existing) return;
 
   const { error } = await supabase.from('treasury_transactions').insert({
-    spend_experience_id: input.spendExperienceId,
-    transaction_type: 'fund_user',
-    amount: input.amount,
-    from_wallet_address: input.fromWalletAddress.trim().toLowerCase(),
-    to_wallet_address: input.toWalletAddress.trim().toLowerCase(),
+    spend_experience_id: params.spendExperienceId,
+    transaction_type: params.transactionType,
+    amount: params.amount,
+    from_wallet_address: params.fromWalletAddress.trim().toLowerCase(),
+    to_wallet_address: params.toWalletAddress.trim().toLowerCase(),
     tx_hash: txLower,
     status: 'confirmed',
   });
 
   if (error) {
-    console.error('insertTreasuryFundUserLedgerIfAbsent:', error);
+    console.error(
+      `insertTreasuryLedgerRowIfAbsent (${params.transactionType}):`,
+      error
+    );
   }
 }
 
-/**
- * Optional audit row for user → receiving wallet USDC (matches `spend_transactions.payment_tx_hash` when confirmed).
- */
-export async function insertTreasuryReceivePaymentLedgerIfAbsent(input: {
+/** Optional audit row: treasury → user USDC (matches funded `point_conversions.funding_tx_hash`). */
+export function insertTreasuryFundUserLedgerIfAbsent(input: {
   spendExperienceId: string;
   amount: number;
   fromWalletAddress: string;
   toWalletAddress: string;
   txHash: string;
 }): Promise<void> {
-  const txLower = input.txHash.trim().toLowerCase();
-  const { data: existing } = await supabase
-    .from('treasury_transactions')
-    .select('id')
-    .eq('spend_experience_id', input.spendExperienceId)
-    .eq('transaction_type', 'receive_payment')
-    .eq('tx_hash', txLower)
-    .maybeSingle();
-
-  if (existing) return;
-
-  const { error } = await supabase.from('treasury_transactions').insert({
-    spend_experience_id: input.spendExperienceId,
-    transaction_type: 'receive_payment',
+  return insertTreasuryLedgerRowIfAbsent({
+    spendExperienceId: input.spendExperienceId,
+    transactionType: 'fund_user',
     amount: input.amount,
-    from_wallet_address: input.fromWalletAddress.trim().toLowerCase(),
-    to_wallet_address: input.toWalletAddress.trim().toLowerCase(),
-    tx_hash: txLower,
-    status: 'confirmed',
+    fromWalletAddress: input.fromWalletAddress,
+    toWalletAddress: input.toWalletAddress,
+    txHash: input.txHash,
   });
+}
 
-  if (error) {
-    console.error('insertTreasuryReceivePaymentLedgerIfAbsent:', error);
-  }
+/** Optional audit row: user → event wallet USDC (matches confirmed `spend_transactions.payment_tx_hash`). */
+export function insertTreasuryReceivePaymentLedgerIfAbsent(input: {
+  spendExperienceId: string;
+  amount: number;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  txHash: string;
+}): Promise<void> {
+  return insertTreasuryLedgerRowIfAbsent({
+    spendExperienceId: input.spendExperienceId,
+    transactionType: 'receive_payment',
+    amount: input.amount,
+    fromWalletAddress: input.fromWalletAddress,
+    toWalletAddress: input.toWalletAddress,
+    txHash: input.txHash,
+  });
 }
 
 export async function listTreasuryTransactionsForExperience(

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -21,6 +21,7 @@ import {
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
 } from '@/lib/spend-treasury-usdc-transfer';
+import { insertTreasuryFundUserLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import type {
   PointConversion,
   SpendExperience,
@@ -438,6 +439,13 @@ export async function runSpendConversionConfirm(
     status: 'funded',
     completed_at: new Date().toISOString(),
   });
+  void insertTreasuryFundUserLedgerIfAbsent({
+    spendExperienceId: spendExperience.id,
+    amount: completed.usdc_amount,
+    fromWalletAddress: spendExperience.treasury_wallet_address,
+    toWalletAddress: completed.user_wallet_address,
+    txHash,
+  });
   await markSessionAfterFunding(session.id);
   trackSpendConversionCompleted(distinctId, {
     ...baseAnalytics,
@@ -587,6 +595,13 @@ async function fundOrResumeUsdc(input: {
   const done = await updatePointConversionFields(conv.id, {
     status: 'funded',
     completed_at: new Date().toISOString(),
+  });
+  void insertTreasuryFundUserLedgerIfAbsent({
+    spendExperienceId: spendExperience.id,
+    amount: done.usdc_amount,
+    fromWalletAddress: spendExperience.treasury_wallet_address,
+    toWalletAddress: done.user_wallet_address,
+    txHash: hash,
   });
   await markSessionAfterFunding(session.id);
   trackSpendConversionCompleted(distinctId, {

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -8,6 +8,7 @@ import {
   updateSpendTransactionFields,
   confirmSpendTransactionIfSubmitted,
 } from '@/lib/db/spend-sessions';
+import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import { computeConversionAmounts } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
@@ -348,6 +349,16 @@ export async function runSpendPaymentConfirm(input: {
     getSpendTransactionBySessionId(session.id),
     getSpendSessionById(session.id),
   ]);
+
+  if (updatedTx?.status === 'confirmed' && updatedTx.payment_tx_hash) {
+    void insertTreasuryReceivePaymentLedgerIfAbsent({
+      spendExperienceId: spendExperience.id,
+      amount: updatedTx.usdc_amount,
+      fromWalletAddress: updatedTx.from_wallet_address,
+      toWalletAddress: updatedTx.to_wallet_address,
+      txHash: updatedTx.payment_tx_hash,
+    });
+  }
 
   if (!didWinRace && updatedTx?.status === 'confirmed') {
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements GitHub issue [#509](https://github.com/hurley87/refraction/issues/509): admin monitoring for the spend pilot—activity aggregates, treasury balance, failed conversion/payment visibility, and optional `treasury_transactions` ledger rows aligned with on-chain hashes.

## Changes

- **API:** `GET /api/admin/spend-experiences/{experienceId}/activity` returns totals (users converted, USDC distributed, USDC received at event wallet, session count), recent sessions with conversion/payment joins, failed conversions/payments with truncated reasons, and a Mixpanel events URL when `NEXT_PUBLIC_MIXPANEL_TOKEN` is set.
- **API:** `GET /api/admin/spend-experiences/{experienceId}/treasury` returns treasury and receiving addresses, live treasury USDC balance via existing RPC helper, optional ledger rows, and ledger totals by type.
- **Ledger:** On successful conversion funding and confirmed payments, idempotent `fund_user` / `receive_payment` rows are inserted into `treasury_transactions` (matches `funding_tx_hash` / `payment_tx_hash`).
- **UI:** `/admin/spend-experiences/[experienceId]` dashboard with metrics, treasury block, failed tx panel (with BaseScan links, no secrets), session table, QR + refresh, Mixpanel link when token exists. List page adds an **Activity** button per experience.

Follow-up: deduped treasury ledger insert logic, clearer admin page helpers, single-pass ledger totals on the treasury route.

## Testing

- Vitest coverage for both admin routes.
- `yarn build` succeeds.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e06d6745-010e-4564-aaef-0d66cea90f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e06d6745-010e-4564-aaef-0d66cea90f43"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

