### PR TITLE
Replace spend wallet fields with Privy server wallet

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -20,6 +20,7 @@ import type {
   SpendTransaction,
   TreasuryTransaction,
 } from '@/lib/types';
+import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
 
 type ActivityTotals = {
   usersConverted: number;
@@ -50,13 +51,7 @@ type TreasuryPayload = {
   serverWalletChain: string | null;
   serverWalletCreatedAt: string | null;
   serverWalletUsdcBalance: number | null;
-  funding: {
-    serverWalletAddress: string;
-    chain: string;
-    minimumUsdc: number;
-    usdcBalance: number | null;
-    funded: boolean;
-  };
+  funding: SpendServerWalletFundingMetadata;
   treasuryWalletAddress: string;
   receivingWalletAddress: string;
   treasuryUsdcBalance: number | null;

--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -5,7 +5,13 @@ import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
-import { Loader2, ArrowLeft, ExternalLink, RefreshCw } from 'lucide-react';
+import {
+  Loader2,
+  ArrowLeft,
+  ExternalLink,
+  RefreshCw,
+  Copy,
+} from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type {
   PointConversion,
@@ -39,6 +45,18 @@ type ActivityPayload = {
 
 type TreasuryPayload = {
   spendExperienceId: string;
+  serverWalletAddress: string;
+  privyServerWalletId: string | null;
+  serverWalletChain: string | null;
+  serverWalletCreatedAt: string | null;
+  serverWalletUsdcBalance: number | null;
+  funding: {
+    serverWalletAddress: string;
+    chain: string;
+    minimumUsdc: number;
+    usdcBalance: number | null;
+    funded: boolean;
+  };
   treasuryWalletAddress: string;
   receivingWalletAddress: string;
   treasuryUsdcBalance: number | null;
@@ -68,6 +86,10 @@ function shortenAddr(a: string): string {
 function baseScanTxUrl(hash: string): string {
   const h = hash.trim().toLowerCase();
   return `https://basescan.org/tx/${h}`;
+}
+
+async function copyText(value: string): Promise<void> {
+  await navigator.clipboard.writeText(value);
 }
 
 function TxHashShortLink({
@@ -279,6 +301,7 @@ export default function SpendExperienceDetailPage() {
   const treasuryData = treasuryQuery.data;
   const totals = activityData?.totals;
   const mixpanelUrl = activityData?.mixpanelInsightUrl;
+  const funding = treasuryData?.funding;
   const ledgerTotalsSuffix =
     treasuryData && treasuryData.ledgerTotals.admin_recovery_usdc > 0
       ? ` · admin_recovery ${fmtUsdc(treasuryData.ledgerTotals.admin_recovery_usdc)}`
@@ -344,6 +367,35 @@ export default function SpendExperienceDetailPage() {
         </p>
       )}
 
+      {funding && !funding.funded && (
+        <section className="mb-8 rounded-lg border border-amber-200 bg-amber-50 p-5 text-sm text-amber-950">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <h2 className="font-semibold">
+                Fund server wallet before activation
+              </h2>
+              <p className="mt-1">
+                Send at least {fmtUsdc(funding.minimumUsdc)} USDC on Base now,
+                and enough USDC for expected redemptions.
+              </p>
+              <code className="mt-3 block break-all rounded bg-white/70 p-2 text-xs text-neutral-900">
+                {funding.serverWalletAddress}
+              </code>
+            </div>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              className="gap-1 bg-white"
+              onClick={() => void copyText(funding.serverWalletAddress)}
+            >
+              <Copy className="size-3.5" />
+              Copy
+            </Button>
+          </div>
+        </section>
+      )}
+
       {totals && treasuryData && (
         <section className="mb-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
           <div className="rounded-lg border border-neutral-200 bg-white p-4">
@@ -364,7 +416,7 @@ export default function SpendExperienceDetailPage() {
           </div>
           <div className="rounded-lg border border-neutral-200 bg-white p-4">
             <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
-              USDC at event wallet
+              USDC received
             </div>
             <div className="mt-1 text-2xl font-semibold tabular-nums">
               {fmtUsdc(totals.totalUsdcReceivedAtEventWallet)}
@@ -372,7 +424,7 @@ export default function SpendExperienceDetailPage() {
           </div>
           <div className="rounded-lg border border-neutral-200 bg-white p-4">
             <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
-              Treasury USDC (live)
+              Server wallet USDC
             </div>
             <div className="mt-1 text-2xl font-semibold tabular-nums">
               {fmtUsdc(treasuryData.treasuryUsdcBalance)}
@@ -383,19 +435,21 @@ export default function SpendExperienceDetailPage() {
 
       {treasuryData && (
         <section className="mb-8 rounded-lg border border-neutral-200 bg-white p-5">
-          <h2 className="text-lg font-semibold text-[#171717]">Treasury</h2>
+          <h2 className="text-lg font-semibold text-[#171717]">
+            Server wallet
+          </h2>
           <div className="mt-3 grid gap-4 text-sm sm:grid-cols-2">
             <div>
-              <div className="text-neutral-500">Treasury wallet</div>
+              <div className="text-neutral-500">Wallet address</div>
               <code className="mt-0.5 block break-all text-xs text-neutral-800">
-                {treasuryData.treasuryWalletAddress}
+                {treasuryData.serverWalletAddress}
               </code>
             </div>
             <div>
-              <div className="text-neutral-500">Receiving (event) wallet</div>
-              <code className="mt-0.5 block break-all text-xs text-neutral-800">
-                {treasuryData.receivingWalletAddress}
-              </code>
+              <div className="text-neutral-500">Base USDC balance</div>
+              <div className="mt-0.5 text-neutral-800">
+                {fmtUsdc(treasuryData.serverWalletUsdcBalance)}
+              </div>
             </div>
           </div>
           {treasuryData.ledger.length > 0 && (

--- a/app/admin/spend-experiences/form-state.ts
+++ b/app/admin/spend-experiences/form-state.ts
@@ -7,8 +7,6 @@ export type SpendExperienceFormState = {
   status: SpendExperienceStatus;
   points_to_usdc_rate: string;
   max_usdc_per_user: string;
-  treasury_wallet_address: string;
-  receiving_wallet_address: string;
   start_time_local: string;
   end_time_local: string;
 };
@@ -37,8 +35,6 @@ export function experienceToForm(e: SpendExperience): SpendExperienceFormState {
     status: e.status,
     points_to_usdc_rate: String(e.points_to_usdc_rate),
     max_usdc_per_user: String(e.max_usdc_per_user),
-    treasury_wallet_address: e.treasury_wallet_address,
-    receiving_wallet_address: e.receiving_wallet_address,
     start_time_local: isoToDatetimeLocalValue(e.start_time),
     end_time_local: isoToDatetimeLocalValue(e.end_time),
   };
@@ -53,8 +49,6 @@ export function emptySpendExperienceForm(): SpendExperienceFormState {
     status: 'draft',
     points_to_usdc_rate: '1000',
     max_usdc_per_user: '5',
-    treasury_wallet_address: '',
-    receiving_wallet_address: '',
     start_time_local: isoToDatetimeLocalValue(start),
     end_time_local: isoToDatetimeLocalValue(end),
   };

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -15,18 +15,13 @@ import {
 } from './form-state';
 import { SpendExperienceFormPanel } from './spend-experience-form-panel';
 import { SpendExperienceList } from './spend-experience-list';
+import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
 
 const QUERY_KEY = ['admin-spend-experiences'] as const;
 
 type CreateSpendExperienceResponse = {
   spendExperience: SpendExperience;
-  funding?: {
-    serverWalletAddress: string;
-    chain: string;
-    minimumUsdc: number;
-    usdcBalance: number | null;
-    funded: boolean;
-  };
+  funding?: SpendServerWalletFundingMetadata;
 };
 
 export default function AdminSpendExperiencesPage() {

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -103,7 +103,7 @@ export default function AdminSpendExperiencesPage() {
     setEditing(null);
   }, []);
 
-  const saveMutation = useMutation({
+  const saveMutation = useMutation<CreateSpendExperienceResponse, Error>({
     mutationFn: async () => {
       const payload = {
         title: form.title.trim(),

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -18,6 +18,17 @@ import { SpendExperienceList } from './spend-experience-list';
 
 const QUERY_KEY = ['admin-spend-experiences'] as const;
 
+type CreateSpendExperienceResponse = {
+  spendExperience: SpendExperience;
+  funding?: {
+    serverWalletAddress: string;
+    chain: string;
+    minimumUsdc: number;
+    usdcBalance: number | null;
+    funded: boolean;
+  };
+};
+
 export default function AdminSpendExperiencesPage() {
   const { user, login } = usePrivy();
   const queryClient = useQueryClient();
@@ -25,6 +36,9 @@ export default function AdminSpendExperiencesPage() {
   const [adminLoading, setAdminLoading] = useState(true);
   const [panelOpen, setPanelOpen] = useState(false);
   const [editing, setEditing] = useState<SpendExperience | null>(null);
+  const [createdFunding, setCreatedFunding] = useState<
+    CreateSpendExperienceResponse['funding'] | null
+  >(null);
   const [form, setForm] = useState<SpendExperienceFormState>(
     emptySpendExperienceForm
   );
@@ -98,8 +112,6 @@ export default function AdminSpendExperiencesPage() {
         status: form.status,
         points_to_usdc_rate: Number(form.points_to_usdc_rate),
         max_usdc_per_user: Number(form.max_usdc_per_user),
-        treasury_wallet_address: form.treasury_wallet_address.trim(),
-        receiving_wallet_address: form.receiving_wallet_address.trim(),
         start_time: datetimeLocalToIso(form.start_time_local),
         end_time: datetimeLocalToIso(form.end_time_local),
       };
@@ -113,25 +125,32 @@ export default function AdminSpendExperiencesPage() {
         if (!response.ok) {
           throw new Error(j.error || j.message || 'Update failed');
         }
-        return j.data?.spendExperience ?? j.spendExperience;
+        const spendExperience = j.data?.spendExperience ?? j.spendExperience;
+        return { spendExperience } satisfies CreateSpendExperienceResponse;
       }
 
       const response = await fetch('/api/admin/spend-experiences', {
         method: 'POST',
-        headers,
+        headers: {
+          ...headers,
+          'Idempotency-Key': crypto.randomUUID(),
+        },
         body: JSON.stringify(payload),
       });
       const j = await response.json().catch(() => ({}));
       if (!response.ok) {
         throw new Error(j.error || j.message || 'Create failed');
       }
-      return j.data?.spendExperience ?? j.spendExperience;
+      return (j.data ?? j) as CreateSpendExperienceResponse;
     },
-    onSuccess: () => {
+    onSuccess: (result) => {
       void queryClient.invalidateQueries({ queryKey: QUERY_KEY });
       toast.success(
         editing ? 'Spend experience updated' : 'Spend experience created'
       );
+      if (!editing && result.funding) {
+        setCreatedFunding(result.funding);
+      }
       setPanelOpen(false);
       setEditing(null);
       setForm(emptySpendExperienceForm());
@@ -141,12 +160,14 @@ export default function AdminSpendExperiencesPage() {
 
   const openCreate = useCallback(() => {
     setEditing(null);
+    setCreatedFunding(null);
     setForm(emptySpendExperienceForm());
     setPanelOpen(true);
   }, []);
 
   const openEdit = useCallback((e: SpendExperience) => {
     setEditing(e);
+    setCreatedFunding(null);
     setForm(experienceToForm(e));
     setPanelOpen(true);
   }, []);
@@ -186,6 +207,35 @@ export default function AdminSpendExperiencesPage() {
 
   return (
     <div className="mx-auto max-w-3xl p-6 font-grotesk">
+      {createdFunding && (
+        <section className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
+          <div className="font-semibold">Fund the server wallet</div>
+          <p className="mt-1">
+            Send at least ${createdFunding.minimumUsdc.toFixed(2)} USDC on Base
+            to activate this spend experience. Fund enough USDC for expected
+            redemptions.
+          </p>
+          <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
+            <code className="flex-1 break-all rounded bg-white/80 px-2 py-1 text-xs">
+              {createdFunding.serverWalletAddress}
+            </code>
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                void navigator.clipboard.writeText(
+                  createdFunding.serverWalletAddress
+                );
+                toast.success('Server wallet copied');
+              }}
+            >
+              Copy
+            </Button>
+          </div>
+        </section>
+      )}
+
       <SpendExperienceList
         experiences={spendExperiences}
         isLoading={isLoading}

--- a/app/admin/spend-experiences/spend-experience-form-panel.tsx
+++ b/app/admin/spend-experiences/spend-experience-form-panel.tsx
@@ -167,36 +167,19 @@ export function SpendExperienceFormPanel({
               />
             </div>
           </div>
-          <div className="space-y-2">
-            <Label htmlFor="se-treasury">Treasury wallet (funds users)</Label>
-            <Input
-              id="se-treasury"
-              className="font-mono text-sm"
-              value={form.treasury_wallet_address}
-              onChange={(ev) =>
-                setForm((f) => ({
-                  ...f,
-                  treasury_wallet_address: ev.target.value,
-                }))
-              }
-              placeholder="0x…"
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="se-receive">Receiving wallet (event / IRL)</Label>
-            <Input
-              id="se-receive"
-              className="font-mono text-sm"
-              value={form.receiving_wallet_address}
-              onChange={(ev) =>
-                setForm((f) => ({
-                  ...f,
-                  receiving_wallet_address: ev.target.value,
-                }))
-              }
-              placeholder="0x…"
-            />
-          </div>
+          {editing?.server_wallet_address && (
+            <div className="rounded-lg border border-blue-100 bg-blue-50 p-3 text-sm">
+              <div className="font-medium text-blue-950">
+                Privy server wallet
+              </div>
+              <p className="mt-1 text-blue-900">
+                Backend-managed on Base. Admins do not edit wallet addresses.
+              </p>
+              <code className="mt-2 block break-all text-xs text-blue-950">
+                {editing.server_wallet_address}
+              </code>
+            </div>
+          )}
           <div className="grid gap-4 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="se-start">Start (local)</Label>

--- a/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
@@ -4,6 +4,7 @@ import { NextRequest } from 'next/server';
 const mockRequireAdmin = vi.fn();
 const mockGetSpendExperienceById = vi.fn();
 const mockUpdateSpendExperience = vi.fn();
+const mockGetFundingStatus = vi.fn();
 
 vi.mock('@/lib/auth', () => ({
   requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
@@ -14,6 +15,11 @@ vi.mock('@/lib/db/spend-experiences', () => ({
     mockGetSpendExperienceById(...args),
   updateSpendExperience: (...args: unknown[]) =>
     mockUpdateSpendExperience(...args),
+}));
+
+vi.mock('@/lib/spend-server-wallet', () => ({
+  getServerWalletFundingStatus: (...args: unknown[]) =>
+    mockGetFundingStatus(...args),
 }));
 
 import { PATCH, GET } from '../route';
@@ -28,6 +34,11 @@ const existing = {
   max_usdc_per_user: 5,
   treasury_wallet_address: '0x1111111111111111111111111111111111111111',
   receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  privy_server_wallet_id: 'wallet-1',
+  server_wallet_address: '0x1111111111111111111111111111111111111111',
+  server_wallet_chain: 'base-mainnet',
+  server_wallet_created_at: '2026-04-01T00:00:00Z',
+  spend_create_idempotency_key: 'idem-1',
   start_time: '2026-05-01T12:00:00.000Z',
   end_time: '2026-05-08T12:00:00.000Z',
   created_by: 'a@b.com',
@@ -130,5 +141,51 @@ describe('PATCH /api/admin/spend-experiences/[experienceId]', () => {
     expect(j.success).toBe(false);
     expect(j.error).toContain('end_time');
     expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('blocks activation until the server wallet has max USDC per user', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(existing);
+    mockGetFundingStatus.mockResolvedValue({ usdcBalance: 2, isFunded: false });
+
+    const res = await PATCH(
+      patchRequest({ status: 'active' }, 'admin@example.com'),
+      { params: { experienceId: 'exp-1' } }
+    );
+    const j = await res.json();
+
+    expect(res.status).toBe(400);
+    expect(j.error).toContain('Server wallet');
+    expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('allows activation when the server wallet is funded', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(existing);
+    mockGetFundingStatus.mockResolvedValue({ usdcBalance: 6, isFunded: true });
+    mockUpdateSpendExperience.mockResolvedValue({
+      ...existing,
+      status: 'active',
+    });
+
+    const res = await PATCH(
+      patchRequest({ status: 'active' }, 'admin@example.com'),
+      { params: { experienceId: 'exp-1' } }
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockGetFundingStatus).toHaveBeenCalledWith({
+      walletAddress: existing.server_wallet_address,
+      minUsdcRequired: existing.max_usdc_per_user,
+    });
+    expect(mockUpdateSpendExperience).toHaveBeenCalledWith('exp-1', {
+      status: 'active',
+    });
   });
 });

--- a/app/api/admin/spend-experiences/[experienceId]/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/route.ts
@@ -6,6 +6,7 @@ import {
 import { updateSpendExperienceRequestSchema } from '@/lib/schemas/spend-experience';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
+import { getServerWalletFundingStatus } from '@/lib/spend-server-wallet';
 
 interface RouteParams {
   params: { experienceId: string };
@@ -54,6 +55,20 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const nextEnd = validation.data.end_time ?? existing.end_time;
     if (new Date(nextEnd) <= new Date(nextStart)) {
       return apiError('end_time must be after start_time', 400);
+    }
+
+    if (validation.data.status === 'active') {
+      const funding = await getServerWalletFundingStatus({
+        walletAddress: existing.server_wallet_address,
+        minUsdcRequired:
+          validation.data.max_usdc_per_user ?? existing.max_usdc_per_user,
+      });
+      if (!funding.isFunded) {
+        return apiError(
+          'Server wallet must be funded with at least max_usdc_per_user USDC before activation.',
+          400
+        );
+      }
     }
 
     const spendExperience = await updateSpendExperience(

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts
@@ -15,10 +15,15 @@ vi.mock('@/lib/db/spend-experiences', () => ({
     mockGetSpendExperienceById(...args),
 }));
 
-vi.mock('@/lib/spend-conversion-preview', () => ({
-  fetchTreasuryUsdcBalanceSafe: (...args: unknown[]) =>
-    mockFetchBalance(...args),
-}));
+vi.mock('@/lib/spend-server-wallet', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/spend-server-wallet')>();
+  return {
+    ...actual,
+    fetchServerWalletUsdcBalanceSafe: (...args: unknown[]) =>
+      mockFetchBalance(...args),
+  };
+});
 
 vi.mock('@/lib/db/treasury-transactions', () => ({
   listTreasuryTransactionsForExperience: (...args: unknown[]) =>
@@ -37,6 +42,11 @@ const experience = {
   max_usdc_per_user: 5,
   treasury_wallet_address: '0x1111111111111111111111111111111111111111',
   receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  privy_server_wallet_id: 'privy-wallet-1',
+  server_wallet_address: '0x3333333333333333333333333333333333333333',
+  server_wallet_chain: 'base-mainnet',
+  server_wallet_created_at: '2026-04-01T00:00:00Z',
+  spend_create_idempotency_key: 'idem-1',
   start_time: '2026-05-01T12:00:00.000Z',
   end_time: '2026-05-08T12:00:00.000Z',
   created_by: 'a@b.com',
@@ -78,7 +88,13 @@ describe('GET /api/admin/spend-experiences/[experienceId]/treasury', () => {
     const j = await res.json();
 
     expect(res.status).toBe(200);
-    expect(j.data.treasuryUsdcBalance).toBe(123.45);
+    expect(mockFetchBalance).toHaveBeenCalledWith(
+      expect.objectContaining({
+        server_wallet_address: '0x3333333333333333333333333333333333333333',
+      })
+    );
+    expect(j.data.serverWalletUsdcBalance).toBe(123.45);
+    expect(j.data.funding.funded).toBe(true);
     expect(j.data.ledgerTotals.fund_user_usdc).toBe(5);
   });
 });

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
@@ -1,10 +1,14 @@
 import { NextRequest } from 'next/server';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
-import { fetchTreasuryUsdcBalanceSafe } from '@/lib/spend-conversion-preview';
 import { listTreasuryTransactionsForExperience } from '@/lib/db/treasury-transactions';
 import { apiSuccess, apiError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
 import type { TreasuryTransaction } from '@/lib/types';
+import {
+  fetchServerWalletUsdcBalanceSafe,
+  getSpendServerWalletAddress,
+  spendServerWalletFundingMetadata,
+} from '@/lib/spend-server-wallet';
 
 interface RouteParams {
   params: { experienceId: string };
@@ -31,7 +35,7 @@ function ledgerTotalsFromRows(rows: TreasuryTransaction[]): {
 
 /**
  * GET /api/admin/spend-experiences/{experienceId}/treasury
- * Treasury + receiving addresses, live USDC balance, optional ledger (PRD §12).
+ * Server wallet address, live USDC balance, optional ledger (PRD §12).
  */
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
@@ -45,21 +49,30 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       return apiError('Spend experience not found', 404);
     }
 
-    const treasuryWalletAddress = experience.treasury_wallet_address.trim();
-    const receivingWalletAddress = experience.receiving_wallet_address.trim();
+    const serverWalletAddress = getSpendServerWalletAddress(experience).trim();
 
-    const [treasuryUsdcBalance, ledger] = await Promise.all([
-      fetchTreasuryUsdcBalanceSafe(treasuryWalletAddress),
+    const [serverWalletUsdcBalance, ledger] = await Promise.all([
+      fetchServerWalletUsdcBalanceSafe(experience),
       listTreasuryTransactionsForExperience(experience.id),
     ]);
 
     const ledgerTotals = ledgerTotalsFromRows(ledger);
+    const funding = spendServerWalletFundingMetadata(
+      experience,
+      serverWalletUsdcBalance
+    );
 
     return apiSuccess({
       spendExperienceId: experience.id,
-      treasuryWalletAddress,
-      receivingWalletAddress,
-      treasuryUsdcBalance,
+      serverWalletAddress,
+      privyServerWalletId: experience.privy_server_wallet_id,
+      serverWalletChain: experience.server_wallet_chain,
+      serverWalletCreatedAt: experience.server_wallet_created_at,
+      serverWalletUsdcBalance,
+      funding,
+      treasuryWalletAddress: serverWalletAddress,
+      receivingWalletAddress: serverWalletAddress,
+      treasuryUsdcBalance: serverWalletUsdcBalance,
       ledger,
       ledgerTotals,
     });

--- a/app/api/admin/spend-experiences/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/__tests__/route.test.ts
@@ -4,6 +4,8 @@ import { NextRequest } from 'next/server';
 const mockRequireAdmin = vi.fn();
 const mockListSpendExperiences = vi.fn();
 const mockCreateSpendExperience = vi.fn();
+const mockGetSpendExperienceByCreateIdempotencyKey = vi.fn();
+const mockCreateSpendPrivyServerWallet = vi.fn();
 
 vi.mock('@/lib/auth', () => ({
   requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
@@ -14,6 +16,13 @@ vi.mock('@/lib/db/spend-experiences', () => ({
     mockListSpendExperiences(...args),
   createSpendExperience: (...args: unknown[]) =>
     mockCreateSpendExperience(...args),
+  getSpendExperienceByCreateIdempotencyKey: (...args: unknown[]) =>
+    mockGetSpendExperienceByCreateIdempotencyKey(...args),
+}));
+
+vi.mock('@/lib/api/privy', () => ({
+  createSpendPrivyServerWallet: (...args: unknown[]) =>
+    mockCreateSpendPrivyServerWallet(...args),
 }));
 
 import { GET, POST } from '../route';
@@ -78,7 +87,16 @@ describe('GET /api/admin/spend-experiences', () => {
 });
 
 describe('POST /api/admin/spend-experiences', () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSpendExperienceByCreateIdempotencyKey.mockResolvedValue(null);
+    mockCreateSpendPrivyServerWallet.mockResolvedValue({
+      privy_server_wallet_id: 'wallet-1',
+      server_wallet_address: '0x9999999999999999999999999999999999999999',
+      server_wallet_chain: 'base-mainnet',
+      server_wallet_created_at: '2026-04-28T00:00:00.000Z',
+    });
+  });
 
   it('returns 400 on validation failure', async () => {
     mockRequireAdmin.mockResolvedValue({
@@ -93,9 +111,6 @@ describe('POST /api/admin/spend-experiences', () => {
           title: '',
           points_to_usdc_rate: 1000,
           max_usdc_per_user: 5,
-          treasury_wallet_address: '0x1111111111111111111111111111111111111111',
-          receiving_wallet_address:
-            '0x2222222222222222222222222222222222222222',
           start_time: '2026-05-01T12:00:00.000Z',
           end_time: '2026-05-08T12:00:00.000Z',
         },
@@ -117,9 +132,6 @@ describe('POST /api/admin/spend-experiences', () => {
           title: 'Ok',
           points_to_usdc_rate: 1000,
           max_usdc_per_user: 5,
-          treasury_wallet_address: '0x1111111111111111111111111111111111111111',
-          receiving_wallet_address:
-            '0x2222222222222222222222222222222222222222',
           start_time: '2026-05-01T12:00:00.000Z',
           end_time: '2026-05-08T12:00:00.000Z',
         },
@@ -127,6 +139,109 @@ describe('POST /api/admin/spend-experiences', () => {
       )
     );
     expect(res.status).toBe(403);
+    expect(mockCreateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('creates a Privy server wallet before inserting the spend experience', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockCreateSpendExperience.mockImplementation(async (input) => ({
+      id: 'exp-1',
+      title: input.title,
+      description: input.description,
+      event_id: input.event_id,
+      status: input.status,
+      points_to_usdc_rate: input.points_to_usdc_rate,
+      max_usdc_per_user: input.max_usdc_per_user,
+      treasury_wallet_address: input.server_wallet_address,
+      receiving_wallet_address: input.server_wallet_address,
+      privy_server_wallet_id: input.privy_server_wallet_id,
+      server_wallet_address: input.server_wallet_address,
+      server_wallet_chain: input.server_wallet_chain,
+      server_wallet_created_at: input.server_wallet_created_at,
+      spend_create_idempotency_key: input.spend_create_idempotency_key,
+      start_time: input.start_time,
+      end_time: input.end_time,
+      created_by: input.created_by,
+      created_at: '2026-04-28T00:00:00.000Z',
+      updated_at: '2026-04-28T00:00:00.000Z',
+    }));
+
+    const res = await POST(
+      jsonRequest(
+        'POST',
+        {
+          title: 'Ok',
+          points_to_usdc_rate: 1000,
+          max_usdc_per_user: 5,
+          status: 'active',
+          start_time: '2026-05-01T12:00:00.000Z',
+          end_time: '2026-05-08T12:00:00.000Z',
+        },
+        'admin@example.com'
+      )
+    );
+    const j = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(mockCreateSpendPrivyServerWallet).toHaveBeenCalledOnce();
+    expect(mockCreateSpendExperience).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'draft',
+        privy_server_wallet_id: 'wallet-1',
+        server_wallet_address: '0x9999999999999999999999999999999999999999',
+      })
+    );
+    expect(j.data.funding.serverWalletAddress).toBe(
+      '0x9999999999999999999999999999999999999999'
+    );
+  });
+
+  it('returns existing experience for repeated idempotency key', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceByCreateIdempotencyKey.mockResolvedValue({
+      id: 'exp-existing',
+      title: 'Existing',
+      description: null,
+      event_id: null,
+      status: 'draft',
+      points_to_usdc_rate: 1000,
+      max_usdc_per_user: 5,
+      treasury_wallet_address: '0x9999999999999999999999999999999999999999',
+      receiving_wallet_address: '0x9999999999999999999999999999999999999999',
+      privy_server_wallet_id: 'wallet-1',
+      server_wallet_address: '0x9999999999999999999999999999999999999999',
+      server_wallet_chain: 'base-mainnet',
+      server_wallet_created_at: '2026-04-28T00:00:00.000Z',
+      spend_create_idempotency_key: 'idem-1',
+      start_time: '2026-05-01T12:00:00.000Z',
+      end_time: '2026-05-08T12:00:00.000Z',
+      created_by: 'admin@example.com',
+      created_at: '2026-04-28T00:00:00.000Z',
+      updated_at: '2026-04-28T00:00:00.000Z',
+    });
+
+    const req = jsonRequest(
+      'POST',
+      {
+        title: 'Ok',
+        points_to_usdc_rate: 1000,
+        max_usdc_per_user: 5,
+        start_time: '2026-05-01T12:00:00.000Z',
+        end_time: '2026-05-08T12:00:00.000Z',
+      },
+      'admin@example.com'
+    );
+    req.headers.set('Idempotency-Key', 'idem-1');
+    const res = await POST(req);
+
+    expect(res.status).toBe(200);
+    expect(mockCreateSpendPrivyServerWallet).not.toHaveBeenCalled();
     expect(mockCreateSpendExperience).not.toHaveBeenCalled();
   });
 });

--- a/app/api/admin/spend-experiences/route.ts
+++ b/app/api/admin/spend-experiences/route.ts
@@ -1,11 +1,24 @@
 import { NextRequest } from 'next/server';
 import {
   createSpendExperience,
+  getSpendExperienceByCreateIdempotencyKey,
   listSpendExperiences,
 } from '@/lib/db/spend-experiences';
 import { createSpendExperienceRequestSchema } from '@/lib/schemas/spend-experience';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
+import { createSpendPrivyServerWallet } from '@/lib/api/privy';
+import { spendServerWalletAddress } from '@/lib/spend-server-wallet';
+
+const DEFAULT_SPEND_WALLET_CHAIN = 'base-mainnet';
+
+function createIdempotencyKey(request: NextRequest): string {
+  return (
+    request.headers.get('idempotency-key') ??
+    request.headers.get('x-idempotency-key') ??
+    crypto.randomUUID()
+  ).trim();
+}
 
 /** GET /api/admin/spend-experiences */
 export async function GET(request: NextRequest) {
@@ -37,18 +50,61 @@ export async function POST(request: NextRequest) {
       return apiValidationError(validation.error);
     }
 
+    const idempotencyKey = createIdempotencyKey(request);
+    if (!idempotencyKey) {
+      return apiError('Missing idempotency key', 400);
+    }
+
+    const existing =
+      await getSpendExperienceByCreateIdempotencyKey(idempotencyKey);
+    if (existing) {
+      return apiSuccess(
+        {
+          spendExperience: existing,
+          funding: {
+            serverWalletAddress: spendServerWalletAddress(existing),
+            chain: existing.server_wallet_chain,
+            minimumUsdc: existing.max_usdc_per_user,
+            usdcBalance: null,
+            funded: false,
+          },
+        },
+        'Spend experience already created'
+      );
+    }
+
+    const wallet = await createSpendPrivyServerWallet({ idempotencyKey });
     const adminEmail = adminCheck.user?.email || undefined;
     const spendExperience = await createSpendExperience({
       ...validation.data,
+      status: 'draft',
+      privy_server_wallet_id: wallet.privy_server_wallet_id,
+      server_wallet_address: wallet.server_wallet_address,
+      server_wallet_chain: DEFAULT_SPEND_WALLET_CHAIN,
+      server_wallet_created_at: wallet.server_wallet_created_at,
+      spend_create_idempotency_key: idempotencyKey,
       created_by: adminEmail ?? null,
     });
 
     return apiSuccess(
-      { spendExperience },
+      {
+        spendExperience,
+        funding: {
+          serverWalletAddress: wallet.server_wallet_address,
+          chain: DEFAULT_SPEND_WALLET_CHAIN,
+          minimumUsdc: spendExperience.max_usdc_per_user,
+          usdcBalance: null,
+          funded: false,
+        },
+      },
       'Spend experience created successfully'
     );
   } catch (error) {
     console.error('Error creating spend experience:', error);
-    return apiError('Failed to create spend experience', 500);
+    const message =
+      error instanceof Error && error.message.includes('Privy')
+        ? error.message
+        : 'Failed to create spend experience';
+    return apiError(message, 500);
   }
 }

--- a/app/api/admin/spend-experiences/route.ts
+++ b/app/api/admin/spend-experiences/route.ts
@@ -8,9 +8,10 @@ import { createSpendExperienceRequestSchema } from '@/lib/schemas/spend-experien
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
 import { createSpendPrivyServerWallet } from '@/lib/api/privy';
-import { spendServerWalletAddress } from '@/lib/spend-server-wallet';
-
-const DEFAULT_SPEND_WALLET_CHAIN = 'base-mainnet';
+import {
+  SPEND_SERVER_WALLET_CHAIN,
+  spendServerWalletFundingMetadata,
+} from '@/lib/spend-server-wallet';
 
 function createIdempotencyKey(request: NextRequest): string {
   return (
@@ -61,13 +62,7 @@ export async function POST(request: NextRequest) {
       return apiSuccess(
         {
           spendExperience: existing,
-          funding: {
-            serverWalletAddress: spendServerWalletAddress(existing),
-            chain: existing.server_wallet_chain,
-            minimumUsdc: existing.max_usdc_per_user,
-            usdcBalance: null,
-            funded: false,
-          },
+          funding: spendServerWalletFundingMetadata(existing, null),
         },
         'Spend experience already created'
       );
@@ -80,7 +75,7 @@ export async function POST(request: NextRequest) {
       status: 'draft',
       privy_server_wallet_id: wallet.privy_server_wallet_id,
       server_wallet_address: wallet.server_wallet_address,
-      server_wallet_chain: DEFAULT_SPEND_WALLET_CHAIN,
+      server_wallet_chain: SPEND_SERVER_WALLET_CHAIN,
       server_wallet_created_at: wallet.server_wallet_created_at,
       spend_create_idempotency_key: idempotencyKey,
       created_by: adminEmail ?? null,
@@ -89,13 +84,7 @@ export async function POST(request: NextRequest) {
     return apiSuccess(
       {
         spendExperience,
-        funding: {
-          serverWalletAddress: wallet.server_wallet_address,
-          chain: DEFAULT_SPEND_WALLET_CHAIN,
-          minimumUsdc: spendExperience.max_usdc_per_user,
-          usdcBalance: null,
-          funded: false,
-        },
+        funding: spendServerWalletFundingMetadata(spendExperience, null),
       },
       'Spend experience created successfully'
     );

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -478,14 +478,6 @@ export function SpendExperiencePage({
                           </span>
                         </div>
                       )}
-                      <div className="border-t border-neutral-100 pt-2">
-                        <p className="text-xs text-neutral-500">
-                          Event wallet (USDC on Base)
-                        </p>
-                        <p className="break-all font-mono text-xs text-[#171717]">
-                          {preview.receivingWalletAddress}
-                        </p>
-                      </div>
                     </div>
                   )}
 

--- a/database/spend-experiences-schema.sql
+++ b/database/spend-experiences-schema.sql
@@ -15,8 +15,14 @@ CREATE TABLE IF NOT EXISTS spend_experiences (
         CHECK (points_to_usdc_rate > 0),
     max_usdc_per_user NUMERIC(24, 8) NOT NULL
         CHECK (max_usdc_per_user > 0),
+    -- Legacy columns retained for existing RPC/ledger compatibility; new rows mirror server_wallet_address.
     treasury_wallet_address TEXT NOT NULL,
     receiving_wallet_address TEXT NOT NULL,
+    privy_server_wallet_id TEXT,
+    server_wallet_address TEXT,
+    server_wallet_chain TEXT NOT NULL DEFAULT 'base-mainnet',
+    server_wallet_created_at TIMESTAMPTZ,
+    spend_create_idempotency_key TEXT,
     start_time TIMESTAMPTZ NOT NULL,
     end_time TIMESTAMPTZ NOT NULL,
     created_by VARCHAR(255),
@@ -39,7 +45,15 @@ CREATE INDEX IF NOT EXISTS idx_spend_experiences_event_id
 CREATE INDEX IF NOT EXISTS idx_spend_experiences_created_at
     ON spend_experiences (created_at DESC);
 
-COMMENT ON TABLE spend_experiences IS 'Admin spend pilot configuration: conversion rate, caps, wallets, active window.';
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spend_experiences_privy_server_wallet_id
+    ON spend_experiences (privy_server_wallet_id)
+    WHERE privy_server_wallet_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spend_experiences_create_idempotency_key
+    ON spend_experiences (spend_create_idempotency_key)
+    WHERE spend_create_idempotency_key IS NOT NULL;
+
+COMMENT ON TABLE spend_experiences IS 'Admin spend pilot configuration: conversion rate, caps, Privy server wallet, active window.';
 
 CREATE OR REPLACE FUNCTION update_spend_experiences_updated_at()
 RETURNS TRIGGER AS $$

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -1,5 +1,6 @@
 import { NextRequest } from 'next/server';
 import { PrivyClient } from '@privy-io/server-auth';
+import type { SpendServerWalletMetadata } from '@/lib/spend-server-wallet';
 
 // Lazy-initialized singleton shared across all API routes
 let privyClient: PrivyClient | null = null;
@@ -99,5 +100,26 @@ export async function verifyWalletOwnership(
     return { authorized: true, userId: verifiedClaims.userId };
   } catch {
     return { authorized: false, error: 'Invalid or expired token' };
+  }
+}
+
+export async function createSpendPrivyServerWallet(params: {
+  idempotencyKey: string;
+}): Promise<SpendServerWalletMetadata> {
+  try {
+    const wallet = await getPrivyClient().walletApi.createWallet({
+      chainType: 'ethereum',
+      idempotencyKey: params.idempotencyKey,
+    });
+
+    return {
+      privy_server_wallet_id: wallet.id,
+      server_wallet_address: wallet.address,
+      server_wallet_chain: 'base-mainnet',
+      server_wallet_created_at: wallet.createdAt.toISOString(),
+    };
+  } catch (error) {
+    console.error('createSpendPrivyServerWallet:', error);
+    throw new Error('Privy server wallet could not be created');
   }
 }

--- a/lib/db/spend-experiences.ts
+++ b/lib/db/spend-experiences.ts
@@ -11,6 +11,11 @@ const SPEND_EXPERIENCE_COLUMNS = `
   max_usdc_per_user,
   treasury_wallet_address,
   receiving_wallet_address,
+  privy_server_wallet_id,
+  server_wallet_address,
+  server_wallet_chain,
+  server_wallet_created_at,
+  spend_create_idempotency_key,
   start_time,
   end_time,
   created_by,
@@ -37,6 +42,24 @@ const normalizeRow = (row: Record<string, unknown>): SpendExperience => ({
   max_usdc_per_user: toNumber(row.max_usdc_per_user),
   treasury_wallet_address: String(row.treasury_wallet_address),
   receiving_wallet_address: String(row.receiving_wallet_address),
+  privy_server_wallet_id:
+    row.privy_server_wallet_id == null
+      ? null
+      : String(row.privy_server_wallet_id),
+  server_wallet_address:
+    row.server_wallet_address == null
+      ? null
+      : String(row.server_wallet_address),
+  server_wallet_chain:
+    row.server_wallet_chain == null ? null : String(row.server_wallet_chain),
+  server_wallet_created_at:
+    row.server_wallet_created_at == null
+      ? null
+      : String(row.server_wallet_created_at),
+  spend_create_idempotency_key:
+    row.spend_create_idempotency_key == null
+      ? null
+      : String(row.spend_create_idempotency_key),
   start_time: String(row.start_time),
   end_time: String(row.end_time),
   created_by: row.created_by == null ? null : String(row.created_by),
@@ -67,8 +90,11 @@ export type CreateSpendExperienceInput = {
   status: SpendExperienceStatus;
   points_to_usdc_rate: number;
   max_usdc_per_user: number;
-  treasury_wallet_address: string;
-  receiving_wallet_address: string;
+  privy_server_wallet_id: string;
+  server_wallet_address: string;
+  server_wallet_chain: string;
+  server_wallet_created_at: string;
+  spend_create_idempotency_key: string;
   start_time: string;
   end_time: string;
   created_by?: string | null;
@@ -84,8 +110,13 @@ export async function createSpendExperience(
     status: input.status,
     points_to_usdc_rate: input.points_to_usdc_rate,
     max_usdc_per_user: input.max_usdc_per_user,
-    treasury_wallet_address: input.treasury_wallet_address,
-    receiving_wallet_address: input.receiving_wallet_address,
+    treasury_wallet_address: input.server_wallet_address,
+    receiving_wallet_address: input.server_wallet_address,
+    privy_server_wallet_id: input.privy_server_wallet_id,
+    server_wallet_address: input.server_wallet_address,
+    server_wallet_chain: input.server_wallet_chain,
+    server_wallet_created_at: input.server_wallet_created_at,
+    spend_create_idempotency_key: input.spend_create_idempotency_key,
     start_time: input.start_time,
     end_time: input.end_time,
     created_by: input.created_by ?? null,
@@ -98,6 +129,12 @@ export async function createSpendExperience(
     .single();
 
   if (error) {
+    if (error.code === '23505' && input.spend_create_idempotency_key) {
+      const existing = await getSpendExperienceByCreateIdempotencyKey(
+        input.spend_create_idempotency_key
+      );
+      if (existing) return existing;
+    }
     console.error('createSpendExperience error:', error);
     throw new Error(error.message || 'Failed to create spend experience');
   }
@@ -112,8 +149,6 @@ export type UpdateSpendExperienceInput = Partial<{
   status: SpendExperienceStatus;
   points_to_usdc_rate: number;
   max_usdc_per_user: number;
-  treasury_wallet_address: string;
-  receiving_wallet_address: string;
   start_time: string;
   end_time: string;
 }>;
@@ -125,8 +160,6 @@ const UPDATE_SPEND_EXPERIENCE_KEYS: (keyof UpdateSpendExperienceInput)[] = [
   'status',
   'points_to_usdc_rate',
   'max_usdc_per_user',
-  'treasury_wallet_address',
-  'receiving_wallet_address',
   'start_time',
   'end_time',
 ];
@@ -155,6 +188,24 @@ export async function getSpendExperienceById(
 
   if (error) {
     console.error('getSpendExperienceById error:', error);
+    throw new Error(error.message || 'Failed to load spend experience');
+  }
+
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function getSpendExperienceByCreateIdempotencyKey(
+  idempotencyKey: string
+): Promise<SpendExperience | null> {
+  const { data, error } = await supabase
+    .from('spend_experiences')
+    .select(SPEND_EXPERIENCE_COLUMNS)
+    .eq('spend_create_idempotency_key', idempotencyKey)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendExperienceByCreateIdempotencyKey error:', error);
     throw new Error(error.message || 'Failed to load spend experience');
   }
 

--- a/lib/schemas/__tests__/spend-experience.test.ts
+++ b/lib/schemas/__tests__/spend-experience.test.ts
@@ -11,8 +11,6 @@ const validBase = {
   status: 'draft' as const,
   points_to_usdc_rate: 1000,
   max_usdc_per_user: 5,
-  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
-  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
   start_time: '2026-05-01T12:00:00.000Z',
   end_time: '2026-05-08T12:00:00.000Z',
 };
@@ -23,10 +21,10 @@ describe('createSpendExperienceRequestSchema', () => {
     expect(r.success).toBe(true);
   });
 
-  it('rejects invalid treasury address', () => {
+  it('does not accept admin-managed wallet addresses', () => {
     const r = createSpendExperienceRequestSchema.safeParse({
       ...validBase,
-      treasury_wallet_address: 'not-an-address',
+      treasury_wallet_address: '0x1111111111111111111111111111111111111111',
     });
     expect(r.success).toBe(false);
   });

--- a/lib/schemas/spend-experience.ts
+++ b/lib/schemas/spend-experience.ts
@@ -1,6 +1,4 @@
 import { z } from 'zod';
-import { walletAddressSchema } from './player';
-
 export const spendExperienceStatusSchema = z.enum(['draft', 'active', 'ended']);
 
 /**
@@ -14,11 +12,11 @@ export const createSpendExperienceRequestSchema = z
     status: spendExperienceStatusSchema.default('draft'),
     points_to_usdc_rate: z.coerce.number().positive().max(1e15),
     max_usdc_per_user: z.coerce.number().positive().max(1e9),
-    treasury_wallet_address: walletAddressSchema,
-    receiving_wallet_address: walletAddressSchema,
     start_time: z.string().datetime({ offset: true }),
     end_time: z.string().datetime({ offset: true }),
+    idempotency_key: z.string().min(8).max(256).optional(),
   })
+  .strict()
   .refine((data) => new Date(data.end_time) > new Date(data.start_time), {
     message: 'end_time must be after start_time',
     path: ['end_time'],
@@ -32,11 +30,10 @@ export const updateSpendExperienceRequestSchema = z
     status: spendExperienceStatusSchema.optional(),
     points_to_usdc_rate: z.coerce.number().positive().max(1e15).optional(),
     max_usdc_per_user: z.coerce.number().positive().max(1e9).optional(),
-    treasury_wallet_address: walletAddressSchema.optional(),
-    receiving_wallet_address: walletAddressSchema.optional(),
     start_time: z.string().datetime({ offset: true }).optional(),
     end_time: z.string().datetime({ offset: true }).optional(),
   })
+  .strict()
   .refine((data) => Object.keys(data).length > 0, {
     message: 'At least one field is required',
   })

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -227,13 +227,18 @@ export async function runSpendConversionConfirm(
   }
 
   const serverWalletAddress = getSpendServerWalletAddress(spendExperience);
-  if (!serverWalletAddress || !spendExperience.privy_server_wallet_id) {
+  if (
+    !serverWalletAddress ||
+    !isEvmAddress(serverWalletAddress) ||
+    !spendExperience.privy_server_wallet_id
+  ) {
     return {
       ok: false,
       httpStatus: 500,
       error: 'Conversion is not configured correctly. Please contact support.',
     };
   }
+  const serverWalletAddressHex = serverWalletAddress as `0x${string}`;
 
   if (!isEvmAddress(session.wallet_address.trim())) {
     return {
@@ -244,7 +249,7 @@ export async function runSpendConversionConfirm(
   }
 
   const userRecipient = recipientUsdcAddressForSpendTransfer({
-    serverWalletAddress,
+    serverWalletAddress: serverWalletAddressHex,
     sessionWalletTrimmed: session.wallet_address.trim(),
     normalizedWalletLower: normalizedWallet,
   });
@@ -258,7 +263,7 @@ export async function runSpendConversionConfirm(
       spendExperienceId: spendExperience.id,
       pointsToDeduct: pointsRequired,
       usdcAmount,
-      treasuryWalletAddress: serverWalletAddress,
+      treasuryWalletAddress: serverWalletAddressHex,
       userWalletAddress: session.wallet_address,
     });
   } catch (e) {
@@ -316,7 +321,7 @@ export async function runSpendConversionConfirm(
 
   const sub = await submitTreasuryUsdcTransfer({
     serverWalletId: spendExperience.privy_server_wallet_id,
-    serverWalletAddress,
+    serverWalletAddress: serverWalletAddressHex,
     recipientAddress: userRecipient,
     usdcAmount,
   });
@@ -415,7 +420,7 @@ export async function runSpendConversionConfirm(
   void insertTreasuryFundUserLedgerIfAbsent({
     spendExperienceId: spendExperience.id,
     amount: completed.usdc_amount,
-    fromWalletAddress: serverWalletAddress,
+    fromWalletAddress: serverWalletAddressHex,
     toWalletAddress: completed.user_wallet_address,
     txHash,
   });
@@ -459,7 +464,11 @@ async function fundOrResumeUsdc(input: {
   } = input;
 
   const serverWalletAddress = getSpendServerWalletAddress(spendExperience);
-  if (!serverWalletAddress || !spendExperience.privy_server_wallet_id) {
+  if (
+    !serverWalletAddress ||
+    !isEvmAddress(serverWalletAddress) ||
+    !spendExperience.privy_server_wallet_id
+  ) {
     return {
       error: {
         ok: false,
@@ -469,18 +478,19 @@ async function fundOrResumeUsdc(input: {
       },
     };
   }
+  const serverWalletAddressHex = serverWalletAddress as `0x${string}`;
 
   let conv = pointConversion;
   if (conv.status === 'points_deducted' && !conv.funding_tx_hash) {
     const userRecipient = recipientUsdcAddressForSpendTransfer({
-      serverWalletAddress,
+      serverWalletAddress: serverWalletAddressHex,
       sessionWalletTrimmed: session.wallet_address.trim(),
       normalizedWalletLower: normalizedWallet,
     });
 
     const sub = await submitTreasuryUsdcTransfer({
       serverWalletId: spendExperience.privy_server_wallet_id,
-      serverWalletAddress,
+      serverWalletAddress: serverWalletAddressHex,
       recipientAddress: userRecipient,
       usdcAmount,
     });
@@ -575,7 +585,7 @@ async function fundOrResumeUsdc(input: {
   void insertTreasuryFundUserLedgerIfAbsent({
     spendExperienceId: spendExperience.id,
     amount: done.usdc_amount,
-    fromWalletAddress: serverWalletAddress,
+    fromWalletAddress: serverWalletAddressHex,
     toWalletAddress: done.user_wallet_address,
     txHash: hash,
   });

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -12,15 +12,15 @@ import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import {
   computeConversionAmounts,
-  fetchTreasuryUsdcBalanceSafe,
+  fetchServerWalletUsdcBalanceSafe,
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
 import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
 import {
-  getServerWalletAddress,
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
 } from '@/lib/spend-treasury-usdc-transfer';
+import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
 import { insertTreasuryFundUserLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import type {
   PointConversion,
@@ -52,45 +52,18 @@ type ConfirmContext = {
   pointsRequired: number;
 };
 
-function assertServerTreasuryMatchesExperience(
-  experience: SpendExperience
-):
-  | { ok: true; serverAddress: `0x${string}` }
-  | { ok: false; userMessage: string } {
-  const serverAddress = getServerWalletAddress();
-  if (!serverAddress) {
-    return { ok: false, userMessage: 'Conversion is temporarily unavailable.' };
-  }
-  const expected = experience.treasury_wallet_address.trim().toLowerCase();
-  const actual = serverAddress.toLowerCase();
-  if (expected !== actual) {
-    console.error(
-      'Treasury address mismatch: experience expects',
-      expected,
-      'server key derives',
-      actual
-    );
-    return {
-      ok: false,
-      userMessage:
-        'Conversion is not configured correctly. Please contact support.',
-    };
-  }
-  return { ok: true, serverAddress };
-}
-
 /**
- * Treasury-funded USDC goes to the session embedded wallet. If session wallet equals treasury
+ * Server-wallet-funded USDC goes to the session embedded wallet. If session wallet equals the server wallet
  * (misconfiguration), fall back to the normalized embedded address from auth.
  */
 function recipientUsdcAddressForSpendTransfer(params: {
-  treasuryWalletAddress: string;
+  serverWalletAddress: string;
   sessionWalletTrimmed: string;
   normalizedWalletLower: string;
 }): `0x${string}` {
-  const treasuryLower = params.treasuryWalletAddress.trim().toLowerCase();
+  const serverWalletLower = params.serverWalletAddress.trim().toLowerCase();
   const sessionLower = params.sessionWalletTrimmed.toLowerCase();
-  if (treasuryLower === sessionLower) {
+  if (serverWalletLower === sessionLower) {
     return params.normalizedWalletLower as `0x${string}`;
   }
   return params.sessionWalletTrimmed as `0x${string}`;
@@ -239,9 +212,7 @@ export async function runSpendConversionConfirm(
     };
   }
 
-  const bal = await fetchTreasuryUsdcBalanceSafe(
-    spendExperience.treasury_wallet_address
-  );
+  const bal = await fetchServerWalletUsdcBalanceSafe(spendExperience);
   if (bal === null || bal < usdcAmount) {
     trackSpendTreasuryInsufficientFunds(distinctId, {
       ...baseAnalytics,
@@ -255,12 +226,12 @@ export async function runSpendConversionConfirm(
     };
   }
 
-  const treasuryCheck = assertServerTreasuryMatchesExperience(spendExperience);
-  if (!treasuryCheck.ok) {
+  const serverWalletAddress = getSpendServerWalletAddress(spendExperience);
+  if (!serverWalletAddress || !spendExperience.privy_server_wallet_id) {
     return {
       ok: false,
       httpStatus: 500,
-      error: treasuryCheck.userMessage,
+      error: 'Conversion is not configured correctly. Please contact support.',
     };
   }
 
@@ -273,7 +244,7 @@ export async function runSpendConversionConfirm(
   }
 
   const userRecipient = recipientUsdcAddressForSpendTransfer({
-    treasuryWalletAddress: spendExperience.treasury_wallet_address,
+    serverWalletAddress,
     sessionWalletTrimmed: session.wallet_address.trim(),
     normalizedWalletLower: normalizedWallet,
   });
@@ -287,7 +258,7 @@ export async function runSpendConversionConfirm(
       spendExperienceId: spendExperience.id,
       pointsToDeduct: pointsRequired,
       usdcAmount,
-      treasuryWalletAddress: spendExperience.treasury_wallet_address,
+      treasuryWalletAddress: serverWalletAddress,
       userWalletAddress: session.wallet_address,
     });
   } catch (e) {
@@ -344,6 +315,8 @@ export async function runSpendConversionConfirm(
   }
 
   const sub = await submitTreasuryUsdcTransfer({
+    serverWalletId: spendExperience.privy_server_wallet_id,
+    serverWalletAddress,
     recipientAddress: userRecipient,
     usdcAmount,
   });
@@ -442,7 +415,7 @@ export async function runSpendConversionConfirm(
   void insertTreasuryFundUserLedgerIfAbsent({
     spendExperienceId: spendExperience.id,
     amount: completed.usdc_amount,
-    fromWalletAddress: spendExperience.treasury_wallet_address,
+    fromWalletAddress: serverWalletAddress,
     toWalletAddress: completed.user_wallet_address,
     txHash,
   });
@@ -485,13 +458,14 @@ async function fundOrResumeUsdc(input: {
     baseAnalytics,
   } = input;
 
-  const tre = assertServerTreasuryMatchesExperience(spendExperience);
-  if (!tre.ok) {
+  const serverWalletAddress = getSpendServerWalletAddress(spendExperience);
+  if (!serverWalletAddress || !spendExperience.privy_server_wallet_id) {
     return {
       error: {
         ok: false,
         httpStatus: 500,
-        error: tre.userMessage,
+        error:
+          'Conversion is not configured correctly. Please contact support.',
       },
     };
   }
@@ -499,12 +473,14 @@ async function fundOrResumeUsdc(input: {
   let conv = pointConversion;
   if (conv.status === 'points_deducted' && !conv.funding_tx_hash) {
     const userRecipient = recipientUsdcAddressForSpendTransfer({
-      treasuryWalletAddress: spendExperience.treasury_wallet_address,
+      serverWalletAddress,
       sessionWalletTrimmed: session.wallet_address.trim(),
       normalizedWalletLower: normalizedWallet,
     });
 
     const sub = await submitTreasuryUsdcTransfer({
+      serverWalletId: spendExperience.privy_server_wallet_id,
+      serverWalletAddress,
       recipientAddress: userRecipient,
       usdcAmount,
     });
@@ -599,7 +575,7 @@ async function fundOrResumeUsdc(input: {
   void insertTreasuryFundUserLedgerIfAbsent({
     spendExperienceId: spendExperience.id,
     amount: done.usdc_amount,
-    fromWalletAddress: spendExperience.treasury_wallet_address,
+    fromWalletAddress: serverWalletAddress,
     toWalletAddress: done.user_wallet_address,
     txHash: hash,
   });

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -12,7 +12,6 @@ import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import {
   computeConversionAmounts,
-  fetchServerWalletUsdcBalanceSafe,
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
 import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
@@ -20,7 +19,10 @@ import {
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
 } from '@/lib/spend-treasury-usdc-transfer';
-import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
+import {
+  fetchServerWalletUsdcBalanceSafe,
+  getSpendServerWalletTransferConfig,
+} from '@/lib/spend-server-wallet';
 import { insertTreasuryFundUserLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import type {
   PointConversion,
@@ -41,6 +43,8 @@ const RESUMABLE: PointConversion['status'][] = [
   'points_deducted',
   'funding_pending',
 ];
+const MISCONFIGURED_CONVERSION_ERROR =
+  'Conversion is not configured correctly. Please contact support.';
 
 type ConfirmContext = {
   session: SpendSession;
@@ -226,19 +230,14 @@ export async function runSpendConversionConfirm(
     };
   }
 
-  const serverWalletAddress = getSpendServerWalletAddress(spendExperience);
-  if (
-    !serverWalletAddress ||
-    !isEvmAddress(serverWalletAddress) ||
-    !spendExperience.privy_server_wallet_id
-  ) {
+  const serverWallet = getSpendServerWalletTransferConfig(spendExperience);
+  if (!serverWallet) {
     return {
       ok: false,
       httpStatus: 500,
-      error: 'Conversion is not configured correctly. Please contact support.',
+      error: MISCONFIGURED_CONVERSION_ERROR,
     };
   }
-  const serverWalletAddressHex = serverWalletAddress as `0x${string}`;
 
   if (!isEvmAddress(session.wallet_address.trim())) {
     return {
@@ -249,7 +248,7 @@ export async function runSpendConversionConfirm(
   }
 
   const userRecipient = recipientUsdcAddressForSpendTransfer({
-    serverWalletAddress: serverWalletAddressHex,
+    serverWalletAddress: serverWallet.address,
     sessionWalletTrimmed: session.wallet_address.trim(),
     normalizedWalletLower: normalizedWallet,
   });
@@ -263,7 +262,7 @@ export async function runSpendConversionConfirm(
       spendExperienceId: spendExperience.id,
       pointsToDeduct: pointsRequired,
       usdcAmount,
-      treasuryWalletAddress: serverWalletAddressHex,
+      treasuryWalletAddress: serverWallet.address,
       userWalletAddress: session.wallet_address,
     });
   } catch (e) {
@@ -320,8 +319,8 @@ export async function runSpendConversionConfirm(
   }
 
   const sub = await submitTreasuryUsdcTransfer({
-    serverWalletId: spendExperience.privy_server_wallet_id,
-    serverWalletAddress: serverWalletAddressHex,
+    serverWalletId: serverWallet.walletId,
+    serverWalletAddress: serverWallet.address,
     recipientAddress: userRecipient,
     usdcAmount,
   });
@@ -420,7 +419,7 @@ export async function runSpendConversionConfirm(
   void insertTreasuryFundUserLedgerIfAbsent({
     spendExperienceId: spendExperience.id,
     amount: completed.usdc_amount,
-    fromWalletAddress: serverWalletAddressHex,
+    fromWalletAddress: serverWallet.address,
     toWalletAddress: completed.user_wallet_address,
     txHash,
   });
@@ -463,34 +462,28 @@ async function fundOrResumeUsdc(input: {
     baseAnalytics,
   } = input;
 
-  const serverWalletAddress = getSpendServerWalletAddress(spendExperience);
-  if (
-    !serverWalletAddress ||
-    !isEvmAddress(serverWalletAddress) ||
-    !spendExperience.privy_server_wallet_id
-  ) {
+  const serverWallet = getSpendServerWalletTransferConfig(spendExperience);
+  if (!serverWallet) {
     return {
       error: {
         ok: false,
         httpStatus: 500,
-        error:
-          'Conversion is not configured correctly. Please contact support.',
+        error: MISCONFIGURED_CONVERSION_ERROR,
       },
     };
   }
-  const serverWalletAddressHex = serverWalletAddress as `0x${string}`;
 
   let conv = pointConversion;
   if (conv.status === 'points_deducted' && !conv.funding_tx_hash) {
     const userRecipient = recipientUsdcAddressForSpendTransfer({
-      serverWalletAddress: serverWalletAddressHex,
+      serverWalletAddress: serverWallet.address,
       sessionWalletTrimmed: session.wallet_address.trim(),
       normalizedWalletLower: normalizedWallet,
     });
 
     const sub = await submitTreasuryUsdcTransfer({
-      serverWalletId: spendExperience.privy_server_wallet_id,
-      serverWalletAddress: serverWalletAddressHex,
+      serverWalletId: serverWallet.walletId,
+      serverWalletAddress: serverWallet.address,
       recipientAddress: userRecipient,
       usdcAmount,
     });
@@ -585,7 +578,7 @@ async function fundOrResumeUsdc(input: {
   void insertTreasuryFundUserLedgerIfAbsent({
     spendExperienceId: spendExperience.id,
     amount: done.usdc_amount,
-    fromWalletAddress: serverWalletAddressHex,
+    fromWalletAddress: serverWallet.address,
     toWalletAddress: done.user_wallet_address,
     txHash: hash,
   });

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -17,6 +17,11 @@ const exp = (over: Partial<SpendExperience> = {}): SpendExperience => ({
   max_usdc_per_user: 5,
   treasury_wallet_address: '0x1111111111111111111111111111111111111111',
   receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  privy_server_wallet_id: 'wallet_e1',
+  server_wallet_address: '0x4444444444444444444444444444444444444444',
+  server_wallet_chain: 'base-mainnet',
+  server_wallet_created_at: '2026-01-01T00:00:00.000Z',
+  spend_create_idempotency_key: 'idem-e1',
   start_time: '2026-01-01T00:00:00.000Z',
   end_time: '2030-01-01T00:00:00.000Z',
   created_by: null,
@@ -65,6 +70,12 @@ describe('buildSpendEligibilityPreview', () => {
     expect(r.status).toBe('eligible');
     expect(r.preview?.pointsRequired).toBe(5000);
     expect(r.preview?.usdcAmount).toBe(5);
+    expect(r.preview?.treasuryWalletAddress).toBe(
+      '0x4444444444444444444444444444444444444444'
+    );
+    expect(r.preview?.receivingWalletAddress).toBe(
+      '0x4444444444444444444444444444444444444444'
+    );
   });
 
   it('returns insufficient_points', () => {

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -2,6 +2,7 @@ import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
+import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import {
   fetchUsdcBalanceOnBase,
@@ -93,8 +94,8 @@ export function buildSpendEligibilityPreview(
   const basePreview = (): SpendConversionPreview => ({
     pointsRequired,
     usdcAmount,
-    receivingWalletAddress: spendExperience.receiving_wallet_address,
-    treasuryWalletAddress: spendExperience.treasury_wallet_address,
+    receivingWalletAddress: getSpendServerWalletAddress(spendExperience),
+    treasuryWalletAddress: getSpendServerWalletAddress(spendExperience),
     userPointsBalance:
       player?.total_points != null ? Number(player.total_points) : null,
     treasuryUsdcBalance,
@@ -184,7 +185,7 @@ export function buildSpendEligibilityPreview(
 }
 
 /**
- * Reads treasury USDC on Base; returns null if address invalid or RPC fails (caller may treat as insufficient).
+ * Reads server wallet USDC on Base; returns null if address invalid or RPC fails.
  */
 export async function fetchTreasuryUsdcBalanceSafe(
   treasuryWalletAddress: string
@@ -225,7 +226,7 @@ export async function loadSpendEligibilityForSession(
         spendExperience.id,
         session.user_id
       ),
-      fetchTreasuryUsdcBalanceSafe(spendExperience.treasury_wallet_address),
+      fetchServerWalletUsdcBalanceSafe(spendExperience),
       getSpendTransactionBySessionId(session.id),
     ]);
 
@@ -242,4 +243,13 @@ export async function loadSpendEligibilityForSession(
     treasuryUsdcBalance,
     now,
   });
+}
+
+export function fetchServerWalletUsdcBalanceSafe(
+  experience: Pick<
+    SpendExperience,
+    'server_wallet_address' | 'treasury_wallet_address'
+  >
+): Promise<number | null> {
+  return fetchTreasuryUsdcBalanceSafe(getSpendServerWalletAddress(experience));
 }

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -251,5 +251,6 @@ export function fetchServerWalletUsdcBalanceSafe(
     'server_wallet_address' | 'treasury_wallet_address'
   >
 ): Promise<number | null> {
-  return fetchTreasuryUsdcBalanceSafe(getSpendServerWalletAddress(experience));
+  const walletAddress = getSpendServerWalletAddress(experience);
+  return fetchTreasuryUsdcBalanceSafe(walletAddress);
 }

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -2,12 +2,11 @@ import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
-import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
-import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import {
-  fetchUsdcBalanceOnBase,
-  isEvmAddress,
-} from '@/lib/walletconnect-poster-direct-usdc';
+  fetchServerWalletUsdcBalanceSafe,
+  getSpendServerWalletAddress,
+} from '@/lib/spend-server-wallet';
+import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import type {
   PointConversion,
   Player,
@@ -184,24 +183,6 @@ export function buildSpendEligibilityPreview(
   };
 }
 
-/**
- * Reads server wallet USDC on Base; returns null if address invalid or RPC fails.
- */
-export async function fetchTreasuryUsdcBalanceSafe(
-  treasuryWalletAddress: string
-): Promise<number | null> {
-  const trimmed = treasuryWalletAddress.trim();
-  if (!isEvmAddress(trimmed)) {
-    return null;
-  }
-  try {
-    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`);
-  } catch (e) {
-    console.error('fetchTreasuryUsdcBalanceSafe:', e);
-    return null;
-  }
-}
-
 type LoadEligibilityInput = {
   session: SpendSession;
   spendExperience: SpendExperience;
@@ -243,14 +224,4 @@ export async function loadSpendEligibilityForSession(
     treasuryUsdcBalance,
     now,
   });
-}
-
-export function fetchServerWalletUsdcBalanceSafe(
-  experience: Pick<
-    SpendExperience,
-    'server_wallet_address' | 'treasury_wallet_address'
-  >
-): Promise<number | null> {
-  const walletAddress = getSpendServerWalletAddress(experience);
-  return fetchTreasuryUsdcBalanceSafe(walletAddress);
 }

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -12,6 +12,7 @@ import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-tr
 import { computeConversionAmounts } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
+import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import type {
   SpendExperience,
@@ -180,7 +181,7 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  const receiving = spendExperience.receiving_wallet_address.trim();
+  const receiving = getSpendServerWalletAddress(spendExperience).trim();
   if (!isEvmAddress(receiving)) {
     return {
       ok: false,

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -85,6 +85,24 @@ export async function getServerWalletFundingStatus(params: {
   };
 }
 
+export function fetchServerWalletUsdcBalanceSafe(
+  experience: Pick<
+    SpendExperience,
+    'server_wallet_address' | 'treasury_wallet_address'
+  >
+): Promise<number | null> {
+  const walletAddress = spendServerWalletAddress(experience);
+  if (!walletAddress || !isEvmAddress(walletAddress)) {
+    return Promise.resolve(null);
+  }
+  return fetchUsdcBalanceOnBase(walletAddress as `0x${string}`).catch(
+    (error) => {
+      console.error('fetchServerWalletUsdcBalanceSafe:', error);
+      return null;
+    }
+  );
+}
+
 export function buildSpendUsdcTransferTx(params: {
   fromAddress: `0x${string}`;
   recipientAddress: `0x${string}`;

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -1,0 +1,98 @@
+import {
+  encodeUsdcTransferData,
+  fetchUsdcBalanceOnBase,
+  isEvmAddress,
+} from '@/lib/walletconnect-poster-direct-usdc';
+import type { SpendExperience } from '@/lib/types';
+
+export const SPEND_SERVER_WALLET_CHAIN = 'base-mainnet';
+export const SPEND_SERVER_WALLET_CAIP2 = 'eip155:8453';
+
+export type SpendServerWalletMetadata = {
+  privy_server_wallet_id: string;
+  server_wallet_address: string;
+  server_wallet_chain: string;
+  server_wallet_created_at: string;
+};
+
+export function spendServerWalletAddress(
+  experience: Pick<
+    SpendExperience,
+    'server_wallet_address' | 'treasury_wallet_address'
+  >
+): string {
+  return (
+    experience.server_wallet_address?.trim() ||
+    experience.treasury_wallet_address.trim()
+  );
+}
+
+export const getSpendServerWalletAddress = spendServerWalletAddress;
+
+export function spendPaymentRecipientAddress(
+  experience: Pick<
+    SpendExperience,
+    'server_wallet_address' | 'receiving_wallet_address'
+  >
+): string {
+  return (
+    experience.server_wallet_address?.trim() ||
+    experience.receiving_wallet_address.trim()
+  );
+}
+
+export function spendServerWalletFundingMetadata(
+  experience: Pick<
+    SpendExperience,
+    'server_wallet_address' | 'treasury_wallet_address' | 'max_usdc_per_user'
+  >,
+  usdcBalance: number | null
+): {
+  serverWalletAddress: string;
+  chain: string;
+  minimumUsdc: number;
+  usdcBalance: number | null;
+  funded: boolean;
+} {
+  const minimumUsdc = Number(experience.max_usdc_per_user);
+  return {
+    serverWalletAddress: spendServerWalletAddress(experience),
+    chain: SPEND_SERVER_WALLET_CHAIN,
+    minimumUsdc,
+    usdcBalance,
+    funded: usdcBalance !== null && usdcBalance >= minimumUsdc,
+  };
+}
+
+export async function getServerWalletFundingStatus(params: {
+  walletAddress: string | null;
+  minUsdcRequired: number;
+}): Promise<{ usdcBalance: number | null; isFunded: boolean }> {
+  const walletAddress = params.walletAddress?.trim();
+  if (!walletAddress || !isEvmAddress(walletAddress)) {
+    return { usdcBalance: null, isFunded: false };
+  }
+  let usdcBalance: number | null = null;
+  try {
+    usdcBalance = await fetchUsdcBalanceOnBase(walletAddress as `0x${string}`);
+  } catch (error) {
+    console.error('getServerWalletFundingStatus:', error);
+  }
+  return {
+    usdcBalance,
+    isFunded:
+      usdcBalance !== null && usdcBalance >= Number(params.minUsdcRequired),
+  };
+}
+
+export function buildSpendUsdcTransferTx(params: {
+  fromAddress: `0x${string}`;
+  recipientAddress: `0x${string}`;
+  usdcAmount: number;
+}): { from: `0x${string}`; to: `0x${string}`; data: `0x${string}` } {
+  return {
+    from: params.fromAddress,
+    to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+    data: encodeUsdcTransferData(params.recipientAddress, params.usdcAmount),
+  };
+}

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -1,5 +1,4 @@
 import {
-  encodeUsdcTransferData,
   fetchUsdcBalanceOnBase,
   isEvmAddress,
 } from '@/lib/walletconnect-poster-direct-usdc';
@@ -15,7 +14,20 @@ export type SpendServerWalletMetadata = {
   server_wallet_created_at: string;
 };
 
-export function spendServerWalletAddress(
+export type SpendServerWalletFundingMetadata = {
+  serverWalletAddress: string;
+  chain: string;
+  minimumUsdc: number;
+  usdcBalance: number | null;
+  funded: boolean;
+};
+
+export type SpendServerWalletTransferConfig = {
+  walletId: string;
+  address: `0x${string}`;
+};
+
+export function getSpendServerWalletAddress(
   experience: Pick<
     SpendExperience,
     'server_wallet_address' | 'treasury_wallet_address'
@@ -27,36 +39,16 @@ export function spendServerWalletAddress(
   );
 }
 
-export const getSpendServerWalletAddress = spendServerWalletAddress;
-
-export function spendPaymentRecipientAddress(
-  experience: Pick<
-    SpendExperience,
-    'server_wallet_address' | 'receiving_wallet_address'
-  >
-): string {
-  return (
-    experience.server_wallet_address?.trim() ||
-    experience.receiving_wallet_address.trim()
-  );
-}
-
 export function spendServerWalletFundingMetadata(
   experience: Pick<
     SpendExperience,
     'server_wallet_address' | 'treasury_wallet_address' | 'max_usdc_per_user'
   >,
   usdcBalance: number | null
-): {
-  serverWalletAddress: string;
-  chain: string;
-  minimumUsdc: number;
-  usdcBalance: number | null;
-  funded: boolean;
-} {
+): SpendServerWalletFundingMetadata {
   const minimumUsdc = Number(experience.max_usdc_per_user);
   return {
-    serverWalletAddress: spendServerWalletAddress(experience),
+    serverWalletAddress: getSpendServerWalletAddress(experience),
     chain: SPEND_SERVER_WALLET_CHAIN,
     minimumUsdc,
     usdcBalance,
@@ -64,20 +56,48 @@ export function spendServerWalletFundingMetadata(
   };
 }
 
+export function getSpendServerWalletTransferConfig(
+  experience: Pick<
+    SpendExperience,
+    | 'privy_server_wallet_id'
+    | 'server_wallet_address'
+    | 'treasury_wallet_address'
+  >
+): SpendServerWalletTransferConfig | null {
+  const address = getSpendServerWalletAddress(experience);
+  const walletId = experience.privy_server_wallet_id?.trim();
+  if (!walletId || !isEvmAddress(address)) {
+    return null;
+  }
+
+  return { walletId, address: address as `0x${string}` };
+}
+
+async function fetchUsdcBalanceSafe(
+  walletAddress: string | null | undefined,
+  logContext: string
+): Promise<number | null> {
+  const trimmed = walletAddress?.trim();
+  if (!trimmed || !isEvmAddress(trimmed)) {
+    return null;
+  }
+
+  try {
+    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`);
+  } catch (error) {
+    console.error(`${logContext}:`, error);
+    return null;
+  }
+}
+
 export async function getServerWalletFundingStatus(params: {
   walletAddress: string | null;
   minUsdcRequired: number;
 }): Promise<{ usdcBalance: number | null; isFunded: boolean }> {
-  const walletAddress = params.walletAddress?.trim();
-  if (!walletAddress || !isEvmAddress(walletAddress)) {
-    return { usdcBalance: null, isFunded: false };
-  }
-  let usdcBalance: number | null = null;
-  try {
-    usdcBalance = await fetchUsdcBalanceOnBase(walletAddress as `0x${string}`);
-  } catch (error) {
-    console.error('getServerWalletFundingStatus:', error);
-  }
+  const usdcBalance = await fetchUsdcBalanceSafe(
+    params.walletAddress,
+    'getServerWalletFundingStatus'
+  );
   return {
     usdcBalance,
     isFunded:
@@ -91,26 +111,8 @@ export function fetchServerWalletUsdcBalanceSafe(
     'server_wallet_address' | 'treasury_wallet_address'
   >
 ): Promise<number | null> {
-  const walletAddress = spendServerWalletAddress(experience);
-  if (!walletAddress || !isEvmAddress(walletAddress)) {
-    return Promise.resolve(null);
-  }
-  return fetchUsdcBalanceOnBase(walletAddress as `0x${string}`).catch(
-    (error) => {
-      console.error('fetchServerWalletUsdcBalanceSafe:', error);
-      return null;
-    }
+  return fetchUsdcBalanceSafe(
+    getSpendServerWalletAddress(experience),
+    'fetchServerWalletUsdcBalanceSafe'
   );
-}
-
-export function buildSpendUsdcTransferTx(params: {
-  fromAddress: `0x${string}`;
-  recipientAddress: `0x${string}`;
-  usdcAmount: number;
-}): { from: `0x${string}`; to: `0x${string}`; data: `0x${string}` } {
-  return {
-    from: params.fromAddress,
-    to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-    data: encodeUsdcTransferData(params.recipientAddress, params.usdcAmount),
-  };
 }

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -1,12 +1,6 @@
-import {
-  createPublicClient,
-  createWalletClient,
-  erc20Abi,
-  http,
-  parseUnits,
-} from 'viem';
-import { privateKeyToAccount } from 'viem/accounts';
-import { getServerPrivateKey } from '@/lib/server-private-key';
+import { encodeFunctionData, erc20Abi, http, parseUnits } from 'viem';
+import { getPrivyClient } from '@/lib/api/privy';
+import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
 import {
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
   POSTER_CHECKOUT_CHAIN,
@@ -21,47 +15,32 @@ export type TreasuryUsdcSubmitResult =
  * so the caller can persist it before awaiting confirmation.
  */
 export async function submitTreasuryUsdcTransfer(params: {
+  serverWalletId: string;
+  serverWalletAddress: `0x${string}`;
   recipientAddress: `0x${string}`;
   /** Human-readable USDC amount (6 decimals). */
   usdcAmount: number;
 }): Promise<TreasuryUsdcSubmitResult> {
-  const rpcUrl = process.env.NEXT_PUBLIC_BASE_RPC?.trim();
-  if (!rpcUrl) {
-    return { ok: false, error: 'RPC not configured' };
-  }
-
-  const pk = getServerPrivateKey();
-  if (!pk) {
-    return { ok: false, error: 'Server wallet not configured' };
-  }
-
-  const trimmedPk = pk.startsWith('0x') ? pk : `0x${pk}`;
-  let account;
-  try {
-    account = privateKeyToAccount(trimmedPk as `0x${string}`);
-  } catch {
-    return { ok: false, error: 'Invalid server wallet key' };
-  }
-
-  const transport = http(rpcUrl);
-  const walletClient = createWalletClient({
-    account,
-    chain: POSTER_CHECKOUT_CHAIN,
-    transport,
-  });
-
   const rawAmount = parseUnits(params.usdcAmount.toFixed(6), 6);
 
   try {
-    const hash = await walletClient.writeContract({
-      account,
-      address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-      abi: erc20Abi,
-      functionName: 'transfer',
-      args: [params.recipientAddress, rawAmount],
-      chain: POSTER_CHECKOUT_CHAIN,
+    const result = await getPrivyClient().walletApi.ethereum.sendTransaction({
+      walletId: params.serverWalletId,
+      caip2: SPEND_SERVER_WALLET_CAIP2,
+      sponsor: true,
+      transaction: {
+        from: params.serverWalletAddress,
+        to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+        chainId: POSTER_CHECKOUT_CHAIN.id,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'transfer',
+          args: [params.recipientAddress, rawAmount],
+        }),
+        value: '0x0',
+      },
     });
-    return { ok: true, txHash: hash };
+    return { ok: true, txHash: result.hash as `0x${string}` };
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'USDC transfer failed';
     console.error('submitTreasuryUsdcTransfer:', e);
@@ -76,6 +55,7 @@ export async function waitForTreasuryTxReceipt(
   if (!rpcUrl) {
     throw new Error('RPC not configured');
   }
+  const { createPublicClient } = await import('viem');
   const publicClient = createPublicClient({
     chain: POSTER_CHECKOUT_CHAIN,
     transport: http(rpcUrl),
@@ -84,18 +64,4 @@ export async function waitForTreasuryTxReceipt(
     hash: txHash,
     timeout: 120_000,
   });
-}
-
-/**
- * Address derived from `SERVER_WALLET_PRIVATE_KEY` / `SERVER_PRIVATE_KEY`, or null if missing/invalid.
- */
-export function getServerWalletAddress(): `0x${string}` | null {
-  const pk = getServerPrivateKey();
-  if (!pk) return null;
-  const trimmed = pk.startsWith('0x') ? pk : `0x${pk}`;
-  try {
-    return privateKeyToAccount(trimmed as `0x${string}`).address;
-  } catch {
-    return null;
-  }
 }

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -280,6 +280,11 @@ export type SpendExperience = {
   max_usdc_per_user: number;
   treasury_wallet_address: string;
   receiving_wallet_address: string;
+  privy_server_wallet_id: string | null;
+  server_wallet_address: string | null;
+  server_wallet_chain: string | null;
+  server_wallet_created_at: string | null;
+  spend_create_idempotency_key: string | null;
   start_time: string;
   end_time: string;
   created_by: string | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove admin-managed spend treasury and receiving wallet inputs from create/edit flows.
- Create one Privy server wallet per new spend experience using request idempotency and persist non-secret wallet metadata.
- Use server wallet metadata for funding checks, activation blocking, conversion preview/confirm, user payment recipient verification, and admin funding callouts.
- Replace private-key treasury sends with Privy wallet API sends.
- Simplify the new server-wallet helpers by sharing funding metadata types, safe balance reads, and transfer config validation.

## Testing
- `yarn build`
- `yarn test lib/schemas/__tests__/spend-experience.test.ts lib/spend-conversion-preview.test.ts app/api/admin/spend-experiences/__tests__/route.test.ts app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts`
- `yarn lint`
- Manual admin page smoke test reached the Privy auth gate; full create panel requires admin credentials.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3be4070f-4af4-4395-ae02-fc4b8faf327f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3be4070f-4af4-4395-ae02-fc4b8faf327f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

