### PR TITLE
fix: repair spend experience server wallet schema

### DIFF
--- a/database/add-server-wallet-columns-to-spend-experiences.sql
+++ b/database/add-server-wallet-columns-to-spend-experiences.sql
@@ -1,0 +1,21 @@
+-- Adds Privy server wallet metadata used by the spend pilot admin API.
+ALTER TABLE spend_experiences
+  ADD COLUMN IF NOT EXISTS privy_server_wallet_id TEXT,
+  ADD COLUMN IF NOT EXISTS server_wallet_address TEXT,
+  ADD COLUMN IF NOT EXISTS server_wallet_chain TEXT NOT NULL DEFAULT 'base-mainnet',
+  ADD COLUMN IF NOT EXISTS server_wallet_created_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS spend_create_idempotency_key TEXT;
+
+-- Existing pilot rows used treasury_wallet_address as the payout wallet.
+UPDATE spend_experiences
+SET server_wallet_address = treasury_wallet_address
+WHERE server_wallet_address IS NULL
+  AND treasury_wallet_address IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spend_experiences_privy_server_wallet_id
+  ON spend_experiences (privy_server_wallet_id)
+  WHERE privy_server_wallet_id IS NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_spend_experiences_create_idempotency_key
+  ON spend_experiences (spend_create_idempotency_key)
+  WHERE spend_create_idempotency_key IS NOT NULL;

--- a/lib/db/__tests__/spend-experiences.test.ts
+++ b/lib/db/__tests__/spend-experiences.test.ts
@@ -1,0 +1,110 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { mockFrom, mockSelect, mockOrder } = vi.hoisted(() => {
+  const order = vi.fn();
+  const select = vi.fn(() => ({ order }));
+  const from = vi.fn(() => ({ select }));
+
+  return {
+    mockFrom: from,
+    mockSelect: select,
+    mockOrder: order,
+  };
+});
+
+vi.mock('@/lib/db/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+import { listSpendExperiences } from '../spend-experiences';
+
+const legacySpendExperienceRow = {
+  id: 'exp-1',
+  title: 'Pilot',
+  description: null,
+  event_id: null,
+  status: 'draft',
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  start_time: '2026-05-01T00:00:00.000Z',
+  end_time: '2026-05-02T00:00:00.000Z',
+  created_by: 'admin@example.com',
+  created_at: '2026-04-01T00:00:00.000Z',
+  updated_at: '2026-04-01T00:00:00.000Z',
+};
+
+describe('listSpendExperiences', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('retries without server wallet columns when an older schema is missing them', async () => {
+    mockOrder
+      .mockResolvedValueOnce({
+        data: null,
+        error: {
+          code: '42703',
+          message:
+            'column spend_experiences.privy_server_wallet_id does not exist',
+        },
+      })
+      .mockResolvedValueOnce({
+        data: [legacySpendExperienceRow],
+        error: null,
+      });
+
+    const experiences = await listSpendExperiences();
+
+    expect(mockFrom).toHaveBeenCalledWith('spend_experiences');
+    expect(mockSelect).toHaveBeenNthCalledWith(
+      1,
+      expect.stringContaining('privy_server_wallet_id')
+    );
+    expect(mockSelect).toHaveBeenNthCalledWith(
+      2,
+      expect.not.stringContaining('privy_server_wallet_id')
+    );
+    expect(experiences).toEqual([
+      expect.objectContaining({
+        id: 'exp-1',
+        title: 'Pilot',
+        privy_server_wallet_id: null,
+        server_wallet_address: null,
+      }),
+    ]);
+  });
+
+  it('uses server wallet columns when the schema has them', async () => {
+    mockOrder.mockResolvedValueOnce({
+      data: [
+        {
+          ...legacySpendExperienceRow,
+          privy_server_wallet_id: 'wallet-1',
+          server_wallet_address: '0x3333333333333333333333333333333333333333',
+          server_wallet_chain: 'base-mainnet',
+          server_wallet_created_at: '2026-04-28T00:00:00.000Z',
+          spend_create_idempotency_key: 'idem-1',
+        },
+      ],
+      error: null,
+    });
+
+    const experiences = await listSpendExperiences();
+
+    expect(mockSelect).toHaveBeenCalledOnce();
+    expect(mockSelect).toHaveBeenCalledWith(
+      expect.stringContaining('server_wallet_created_at')
+    );
+    expect(experiences[0]).toEqual(
+      expect.objectContaining({
+        privy_server_wallet_id: 'wallet-1',
+        server_wallet_address: '0x3333333333333333333333333333333333333333',
+        spend_create_idempotency_key: 'idem-1',
+      })
+    );
+  });
+});

--- a/lib/db/spend-experiences.ts
+++ b/lib/db/spend-experiences.ts
@@ -1,27 +1,91 @@
 import { supabase } from './client';
 import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
 
-const SPEND_EXPERIENCE_COLUMNS = `
-  id,
-  title,
-  description,
-  event_id,
-  status,
-  points_to_usdc_rate,
-  max_usdc_per_user,
-  treasury_wallet_address,
-  receiving_wallet_address,
-  privy_server_wallet_id,
-  server_wallet_address,
-  server_wallet_chain,
-  server_wallet_created_at,
-  spend_create_idempotency_key,
-  start_time,
-  end_time,
-  created_by,
-  created_at,
-  updated_at
-`;
+const LEGACY_SPEND_EXPERIENCE_COLUMN_NAMES = [
+  'id',
+  'title',
+  'description',
+  'event_id',
+  'status',
+  'points_to_usdc_rate',
+  'max_usdc_per_user',
+  'treasury_wallet_address',
+  'receiving_wallet_address',
+  'start_time',
+  'end_time',
+  'created_by',
+  'created_at',
+  'updated_at',
+] as const;
+
+const SERVER_WALLET_COLUMN_NAMES = [
+  'privy_server_wallet_id',
+  'server_wallet_address',
+  'server_wallet_chain',
+  'server_wallet_created_at',
+  'spend_create_idempotency_key',
+] as const;
+
+const SPEND_EXPERIENCE_COLUMNS = [
+  ...LEGACY_SPEND_EXPERIENCE_COLUMN_NAMES,
+  ...SERVER_WALLET_COLUMN_NAMES,
+].join(', ');
+
+const LEGACY_SPEND_EXPERIENCE_COLUMNS =
+  LEGACY_SPEND_EXPERIENCE_COLUMN_NAMES.join(', ');
+
+type SupabaseErrorLike = {
+  code?: string;
+  message?: string;
+};
+
+type SupabaseResult<T> = {
+  data: T | null;
+  error: SupabaseErrorLike | null;
+};
+
+const SPEND_EXPERIENCES_TABLE = 'spend_experiences';
+
+const spendExperiencesTable = () =>
+  supabase.from(SPEND_EXPERIENCES_TABLE) as ReturnType<typeof supabase.from>;
+
+const isMissingServerWalletColumnError = (
+  error: SupabaseErrorLike | null
+): boolean =>
+  error?.code === '42703' &&
+  SERVER_WALLET_COLUMN_NAMES.some((columnName) =>
+    error.message?.includes(columnName)
+  );
+
+async function runSpendExperienceRead<T>(
+  operation: string,
+  query: (columns: string) => PromiseLike<unknown>
+): Promise<T | null> {
+  const result = (await query(SPEND_EXPERIENCE_COLUMNS)) as SupabaseResult<T>;
+  if (!isMissingServerWalletColumnError(result.error)) {
+    if (result.error) {
+      console.error(`${operation} error:`, result.error);
+      throw new Error(
+        result.error.message || 'Failed to load spend experience'
+      );
+    }
+    return result.data;
+  }
+
+  console.warn(
+    `${operation} retrying without server wallet columns; apply the spend_experiences server wallet migration.`
+  );
+  const legacyResult = (await query(
+    LEGACY_SPEND_EXPERIENCE_COLUMNS
+  )) as SupabaseResult<T>;
+  if (legacyResult.error) {
+    console.error(`${operation} error:`, legacyResult.error);
+    throw new Error(
+      legacyResult.error.message || 'Failed to load spend experience'
+    );
+  }
+  return legacyResult.data;
+}
 
 const toNumber = (value: unknown): number => {
   if (typeof value === 'number' && !Number.isNaN(value)) return value;
@@ -68,19 +132,15 @@ const normalizeRow = (row: Record<string, unknown>): SpendExperience => ({
 });
 
 export async function listSpendExperiences(): Promise<SpendExperience[]> {
-  const { data, error } = await supabase
-    .from('spend_experiences')
-    .select(SPEND_EXPERIENCE_COLUMNS)
-    .order('created_at', { ascending: false });
-
-  if (error) {
-    console.error('listSpendExperiences error:', error);
-    throw new Error(error.message || 'Failed to list spend experiences');
-  }
-
-  return (data || []).map((row) =>
-    normalizeRow(row as Record<string, unknown>)
+  const data = await runSpendExperienceRead<Record<string, unknown>[]>(
+    'listSpendExperiences',
+    (columns) =>
+      spendExperiencesTable()
+        .select(columns)
+        .order('created_at', { ascending: false })
   );
+
+  return (data || []).map(normalizeRow);
 }
 
 export type CreateSpendExperienceInput = {
@@ -122,8 +182,7 @@ export async function createSpendExperience(
     created_by: input.created_by ?? null,
   };
 
-  const { data, error } = await supabase
-    .from('spend_experiences')
+  const { data, error } = await spendExperiencesTable()
     .insert(insertRow)
     .select(SPEND_EXPERIENCE_COLUMNS)
     .single();
@@ -139,7 +198,7 @@ export async function createSpendExperience(
     throw new Error(error.message || 'Failed to create spend experience');
   }
 
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeRow(data as unknown as Record<string, unknown>);
 }
 
 export type UpdateSpendExperienceInput = Partial<{
@@ -180,37 +239,30 @@ function buildSpendExperiencePatch(
 export async function getSpendExperienceById(
   id: string
 ): Promise<SpendExperience | null> {
-  const { data, error } = await supabase
-    .from('spend_experiences')
-    .select(SPEND_EXPERIENCE_COLUMNS)
-    .eq('id', id)
-    .maybeSingle();
-
-  if (error) {
-    console.error('getSpendExperienceById error:', error);
-    throw new Error(error.message || 'Failed to load spend experience');
-  }
+  const data = await runSpendExperienceRead<Record<string, unknown>>(
+    'getSpendExperienceById',
+    (columns) =>
+      spendExperiencesTable().select(columns).eq('id', id).maybeSingle()
+  );
 
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeRow(data as unknown as Record<string, unknown>);
 }
 
 export async function getSpendExperienceByCreateIdempotencyKey(
   idempotencyKey: string
 ): Promise<SpendExperience | null> {
-  const { data, error } = await supabase
-    .from('spend_experiences')
-    .select(SPEND_EXPERIENCE_COLUMNS)
-    .eq('spend_create_idempotency_key', idempotencyKey)
-    .maybeSingle();
-
-  if (error) {
-    console.error('getSpendExperienceByCreateIdempotencyKey error:', error);
-    throw new Error(error.message || 'Failed to load spend experience');
-  }
+  const data = await runSpendExperienceRead<Record<string, unknown>>(
+    'getSpendExperienceByCreateIdempotencyKey',
+    (columns) =>
+      spendExperiencesTable()
+        .select(columns)
+        .eq('spend_create_idempotency_key', idempotencyKey)
+        .maybeSingle()
+  );
 
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeRow(data as unknown as Record<string, unknown>);
 }
 
 export async function updateSpendExperience(
@@ -222,8 +274,7 @@ export async function updateSpendExperience(
     throw new Error('No fields to update');
   }
 
-  const { data, error } = await supabase
-    .from('spend_experiences')
+  const { data, error } = await spendExperiencesTable()
     .update(patch)
     .eq('id', id)
     .select(SPEND_EXPERIENCE_COLUMNS)
@@ -234,5 +285,5 @@ export async function updateSpendExperience(
     throw new Error(error.message || 'Failed to update spend experience');
   }
 
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeRow(data as unknown as Record<string, unknown>);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add an idempotent migration for the missing spend_experiences server wallet columns and indexes.
- Add a schema compatibility retry for spend experience reads so admin listing can still load if a deployment briefly sees the older schema.
- Add focused Vitest coverage for the missing-column fallback and normal server-wallet read path.

### Testing
- `yarn test lib/db/__tests__/spend-experiences.test.ts app/api/admin/spend-experiences/__tests__/route.test.ts`
- `yarn lint`
- `yarn build`

### Notes
- Applied the same idempotent migration to the live IRL Supabase project and verified the columns now exist on `public.spend_experiences`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-273539cd-be6d-4c1f-a6ef-e17b3d9a2333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-273539cd-be6d-4c1f-a6ef-e17b3d9a2333"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

