### PR TITLE
Fix spend conversion player lookup

### DIFF
--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -6,6 +6,7 @@ const mockGetPrivyUserId = vi.fn();
 const mockGetSpendContext = vi.fn();
 const mockRunConfirm = vi.fn();
 const mockResolve = vi.fn();
+const mockCaptureHandledException = vi.fn();
 
 vi.mock('@/lib/api/privy', () => ({
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
@@ -19,6 +20,11 @@ vi.mock('@/lib/spend-conversion-confirm', () => ({
 
 vi.mock('@/lib/analytics/server', () => ({
   resolveServerIdentity: (...a: unknown[]) => mockResolve(...a),
+}));
+
+vi.mock('@/lib/monitoring/capture-handled-exception', () => ({
+  captureHandledException: (...a: unknown[]) =>
+    mockCaptureHandledException(...a),
 }));
 
 import { POST } from '../route';
@@ -119,5 +125,47 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
     };
     expect(json.success).toBe(true);
     expect(json.data.pointConversion.status).toBe('funded');
+  });
+
+  it('captures handled conversion failures when requested by domain logic', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: true,
+      userId: 'privy-1',
+    });
+    mockGetPrivyUserId.mockResolvedValue('privy-1');
+    mockGetSpendContext.mockResolvedValue({
+      session,
+      spendExperience,
+      usdcAmount: 5,
+      pointsRequired: 5000,
+    });
+    mockResolve.mockReturnValue('distinct-1');
+    mockRunConfirm.mockResolvedValue({
+      ok: false,
+      httpStatus: 400,
+      error: 'Insufficient points',
+      capture: true,
+    });
+
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/conversion/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: session.wallet_address,
+        }),
+      }
+    );
+
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(400);
+    expect(mockCaptureHandledException).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        route: '/api/spend-sessions/[sessionId]/conversion/confirm',
+        operation: 'spend_conversion_confirm',
+        statusCode: 400,
+      })
+    );
   });
 });

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -4,6 +4,7 @@ import {
   verifyWalletOwnership,
 } from '@/lib/api/privy';
 import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
+import { captureHandledException } from '@/lib/monitoring/capture-handled-exception';
 import { resolveServerIdentity } from '@/lib/analytics/server';
 import {
   getSpendContextOr404,
@@ -82,6 +83,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
 
     if (!result.ok) {
+      if (result.capture) {
+        captureHandledException(new Error(result.error), {
+          route: '/api/spend-sessions/[sessionId]/conversion/confirm',
+          operation: 'spend_conversion_confirm',
+          statusCode: result.httpStatus,
+          extra: {
+            sessionId,
+            spendExperienceId: spendExperience.id,
+            userId: auth.userId,
+            walletAddressSuffix: normalizedWallet.slice(-8),
+          },
+        });
+      }
+
       return apiError(result.error, result.httpStatus);
     }
 

--- a/database/fix-spend-conversion-player-case-duplicates.sql
+++ b/database/fix-spend-conversion-player-case-duplicates.sql
@@ -1,0 +1,227 @@
+-- Ensure spend conversion RPCs choose a deterministic point-bearing player row
+-- when duplicate EVM wallet rows exist with different casing.
+
+CREATE OR REPLACE FUNCTION confirm_spend_conversion_atomic(
+  p_spend_session_id UUID,
+  p_user_id TEXT,
+  p_wallet_address TEXT,
+  p_spend_experience_id UUID,
+  p_points_to_deduct INTEGER,
+  p_usdc_amount NUMERIC(24, 8),
+  p_treasury_wallet_address TEXT,
+  p_user_wallet_address TEXT
+) RETURNS TABLE (
+  outcome TEXT,
+  conversion_id UUID,
+  player_total_points INTEGER
+) AS $$
+DECLARE
+  v_session spend_sessions%ROWTYPE;
+  v_existing_id UUID;
+  v_player_id BIGINT;
+  v_player_total INTEGER;
+  v_funded_exists BOOLEAN;
+BEGIN
+  IF p_points_to_deduct IS NULL OR p_points_to_deduct <= 0 THEN
+    RAISE EXCEPTION 'Invalid points amount';
+  END IF;
+
+  IF p_usdc_amount IS NULL OR p_usdc_amount <= 0 THEN
+    RAISE EXCEPTION 'Invalid USDC amount';
+  END IF;
+
+  SELECT *
+  INTO v_session
+  FROM spend_sessions
+  WHERE id = p_spend_session_id
+  FOR UPDATE;
+
+  IF v_session.id IS NULL THEN
+    RAISE EXCEPTION 'Spend session not found';
+  END IF;
+
+  IF v_session.user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Session does not belong to this user';
+  END IF;
+
+  IF lower(trim(v_session.wallet_address)) IS DISTINCT FROM lower(trim(p_wallet_address)) THEN
+    RAISE EXCEPTION 'Wallet does not match this session';
+  END IF;
+
+  IF v_session.spend_experience_id IS DISTINCT FROM p_spend_experience_id THEN
+    RAISE EXCEPTION 'Spend experience mismatch';
+  END IF;
+
+  SELECT pc.id
+  INTO v_existing_id
+  FROM point_conversions pc
+  WHERE pc.spend_session_id = p_spend_session_id
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL THEN
+    SELECT COALESCE(total_points, 0)::INTEGER
+    INTO v_player_total
+    FROM players
+    WHERE lower(trim(wallet_address)) = lower(trim(v_session.wallet_address))
+    ORDER BY
+      (trim(wallet_address) = trim(p_wallet_address)) DESC,
+      COALESCE(total_points, 0) DESC,
+      (trim(wallet_address) = trim(v_session.wallet_address)) DESC,
+      id ASC
+    LIMIT 1;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Player not found';
+    END IF;
+
+    RETURN QUERY SELECT 'already_exists'::TEXT, v_existing_id, v_player_total;
+    RETURN;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM point_conversions pc
+    WHERE pc.spend_experience_id = p_spend_experience_id
+      AND pc.user_id = p_user_id
+      AND pc.status = 'funded'
+  )
+  INTO v_funded_exists;
+
+  IF v_funded_exists THEN
+    RAISE EXCEPTION 'Already converted for this spend experience';
+  END IF;
+
+  SELECT id, COALESCE(total_points, 0)::INTEGER
+  INTO v_player_id, v_player_total
+  FROM players
+  WHERE lower(trim(wallet_address)) = lower(trim(v_session.wallet_address))
+    ORDER BY
+      (trim(wallet_address) = trim(p_wallet_address)) DESC,
+      COALESCE(total_points, 0) DESC,
+      (trim(wallet_address) = trim(v_session.wallet_address)) DESC,
+    id ASC
+  LIMIT 1
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found';
+  END IF;
+
+  IF v_player_total < p_points_to_deduct THEN
+    RAISE EXCEPTION 'Insufficient points';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) - p_points_to_deduct,
+      updated_at = NOW()
+  WHERE id = v_player_id
+  RETURNING total_points::INTEGER INTO v_player_total;
+
+  INSERT INTO point_conversions (
+    spend_experience_id,
+    spend_session_id,
+    user_id,
+    points_deducted,
+    usdc_amount,
+    status,
+    treasury_wallet_address,
+    user_wallet_address
+  )
+  VALUES (
+    p_spend_experience_id,
+    p_spend_session_id,
+    p_user_id,
+    p_points_to_deduct,
+    p_usdc_amount,
+    'points_deducted',
+    p_treasury_wallet_address,
+    p_user_wallet_address
+  )
+  RETURNING id INTO v_existing_id;
+
+  RETURN QUERY SELECT 'created'::TEXT, v_existing_id, v_player_total;
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE EXCEPTION 'Conversion already in progress';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION confirm_spend_conversion_atomic IS
+  'Spend pilot: atomically deduct points and create point_conversions row (pending). Idempotent per session if row exists.';
+
+CREATE OR REPLACE FUNCTION refund_spend_conversion_on_funding_failure(
+  p_conversion_id UUID,
+  p_user_id TEXT,
+  p_spend_session_id UUID,
+  p_points_to_refund INTEGER,
+  p_failed_reason TEXT
+) RETURNS VOID AS $$
+DECLARE
+  v_status VARCHAR(32);
+  v_session TEXT;
+  v_user TEXT;
+  v_points NUMERIC(24, 8);
+  v_player_id BIGINT;
+BEGIN
+  IF p_points_to_refund IS NULL OR p_points_to_refund <= 0 THEN
+    RAISE EXCEPTION 'Invalid refund amount';
+  END IF;
+
+  SELECT status, user_id, spend_session_id, points_deducted
+  INTO v_status, v_user, v_session, v_points
+  FROM point_conversions
+  WHERE id = p_conversion_id
+  FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'Conversion not found';
+  END IF;
+
+  IF v_user IS DISTINCT FROM p_user_id OR v_session::TEXT IS DISTINCT FROM p_spend_session_id::TEXT THEN
+    RAISE EXCEPTION 'Conversion mismatch';
+  END IF;
+
+  IF v_status IS DISTINCT FROM 'points_deducted' THEN
+    RAISE EXCEPTION 'Conversion is not in points_deducted state';
+  END IF;
+
+  IF v_points::INTEGER IS DISTINCT FROM p_points_to_refund THEN
+    RAISE EXCEPTION 'Points amount mismatch';
+  END IF;
+
+  SELECT p.id
+  INTO v_player_id
+  FROM players p
+  JOIN spend_sessions ss ON ss.id = p_spend_session_id
+  WHERE lower(trim(p.wallet_address)) = lower(trim(ss.wallet_address))
+  ORDER BY
+    COALESCE(p.total_points, 0) DESC,
+    (trim(p.wallet_address) = trim(ss.wallet_address)) DESC,
+    p.id ASC
+  LIMIT 1
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found for session';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) + p_points_to_refund,
+      updated_at = NOW()
+  WHERE id = v_player_id;
+
+  UPDATE point_conversions
+  SET
+    status = 'failed',
+    failed_reason = left(
+      COALESCE(p_failed_reason, 'funding_transaction_failed'),
+      256
+    ),
+    completed_at = NOW()
+  WHERE id = p_conversion_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION refund_spend_conversion_on_funding_failure IS
+  'Reverses a pending spend conversion: restores points to the user and marks the conversion failed.';

--- a/lib/db/__tests__/players.test.ts
+++ b/lib/db/__tests__/players.test.ts
@@ -135,6 +135,25 @@ describe('Players Database Module', () => {
       expect(mockSingle).toHaveBeenCalledTimes(2);
     });
 
+    it('prefers the checksummed EVM row before lowercase duplicates', async () => {
+      const rawLower = '0x4d418f71c531465337b65127b207aa849fa5a9e3';
+      const checksummed = getAddress(rawLower as `0x${string}`);
+      const mockPlayer: Player = {
+        id: 2,
+        wallet_address: checksummed,
+        username: 'checksummed',
+        total_points: 16000,
+      };
+
+      mockSingle.mockResolvedValueOnce({ data: mockPlayer, error: null });
+
+      const result = await getPlayerByWallet(rawLower);
+
+      expect(result).toEqual(mockPlayer);
+      expect(mockEq).toHaveBeenCalledWith('wallet_address', checksummed);
+      expect(mockSingle).toHaveBeenCalledTimes(1);
+    });
+
     it('should return null when not found (PGRST116)', async () => {
       mockSingle
         .mockResolvedValueOnce({

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -119,6 +119,7 @@ export type SpendConversionConfirmResult =
       ok: false;
       httpStatus: 400 | 401 | 403 | 404 | 409 | 500;
       error: string;
+      capture?: boolean;
     };
 
 /**
@@ -182,7 +183,7 @@ export async function runSpendConversionConfirm(
     };
   }
 
-  const player = await getPlayerByWallet(normalizedWallet);
+  const player = await getPlayerByWallet(session.wallet_address);
   const preRpcPoints = player != null ? Number(player.total_points ?? 0) : 0;
 
   if (now > new Date(session.expires_at)) {
@@ -258,7 +259,7 @@ export async function runSpendConversionConfirm(
     rpc = await confirmSpendConversionAtomic({
       spendSessionId: session.id,
       userId: authUserId,
-      walletAddress: normalizedWallet,
+      walletAddress: session.wallet_address,
       spendExperienceId: spendExperience.id,
       pointsToDeduct: pointsRequired,
       usdcAmount,
@@ -278,7 +279,7 @@ export async function runSpendConversionConfirm(
       msg.includes('Insufficient points') ||
       msg.includes('Player not found')
     ) {
-      return { ok: false, httpStatus: 400, error: msg };
+      return { ok: false, httpStatus: 400, error: msg, capture: true };
     }
     if (
       msg.includes('PGRST202') ||
@@ -508,7 +509,7 @@ async function fundOrResumeUsdc(input: {
         error_reason: 'funding_submission_failed',
       });
 
-      const p = await getPlayerByWallet(normalizedWallet);
+      const p = await getPlayerByWallet(session.wallet_address);
       if (p) {
         const cur = Number(p.total_points ?? 0);
         const refunded = Math.ceil(Number(conv.points_deducted));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Fix spend conversion confirmation to use the session wallet casing for player lookups and RPC input.
- Add a Supabase migration that makes conversion/refund RPC player-row selection deterministic when duplicate EVM wallet rows exist with different casing.
- Capture handled conversion confirm failures in Sentry when domain logic marks them for reporting.
- Make USDC funding finalization timeout-safe: persist/validate tx hashes before returning, avoid long receipt waits inside the confirm request, recover hashes from recent Base USDC Transfer logs when needed, and let preview polling finalize pending conversions.

### Production repair
- Applied the database RPC migration to Supabase project `pwuhplqevqeonostnkgj`.
- Repaired the reported session `dfa0598f-4d3e-4b46-a067-a56f29db3d50` after confirming Base tx `0xb9b462dbfff9d04c47f3755809fa8467c9ed0face9d2e0a734e401cabb86452d` transferred 5 USDC from the server wallet to the user wallet.
- The session is now `conversion_complete`, the conversion is `funded`, and the funding tx hash is stored.

### Testing
- `yarn test app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts lib/db/__tests__/players.test.ts`
- `yarn lint`
- `yarn build`
- Supabase rollback transaction for the reported session returned `outcome = created` and `player_total_points = 11000`, with no persisted conversion row after rollback.
- Base receipt inspection confirmed tx status `success` and a USDC Transfer log from `0x8C7Fe5a913c1E274aD325939Cb1AC24650F5F076` to `0x4D418f71c531465337b65127B207aa849Fa5a9e3` for 5 USDC.
- `yarn test` still has unrelated baseline failures in `components/location-search.test.tsx`, `components/layout/user-menu.test.tsx`, and `lib/db/__tests__/admin.test.ts`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81e24531-3945-401e-ade2-20af55652698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81e24531-3945-401e-ade2-20af55652698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

