### PR TITLE
fix(spend): update post-conversion message and pay button copy

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -514,7 +514,7 @@ export function SpendExperiencePage({
                           Pay with USDC…
                         </>
                       ) : (
-                        `Send $${preview.usdcAmount.toFixed(2)} USDC on Base`
+                        `Spend $${preview.usdcAmount.toFixed(2)} UDSC`
                       )}
                     </Button>
                   )}

--- a/lib/spend-eligibility-messages.ts
+++ b/lib/spend-eligibility-messages.ts
@@ -30,8 +30,7 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
     'The event wallet is temporarily out of USDC. Please try again later or ask an event host.',
   wallet_unavailable:
     'Wallet unavailable. Add or connect your embedded wallet in your profile.',
-  ready_for_payment:
-    'Your points were converted to USDC. Send payment to the event wallet below to finish.',
+  ready_for_payment: 'Your points were converted to USDC.',
   payment_failed:
     'Your last payment could not be verified on-chain. You can try sending payment again.',
   payment_complete:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Shortens the `ready_for_payment` eligibility message to only: "Your points were converted to USDC." (removes the sentence about sending payment to the event wallet).
- Updates the spend experience pay button label from "Send $X.XX USDC on Base" to "Spend $X.XX UDSC" as requested.

## Testing

- `yarn test lib/spend-conversion-preview.test.ts` (passes). Full `yarn test` currently fails on unrelated suites (`location-search`, `user-menu`, `admin.test.ts`).

## Note

The button label uses **UDSC** exactly as specified; if that was meant to be **USDC**, say so and we can adjust in a follow-up.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-20b647f5-6a74-48d0-9463-2d4282ad9e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-20b647f5-6a74-48d0-9463-2d4282ad9e3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

