### PR TITLE
fix: respect 1000-block limit for USDC transfer log lookup on Base

### DIFF
--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -20,7 +20,9 @@ const EVM_TX_HASH_RE = /^0x[a-fA-F0-9]{64}$/;
 const TRANSFER_EVENT = parseAbiItem(
   'event Transfer(address indexed from, address indexed to, uint256 value)'
 );
-const FALLBACK_SCAN_BLOCKS = 1_200n;
+const FALLBACK_SCAN_BLOCKS = 1_000n;
+/** Coinbase (and other) Base RPCs reject eth_getLogs when the range exceeds 1000 blocks. */
+const MAX_LOG_BLOCK_SPAN = 1_000n;
 
 function rpcUrl(): string {
   return process.env.NEXT_PUBLIC_BASE_RPC?.trim() || 'https://mainnet.base.org';
@@ -45,32 +47,47 @@ async function findRecentTreasuryTransferHash(params: {
   const rawAmount = parseUnits(params.usdcAmount.toFixed(6), 6);
   const fallbackFrom =
     latest > FALLBACK_SCAN_BLOCKS ? latest - FALLBACK_SCAN_BLOCKS : 0n;
-  const fromBlock =
+  const scanFrom =
     params.fromBlock != null && params.fromBlock < latest
       ? params.fromBlock
       : fallbackFrom;
 
-  const logs = await publicClient.getLogs({
-    address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-    event: TRANSFER_EVENT,
-    args: {
-      from: params.serverWalletAddress,
-      to: params.recipientAddress,
-    },
-    fromBlock,
-    toBlock: 'latest',
-  });
+  const buildMatching = (
+    chunk: Awaited<ReturnType<typeof publicClient.getLogs>>
+  ) =>
+    chunk
+      .filter((log) => log.args.value === rawAmount)
+      .sort((a, b) => {
+        const aBlock = a.blockNumber ?? 0n;
+        const bBlock = b.blockNumber ?? 0n;
+        if (aBlock === bBlock) return 0;
+        return aBlock > bBlock ? -1 : 1;
+      });
 
-  const matching = logs
-    .filter((log) => log.args.value === rawAmount)
-    .sort((a, b) => {
-      const aBlock = a.blockNumber ?? 0n;
-      const bBlock = b.blockNumber ?? 0n;
-      if (aBlock === bBlock) return 0;
-      return aBlock > bBlock ? -1 : 1;
+  // Newest first so the first non-empty chunk yields the most recent transfer.
+  let chunkTo = latest;
+  while (chunkTo >= scanFrom) {
+    const maxFrom = chunkTo - (MAX_LOG_BLOCK_SPAN - 1n);
+    const fromBlock = maxFrom > scanFrom ? maxFrom : scanFrom;
+    const logs = await publicClient.getLogs({
+      address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+      event: TRANSFER_EVENT,
+      args: {
+        from: params.serverWalletAddress,
+        to: params.recipientAddress,
+      },
+      fromBlock,
+      toBlock: chunkTo,
     });
+    const matching = buildMatching(logs);
+    if (matching.length > 0) {
+      return matching[0]!.transactionHash;
+    }
+    if (fromBlock === 0n) break;
+    chunkTo = fromBlock - 1n;
+  }
 
-  return matching[0]?.transactionHash ?? null;
+  return null;
 }
 
 export function isEvmTxHash(value: unknown): value is `0x${string}` {

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -2,6 +2,7 @@ import {
   encodeFunctionData,
   erc20Abi,
   http,
+  hexToBigInt,
   parseAbiItem,
   parseUnits,
 } from 'viem';
@@ -52,17 +53,37 @@ async function findRecentTreasuryTransferHash(params: {
       ? params.fromBlock
       : fallbackFrom;
 
+  /** For ERC-20 Transfer, `value` is the only field in `data` (from/to are indexed in topics). */
+  const getTransferValue = (log: { data: `0x${string}` }) => {
+    try {
+      if (!log.data || log.data.length < 66) return null;
+      return hexToBigInt(log.data);
+    } catch {
+      return null;
+    }
+  };
+
   const buildMatching = (
     chunk: Awaited<ReturnType<typeof publicClient.getLogs>>
-  ) =>
-    chunk
-      .filter((log) => log.args.value === rawAmount)
+  ) => {
+    const withValue = chunk
+      .map((log) => {
+        const value = getTransferValue(log);
+        if (value === null || value !== rawAmount) return null;
+        return { log, value };
+      })
+      .filter(
+        (x): x is { log: (typeof chunk)[number]; value: bigint } => x !== null
+      );
+    return withValue
       .sort((a, b) => {
-        const aBlock = a.blockNumber ?? 0n;
-        const bBlock = b.blockNumber ?? 0n;
+        const aBlock = a.log.blockNumber ?? 0n;
+        const bBlock = b.log.blockNumber ?? 0n;
         if (aBlock === bBlock) return 0;
         return aBlock > bBlock ? -1 : 1;
-      });
+      })
+      .map(({ log }) => log);
+  };
 
   // Newest first so the first non-empty chunk yields the most recent transfer.
   let chunkTo = latest;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Coinbase Developer Base RPC returns `LimitExceededRpcError` for `eth_getLogs` when the block range exceeds 1000 blocks. The treasury USDC transfer fallback in `findRecentTreasuryTransferHash` used a 1200-block window and `toBlock: "latest"`, which triggered that error.

## Changes
- Cap each `getLogs` request to at most 1000 blocks by chunking from `latest` backward (newest chunk first) until the scan window is covered.
- Align the default fallback window with the RPC cap (`FALLBACK_SCAN_BLOCKS` 1200 → 1000) so a single full-window scan is valid for providers with this limit.
- For matching amount: `getLogs` return type does not always include `args`; read `value` from the Transfer log `data` with `hexToBigInt` (ERC-20: only non-indexed field in `data` is `value`).

## Testing
- `yarn build` (passes; pre-existing lint warnings, runtime fetch warning during SSG is non-fatal in output).
- `yarn test` — suite has pre-existing failures unrelated to this change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9e7652fc-f264-4b5d-ba39-970591f2f516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e7652fc-f264-4b5d-ba39-970591f2f516"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

