### PR TITLE
Spend: skip points→USDC when wallet already has enough USDC

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -48,6 +48,7 @@ type ConversionPreviewResponse = {
       receivingWalletAddress: string;
       treasuryWalletAddress: string;
       userPointsBalance: number | null;
+      userUsdcBalance: number | null;
       treasuryUsdcBalance: number | null;
     } | null;
   };
@@ -139,6 +140,7 @@ function eligibilityToneClass(status: SpendEligibilityStatus): string {
   if (
     status === 'eligible' ||
     status === 'ready_for_payment' ||
+    status === 'ready_for_payment_own_usdc' ||
     status === 'payment_complete'
   ) {
     return 'text-sm text-emerald-800';
@@ -371,6 +373,8 @@ export function SpendExperiencePage({
   const showSessionError = user && walletAddress && sessionError;
   const showWalletBlock = user && !walletAddress;
 
+  const showPayDirectUsdc = elig?.status === 'ready_for_payment_own_usdc';
+
   const showConvert =
     elig?.status === 'eligible' &&
     preview &&
@@ -378,6 +382,7 @@ export function SpendExperiencePage({
 
   const showPay =
     (elig?.status === 'ready_for_payment' ||
+      elig?.status === 'ready_for_payment_own_usdc' ||
       elig?.status === 'payment_failed') &&
     preview &&
     isEvmAddress(preview.receivingWalletAddress);
@@ -460,27 +465,52 @@ export function SpendExperiencePage({
                 <div className="space-y-3">
                   {preview && (
                     <div className="space-y-2 rounded-lg border border-neutral-200 bg-white p-4 text-sm">
-                      <div className="flex justify-between">
-                        <span className="text-neutral-600">You will use</span>
-                        <span className="font-medium">
-                          {preview.pointsRequired.toLocaleString()} points
-                        </span>
-                      </div>
-                      <div className="flex justify-between">
-                        <span className="text-neutral-600">
-                          You will receive
-                        </span>
-                        <span className="font-medium">
-                          ${preview.usdcAmount.toFixed(2)} USDC
-                        </span>
-                      </div>
-                      {preview.userPointsBalance != null && (
-                        <div className="flex justify-between text-neutral-500">
-                          <span>Your points balance</span>
-                          <span>
-                            {Number(preview.userPointsBalance).toLocaleString()}
-                          </span>
-                        </div>
+                      {showPayDirectUsdc ? (
+                        <>
+                          <div className="flex justify-between">
+                            <span className="text-neutral-600">Pay</span>
+                            <span className="font-medium">
+                              ${preview.usdcAmount.toFixed(2)} USDC
+                            </span>
+                          </div>
+                          {preview.userUsdcBalance != null && (
+                            <div className="flex justify-between text-neutral-500">
+                              <span>Your wallet (Base)</span>
+                              <span>
+                                ${preview.userUsdcBalance.toFixed(2)} USDC
+                              </span>
+                            </div>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          <div className="flex justify-between">
+                            <span className="text-neutral-600">
+                              You will use
+                            </span>
+                            <span className="font-medium">
+                              {preview.pointsRequired.toLocaleString()} points
+                            </span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-neutral-600">
+                              You will receive
+                            </span>
+                            <span className="font-medium">
+                              ${preview.usdcAmount.toFixed(2)} USDC
+                            </span>
+                          </div>
+                          {preview.userPointsBalance != null && (
+                            <div className="flex justify-between text-neutral-500">
+                              <span>Your points balance</span>
+                              <span>
+                                {Number(
+                                  preview.userPointsBalance
+                                ).toLocaleString()}
+                              </span>
+                            </div>
+                          )}
+                        </>
                       )}
                     </div>
                   )}
@@ -518,7 +548,7 @@ export function SpendExperiencePage({
                           Pay with USDC…
                         </>
                       ) : (
-                        `Spend $${preview.usdcAmount.toFixed(2)} UDSC`
+                        `Spend $${preview.usdcAmount.toFixed(2)} USDC`
                       )}
                     </Button>
                   )}
@@ -545,8 +575,9 @@ export function SpendExperiencePage({
                         <span className="font-medium">
                           {Number(
                             receiptConversion?.points_deducted ??
-                              preview?.pointsRequired ??
-                              0
+                              (displayReceipt && !receiptConversion
+                                ? 0
+                                : (preview?.pointsRequired ?? 0))
                           ).toLocaleString()}
                         </span>
                       </div>

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -65,11 +65,13 @@ describe('buildSpendEligibilityPreview', () => {
       spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 10,
+      userUsdcBalance: null,
       now,
     });
     expect(r.status).toBe('eligible');
     expect(r.preview?.pointsRequired).toBe(5000);
     expect(r.preview?.usdcAmount).toBe(5);
+    expect(r.preview?.userUsdcBalance).toBeNull();
     expect(r.preview?.treasuryWalletAddress).toBe(
       '0x4444444444444444444444444444444444444444'
     );
@@ -87,6 +89,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
       now,
     });
     expect(r.status).toBe('insufficient_points');
@@ -101,6 +104,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 2,
+      userUsdcBalance: null,
       now,
     });
     expect(r.status).toBe('treasury_insufficient');
@@ -131,6 +135,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendTransaction: null,
       fundedConversionForOtherSession: funded,
       treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
       now,
     });
     expect(r.status).toBe('already_converted');
@@ -161,6 +166,7 @@ describe('buildSpendEligibilityPreview', () => {
       spendTransaction: null,
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
       now,
     });
     expect(r.status).toBe('ready_for_payment');
@@ -205,8 +211,24 @@ describe('buildSpendEligibilityPreview', () => {
       },
       fundedConversionForOtherSession: null,
       treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
       now,
     });
     expect(r.status).toBe('payment_complete');
+  });
+
+  it('returns ready_for_payment_own_usdc when wallet has enough USDC (no conversion)', () => {
+    const r = buildSpendEligibilityPreview({
+      session: sess(),
+      spendExperience: exp(),
+      player: player(0),
+      pointConversion: null,
+      spendTransaction: null,
+      fundedConversionForOtherSession: null,
+      treasuryUsdcBalance: 0,
+      userUsdcBalance: 5.5,
+      now,
+    });
+    expect(r.status).toBe('ready_for_payment_own_usdc');
   });
 });

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -6,6 +6,10 @@ import {
   fetchServerWalletUsdcBalanceSafe,
   getSpendServerWalletAddress,
 } from '@/lib/spend-server-wallet';
+import {
+  fetchUsdcBalanceOnBase,
+  isEvmAddress,
+} from '@/lib/walletconnect-poster-direct-usdc';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import type {
   PointConversion,
@@ -36,6 +40,8 @@ export type SpendConversionPreview = {
   receivingWalletAddress: string;
   treasuryWalletAddress: string;
   userPointsBalance: number | null;
+  /** Embedded wallet USDC on Base (null if unavailable). */
+  userUsdcBalance: number | null;
   treasuryUsdcBalance: number | null;
 };
 
@@ -54,6 +60,7 @@ type BuildPreviewInput = {
   /** Funded conversion for same user+experience on a different session (one per user). */
   fundedConversionForOtherSession: PointConversion | null;
   treasuryUsdcBalance: number | null;
+  userUsdcBalance: number | null;
   now: Date;
 };
 
@@ -84,6 +91,7 @@ export function buildSpendEligibilityPreview(
     spendTransaction,
     fundedConversionForOtherSession,
     treasuryUsdcBalance,
+    userUsdcBalance,
     now,
   } = input;
 
@@ -97,6 +105,7 @@ export function buildSpendEligibilityPreview(
     treasuryWalletAddress: getSpendServerWalletAddress(spendExperience),
     userPointsBalance:
       player?.total_points != null ? Number(player.total_points) : null,
+    userUsdcBalance,
     treasuryUsdcBalance,
   });
 
@@ -158,6 +167,16 @@ export function buildSpendEligibilityPreview(
     };
   }
 
+  const userHasEnoughUsdc =
+    userUsdcBalance !== null && userUsdcBalance >= usdcAmount;
+  if (userHasEnoughUsdc) {
+    return {
+      status: 'ready_for_payment_own_usdc',
+      message: SPEND_ELIGIBILITY_MESSAGES.ready_for_payment_own_usdc,
+      preview: basePreview(),
+    };
+  }
+
   const balance =
     player?.total_points != null ? Number(player.total_points) : 0;
   if (balance < pointsRequired) {
@@ -192,6 +211,19 @@ type LoadEligibilityInput = {
 /**
  * Loads player, treasury balance, conversions, and builds eligibility (for API routes).
  */
+export async function fetchUserUsdcBalanceSafe(
+  walletAddress: string
+): Promise<number | null> {
+  const trimmed = walletAddress.trim();
+  if (!isEvmAddress(trimmed)) return null;
+  try {
+    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`);
+  } catch (e) {
+    console.error('fetchUserUsdcBalanceSafe:', e);
+    return null;
+  }
+}
+
 export async function loadSpendEligibilityForSession(
   input: LoadEligibilityInput
 ): Promise<SpendEligibilityResult> {
@@ -199,17 +231,24 @@ export async function loadSpendEligibilityForSession(
   const session = input.session;
   const spendExperience = input.spendExperience;
 
-  const [player, pointConversion, fundedOther, treasuryUsdcBalance, spendTx] =
-    await Promise.all([
-      getPlayerByWallet(session.wallet_address),
-      getPointConversionBySessionId(session.id),
-      getFundedPointConversionForUserExperience(
-        spendExperience.id,
-        session.user_id
-      ),
-      fetchServerWalletUsdcBalanceSafe(spendExperience),
-      getSpendTransactionBySessionId(session.id),
-    ]);
+  const [
+    player,
+    pointConversion,
+    fundedOther,
+    treasuryUsdcBalance,
+    spendTx,
+    userUsdcBalance,
+  ] = await Promise.all([
+    getPlayerByWallet(session.wallet_address),
+    getPointConversionBySessionId(session.id),
+    getFundedPointConversionForUserExperience(
+      spendExperience.id,
+      session.user_id
+    ),
+    fetchServerWalletUsdcBalanceSafe(spendExperience),
+    getSpendTransactionBySessionId(session.id),
+    fetchUserUsdcBalanceSafe(session.wallet_address),
+  ]);
 
   return buildSpendEligibilityPreview({
     session,
@@ -222,6 +261,7 @@ export async function loadSpendEligibilityForSession(
         ? fundedOther
         : null,
     treasuryUsdcBalance,
+    userUsdcBalance,
     now,
   });
 }

--- a/lib/spend-eligibility-messages.ts
+++ b/lib/spend-eligibility-messages.ts
@@ -11,6 +11,8 @@ export type SpendEligibilityStatus =
   | 'treasury_insufficient'
   | 'wallet_unavailable'
   | 'ready_for_payment'
+  /** Same payment step as `ready_for_payment`, but user already holds enough USDC (no points conversion). */
+  | 'ready_for_payment_own_usdc'
   | 'payment_failed'
   | 'payment_complete';
 
@@ -31,6 +33,8 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
   wallet_unavailable:
     'Wallet unavailable. Add or connect your embedded wallet in your profile.',
   ready_for_payment: 'Your points were converted to USDC.',
+  ready_for_payment_own_usdc:
+    'You have enough USDC in your wallet to complete this payment.',
   payment_failed:
     'Your last payment could not be verified on-chain. You can try sending payment again.',
   payment_complete:

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -9,7 +9,10 @@ import {
   confirmSpendTransactionIfSubmitted,
 } from '@/lib/db/spend-sessions';
 import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-transactions';
-import { computeConversionAmounts } from '@/lib/spend-conversion-preview';
+import {
+  computeConversionAmounts,
+  fetchUserUsdcBalanceSafe,
+} from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
 import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
@@ -173,12 +176,21 @@ export async function runSpendPaymentConfirm(input: {
   }
 
   const pointConversion = await getPointConversionBySessionId(session.id);
-  if (!pointConversion || pointConversion.status !== 'funded') {
-    return {
-      ok: false,
-      error: 'Conversion must be completed before payment',
-      httpStatus: 400,
-    };
+  const fundedConversion =
+    pointConversion?.status === 'funded' ? pointConversion : null;
+
+  let payingWithOwnUsdc = false;
+  if (!fundedConversion) {
+    const userUsdc = await fetchUserUsdcBalanceSafe(normalizedWallet);
+    if (userUsdc !== null && userUsdc >= input.usdcAmount) {
+      payingWithOwnUsdc = true;
+    } else {
+      return {
+        ok: false,
+        error: 'Conversion must be completed before payment',
+        httpStatus: 400,
+      };
+    }
   }
 
   const receiving = getSpendServerWalletAddress(spendExperience).trim();
@@ -200,18 +212,22 @@ export async function runSpendPaymentConfirm(input: {
     event_id: spendExperience.event_id,
     user_id: authUserId,
     wallet_address: normalizedWallet,
-    points_amount: pointConversion.points_deducted,
+    points_amount: fundedConversion ? fundedConversion.points_deducted : 0,
     usdc_amount: usdcAmount,
     status: 'submitted',
     spend_session_id: session.id,
-    point_conversion_id: pointConversion.id,
+    point_conversion_id: fundedConversion?.id,
     payment_tx_hash: txHash,
   };
 
-  if (
-    session.status !== 'conversion_complete' &&
-    session.status !== 'payment_pending'
-  ) {
+  const sessionReadyForFundedConversion =
+    session.status === 'conversion_complete' ||
+    session.status === 'payment_pending';
+  const sessionReadyForOwnUsdc =
+    payingWithOwnUsdc &&
+    (session.status === 'created' || session.status === 'payment_pending');
+
+  if (!sessionReadyForFundedConversion && !sessionReadyForOwnUsdc) {
     if (session.status === 'payment_complete') {
       const existing = await getSpendTransactionBySessionId(session.id);
       if (existing?.status === 'confirmed') {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Users visiting `/spend/:id` (spend pilot experiences) who already hold enough USDC on Base in their embedded wallet are no longer forced through **Convert points to USDC**. Eligibility and payment confirmation treat that case like the payment step: show **Spend $X USDC** immediately.

## Implementation

- **`loadSpendEligibilityForSession`** fetches the session wallet’s Base USDC balance (same helper as elsewhere). New eligibility status **`ready_for_payment_own_usdc`** with dedicated copy.
- **`buildSpendEligibilityPreview`** returns that status when there is no funded conversion yet and `userUsdcBalance >= usdcAmount` (still after gates like session expiry and active window).
- **`runSpendPaymentConfirm`** allows payment without a **funded** point conversion when the wallet still has enough USDC at confirm time; session may stay **`created`** until payment proceeds; analytics use **0** points and omit **point_conversion_id** when paying from own USDC.
- **UI** (`spend-experience-page.tsx`): summary card for direct-USDC path shows pay amount + wallet balance; payment button includes **`ready_for_payment_own_usdc`**; receipt shows **0** points when there was no conversion; fixed **UDSC** → **USDC** typo on the button.

## Testing

- Extended **`lib/spend-conversion-preview.test.ts`** with the own-USDC case.
- Ran ESLint on touched files; full test suite has pre-existing unrelated failures.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a9213d8-028f-4f8e-a9b5-09e056dc1fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a9213d8-028f-4f8e-a9b5-09e056dc1fcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

