### PR TITLE
feat(admin): withdraw spend server wallet USDC to external address

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -263,7 +263,7 @@ export default function SpendExperienceDetailPage() {
     void treasuryQuery.refetch();
   }, [experienceQuery, activityQuery, treasuryQuery]);
 
-  const handleWithdrawServerWallet = useCallback(async () => {
+  async function handleWithdrawServerWallet() {
     const trimmed = withdrawDestination.trim();
     if (!trimmed) {
       toast.error('Enter the wallet address that will receive the funds.');
@@ -292,7 +292,7 @@ export default function SpendExperienceDetailPage() {
     } finally {
       setWithdrawSubmitting(false);
     }
-  }, [experienceId, headers, refetchAll, withdrawDestination]);
+  }
 
   if (adminLoading || (user && isAdmin === null)) {
     return (
@@ -504,8 +504,8 @@ export default function SpendExperienceDetailPage() {
                   className="font-mono text-xs"
                 />
                 <p className="text-xs text-neutral-500">
-                  Sends the full Base USDC balance (whole micro-USDC units) to
-                  this address. Gas is sponsored.
+                  Withdraws the full Base USDC balance (6 decimals). Gas is
+                  sponsored.
                 </p>
               </div>
               <Button
@@ -517,7 +517,9 @@ export default function SpendExperienceDetailPage() {
                   treasuryData.serverWalletUsdcBalance === null ||
                   treasuryData.serverWalletUsdcBalance <= 0
                 }
-                onClick={() => void handleWithdrawServerWallet()}
+                onClick={() => {
+                  void handleWithdrawServerWallet();
+                }}
               >
                 {withdrawSubmitting ? (
                   <>

--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -12,7 +12,10 @@ import {
   RefreshCw,
   Copy,
 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import type {
   PointConversion,
   SpendExperience,
@@ -164,6 +167,8 @@ export default function SpendExperienceDetailPage() {
   const { user, login } = usePrivy();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
+  const [withdrawDestination, setWithdrawDestination] = useState('');
+  const [withdrawSubmitting, setWithdrawSubmitting] = useState(false);
 
   const checkAdminStatus = useCallback(async () => {
     if (!user?.email?.address) return false;
@@ -257,6 +262,37 @@ export default function SpendExperienceDetailPage() {
     void activityQuery.refetch();
     void treasuryQuery.refetch();
   }, [experienceQuery, activityQuery, treasuryQuery]);
+
+  const handleWithdrawServerWallet = useCallback(async () => {
+    const trimmed = withdrawDestination.trim();
+    if (!trimmed) {
+      toast.error('Enter the wallet address that will receive the funds.');
+      return;
+    }
+    setWithdrawSubmitting(true);
+    try {
+      const response = await fetch(
+        `/api/admin/spend-experiences/${experienceId}/treasury/withdraw`,
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ destinationAddress: trimmed }),
+        }
+      );
+      const j = await response.json();
+      if (!response.ok) {
+        toast.error(j.error ?? 'Withdrawal failed');
+        return;
+      }
+      toast.success(j.message ?? 'Withdrawal confirmed.');
+      setWithdrawDestination('');
+      refetchAll();
+    } catch {
+      toast.error('Withdrawal failed');
+    } finally {
+      setWithdrawSubmitting(false);
+    }
+  }, [experienceId, headers, refetchAll, withdrawDestination]);
 
   if (adminLoading || (user && isAdmin === null)) {
     return (
@@ -445,6 +481,53 @@ export default function SpendExperienceDetailPage() {
               <div className="mt-0.5 text-neutral-800">
                 {fmtUsdc(treasuryData.serverWalletUsdcBalance)}
               </div>
+            </div>
+          </div>
+          <div className="mt-5 border-t border-neutral-100 pt-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="min-w-0 flex-1 space-y-1.5">
+                <Label
+                  htmlFor="withdraw-destination"
+                  className="text-neutral-500"
+                >
+                  Withdraw to address
+                </Label>
+                <Input
+                  id="withdraw-destination"
+                  type="text"
+                  placeholder="0x…"
+                  autoComplete="off"
+                  spellCheck={false}
+                  value={withdrawDestination}
+                  onChange={(e) => setWithdrawDestination(e.target.value)}
+                  disabled={withdrawSubmitting}
+                  className="font-mono text-xs"
+                />
+                <p className="text-xs text-neutral-500">
+                  Sends the full Base USDC balance (whole micro-USDC units) to
+                  this address. Gas is sponsored.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                className="shrink-0"
+                disabled={
+                  withdrawSubmitting ||
+                  treasuryData.serverWalletUsdcBalance === null ||
+                  treasuryData.serverWalletUsdcBalance <= 0
+                }
+                onClick={() => void handleWithdrawServerWallet()}
+              >
+                {withdrawSubmitting ? (
+                  <>
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                    Withdrawing…
+                  </>
+                ) : (
+                  'Withdraw USDC'
+                )}
+              </Button>
             </div>
           </div>
           {treasuryData.ledger.length > 0 && (

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockGetSpendExperienceById = vi.fn();
+const mockFetchBalance = vi.fn();
+const mockGetTransferConfig = vi.fn();
+const mockSubmitTransfer = vi.fn();
+const mockWaitReceipt = vi.fn();
+const mockInsertLedger = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/spend-experiences', () => ({
+  getSpendExperienceById: (...args: unknown[]) =>
+    mockGetSpendExperienceById(...args),
+}));
+
+vi.mock('@/lib/spend-server-wallet', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/spend-server-wallet')>();
+  return {
+    ...actual,
+    fetchServerWalletUsdcBalanceSafe: (...args: unknown[]) =>
+      mockFetchBalance(...args),
+    getSpendServerWalletTransferConfig: (...args: unknown[]) =>
+      mockGetTransferConfig(...args),
+  };
+});
+
+vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
+  submitTreasuryUsdcTransfer: (...args: unknown[]) =>
+    mockSubmitTransfer(...args),
+  waitForTreasuryTxReceipt: (...args: unknown[]) => mockWaitReceipt(...args),
+}));
+
+vi.mock('@/lib/db/treasury-transactions', () => ({
+  insertTreasuryAdminRecoveryLedgerIfAbsent: (...args: unknown[]) =>
+    mockInsertLedger(...args),
+}));
+
+import { POST } from '../route';
+
+const experience = {
+  id: 'exp-1',
+  title: 'Pilot',
+  description: null,
+  event_id: null,
+  status: 'active' as const,
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  privy_server_wallet_id: 'privy-wallet-1',
+  server_wallet_address: '0x3333333333333333333333333333333333333333',
+  server_wallet_chain: 'base-mainnet',
+  server_wallet_created_at: '2026-04-01T00:00:00Z',
+  spend_create_idempotency_key: 'idem-1',
+  start_time: '2026-05-01T12:00:00.000Z',
+  end_time: '2026-05-08T12:00:00.000Z',
+  created_by: 'a@b.com',
+  created_at: '2026-04-01T00:00:00Z',
+  updated_at: '2026-04-01T00:00:00Z',
+};
+
+describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(experience);
+    mockFetchBalance.mockResolvedValue(2.0001);
+    mockGetTransferConfig.mockReturnValue({
+      walletId: 'privy-wallet-1',
+      address: '0x3333333333333333333333333333333333333333' as `0x${string}`,
+    });
+    mockSubmitTransfer.mockResolvedValue({
+      ok: true,
+      txHash:
+        '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    });
+    mockWaitReceipt.mockResolvedValue(undefined);
+    mockInsertLedger.mockResolvedValue(undefined);
+  });
+
+  it('returns 400 when destination equals server wallet', async () => {
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('x-user-email', 'admin@example.com');
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          destinationAddress: experience.server_wallet_address,
+        }),
+      }
+    );
+    const res = await POST(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(400);
+    expect(j.error).toContain('must differ');
+    expect(mockSubmitTransfer).not.toHaveBeenCalled();
+  });
+
+  it('submits transfer for full balance and records ledger', async () => {
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('x-user-email', 'admin@example.com');
+    const dest = '0x4444444444444444444444444444444444444444';
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ destinationAddress: dest }),
+      }
+    );
+    const res = await POST(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.success).toBe(true);
+    expect(j.data.amountUsdc).toBe(2.0001);
+    expect(mockSubmitTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientAddress: dest,
+        usdcAmount: 2.0001,
+      })
+    );
+    expect(mockInsertLedger).toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -18,18 +18,6 @@ interface RouteParams {
   params: { experienceId: string };
 }
 
-function normalizeAddr(a: string): string {
-  return a.trim().toLowerCase();
-}
-
-function balanceToMicroUsdc(balance: number): number {
-  return Math.floor(balance * 1e6);
-}
-
-function microUsdcToAmount(micro: number): number {
-  return micro / 1e6;
-}
-
 /**
  * POST /api/admin/spend-experiences/{experienceId}/treasury/withdraw
  * Sends USDC from the experience server wallet to an admin-provided address on Base.
@@ -67,10 +55,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     const { destinationAddress, amountUsdc } = validation.data;
-    const destNorm = normalizeAddr(destinationAddress);
-    const serverNorm = normalizeAddr(getSpendServerWalletAddress(experience));
+    const destLower = destinationAddress.toLowerCase();
+    const serverLower = getSpendServerWalletAddress(experience)
+      .trim()
+      .toLowerCase();
 
-    if (destNorm === serverNorm) {
+    if (destLower === serverLower) {
       return apiError(
         'Destination must differ from the server wallet address.',
         400
@@ -82,7 +72,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError('Could not read server wallet USDC balance.', 500);
     }
 
-    const maxMicro = balanceToMicroUsdc(balance);
+    const maxMicro = Math.floor(balance * 1e6);
     let withdrawMicro: number;
     if (amountUsdc != null && amountUsdc > 0) {
       withdrawMicro = Math.floor(amountUsdc * 1e6);
@@ -91,7 +81,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       }
       if (withdrawMicro > maxMicro) {
         return apiError(
-          `Amount exceeds available balance (${microUsdcToAmount(maxMicro).toFixed(6)} USDC).`,
+          `Amount exceeds available balance (${(maxMicro / 1e6).toFixed(6)} USDC).`,
           400
         );
       }
@@ -103,12 +93,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError('No USDC available to withdraw.', 400);
     }
 
-    const withdrawAmount = microUsdcToAmount(withdrawMicro);
+    const withdrawAmount = withdrawMicro / 1e6;
 
     const submit = await submitTreasuryUsdcTransfer({
       serverWalletId: walletConfig.walletId,
       serverWalletAddress: walletConfig.address,
-      recipientAddress: destinationAddress.trim() as `0x${string}`,
+      recipientAddress: destinationAddress as `0x${string}`,
       usdcAmount: withdrawAmount,
     });
 
@@ -132,7 +122,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       spendExperienceId: experience.id,
       amount: withdrawAmount,
       fromWalletAddress: walletConfig.address,
-      toWalletAddress: destinationAddress.trim(),
+      toWalletAddress: destinationAddress,
       txHash: submit.txHash,
     });
 
@@ -140,7 +130,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       {
         txHash: submit.txHash,
         amountUsdc: withdrawAmount,
-        destinationAddress: destinationAddress.trim(),
+        destinationAddress,
       },
       'Withdrawal confirmed.'
     );

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -1,0 +1,151 @@
+import { NextRequest } from 'next/server';
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import { insertTreasuryAdminRecoveryLedgerIfAbsent } from '@/lib/db/treasury-transactions';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+import { treasuryWithdrawRequestSchema } from '@/lib/schemas/treasury-withdraw';
+import {
+  fetchServerWalletUsdcBalanceSafe,
+  getSpendServerWalletAddress,
+  getSpendServerWalletTransferConfig,
+} from '@/lib/spend-server-wallet';
+import {
+  submitTreasuryUsdcTransfer,
+  waitForTreasuryTxReceipt,
+} from '@/lib/spend-treasury-usdc-transfer';
+
+interface RouteParams {
+  params: { experienceId: string };
+}
+
+function normalizeAddr(a: string): string {
+  return a.trim().toLowerCase();
+}
+
+function balanceToMicroUsdc(balance: number): number {
+  return Math.floor(balance * 1e6);
+}
+
+function microUsdcToAmount(micro: number): number {
+  return micro / 1e6;
+}
+
+/**
+ * POST /api/admin/spend-experiences/{experienceId}/treasury/withdraw
+ * Sends USDC from the experience server wallet to an admin-provided address on Base.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const experience = await getSpendExperienceById(params.experienceId);
+    if (!experience) {
+      return apiError('Spend experience not found', 404);
+    }
+
+    const walletConfig = getSpendServerWalletTransferConfig(experience);
+    if (!walletConfig) {
+      return apiError(
+        'Server wallet is not configured for this experience.',
+        400
+      );
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return apiError('Invalid JSON body', 400);
+    }
+
+    const validation = treasuryWithdrawRequestSchema.safeParse(raw);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+
+    const { destinationAddress, amountUsdc } = validation.data;
+    const destNorm = normalizeAddr(destinationAddress);
+    const serverNorm = normalizeAddr(getSpendServerWalletAddress(experience));
+
+    if (destNorm === serverNorm) {
+      return apiError(
+        'Destination must differ from the server wallet address.',
+        400
+      );
+    }
+
+    const balance = await fetchServerWalletUsdcBalanceSafe(experience);
+    if (balance === null || Number.isNaN(balance)) {
+      return apiError('Could not read server wallet USDC balance.', 500);
+    }
+
+    const maxMicro = balanceToMicroUsdc(balance);
+    let withdrawMicro: number;
+    if (amountUsdc != null && amountUsdc > 0) {
+      withdrawMicro = Math.floor(amountUsdc * 1e6);
+      if (withdrawMicro <= 0) {
+        return apiError('Withdraw amount must be positive.', 400);
+      }
+      if (withdrawMicro > maxMicro) {
+        return apiError(
+          `Amount exceeds available balance (${microUsdcToAmount(maxMicro).toFixed(6)} USDC).`,
+          400
+        );
+      }
+    } else {
+      withdrawMicro = maxMicro;
+    }
+
+    if (withdrawMicro <= 0) {
+      return apiError('No USDC available to withdraw.', 400);
+    }
+
+    const withdrawAmount = microUsdcToAmount(withdrawMicro);
+
+    const submit = await submitTreasuryUsdcTransfer({
+      serverWalletId: walletConfig.walletId,
+      serverWalletAddress: walletConfig.address,
+      recipientAddress: destinationAddress.trim() as `0x${string}`,
+      usdcAmount: withdrawAmount,
+    });
+
+    if (!submit.ok) {
+      return apiError(submit.error || 'USDC transfer failed', 500);
+    }
+
+    try {
+      await waitForTreasuryTxReceipt(submit.txHash);
+    } catch (waitErr) {
+      const msg =
+        waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
+      console.error('treasury withdraw waitForReceipt:', waitErr);
+      return apiError(
+        `${msg}. Transaction was submitted: ${submit.txHash}`,
+        500
+      );
+    }
+
+    await insertTreasuryAdminRecoveryLedgerIfAbsent({
+      spendExperienceId: experience.id,
+      amount: withdrawAmount,
+      fromWalletAddress: walletConfig.address,
+      toWalletAddress: destinationAddress.trim(),
+      txHash: submit.txHash,
+    });
+
+    return apiSuccess(
+      {
+        txHash: submit.txHash,
+        amountUsdc: withdrawAmount,
+        destinationAddress: destinationAddress.trim(),
+      },
+      'Withdrawal confirmed.'
+    );
+  } catch (error) {
+    console.error('admin treasury withdraw:', error);
+    return apiError('Failed to withdraw USDC', 500);
+  }
+}

--- a/lib/db/treasury-transactions.ts
+++ b/lib/db/treasury-transactions.ts
@@ -34,7 +34,7 @@ function rowToTreasury(row: Record<string, unknown>): TreasuryTransaction {
 
 type TreasuryLedgerInsertType = Extract<
   TreasuryTransaction['transaction_type'],
-  'fund_user' | 'receive_payment'
+  'fund_user' | 'receive_payment' | 'admin_recovery'
 >;
 
 async function insertTreasuryLedgerRowIfAbsent(params: {
@@ -103,6 +103,24 @@ export function insertTreasuryReceivePaymentLedgerIfAbsent(input: {
   return insertTreasuryLedgerRowIfAbsent({
     spendExperienceId: input.spendExperienceId,
     transactionType: 'receive_payment',
+    amount: input.amount,
+    fromWalletAddress: input.fromWalletAddress,
+    toWalletAddress: input.toWalletAddress,
+    txHash: input.txHash,
+  });
+}
+
+/** Optional audit row: admin withdrawal from server wallet to an external address. */
+export function insertTreasuryAdminRecoveryLedgerIfAbsent(input: {
+  spendExperienceId: string;
+  amount: number;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  txHash: string;
+}): Promise<void> {
+  return insertTreasuryLedgerRowIfAbsent({
+    spendExperienceId: input.spendExperienceId,
+    transactionType: 'admin_recovery',
     amount: input.amount,
     fromWalletAddress: input.fromWalletAddress,
     toWalletAddress: input.toWalletAddress,

--- a/lib/schemas/treasury-withdraw.ts
+++ b/lib/schemas/treasury-withdraw.ts
@@ -7,7 +7,7 @@ export const treasuryWithdrawRequestSchema = z.object({
     .trim()
     .min(1, 'Destination address is required')
     .refine((v) => isEvmAddress(v), 'Invalid Ethereum address'),
-  /** Omit or null to withdraw the full USDC balance (minus rounding). */
+  /** Omit or null to withdraw the full USDC balance at max precision (6 decimals). */
   amountUsdc: z.number().positive().finite().optional().nullable(),
 });
 

--- a/lib/schemas/treasury-withdraw.ts
+++ b/lib/schemas/treasury-withdraw.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
+
+export const treasuryWithdrawRequestSchema = z.object({
+  destinationAddress: z
+    .string()
+    .trim()
+    .min(1, 'Destination address is required')
+    .refine((v) => isEvmAddress(v), 'Invalid Ethereum address'),
+  /** Omit or null to withdraw the full USDC balance (minus rounding). */
+  amountUsdc: z.number().positive().finite().optional().nullable(),
+});
+
+export type TreasuryWithdrawRequest = z.infer<
+  typeof treasuryWithdrawRequestSchema
+>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds an admin-only withdrawal flow for the spend pilot **Server wallet** card so treasury USDC on Base can be sent to any valid `0x` destination.

## Changes

- **UI** (`app/admin/spend-experiences/[experienceId]/page.tsx`): "Withdraw to address" field, **Withdraw USDC** button (full balance at 6-decimal precision), disabled when balance is zero or missing; uses existing admin headers and refreshes treasury after success.
- **API** (`POST /api/admin/spend-experiences/{experienceId}/treasury/withdraw`): Validates destination with Zod, rejects self-transfer, reads live balance, submits via existing `submitTreasuryUsdcTransfer` (Privy server wallet, gas sponsored), waits for receipt, inserts optional ledger row as `admin_recovery`.
- **DB** (`lib/db/treasury-transactions.ts`): `insertTreasuryAdminRecoveryLedgerIfAbsent` for audit rows (same idempotency pattern as other treasury ledger inserts).

## Tests

- `app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts`

## Notes

- Optional body field `amountUsdc` is supported by the API for partial withdrawals; the current UI only triggers a full-balance withdrawal.

## Follow-up (refactor)

- Inlined micro-USDC math in the withdraw route; withdraw handler no longer uses `useCallback` with input in the dependency array.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-252b2f46-2e64-495b-af54-83f7c89d1583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-252b2f46-2e64-495b-af54-83f7c89d1583"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

