### PR TITLE
fix(admin): withdraw button layout and treasury withdraw confirmation

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -484,8 +484,8 @@ export default function SpendExperienceDetailPage() {
             </div>
           </div>
           <div className="mt-5 border-t border-neutral-100 pt-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-              <div className="min-w-0 flex-1 space-y-1.5">
+            <div className="flex max-w-xl flex-col gap-3">
+              <div className="min-w-0 space-y-1.5">
                 <Label
                   htmlFor="withdraw-destination"
                   className="text-neutral-500"
@@ -511,7 +511,7 @@ export default function SpendExperienceDetailPage() {
               <Button
                 type="button"
                 variant="outline"
-                className="shrink-0"
+                className="w-full shrink-0 sm:w-auto"
                 disabled={
                   withdrawSubmitting ||
                   treasuryData.serverWalletUsdcBalance === null ||

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import { TransactionNotFoundError } from 'viem';
 
 const mockRequireAdmin = vi.fn();
 const mockGetSpendExperienceById = vi.fn();
@@ -7,6 +8,7 @@ const mockFetchBalance = vi.fn();
 const mockGetTransferConfig = vi.fn();
 const mockSubmitTransfer = vi.fn();
 const mockWaitReceipt = vi.fn();
+const mockFindRecentTransfer = vi.fn();
 const mockInsertLedger = vi.fn();
 
 vi.mock('@/lib/auth', () => ({
@@ -34,6 +36,8 @@ vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
   submitTreasuryUsdcTransfer: (...args: unknown[]) =>
     mockSubmitTransfer(...args),
   waitForTreasuryTxReceipt: (...args: unknown[]) => mockWaitReceipt(...args),
+  findRecentTreasuryUsdcTransfer: (...args: unknown[]) =>
+    mockFindRecentTransfer(...args),
 }));
 
 vi.mock('@/lib/db/treasury-transactions', () => ({
@@ -84,6 +88,7 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
         '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
     });
     mockWaitReceipt.mockResolvedValue(undefined);
+    mockFindRecentTransfer.mockResolvedValue(null);
     mockInsertLedger.mockResolvedValue(undefined);
   });
 
@@ -133,5 +138,45 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
       })
     );
     expect(mockInsertLedger).toHaveBeenCalled();
+    expect(mockFindRecentTransfer).not.toHaveBeenCalled();
+  });
+
+  it('resolves confirmation via transfer logs when receipt wait hits indexing lag', async () => {
+    const submittedHash =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    const resolvedFromLogs =
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    mockWaitReceipt
+      .mockRejectedValueOnce(
+        new TransactionNotFoundError({ hash: submittedHash as `0x${string}` })
+      )
+      .mockResolvedValueOnce(undefined);
+    mockFindRecentTransfer.mockResolvedValueOnce(
+      resolvedFromLogs as `0x${string}`
+    );
+
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('x-user-email', 'admin@example.com');
+    const dest = '0x4444444444444444444444444444444444444444';
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ destinationAddress: dest }),
+      }
+    );
+    const res = await POST(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.success).toBe(true);
+    expect(j.data.txHash).toBe(resolvedFromLogs);
+    expect(mockWaitReceipt).toHaveBeenNthCalledWith(1, submittedHash);
+    expect(mockWaitReceipt).toHaveBeenNthCalledWith(2, resolvedFromLogs);
+    expect(mockFindRecentTransfer).toHaveBeenCalled();
+    expect(mockInsertLedger).toHaveBeenCalledWith(
+      expect.objectContaining({ txHash: resolvedFromLogs })
+    );
   });
 });

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest } from 'next/server';
+import {
+  TransactionNotFoundError,
+  WaitForTransactionReceiptTimeoutError,
+} from 'viem';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { insertTreasuryAdminRecoveryLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
@@ -10,6 +14,7 @@ import {
   getSpendServerWalletTransferConfig,
 } from '@/lib/spend-server-wallet';
 import {
+  findRecentTreasuryUsdcTransfer,
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
 } from '@/lib/spend-treasury-usdc-transfer';
@@ -106,16 +111,73 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError(submit.error || 'USDC transfer failed', 500);
     }
 
+    const destHex = destinationAddress as `0x${string}`;
+    const serverHex = walletConfig.address;
+    let confirmedTxHash = submit.txHash;
+
+    const isLikelyIndexingLag = (err: unknown) =>
+      err instanceof TransactionNotFoundError ||
+      err instanceof WaitForTransactionReceiptTimeoutError ||
+      (err instanceof Error && /could not be found/i.test(err.message));
+
     try {
-      await waitForTreasuryTxReceipt(submit.txHash);
+      await waitForTreasuryTxReceipt(confirmedTxHash);
     } catch (waitErr) {
-      const msg =
-        waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
-      console.error('treasury withdraw waitForReceipt:', waitErr);
-      return apiError(
-        `${msg}. Transaction was submitted: ${submit.txHash}`,
-        500
+      if (!isLikelyIndexingLag(waitErr)) {
+        const msg =
+          waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
+        console.error('treasury withdraw waitForReceipt:', waitErr);
+        return apiError(
+          `${msg}. Transaction was submitted: ${confirmedTxHash}`,
+          500
+        );
+      }
+
+      console.warn(
+        'treasury withdraw: receipt wait failed (possible RPC lag), resolving via logs:',
+        waitErr
       );
+
+      const logResolveDeadline = Date.now() + 120_000;
+      let fromLogs: `0x${string}` | null = null;
+      while (Date.now() < logResolveDeadline) {
+        fromLogs = await findRecentTreasuryUsdcTransfer({
+          serverWalletAddress: serverHex,
+          recipientAddress: destHex,
+          usdcAmount: withdrawAmount,
+        });
+        if (fromLogs) break;
+        await new Promise((r) => setTimeout(r, 2_000));
+      }
+
+      if (!fromLogs) {
+        const msg =
+          waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
+        console.error(
+          'treasury withdraw waitForReceipt (no log match):',
+          waitErr
+        );
+        return apiError(
+          `${msg}. Transaction was submitted: ${confirmedTxHash}`,
+          500
+        );
+      }
+
+      confirmedTxHash = fromLogs;
+      try {
+        await waitForTreasuryTxReceipt(confirmedTxHash);
+      } catch (finalErr) {
+        const msg =
+          finalErr instanceof Error ? finalErr.message : 'Confirmation failed';
+        console.error(
+          'treasury withdraw waitForReceipt (after log resolve):',
+          finalErr
+        );
+        return apiError(
+          `${msg}. Transaction was submitted: ${confirmedTxHash}`,
+          500
+        );
+      }
     }
 
     await insertTreasuryAdminRecoveryLedgerIfAbsent({
@@ -123,12 +185,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       amount: withdrawAmount,
       fromWalletAddress: walletConfig.address,
       toWalletAddress: destinationAddress,
-      txHash: submit.txHash,
+      txHash: confirmedTxHash,
     });
 
     return apiSuccess(
       {
-        txHash: submit.txHash,
+        txHash: confirmedTxHash,
         amountUsdc: withdrawAmount,
         destinationAddress,
       },

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -200,6 +200,9 @@ export async function waitForTreasuryTxReceipt(
   const receipt = await publicClient.waitForTransactionReceipt({
     hash: txHash,
     timeout,
+    /** Privy / some RPCs lag indexing `eth_getTransactionByHash`; default viem retries are too low. */
+    retryCount: 25,
+    retryDelay: ({ count }) => ~~(1 << Math.min(count, 6)) * 250,
   });
   if (receipt.status !== 'success') {
     throw new Error('Funding transaction reverted');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **UI:** On the spend experience admin page, **Withdraw USDC** is stacked under the destination address field (full width on small screens, auto width from `sm` up).
- **API:** The treasury withdraw route could return **500** with a viem message like *Transaction with hash "0x…" could not be found* when the chain RPC lags behind Privy’s submitted hash. We now:
  - Pass higher `retryCount` / `retryDelay` into `waitForTransactionReceipt` in `waitForTreasuryTxReceipt`.
  - On `TransactionNotFoundError`, `WaitForTransactionReceiptTimeoutError`, or generic “could not be found” errors, poll `findRecentTreasuryUsdcTransfer` (same log-based matching as submit fallback) for up to ~2 minutes, then wait for receipt and write the ledger using the resolved hash.

## Testing

- `yarn lint` (existing repo warnings only)
- `yarn test` on `app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts` (includes new case for log-based recovery)

## Note on CSP / Sentry

Sentry `connect-src` violations are separate from the withdraw flow; fixing those would be a headers / CSP config change if you want error reporting in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-491800cd-9d27-4391-858f-84a6304cf193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-491800cd-9d27-4391-858f-84a6304cf193"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

