### PR TITLE
fix: resolve Privy server transaction hashes

### DIFF
--- a/lib/api/privy.test.ts
+++ b/lib/api/privy.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetTransaction = vi.fn();
+
+vi.mock('@privy-io/server-auth', () => ({
+  PrivyClient: vi.fn(function PrivyClient() {
+    return {
+      walletApi: {
+        getTransaction: mockGetTransaction,
+      },
+    };
+  }),
+}));
+
+import { resolvePrivyServerTransactionHash } from './privy';
+
+const directHash =
+  '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+const polledHash =
+  '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+describe('resolvePrivyServerTransactionHash', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'app-id';
+    process.env.PRIVY_APP_SECRET = 'app-secret';
+  });
+
+  it('returns direct sendTransaction hashes', async () => {
+    await expect(
+      resolvePrivyServerTransactionHash({ hash: directHash })
+    ).resolves.toBe(directHash);
+    expect(mockGetTransaction).not.toHaveBeenCalled();
+  });
+
+  it('polls Privy transaction ids until the hash is available', async () => {
+    mockGetTransaction
+      .mockResolvedValueOnce({
+        id: 'tx-1',
+        status: 'broadcasted',
+        transactionHash: null,
+      })
+      .mockResolvedValueOnce({
+        id: 'tx-1',
+        status: 'confirmed',
+        transactionHash: polledHash,
+      });
+
+    await expect(
+      resolvePrivyServerTransactionHash(
+        { transactionId: 'tx-1' },
+        { timeoutMs: 100, pollIntervalMs: 1 }
+      )
+    ).resolves.toBe(polledHash);
+
+    expect(mockGetTransaction).toHaveBeenCalledWith({ id: 'tx-1' });
+    expect(mockGetTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws when Privy marks the transaction failed before returning a hash', async () => {
+    mockGetTransaction.mockResolvedValueOnce({
+      id: 'tx-1',
+      status: 'execution_reverted',
+      transactionHash: null,
+    });
+
+    await expect(
+      resolvePrivyServerTransactionHash(
+        { data: { transactionId: 'tx-1' } },
+        { timeoutMs: 100, pollIntervalMs: 1 }
+      )
+    ).rejects.toThrow('execution_reverted');
+  });
+});

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -5,6 +5,64 @@ import type { SpendServerWalletMetadata } from '@/lib/spend-server-wallet';
 // Lazy-initialized singleton shared across all API routes
 let privyClient: PrivyClient | null = null;
 
+const PRIVY_TRANSACTION_POLL_INTERVAL_MS = 1_000;
+const PRIVY_TRANSACTION_HASH_TIMEOUT_MS = 30_000;
+const PRIVY_TRANSACTION_FAILED_STATUSES = new Set([
+  'execution_reverted',
+  'failed',
+  'provider_error',
+]);
+
+function getRecord(value: unknown): Record<string, unknown> | null {
+  return value !== null && typeof value === 'object'
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function getStringField(
+  value: unknown,
+  keys: readonly string[]
+): string | null {
+  const record = getRecord(value);
+  if (!record) return null;
+
+  for (const key of keys) {
+    const field = record[key];
+    if (typeof field === 'string' && field.trim()) {
+      return field.trim();
+    }
+  }
+
+  return null;
+}
+
+function extractPrivyTransactionHash(value: unknown): string | null {
+  const direct = getStringField(value, [
+    'hash',
+    'transactionHash',
+    'transaction_hash',
+  ]);
+  if (direct) return direct;
+
+  const data = getRecord(value)?.data;
+  return getStringField(data, ['hash', 'transactionHash', 'transaction_hash']);
+}
+
+function extractPrivyTransactionId(value: unknown): string | null {
+  const direct = getStringField(value, ['transactionId', 'transaction_id']);
+  if (direct) return direct;
+
+  const data = getRecord(value)?.data;
+  const dataId = getStringField(data, ['transactionId', 'transaction_id']);
+  if (dataId) return dataId;
+
+  return getStringField(value, ['id']);
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
 export function getPrivyClient(): PrivyClient {
   if (!privyClient) {
     const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID;
@@ -19,6 +77,47 @@ export function getPrivyClient(): PrivyClient {
     privyClient = new PrivyClient(appId, appSecret);
   }
   return privyClient;
+}
+
+/**
+ * Privy may return only a transaction id for server-wallet sends. Poll Privy's
+ * transaction API so callers can persist the on-chain hash before resuming work.
+ */
+export async function resolvePrivyServerTransactionHash(
+  response: unknown,
+  options: {
+    timeoutMs?: number;
+    pollIntervalMs?: number;
+  } = {}
+): Promise<string | null> {
+  const directHash = extractPrivyTransactionHash(response);
+  if (directHash) return directHash;
+
+  const transactionId = extractPrivyTransactionId(response);
+  if (!transactionId) return null;
+
+  const timeoutMs = options.timeoutMs ?? PRIVY_TRANSACTION_HASH_TIMEOUT_MS;
+  const pollIntervalMs =
+    options.pollIntervalMs ?? PRIVY_TRANSACTION_POLL_INTERVAL_MS;
+  const deadline = Date.now() + timeoutMs;
+
+  do {
+    const transaction = await getPrivyClient().walletApi.getTransaction({
+      id: transactionId,
+    });
+    const hash = extractPrivyTransactionHash(transaction);
+    if (hash) return hash;
+
+    const status = getStringField(transaction, ['status']);
+    if (status && PRIVY_TRANSACTION_FAILED_STATUSES.has(status)) {
+      throw new Error(`Privy transaction ${transactionId} ${status}`);
+    }
+
+    if (Date.now() >= deadline) break;
+    await delay(Math.min(pollIntervalMs, Math.max(deadline - Date.now(), 0)));
+  } while (Date.now() <= deadline);
+
+  return null;
 }
 
 /**

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -6,7 +6,10 @@ import {
   parseAbiItem,
   parseUnits,
 } from 'viem';
-import { getPrivyClient } from '@/lib/api/privy';
+import {
+  getPrivyClient,
+  resolvePrivyServerTransactionHash,
+} from '@/lib/api/privy';
 import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
 import {
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
@@ -165,7 +168,9 @@ export async function submitTreasuryUsdcTransfer(params: {
         value: '0x0',
       },
     });
-    const txHash = normalizeEvmTxHash(result.hash);
+    const txHash = normalizeEvmTxHash(
+      await resolvePrivyServerTransactionHash(result)
+    );
     if (txHash) {
       return { ok: true, txHash };
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary
- Add a shared Privy server transaction hash resolver that accepts direct hashes or polls Privy's transaction API by transaction id.
- Use the resolver for spend treasury USDC transfers before falling back to on-chain transfer-log recovery.
- Add focused Vitest coverage for direct hash, delayed hash, and failed Privy transaction statuses.

### Testing
- `yarn test lib/api/privy.test.ts app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts`
- `yarn lint`
- `yarn build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7134084c-a9fe-48de-b69c-724aa840a59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7134084c-a9fe-48de-b69c-724aa840a59d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

