### PR TITLE
fix: Privy gas sponsorship for treasury USDC withdrawals

### DIFF
--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
 
+const { mockPrivyGetWallet } = vi.hoisted(() => ({
+  mockPrivyGetWallet: vi.fn(),
+}));
+
 const mockRequireAdmin = vi.fn();
 const mockGetSpendExperienceById = vi.fn();
 const mockFetchBalance = vi.fn();
@@ -34,6 +38,18 @@ vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
   submitTreasuryUsdcTransfer: (...args: unknown[]) =>
     mockSubmitTransfer(...args),
   waitForTreasuryTxReceipt: (...args: unknown[]) => mockWaitReceipt(...args),
+}));
+
+vi.mock('@/lib/api/privy', () => ({
+  formatPrivyResponseForLog: (value: unknown) => ({
+    keys:
+      value !== null && typeof value === 'object'
+        ? Object.keys(value as object)
+        : [],
+  }),
+  getPrivyClient: () => ({
+    walletApi: { getWallet: mockPrivyGetWallet },
+  }),
 }));
 
 vi.mock('@/lib/db/treasury-transactions', () => ({
@@ -82,9 +98,16 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
       ok: true,
       txHash:
         '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      privySendSummary: {
+        hash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
     });
     mockWaitReceipt.mockResolvedValue(undefined);
     mockInsertLedger.mockResolvedValue(undefined);
+    mockPrivyGetWallet.mockResolvedValue({
+      id: 'privy-wallet-1',
+      address: experience.server_wallet_address,
+    });
   });
 
   it('returns 400 when destination equals server wallet', async () => {

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest } from 'next/server';
+import { formatPrivyResponseForLog, getPrivyClient } from '@/lib/api/privy';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { insertTreasuryAdminRecoveryLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
@@ -13,6 +14,7 @@ import {
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
 } from '@/lib/spend-treasury-usdc-transfer';
+import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
 
 interface RouteParams {
   params: { experienceId: string };
@@ -95,6 +97,29 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     const withdrawAmount = withdrawMicro / 1e6;
 
+    try {
+      const privy = getPrivyClient();
+      const wallet = await privy.walletApi.getWallet({
+        id: walletConfig.walletId,
+      });
+      console.info('treasury withdraw Privy preflight', {
+        walletId: walletConfig.walletId,
+        walletAddress: wallet.address,
+        caip2: SPEND_SERVER_WALLET_CAIP2,
+        sponsor: true,
+        privyWalletSummary: formatPrivyResponseForLog(wallet),
+      });
+    } catch (preflightErr) {
+      console.error(
+        'treasury withdraw Privy wallet preflight failed:',
+        preflightErr
+      );
+      return apiError(
+        'Could not load Privy server wallet for withdrawal. Check privy_server_wallet_id and credentials.',
+        500
+      );
+    }
+
     const submit = await submitTreasuryUsdcTransfer({
       serverWalletId: walletConfig.walletId,
       serverWalletAddress: walletConfig.address,
@@ -105,6 +130,15 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     if (!submit.ok) {
       return apiError(submit.error || 'USDC transfer failed', 500);
     }
+
+    console.info('treasury withdraw Privy sendTransaction result', {
+      walletId: walletConfig.walletId,
+      walletAddress: walletConfig.address,
+      caip2: SPEND_SERVER_WALLET_CAIP2,
+      sponsor: true,
+      txHash: submit.txHash,
+      privyResponseShape: submit.privySendSummary,
+    });
 
     try {
       await waitForTreasuryTxReceipt(submit.txHash);

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -202,6 +202,39 @@ export async function verifyWalletOwnership(
   }
 }
 
+/**
+ * Summarize a Privy API response for logs without dumping large or sensitive payloads.
+ */
+export function formatPrivyResponseForLog(
+  value: unknown
+): Record<string, unknown> {
+  if (value === null || value === undefined) {
+    return { type: typeof value };
+  }
+  if (typeof value !== 'object') {
+    return { type: typeof value, preview: String(value).slice(0, 200) };
+  }
+  const record = value as Record<string, unknown>;
+  const out: Record<string, unknown> = {};
+  for (const key of Object.keys(record).slice(0, 20)) {
+    const v = record[key];
+    if (v === null || v === undefined) {
+      out[key] = v;
+    } else if (typeof v === 'string') {
+      out[key] = v.length > 120 ? `${v.slice(0, 120)}…` : v;
+    } else if (typeof v === 'number' || typeof v === 'boolean') {
+      out[key] = v;
+    } else if (Array.isArray(v)) {
+      out[key] = `[array length ${v.length}]`;
+    } else if (typeof v === 'object') {
+      out[key] = '[object]';
+    } else {
+      out[key] = String(v).slice(0, 80);
+    }
+  }
+  return out;
+}
+
 export async function createSpendPrivyServerWallet(params: {
   idempotencyKey: string;
 }): Promise<SpendServerWalletMetadata> {

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -64,13 +64,13 @@ export function getSpendServerWalletTransferConfig(
     | 'treasury_wallet_address'
   >
 ): SpendServerWalletTransferConfig | null {
-  const address = getSpendServerWalletAddress(experience);
   const walletId = experience.privy_server_wallet_id?.trim();
-  if (!walletId || !isEvmAddress(address)) {
+  const serverAddr = experience.server_wallet_address?.trim();
+  if (!walletId || !serverAddr || !isEvmAddress(serverAddr)) {
     return null;
   }
 
-  return { walletId, address: address as `0x${string}` };
+  return { walletId, address: serverAddr as `0x${string}` };
 }
 
 async function fetchUsdcBalanceSafe(

--- a/lib/spend-treasury-usdc-transfer.test.ts
+++ b/lib/spend-treasury-usdc-transfer.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockPrivyRpc = vi.fn();
+const mockSendTransaction = vi.fn();
+const mockGetWallet = vi.fn();
 const mockGetTransaction = vi.fn();
 const mockGetBlockNumber = vi.fn();
 const mockGetLogs = vi.fn();
@@ -9,7 +10,8 @@ vi.mock('@privy-io/server-auth', () => ({
   PrivyClient: vi.fn(function PrivyClient() {
     return {
       walletApi: {
-        rpc: mockPrivyRpc,
+        ethereum: { sendTransaction: mockSendTransaction },
+        getWallet: mockGetWallet,
         getTransaction: mockGetTransaction,
       },
     };
@@ -27,7 +29,10 @@ vi.mock('viem', async (importOriginal) => {
   };
 });
 
-import { submitTreasuryUsdcTransfer } from './spend-treasury-usdc-transfer';
+import {
+  mapInsufficientNativeGasPrivyError,
+  submitTreasuryUsdcTransfer,
+} from './spend-treasury-usdc-transfer';
 
 const txHash =
   '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
@@ -39,16 +44,55 @@ describe('submitTreasuryUsdcTransfer', () => {
     process.env.PRIVY_APP_SECRET = 'app-secret';
     mockGetBlockNumber.mockResolvedValue(123n);
     mockGetLogs.mockResolvedValue([]);
+    mockGetWallet.mockResolvedValue({
+      id: 'wallet-1',
+      address: '0x1111111111111111111111111111111111111111',
+      chainType: 'ethereum',
+    });
   });
 
-  it('uses Privy RPC transaction ids to recover hashes for sponsored sends', async () => {
-    mockPrivyRpc.mockResolvedValue({
-      method: 'eth_sendTransaction',
-      data: {
-        hash: '',
+  it('uses walletApi.ethereum.sendTransaction with sponsor and resolves tx hash', async () => {
+    mockSendTransaction.mockResolvedValue({
+      hash: txHash,
+      caip2: 'eip155:8453',
+    });
+
+    await expect(
+      submitTreasuryUsdcTransfer({
+        serverWalletId: 'wallet-1',
+        serverWalletAddress: '0x1111111111111111111111111111111111111111',
+        recipientAddress: '0x2222222222222222222222222222222222222222',
+        usdcAmount: 1,
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        txHash,
+        privySendSummary: expect.any(Object),
+      })
+    );
+
+    expect(mockGetWallet).toHaveBeenCalledWith({ id: 'wallet-1' });
+    expect(mockSendTransaction).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walletId: 'wallet-1',
         caip2: 'eip155:8453',
-        transaction_id: 'privy-tx-1',
-      },
+        sponsor: true,
+        transaction: expect.objectContaining({
+          to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+          chainId: 8453,
+          value: '0x0',
+        }),
+      })
+    );
+    expect(mockGetTransaction).not.toHaveBeenCalled();
+  });
+
+  it('uses Privy getTransaction when send returns only a transaction id', async () => {
+    mockSendTransaction.mockResolvedValue({
+      hash: '',
+      caip2: 'eip155:8453',
+      transactionId: 'privy-tx-1',
     });
     mockGetTransaction.mockResolvedValue({
       id: 'privy-tx-1',
@@ -63,15 +107,37 @@ describe('submitTreasuryUsdcTransfer', () => {
         recipientAddress: '0x2222222222222222222222222222222222222222',
         usdcAmount: 1,
       })
-    ).resolves.toEqual({ ok: true, txHash });
+    ).resolves.toEqual(expect.objectContaining({ ok: true, txHash }));
 
-    expect(mockPrivyRpc).toHaveBeenCalledWith(
-      expect.objectContaining({
-        walletId: 'wallet-1',
-        method: 'eth_sendTransaction',
-        sponsor: true,
-      })
-    );
     expect(mockGetTransaction).toHaveBeenCalledWith({ id: 'privy-tx-1' });
+  });
+
+  it('rejects when Privy wallet address does not match server_wallet_address', async () => {
+    mockGetWallet.mockResolvedValue({
+      id: 'wallet-1',
+      address: '0x9999999999999999999999999999999999999999',
+      chainType: 'ethereum',
+    });
+
+    await expect(
+      submitTreasuryUsdcTransfer({
+        serverWalletId: 'wallet-1',
+        serverWalletAddress: '0x1111111111111111111111111111111111111111',
+        recipientAddress: '0x2222222222222222222222222222222222222222',
+        usdcAmount: 1,
+      })
+    ).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('mismatch'),
+    });
+    expect(mockSendTransaction).not.toHaveBeenCalled();
+  });
+
+  it('maps insufficient native gas errors to sponsorship troubleshooting text', () => {
+    expect(
+      mapInsufficientNativeGasPrivyError(
+        'Transaction creation failed. Details: insufficient funds for gas * price + value'
+      )
+    ).toContain('Privy gas sponsorship was not applied');
   });
 });

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -7,6 +7,7 @@ import {
   parseUnits,
 } from 'viem';
 import {
+  formatPrivyResponseForLog,
   getPrivyClient,
   resolvePrivyServerTransactionHash,
 } from '@/lib/api/privy';
@@ -17,7 +18,12 @@ import {
 } from '@/lib/walletconnect-poster-direct-usdc';
 
 export type TreasuryUsdcSubmitResult =
-  | { ok: true; txHash: `0x${string}` }
+  | {
+      ok: true;
+      txHash: `0x${string}`;
+      /** Safe summary of Privy sendTransaction response for server logs only. */
+      privySendSummary?: Record<string, unknown>;
+    }
   | { ok: false; error: string };
 
 const EVM_TX_HASH_RE = /^0x[a-fA-F0-9]{64}$/;
@@ -28,18 +34,27 @@ const FALLBACK_SCAN_BLOCKS = 1_000n;
 /** Coinbase (and other) Base RPCs reject eth_getLogs when the range exceeds 1000 blocks. */
 const MAX_LOG_BLOCK_SPAN = 1_000n;
 
-type PrivyEthSendTransactionRpcResponse = {
-  method?: 'eth_sendTransaction';
-  data?: {
-    hash?: string;
-    transactionId?: string;
-    transaction_id?: string;
-    caip2?: string;
-  };
-  error?: {
-    message?: string;
-  };
-};
+const INSUFFICIENT_NATIVE_GAS_RE =
+  /insufficient\s+funds\s+for\s+gas|insufficient\s+funds/i;
+
+/**
+ * If Privy/the RPC reports missing native ETH for gas, explain that sponsorship
+ * likely did not apply (funding ETH is not the intended fix).
+ */
+export function mapInsufficientNativeGasPrivyError(message: string): string {
+  const trimmed = message.trim();
+  if (!INSUFFICIENT_NATIVE_GAS_RE.test(trimmed)) {
+    return trimmed;
+  }
+  return [
+    'Privy gas sponsorship was not applied: the transaction was treated as if the wallet must pay native ETH for gas.',
+    'Verify production NEXT_PUBLIC_PRIVY_APP_ID and PRIVY_APP_SECRET match the Privy app where Base gas sponsorship is enabled.',
+    'Confirm Base (eip155:8453) is enabled for sponsorship and credits are available.',
+    'Ensure privy_server_wallet_id and server_wallet_address match the Privy server wallet (no mismatch with treasury_wallet_address).',
+    'Confirm server sends via walletApi.ethereum.sendTransaction with sponsor: true (not a raw path that skips sponsorship).',
+    'If issues persist, confirm your Privy plan supports TEE/native gas sponsorship for server wallets on Base.',
+  ].join(' ');
+}
 
 function rpcUrl(): string {
   return process.env.NEXT_PUBLIC_BASE_RPC?.trim() || 'https://mainnet.base.org';
@@ -161,9 +176,34 @@ export async function submitTreasuryUsdcTransfer(params: {
     fromBlock = null;
   }
 
+  const walletId = params.serverWalletId.trim();
+  const expectedAddress = params.serverWalletAddress.trim().toLowerCase();
+  if (!walletId || !expectedAddress) {
+    return {
+      ok: false,
+      error:
+        'Treasury transfer requires both privy_server_wallet_id and server_wallet_address.',
+    };
+  }
+
   try {
+    const privy = getPrivyClient();
+    const privyWallet = await privy.walletApi.getWallet({ id: walletId });
+    const privyAddress = privyWallet.address?.trim().toLowerCase();
+    if (!privyAddress) {
+      return {
+        ok: false,
+        error: 'Privy wallet response did not include an address.',
+      };
+    }
+    if (privyAddress !== expectedAddress) {
+      return {
+        ok: false,
+        error: `Privy wallet address mismatch: wallet ${walletId} is ${privyWallet.address} but server_wallet_address is ${params.serverWalletAddress}. Sponsored sends require matching IDs and addresses.`,
+      };
+    }
+
     const transaction = {
-      from: params.serverWalletAddress,
       to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
       chainId: POSTER_CHECKOUT_CHAIN.id,
       data: encodeFunctionData({
@@ -176,29 +216,21 @@ export async function submitTreasuryUsdcTransfer(params: {
       }),
       value: '0x0' as const,
     };
-    const result = (await getPrivyClient().walletApi.rpc({
-      walletId: params.serverWalletId,
-      method: 'eth_sendTransaction',
+
+    const sendResult = await privy.walletApi.ethereum.sendTransaction({
+      walletId,
       caip2: SPEND_SERVER_WALLET_CAIP2,
       sponsor: true,
-      params: {
-        transaction,
-      },
-    } as Parameters<
-      ReturnType<typeof getPrivyClient>['walletApi']['rpc']
-    >[0])) as PrivyEthSendTransactionRpcResponse;
-    if (result.error) {
-      return {
-        ok: false,
-        error: result.error.message ?? 'USDC transfer failed',
-      };
-    }
+      transaction,
+    });
+
+    const privySendSummary = formatPrivyResponseForLog(sendResult);
 
     const txHash = normalizeEvmTxHash(
-      await resolvePrivyServerTransactionHash(result)
+      await resolvePrivyServerTransactionHash(sendResult)
     );
     if (txHash) {
-      return { ok: true, txHash };
+      return { ok: true, txHash, privySendSummary };
     }
 
     const fallbackHash = await findRecentTreasuryTransferHash({
@@ -209,7 +241,7 @@ export async function submitTreasuryUsdcTransfer(params: {
     });
 
     if (fallbackHash) {
-      return { ok: true, txHash: fallbackHash };
+      return { ok: true, txHash: fallbackHash, privySendSummary };
     }
 
     return {
@@ -217,7 +249,8 @@ export async function submitTreasuryUsdcTransfer(params: {
       error: 'USDC transfer hash was not returned by wallet provider.',
     };
   } catch (e) {
-    const msg = e instanceof Error ? e.message : 'USDC transfer failed';
+    const rawMsg = e instanceof Error ? e.message : 'USDC transfer failed';
+    const msg = mapInsufficientNativeGasPrivyError(rawMsg);
     console.error('submitTreasuryUsdcTransfer:', e);
     return { ok: false, error: msg };
   }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Treasury USDC withdrawals were using the deprecated `walletApi.rpc` path with `eth_sendTransaction`, which led to transactions being treated as unsponsored (insufficient native ETH for gas). This change uses Privy’s server Wallet API `walletApi.ethereum.sendTransaction` with `caip2: eip155:8453` and `sponsor: true`, matching the recommended SDK surface for sponsored sends.

## Details

- **`lib/spend-treasury-usdc-transfer.ts`**: `submitTreasuryUsdcTransfer` now calls `getPrivyClient()` inside the function, verifies the wallet with `walletApi.getWallet`, checks the returned address matches `server_wallet_address`, then sends via `walletApi.ethereum.sendTransaction` with USDC transfer calldata to the Base USDC contract, `chainId: 8453`, `value: '0x0'`. Errors mentioning insufficient native gas are mapped to a clearer message about sponsorship not being applied.
- **`lib/spend-server-wallet.ts`**: `getSpendServerWalletTransferConfig` requires both `privy_server_wallet_id` and `server_wallet_address` (no silent fallback to `treasury_wallet_address` for sponsored transfer config).
- **`lib/api/privy.ts`**: Adds `formatPrivyResponseForLog` for safe logging of Privy response shapes.
- **`app/api/.../treasury/withdraw/route.ts`**: Logs wallet ID, address, `caip2`, `sponsor: true`, and summarized Privy responses before and after send (preflight `getWallet`, post-send result including `privySendSummary` when present).

## Testing

- `yarn test` on spend/treasury-related paths (withdraw route, `spend-treasury-usdc-transfer`, admin spend-experiences, spend-sessions).
- `yarn lint` (existing repo warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0ef2f4b-3449-4786-8731-fb9dcfd9aca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0ef2f4b-3449-4786-8731-fb9dcfd9aca7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

