### PR TITLE
fix: treasury withdraw non-500 after Privy submit or receipt delay

### DIFF
--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -155,6 +155,58 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
         usdcAmount: 2.0001,
       })
     );
+    expect(j.data.status).toBe('confirmed');
     expect(mockInsertLedger).toHaveBeenCalled();
+  });
+
+  it('returns 202 without ledger when receipt wait times out', async () => {
+    mockWaitReceipt.mockRejectedValue(new Error('Timed out'));
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('x-user-email', 'admin@example.com');
+    const dest = '0x4444444444444444444444444444444444444444';
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ destinationAddress: dest }),
+      }
+    );
+    const res = await POST(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(202);
+    expect(j.success).toBe(true);
+    expect(j.data.status).toBe('submitted');
+    expect(j.data.txHash).toBeDefined();
+    expect(mockInsertLedger).not.toHaveBeenCalled();
+  });
+
+  it('returns 202 when submit is pending without on-chain hash', async () => {
+    mockSubmitTransfer.mockResolvedValue({
+      ok: true,
+      submittedPending: true,
+      privyTransactionId: 'privy-pending-1',
+      privySendSummary: { keys: ['transactionId'] },
+    });
+    const headers = new Headers();
+    headers.set('Content-Type', 'application/json');
+    headers.set('x-user-email', 'admin@example.com');
+    const dest = '0x4444444444444444444444444444444444444444';
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
+      {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ destinationAddress: dest }),
+      }
+    );
+    const res = await POST(req, { params: { experienceId: 'exp-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(202);
+    expect(j.data.status).toBe('submitted');
+    expect(j.data.privyTransactionId).toBe('privy-pending-1');
+    expect(mockWaitReceipt).not.toHaveBeenCalled();
+    expect(mockInsertLedger).not.toHaveBeenCalled();
   });
 });

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -102,7 +102,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       const wallet = await privy.walletApi.getWallet({
         id: walletConfig.walletId,
       });
-      console.info('treasury withdraw Privy preflight', {
+      console.info('treasury withdraw preflight_success', {
+        step: 'preflight_success',
         walletId: walletConfig.walletId,
         walletAddress: wallet.address,
         caip2: SPEND_SERVER_WALLET_CAIP2,
@@ -131,7 +132,28 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError(submit.error || 'USDC transfer failed', 500);
     }
 
-    console.info('treasury withdraw Privy sendTransaction result', {
+    if ('submittedPending' in submit && submit.submittedPending) {
+      console.info('treasury withdraw submitted_pending_no_hash', {
+        step: 'tx_hash_pending',
+        privyTransactionId: submit.privyTransactionId,
+        privyResponseShape: submit.privySendSummary,
+      });
+      return apiSuccess(
+        {
+          status: 'submitted' as const,
+          privyTransactionId: submit.privyTransactionId,
+          amountUsdc: withdrawAmount,
+          destinationAddress,
+          message:
+            'Withdrawal was submitted to Privy; on-chain hash is not available yet. Confirmation is pending—reconcile or refresh shortly.',
+        },
+        'Withdrawal submitted; confirmation pending.',
+        202
+      );
+    }
+
+    console.info('treasury withdraw send_transaction_success', {
+      step: 'send_transaction_success',
       walletId: walletConfig.walletId,
       walletAddress: walletConfig.address,
       caip2: SPEND_SERVER_WALLET_CAIP2,
@@ -142,16 +164,36 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     try {
       await waitForTreasuryTxReceipt(submit.txHash);
+      console.info('treasury withdraw receipt_confirmed', {
+        step: 'receipt_confirmed',
+        txHash: submit.txHash,
+      });
     } catch (waitErr) {
       const msg =
         waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
-      console.error('treasury withdraw waitForReceipt:', waitErr);
-      return apiError(
-        `${msg}. Transaction was submitted: ${submit.txHash}`,
-        500
+      console.warn('treasury withdraw receipt_wait_timeout_or_error', {
+        step: 'receipt_wait_timeout_or_error',
+        txHash: submit.txHash,
+        error: msg,
+      });
+      return apiSuccess(
+        {
+          status: 'submitted' as const,
+          txHash: submit.txHash,
+          amountUsdc: withdrawAmount,
+          destinationAddress,
+          message:
+            'Withdrawal was submitted on-chain; receipt confirmation is still pending or timed out. Check the transaction status on a block explorer.',
+        },
+        'Withdrawal submitted; confirmation pending.',
+        202
       );
     }
 
+    console.info('treasury withdraw ledger_insert_attempted', {
+      step: 'ledger_insert_attempted',
+      txHash: submit.txHash,
+    });
     await insertTreasuryAdminRecoveryLedgerIfAbsent({
       spendExperienceId: experience.id,
       amount: withdrawAmount,
@@ -162,6 +204,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     return apiSuccess(
       {
+        status: 'confirmed' as const,
         txHash: submit.txHash,
         amountUsdc: withdrawAmount,
         destinationAddress,

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -152,34 +152,40 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       );
     }
 
+    if (!('txHash' in submit)) {
+      return apiError('Unexpected treasury submit response.', 500);
+    }
+
+    const { txHash, privySendSummary } = submit;
+
     console.info('treasury withdraw send_transaction_success', {
       step: 'send_transaction_success',
       walletId: walletConfig.walletId,
       walletAddress: walletConfig.address,
       caip2: SPEND_SERVER_WALLET_CAIP2,
       sponsor: true,
-      txHash: submit.txHash,
-      privyResponseShape: submit.privySendSummary,
+      txHash,
+      privyResponseShape: privySendSummary,
     });
 
     try {
-      await waitForTreasuryTxReceipt(submit.txHash);
+      await waitForTreasuryTxReceipt(txHash);
       console.info('treasury withdraw receipt_confirmed', {
         step: 'receipt_confirmed',
-        txHash: submit.txHash,
+        txHash,
       });
     } catch (waitErr) {
       const msg =
         waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
       console.warn('treasury withdraw receipt_wait_timeout_or_error', {
         step: 'receipt_wait_timeout_or_error',
-        txHash: submit.txHash,
+        txHash,
         error: msg,
       });
       return apiSuccess(
         {
           status: 'submitted' as const,
-          txHash: submit.txHash,
+          txHash,
           amountUsdc: withdrawAmount,
           destinationAddress,
           message:
@@ -192,20 +198,20 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     console.info('treasury withdraw ledger_insert_attempted', {
       step: 'ledger_insert_attempted',
-      txHash: submit.txHash,
+      txHash,
     });
     await insertTreasuryAdminRecoveryLedgerIfAbsent({
       spendExperienceId: experience.id,
       amount: withdrawAmount,
       fromWalletAddress: walletConfig.address,
       toWalletAddress: destinationAddress,
-      txHash: submit.txHash,
+      txHash,
     });
 
     return apiSuccess(
       {
         status: 'confirmed' as const,
-        txHash: submit.txHash,
+        txHash,
         amountUsdc: withdrawAmount,
         destinationAddress,
       },

--- a/lib/api/privy.test.ts
+++ b/lib/api/privy.test.ts
@@ -12,12 +12,71 @@ vi.mock('@privy-io/server-auth', () => ({
   }),
 }));
 
-import { resolvePrivyServerTransactionHash } from './privy';
+import {
+  extractPrivyTransactionHash,
+  extractPrivyTransactionId,
+  resolvePrivyServerTransactionHash,
+} from './privy';
 
 const directHash =
   '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 const polledHash =
   '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+describe('extractPrivyTransactionHash', () => {
+  it('reads txHash and snake_case variants at root and under data', () => {
+    const h =
+      '0xdddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd';
+    expect(extractPrivyTransactionHash({ txHash: h })).toBe(h);
+    expect(extractPrivyTransactionHash({ tx_hash: h })).toBe(h);
+    expect(extractPrivyTransactionHash({ data: { transaction_hash: h } })).toBe(
+      h
+    );
+  });
+
+  it('reads nested receipt and transaction objects', () => {
+    const h =
+      '0xeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee';
+    expect(
+      extractPrivyTransactionHash({
+        receipt: { transactionHash: h },
+      })
+    ).toBe(h);
+    expect(
+      extractPrivyTransactionHash({
+        transaction: { hash: h },
+      })
+    ).toBe(h);
+    expect(
+      extractPrivyTransactionHash({
+        data: { receipt: { transactionHash: h } },
+      })
+    ).toBe(h);
+  });
+});
+
+describe('extractPrivyTransactionId', () => {
+  it('prefers explicit transaction id fields over generic id', () => {
+    expect(
+      extractPrivyTransactionId({
+        id: 'wallet-ish-id',
+        transactionId: 'tx-abc',
+      })
+    ).toBe('tx-abc');
+  });
+
+  it('uses root id when it is not an EVM tx hash', () => {
+    expect(extractPrivyTransactionId({ id: 'privy-internal-1' })).toBe(
+      'privy-internal-1'
+    );
+  });
+
+  it('does not treat 64-hex id as transaction id', () => {
+    const looksLikeHash =
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+    expect(extractPrivyTransactionId({ id: looksLikeHash })).toBeNull();
+  });
+});
 
 describe('resolvePrivyServerTransactionHash', () => {
   beforeEach(() => {

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -6,7 +6,16 @@ import type { SpendServerWalletMetadata } from '@/lib/spend-server-wallet';
 let privyClient: PrivyClient | null = null;
 
 const PRIVY_TRANSACTION_POLL_INTERVAL_MS = 1_000;
-const PRIVY_TRANSACTION_HASH_TIMEOUT_MS = 30_000;
+/** Longer poll window so slow Base / Privy indexing still resolves the on-chain hash. */
+const PRIVY_TRANSACTION_HASH_TIMEOUT_MS = 120_000;
+
+const EVM_TX_HASH_RE = /^0x[a-fA-F0-9]{64}$/;
+
+function normalizeEvmTxHashString(value: unknown): string | null {
+  if (typeof value !== 'string') return null;
+  const trimmed = value.trim();
+  return EVM_TX_HASH_RE.test(trimmed) ? trimmed : null;
+}
 const PRIVY_TRANSACTION_FAILED_STATUSES = new Set([
   'execution_reverted',
   'failed',
@@ -36,27 +45,111 @@ function getStringField(
   return null;
 }
 
-function extractPrivyTransactionHash(value: unknown): string | null {
-  const direct = getStringField(value, [
-    'hash',
-    'transactionHash',
-    'transaction_hash',
-  ]);
-  if (direct) return direct;
+const TX_HASH_STRING_KEYS = [
+  'hash',
+  'txHash',
+  'transactionHash',
+  'transaction_hash',
+  'tx_hash',
+] as const;
 
-  const data = getRecord(value)?.data;
-  return getStringField(data, ['hash', 'transactionHash', 'transaction_hash']);
+/**
+ * Reads an EVM tx hash from a plain object using common Privy / REST field names.
+ */
+function readTxHashFromRecord(
+  record: Record<string, unknown> | null
+): string | null {
+  if (!record) return null;
+  for (const key of TX_HASH_STRING_KEYS) {
+    const h = normalizeEvmTxHashString(record[key]);
+    if (h) return h;
+  }
+  return null;
 }
 
-function extractPrivyTransactionId(value: unknown): string | null {
-  const direct = getStringField(value, ['transactionId', 'transaction_id']);
-  if (direct) return direct;
+function readTxHashFromNestedTransaction(
+  container: Record<string, unknown> | null
+): string | null {
+  if (!container) return null;
+  const tx =
+    getRecord(container.transaction) ??
+    getRecord(container.tx) ??
+    getRecord(container.result);
+  if (!tx) return null;
+  return (
+    readTxHashFromRecord(tx) ??
+    normalizeEvmTxHashString(tx.hash) ??
+    normalizeEvmTxHashString(tx.transactionHash)
+  );
+}
 
-  const data = getRecord(value)?.data;
-  const dataId = getStringField(data, ['transactionId', 'transaction_id']);
-  if (dataId) return dataId;
+function readTxHashFromNestedReceipt(
+  container: Record<string, unknown> | null
+): string | null {
+  if (!container) return null;
+  const receipt =
+    getRecord(container.receipt) ?? getRecord(container.transactionReceipt);
+  if (!receipt) return null;
+  return (
+    readTxHashFromRecord(receipt) ??
+    normalizeEvmTxHashString(receipt.transactionHash)
+  );
+}
 
-  return getStringField(value, ['id']);
+/**
+ * Extracts an on-chain tx hash from Privy sendTransaction / getTransaction payloads
+ * across documented and observed response shapes.
+ */
+export function extractPrivyTransactionHash(value: unknown): string | null {
+  const root = getRecord(value);
+  const fromRoot =
+    readTxHashFromRecord(root) ??
+    readTxHashFromNestedReceipt(root) ??
+    readTxHashFromNestedTransaction(root);
+  if (fromRoot) return fromRoot;
+
+  const data = root ? getRecord(root.data) : null;
+  const fromData =
+    readTxHashFromRecord(data) ??
+    readTxHashFromNestedReceipt(data) ??
+    readTxHashFromNestedTransaction(data);
+  if (fromData) return fromData;
+
+  for (const rec of [root, data]) {
+    if (!rec) continue;
+    const maybeFromId =
+      normalizeEvmTxHashString(rec.transaction_id) ??
+      normalizeEvmTxHashString(rec.transactionId);
+    if (maybeFromId) return maybeFromId;
+  }
+
+  return null;
+}
+
+/**
+ * Privy transaction id for polling getTransaction when the hash is not inline yet.
+ * Avoid treating a root `id` that is a 0x-prefixed 32-byte string as a tx hash.
+ */
+export function extractPrivyTransactionId(value: unknown): string | null {
+  const tryRecord = (rec: Record<string, unknown> | null): string | null => {
+    if (!rec) return null;
+    const explicit = getStringField(rec, ['transactionId', 'transaction_id']);
+    if (explicit) return explicit;
+
+    const idVal = rec.id;
+    if (typeof idVal === 'string' && idVal.trim()) {
+      const t = idVal.trim();
+      if (!normalizeEvmTxHashString(t)) return t;
+    }
+    return null;
+  };
+
+  const root = getRecord(value);
+  const fromRoot = tryRecord(root);
+  if (fromRoot) return fromRoot;
+
+  const data = root ? getRecord(root.data) : null;
+  return tryRecord(data);
 }
 
 function delay(ms: number): Promise<void> {

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -15,9 +15,11 @@ import {
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
 import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
+import { resolvePrivyServerTransactionHash } from '@/lib/api/privy';
 import {
   findRecentTreasuryUsdcTransfer,
   getTreasuryTxReceiptStatus,
+  isEvmTxHash,
   submitTreasuryUsdcTransfer,
 } from '@/lib/spend-treasury-usdc-transfer';
 import {
@@ -489,6 +491,22 @@ export async function runSpendConversionConfirm(
     };
   }
 
+  if ('submittedPending' in sub && sub.submittedPending) {
+    const fundingPlaceholder = `pending:${sub.privyTransactionId}`;
+    conv = await updatePointConversionFields(conv.id, {
+      status: 'funding_pending',
+      funding_tx_hash: fundingPlaceholder,
+    });
+    await updateSpendSessionStatus(session.id, 'conversion_pending');
+
+    return {
+      ok: true,
+      pointConversion: conv,
+      session: (await getSpendSessionById(session.id)) ?? session,
+      resumed: rpc.outcome === 'already_exists',
+    };
+  }
+
   const txHash = sub.txHash;
   conv = await updatePointConversionFields(conv.id, {
     status: 'funding_pending',
@@ -591,15 +609,49 @@ async function fundOrResumeUsdc(input: {
         },
       };
     }
-    const txHash = sub.txHash;
-    conv = await updatePointConversionFields(conv.id, {
-      status: 'funding_pending',
-      funding_tx_hash: txHash,
-    });
-    await updateSpendSessionStatus(session.id, 'conversion_pending');
+    if ('submittedPending' in sub && sub.submittedPending) {
+      conv = await updatePointConversionFields(conv.id, {
+        status: 'funding_pending',
+        funding_tx_hash: `pending:${sub.privyTransactionId}`,
+      });
+      await updateSpendSessionStatus(session.id, 'conversion_pending');
+    } else {
+      const txHash = sub.txHash;
+      conv = await updatePointConversionFields(conv.id, {
+        status: 'funding_pending',
+        funding_tx_hash: txHash,
+      });
+      await updateSpendSessionStatus(session.id, 'conversion_pending');
+    }
   }
 
   let hash = conv.funding_tx_hash?.trim() as `0x${string}` | undefined;
+  const pendingPrefix = 'pending:';
+  const trimmedFunding = conv.funding_tx_hash?.trim() ?? '';
+  if (
+    !hash &&
+    trimmedFunding.startsWith(pendingPrefix) &&
+    conv.status === 'funding_pending'
+  ) {
+    const privyId = trimmedFunding.slice(pendingPrefix.length).trim();
+    if (privyId) {
+      try {
+        const polled = await resolvePrivyServerTransactionHash(
+          { transactionId: privyId },
+          { timeoutMs: 120_000, pollIntervalMs: 1_000 }
+        );
+        const normalized = polled?.trim();
+        if (normalized && isEvmTxHash(normalized)) {
+          hash = normalized as `0x${string}`;
+          conv = await updatePointConversionFields(conv.id, {
+            funding_tx_hash: hash,
+          });
+        }
+      } catch (e) {
+        console.warn('fundOrResumeUsdc pending privy id resolve failed:', e);
+      }
+    }
+  }
   if (!hash && conv.status === 'funding_pending') {
     const recovered = await findRecentTreasuryUsdcTransfer({
       serverWalletAddress: serverWallet.address,

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -507,6 +507,14 @@ export async function runSpendConversionConfirm(
     };
   }
 
+  if (!('txHash' in sub)) {
+    return {
+      ok: false,
+      httpStatus: 500,
+      error: 'Unexpected treasury submit response.',
+    };
+  }
+
   const txHash = sub.txHash;
   conv = await updatePointConversionFields(conv.id, {
     status: 'funding_pending',
@@ -616,6 +624,15 @@ async function fundOrResumeUsdc(input: {
       });
       await updateSpendSessionStatus(session.id, 'conversion_pending');
     } else {
+      if (!('txHash' in sub)) {
+        return {
+          error: {
+            ok: false,
+            httpStatus: 500,
+            error: 'Unexpected treasury submit response.',
+          },
+        };
+      }
       const txHash = sub.txHash;
       conv = await updatePointConversionFields(conv.id, {
         status: 'funding_pending',

--- a/lib/spend-treasury-usdc-transfer.test.ts
+++ b/lib/spend-treasury-usdc-transfer.test.ts
@@ -106,10 +106,38 @@ describe('submitTreasuryUsdcTransfer', () => {
         serverWalletAddress: '0x1111111111111111111111111111111111111111',
         recipientAddress: '0x2222222222222222222222222222222222222222',
         usdcAmount: 1,
+        privyHashResolveOptions: { timeoutMs: 100, pollIntervalMs: 1 },
       })
     ).resolves.toEqual(expect.objectContaining({ ok: true, txHash }));
 
     expect(mockGetTransaction).toHaveBeenCalledWith({ id: 'privy-tx-1' });
+  });
+
+  it('returns submittedPending when only Privy id is known after poll timeout', async () => {
+    mockSendTransaction.mockResolvedValue({
+      transactionId: 'privy-tx-slow',
+    });
+    mockGetTransaction.mockResolvedValue({
+      id: 'privy-tx-slow',
+      status: 'broadcasted',
+      transactionHash: null,
+    });
+
+    await expect(
+      submitTreasuryUsdcTransfer({
+        serverWalletId: 'wallet-1',
+        serverWalletAddress: '0x1111111111111111111111111111111111111111',
+        recipientAddress: '0x2222222222222222222222222222222222222222',
+        usdcAmount: 1,
+        privyHashResolveOptions: { timeoutMs: 50, pollIntervalMs: 5 },
+      })
+    ).resolves.toEqual(
+      expect.objectContaining({
+        ok: true,
+        submittedPending: true,
+        privyTransactionId: 'privy-tx-slow',
+      })
+    );
   });
 
   it('rejects when Privy wallet address does not match server_wallet_address', async () => {

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -7,6 +7,7 @@ import {
   parseUnits,
 } from 'viem';
 import {
+  extractPrivyTransactionId,
   formatPrivyResponseForLog,
   getPrivyClient,
   resolvePrivyServerTransactionHash,
@@ -22,6 +23,13 @@ export type TreasuryUsdcSubmitResult =
       ok: true;
       txHash: `0x${string}`;
       /** Safe summary of Privy sendTransaction response for server logs only. */
+      privySendSummary?: Record<string, unknown>;
+    }
+  | {
+      ok: true;
+      /** Privy accepted the send but no on-chain hash yet (poll timeout); reconcile later. */
+      submittedPending: true;
+      privyTransactionId: string;
       privySendSummary?: Record<string, unknown>;
     }
   | { ok: false; error: string };
@@ -168,6 +176,8 @@ export async function submitTreasuryUsdcTransfer(params: {
   recipientAddress: `0x${string}`;
   /** Human-readable USDC amount (6 decimals). */
   usdcAmount: number;
+  /** Override Privy hash polling (e.g. tests). */
+  privyHashResolveOptions?: { timeoutMs?: number; pollIntervalMs?: number };
 }): Promise<TreasuryUsdcSubmitResult> {
   let fromBlock: bigint | null = null;
   try {
@@ -224,12 +234,25 @@ export async function submitTreasuryUsdcTransfer(params: {
       transaction,
     });
 
+    console.info('submitTreasuryUsdcTransfer send_transaction_success', {
+      step: 'send_transaction_success',
+      walletId,
+      privySendRawSummary: formatPrivyResponseForLog(sendResult),
+    });
+
     const privySendSummary = formatPrivyResponseForLog(sendResult);
 
-    const txHash = normalizeEvmTxHash(
-      await resolvePrivyServerTransactionHash(sendResult)
+    const resolvedHashRaw = await resolvePrivyServerTransactionHash(
+      sendResult,
+      params.privyHashResolveOptions ?? {}
     );
+    const txHash = normalizeEvmTxHash(resolvedHashRaw);
     if (txHash) {
+      console.info('submitTreasuryUsdcTransfer tx_hash_resolved', {
+        step: 'tx_hash_resolved',
+        walletId,
+        source: 'privy_resolve',
+      });
       return { ok: true, txHash, privySendSummary };
     }
 
@@ -241,7 +264,27 @@ export async function submitTreasuryUsdcTransfer(params: {
     });
 
     if (fallbackHash) {
+      console.info('submitTreasuryUsdcTransfer tx_hash_resolved', {
+        step: 'tx_hash_resolved',
+        walletId,
+        source: 'chain_log_fallback',
+      });
       return { ok: true, txHash: fallbackHash, privySendSummary };
+    }
+
+    const privyTransactionId = extractPrivyTransactionId(sendResult);
+    if (privyTransactionId) {
+      console.info('submitTreasuryUsdcTransfer tx_hash_pending_privy_id', {
+        step: 'tx_hash_pending',
+        walletId,
+        privyTransactionId,
+      });
+      return {
+        ok: true,
+        submittedPending: true,
+        privyTransactionId,
+        privySendSummary,
+      };
     }
 
     return {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the admin treasury withdrawal API returning 500 after a successful Privy-sponsored USDC send when the on-chain hash was missing from the immediate response or when `waitForTransactionReceipt` timed out.

## Changes

- **Privy hash resolution** (`lib/api/privy.ts`): Broader extraction of EVM tx hashes from send/getTransaction payloads (root and `data`, snake_case and camelCase, nested `receipt` / `transaction`, and hash-shaped `transaction_id` / `transactionId`). Default poll window for resolving hash from a Privy transaction id increased from 30s to **120s**.
- **Submit path** (`lib/spend-treasury-usdc-transfer.ts`): Logs `send_transaction_success` with `formatPrivyResponseForLog(sendResult)` immediately after `sendTransaction`, before `resolvePrivyServerTransactionHash`. If hash still missing after resolve + log fallback but a Privy transaction id exists, returns **`submittedPending`** instead of failure. Optional `privyHashResolveOptions` for tests.
- **Withdraw route** (`app/api/.../treasury/withdraw/route.ts`): Structured logs: `preflight_success`, `send_transaction_success`, `receipt_confirmed`, `receipt_wait_timeout_or_error`, `ledger_insert_attempted`. **202** with `status: "submitted"` when receipt wait fails or when only `privyTransactionId` is available; ledger insert only after confirmed receipt. **200** confirmed path includes `status: "confirmed"`. **TypeScript:** after handling `submittedPending`, `if (!('txHash' in submit))` narrows the union so `yarn build` succeeds.
- **Spend conversion** (`lib/spend-conversion-confirm.ts`): Same `submittedPending` handling stores `funding_tx_hash` as `pending:<privyTransactionId>` and on resume polls Privy to replace with a real hash before continuing. Same **`txHash` in** narrowing for the build.

## Testing

- `yarn build` (passes).
- `yarn test` on updated unit tests for `privy`, `spend-treasury-usdc-transfer`, and treasury withdraw route.
- `yarn lint` (existing repo warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11991550-15ba-4280-ae7b-ceedf62e1bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11991550-15ba-4280-ae7b-ceedf62e1bec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

