### PR TITLE
fix: treasury USDC withdraw via Privy REST RPC and poll

### DIFF
--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -98,6 +98,10 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
       ok: true,
       txHash:
         '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      privyTransactionId: 'privy-tx-1',
+      userOperationHash: null,
+      referenceId: 'ref-1',
+      privyStatus: 'finalized',
       privySendSummary: {
         hash: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       },
@@ -153,9 +157,11 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
       expect.objectContaining({
         recipientAddress: dest,
         usdcAmount: 2.0001,
+        withdrawTelemetry: true,
       })
     );
     expect(j.data.status).toBe('confirmed');
+    expect(j.data.privyTransactionId).toBeDefined();
     expect(mockInsertLedger).toHaveBeenCalled();
   });
 

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -126,6 +126,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       serverWalletAddress: walletConfig.address,
       recipientAddress: destinationAddress as `0x${string}`,
       usdcAmount: withdrawAmount,
+      withdrawTelemetry: true,
     });
 
     if (!submit.ok) {
@@ -136,6 +137,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       console.info('treasury withdraw submitted_pending_no_hash', {
         step: 'tx_hash_pending',
         privyTransactionId: submit.privyTransactionId,
+        referenceId: submit.referenceId,
+        userOperationHash: submit.userOperationHash,
+        lastPrivyStatus: submit.lastPrivyStatus,
         privyResponseShape: submit.privySendSummary,
       });
       return apiSuccess(
@@ -144,8 +148,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
           privyTransactionId: submit.privyTransactionId,
           amountUsdc: withdrawAmount,
           destinationAddress,
+          userOperationHash: submit.userOperationHash,
+          referenceId: submit.referenceId,
+          lastPrivyStatus: submit.lastPrivyStatus,
           message:
-            'Withdrawal was submitted to Privy; on-chain hash is not available yet. Confirmation is pending—reconcile or refresh shortly.',
+            'Withdrawal was accepted by Privy; on-chain hash is not available yet. Re-check shortly or use the block explorer with this transaction id.',
         },
         'Withdrawal submitted; confirmation pending.',
         202
@@ -156,9 +163,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError('Unexpected treasury submit response.', 500);
     }
 
-    const { txHash, privySendSummary } = submit;
+    const {
+      txHash,
+      privySendSummary,
+      privyTransactionId,
+      userOperationHash,
+      referenceId,
+      privyStatus,
+    } = submit;
 
-    console.info('treasury withdraw send_transaction_success', {
+    console.info('withdraw_privy_send_success', {
       step: 'send_transaction_success',
       walletId: walletConfig.walletId,
       walletAddress: walletConfig.address,
@@ -170,9 +184,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     try {
       await waitForTreasuryTxReceipt(txHash);
-      console.info('treasury withdraw receipt_confirmed', {
-        step: 'receipt_confirmed',
+      console.info('withdraw_confirmed', {
         txHash,
+        privyTransactionId,
+        userOperationHash,
+        referenceId,
+        privyStatus,
       });
     } catch (waitErr) {
       const msg =
@@ -186,10 +203,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         {
           status: 'submitted' as const,
           txHash,
+          privyTransactionId,
+          userOperationHash,
+          referenceId,
           amountUsdc: withdrawAmount,
           destinationAddress,
           message:
-            'Withdrawal was submitted on-chain; receipt confirmation is still pending or timed out. Check the transaction status on a block explorer.',
+            'Withdrawal was included on-chain; full receipt confirmation is still pending or timed out. Check the block explorer for this transaction hash.',
         },
         'Withdrawal submitted; confirmation pending.',
         202
@@ -212,6 +232,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       {
         status: 'confirmed' as const,
         txHash,
+        privyTransactionId,
+        userOperationHash,
+        referenceId,
         amountUsdc: withdrawAmount,
         destinationAddress,
       },

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -328,6 +328,16 @@ export function formatPrivyResponseForLog(
   return out;
 }
 
+/**
+ * Re-exports: Privy REST RPC for server wallets (sponsored sends, transaction polling).
+ * Prefer importing from `@/lib/privy-server-rest` in new code.
+ */
+export {
+  signAndSendTransaction,
+  waitForTransaction,
+  getPrivyRestTransaction,
+} from '@/lib/privy-server-rest';
+
 export async function createSpendPrivyServerWallet(params: {
   idempotencyKey: string;
 }): Promise<SpendServerWalletMetadata> {

--- a/lib/privy-server-rest.test.ts
+++ b/lib/privy-server-rest.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  PrivyRestApiError,
+  signAndSendTransaction,
+  waitForTransaction,
+} from './privy-server-rest';
+
+const fetchMock = vi.fn();
+
+beforeEach(() => {
+  vi.stubGlobal('fetch', fetchMock);
+  process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'app-id';
+  process.env.PRIVY_APP_SECRET = 'app-secret';
+  fetchMock.mockReset();
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('signAndSendTransaction', () => {
+  it('POSTs eth_sendTransaction and parses data.transaction_id', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          transaction_id: 'tx-abc',
+          user_operation_hash: '0x' + 'b'.repeat(64),
+          hash: '',
+        },
+      }),
+    });
+
+    const r = await signAndSendTransaction({
+      walletId: 'w1',
+      to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+      data: '0x',
+    });
+
+    expect(r.transactionId).toBe('tx-abc');
+    expect(r.userOperationHash).toHaveLength(66);
+    expect(r.hash).toBe('');
+
+    const call = fetchMock.mock.calls[0];
+    expect(String(call[0])).toContain('/wallets/w1/rpc');
+    const body = JSON.parse((call[1] as { body: string }).body);
+    expect(body.method).toBe('eth_sendTransaction');
+    expect(body.sponsor).toBe(true);
+    expect(body.params.transaction.to).toContain('0x');
+  });
+
+  it('throws when transaction_id is missing', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ data: { hash: '' } }),
+    });
+
+    await expect(
+      signAndSendTransaction({
+        walletId: 'w1',
+        to: '0x1',
+        data: '0x',
+      })
+    ).rejects.toBeInstanceOf(PrivyRestApiError);
+  });
+});
+
+describe('waitForTransaction', () => {
+  it('returns hash when GET returns confirmed with transaction_hash', async () => {
+    const h =
+      '0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc';
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        id: 'tx-1',
+        status: 'confirmed',
+        transaction_hash: h,
+        user_operation_hash: null,
+      }),
+    });
+
+    const r = await waitForTransaction('tx-1', { timeoutMs: 2_000 });
+    expect(r.transactionHash).toBe(h);
+    expect(r.status).toBe('confirmed');
+  });
+});

--- a/lib/privy-server-rest.ts
+++ b/lib/privy-server-rest.ts
@@ -1,0 +1,272 @@
+/**
+ * Privy REST RPC for server wallets (eth_sendTransaction + transaction polling).
+ * Use this for sponsored sends where the SDK can return an empty on-chain `hash` immediately.
+ * @see https://docs.privy.io/api-reference/wallets/ethereum/eth-send-transaction
+ * @see https://docs.privy.io/api-reference/transactions/get
+ */
+import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
+
+const PRIVY_API_BASE = 'https://api.privy.io/v1';
+
+const SUCCESS_STATUSES = new Set(['confirmed', 'finalized']);
+
+const FAILURE_STATUSES = new Set([
+  'execution_reverted',
+  'failed',
+  'replaced',
+  'provider_error',
+]);
+
+export class PrivyRestApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly body: string
+  ) {
+    super(`Privy REST error ${status}: ${body.slice(0, 400)}`);
+    this.name = 'PrivyRestApiError';
+  }
+}
+
+export class PrivyRestNotConfiguredError extends Error {
+  constructor() {
+    super(
+      'Privy app credentials are not configured (NEXT_PUBLIC_PRIVY_APP_ID / PRIVY_APP_SECRET)'
+    );
+    this.name = 'PrivyRestNotConfiguredError';
+  }
+}
+
+/**
+ * Polling finished without a success terminal state including an on-chain hash.
+ * The transaction may still complete later — reconcile via `transactionId`.
+ */
+export class PrivyRestTransactionTimeoutError extends Error {
+  public lastStatus: string | null = null;
+  constructor(public readonly transactionId: string) {
+    super(
+      `Privy transaction ${transactionId} did not return a final hash within the timeout`
+    );
+    this.name = 'PrivyRestTransactionTimeoutError';
+  }
+}
+
+export class PrivyRestTransactionFailedError extends Error {
+  constructor(
+    public readonly transactionId: string,
+    public readonly status: string,
+    public readonly transactionHash: string | null
+  ) {
+    super(`Privy transaction ${transactionId} ended in status ${status}`);
+    this.name = 'PrivyRestTransactionFailedError';
+  }
+}
+
+export type SignAndSendPrivyTransactionParams = {
+  walletId: string;
+  /** USDC (or any contract) `to` address. */
+  to: string;
+  /** 0x-prefixed calldata, e.g. ERC-20 transfer. */
+  data: string;
+  value?: `0x${string}`;
+  sponsor?: boolean;
+  /** Reconciliation id (e.g. UUID), optional. */
+  referenceId?: string;
+};
+
+export type PrivySendTransactionResult = {
+  transactionId: string;
+  userOperationHash: string | null;
+  /** May be "" on sponsored sends until the transaction is indexed. */
+  hash: string;
+};
+
+export type PrivyTransactionRecord = {
+  id: string;
+  status: string;
+  transaction_hash: string | null;
+  user_operation_hash?: string | null;
+};
+
+function requireRestCredentials(): { appId: string; appSecret: string } {
+  const appId = process.env.NEXT_PUBLIC_PRIVY_APP_ID?.trim();
+  const appSecret = process.env.PRIVY_APP_SECRET?.trim();
+  if (!appId || !appSecret) {
+    throw new PrivyRestNotConfiguredError();
+  }
+  return { appId, appSecret };
+}
+
+function privyRestFetch(
+  path: string,
+  init: RequestInit = {}
+): Promise<Response> {
+  const { appId, appSecret } = requireRestCredentials();
+  const auth = Buffer.from(`${appId}:${appSecret}`).toString('base64');
+  const headers = new Headers(init.headers);
+  headers.set('Authorization', `Basic ${auth}`);
+  headers.set('privy-app-id', appId);
+  if (init.body !== undefined && !headers.has('content-type')) {
+    headers.set('content-type', 'application/json');
+  }
+  return fetch(`${PRIVY_API_BASE}${path}`, { ...init, headers });
+}
+
+/**
+ * POST /v1/wallets/{walletId}/rpc — `method: eth_sendTransaction`.
+ */
+export async function signAndSendTransaction(
+  params: SignAndSendPrivyTransactionParams
+): Promise<PrivySendTransactionResult> {
+  const { walletId, to, data, referenceId } = params;
+  const sponsor = params.sponsor ?? true;
+  const value = params.value ?? '0x0';
+
+  const body: Record<string, unknown> = {
+    method: 'eth_sendTransaction',
+    caip2: SPEND_SERVER_WALLET_CAIP2,
+    chain_type: 'ethereum',
+    params: {
+      transaction: {
+        to,
+        data,
+        value,
+      },
+    },
+  };
+  if (sponsor) body.sponsor = true;
+  if (referenceId) body.reference_id = referenceId;
+
+  const res = await privyRestFetch(
+    `/wallets/${encodeURIComponent(walletId)}/rpc`,
+    {
+      method: 'POST',
+      body: JSON.stringify(body),
+    }
+  );
+
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new PrivyRestApiError(res.status, text);
+  }
+
+  const json = (await res.json()) as {
+    data?: {
+      transaction_id?: string;
+      user_operation_hash?: string;
+      hash?: string;
+    };
+  };
+  const transactionId = json.data?.transaction_id?.trim();
+  if (!transactionId) {
+    throw new PrivyRestApiError(
+      500,
+      `Malformed Privy response: ${JSON.stringify(json)}`
+    );
+  }
+
+  return {
+    transactionId,
+    userOperationHash: json.data?.user_operation_hash?.trim() ?? null,
+    hash: typeof json.data?.hash === 'string' ? json.data.hash : '',
+  };
+}
+
+function readTxHash(tx: unknown): string | null {
+  if (tx === null || typeof tx !== 'object') return null;
+  const o = tx as Record<string, unknown>;
+  for (const key of ['transaction_hash', 'transactionHash', 'hash'] as const) {
+    const v = o[key];
+    if (typeof v === 'string' && /^0x[a-fA-F0-9]{64}$/.test(v.trim())) {
+      return v.trim();
+    }
+  }
+  return null;
+}
+
+function readStatus(tx: unknown): string | null {
+  if (tx === null || typeof tx !== 'object') return null;
+  const s = (tx as Record<string, unknown>).status;
+  return typeof s === 'string' ? s : null;
+}
+
+/**
+ * GET /v1/transactions/{transactionId}
+ */
+export async function getPrivyRestTransaction(
+  transactionId: string
+): Promise<PrivyTransactionRecord> {
+  const res = await privyRestFetch(
+    `/transactions/${encodeURIComponent(transactionId)}`,
+    { method: 'GET' }
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new PrivyRestApiError(res.status, text);
+  }
+  return (await res.json()) as PrivyTransactionRecord;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export type WaitForPrivyTransactionOptions = {
+  timeoutMs?: number;
+  initialPollMs?: number;
+  maxPollMs?: number;
+};
+
+/**
+ * Poll GET /v1/transactions/{id} until confirmed/finalized with a tx hash, failure, or timeout.
+ * - pending, broadcasted → in progress
+ * - confirmed, finalized with hash → success
+ * - execution_reverted, failed, replaced, provider_error → throw
+ * - success without hash yet → keep polling within timeout
+ */
+export async function waitForTransaction(
+  transactionId: string,
+  options: WaitForPrivyTransactionOptions = {}
+): Promise<{
+  transactionHash: `0x${string}`;
+  status: string;
+  userOperationHash: string | null;
+}> {
+  const timeoutMs = options.timeoutMs ?? 30_000;
+  const initialPollMs = options.initialPollMs ?? 500;
+  const maxPollMs = options.maxPollMs ?? 2_000;
+  const deadline = Date.now() + timeoutMs;
+
+  let nextDelay = initialPollMs;
+  let lastStatus: string | null = null;
+
+  while (Date.now() < deadline) {
+    const tx = await getPrivyRestTransaction(transactionId);
+    const status = readStatus(tx) ?? tx.status;
+    lastStatus = status;
+    const hash = readTxHash(tx);
+    const uo =
+      (tx as { user_operation_hash?: string | null }).user_operation_hash ??
+      null;
+
+    if (status && FAILURE_STATUSES.has(status)) {
+      throw new PrivyRestTransactionFailedError(transactionId, status, hash);
+    }
+
+    if (status && SUCCESS_STATUSES.has(status) && hash) {
+      return {
+        transactionHash: hash as `0x${string}`,
+        status,
+        userOperationHash: uo,
+      };
+    }
+
+    // pending, broadcasted, or success without hash yet
+
+    await sleep(nextDelay);
+    nextDelay = Math.min(nextDelay * 2, maxPollMs);
+  }
+
+  const err = new PrivyRestTransactionTimeoutError(transactionId);
+  err.lastStatus = lastStatus;
+  throw err;
+}

--- a/lib/spend-treasury-usdc-transfer.test.ts
+++ b/lib/spend-treasury-usdc-transfer.test.ts
@@ -1,34 +1,44 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const mockSendTransaction = vi.fn();
 const mockGetWallet = vi.fn();
-const mockGetTransaction = vi.fn();
-const mockGetBlockNumber = vi.fn();
-const mockGetLogs = vi.fn();
+const mockSignAndSend = vi.fn();
+const mockWaitForTransaction = vi.fn();
+
+const { MockPrivyTimeout } = vi.hoisted(() => {
+  class PrivyRestTransactionTimeoutError extends Error {
+    lastStatus: string | null = null;
+    constructor(public transactionId: string) {
+      super(
+        `Privy transaction ${transactionId} did not return a final hash within the timeout`
+      );
+      this.name = 'PrivyRestTransactionTimeoutError';
+    }
+  }
+  return { MockPrivyTimeout: PrivyRestTransactionTimeoutError };
+});
 
 vi.mock('@privy-io/server-auth', () => ({
   PrivyClient: vi.fn(function PrivyClient() {
     return {
       walletApi: {
-        ethereum: { sendTransaction: mockSendTransaction },
         getWallet: mockGetWallet,
-        getTransaction: mockGetTransaction,
       },
     };
   }),
 }));
 
-vi.mock('viem', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('viem')>();
-  return {
-    ...actual,
-    createPublicClient: vi.fn(() => ({
-      getBlockNumber: mockGetBlockNumber,
-      getLogs: mockGetLogs,
-    })),
-  };
-});
-
+vi.mock('@/lib/privy-server-rest', () => ({
+  signAndSendTransaction: (...args: unknown[]) => mockSignAndSend(...args),
+  waitForTransaction: (...args: unknown[]) => mockWaitForTransaction(...args),
+  PrivyRestTransactionTimeoutError: MockPrivyTimeout,
+  PrivyRestApiError: class extends Error {
+    name = 'PrivyRestApiError';
+  },
+  PrivyRestTransactionFailedError: class extends Error {
+    name = 'PrivyRestTransactionFailedError';
+  },
+  getPrivyRestTransaction: vi.fn(),
+}));
 import {
   mapInsufficientNativeGasPrivyError,
   submitTreasuryUsdcTransfer,
@@ -42,8 +52,6 @@ describe('submitTreasuryUsdcTransfer', () => {
     vi.clearAllMocks();
     process.env.NEXT_PUBLIC_PRIVY_APP_ID = 'app-id';
     process.env.PRIVY_APP_SECRET = 'app-secret';
-    mockGetBlockNumber.mockResolvedValue(123n);
-    mockGetLogs.mockResolvedValue([]);
     mockGetWallet.mockResolvedValue({
       id: 'wallet-1',
       address: '0x1111111111111111111111111111111111111111',
@@ -51,10 +59,16 @@ describe('submitTreasuryUsdcTransfer', () => {
     });
   });
 
-  it('uses walletApi.ethereum.sendTransaction with sponsor and resolves tx hash', async () => {
-    mockSendTransaction.mockResolvedValue({
-      hash: txHash,
-      caip2: 'eip155:8453',
+  it('calls Privy REST sign and wait; empty initial hash is not a failure', async () => {
+    mockSignAndSend.mockResolvedValue({
+      transactionId: 'privy-tx-1',
+      userOperationHash: '0x' + 'a'.repeat(64),
+      hash: '',
+    });
+    mockWaitForTransaction.mockResolvedValue({
+      transactionHash: txHash as `0x${string}`,
+      status: 'finalized',
+      userOperationHash: '0x' + 'a'.repeat(64),
     });
 
     await expect(
@@ -68,60 +82,41 @@ describe('submitTreasuryUsdcTransfer', () => {
       expect.objectContaining({
         ok: true,
         txHash,
-        privySendSummary: expect.any(Object),
+        privyTransactionId: 'privy-tx-1',
+        privyStatus: 'finalized',
       })
     );
 
     expect(mockGetWallet).toHaveBeenCalledWith({ id: 'wallet-1' });
-    expect(mockSendTransaction).toHaveBeenCalledWith(
+    expect(mockSignAndSend).toHaveBeenCalledWith(
       expect.objectContaining({
         walletId: 'wallet-1',
-        caip2: 'eip155:8453',
         sponsor: true,
-        transaction: expect.objectContaining({
-          to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
-          chainId: 8453,
-          value: '0x0',
-        }),
+        to: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+        value: '0x0',
+        referenceId: expect.any(String),
       })
     );
-    expect(mockGetTransaction).not.toHaveBeenCalled();
-  });
-
-  it('uses Privy getTransaction when send returns only a transaction id', async () => {
-    mockSendTransaction.mockResolvedValue({
-      hash: '',
-      caip2: 'eip155:8453',
-      transactionId: 'privy-tx-1',
-    });
-    mockGetTransaction.mockResolvedValue({
-      id: 'privy-tx-1',
-      status: 'confirmed',
-      transactionHash: txHash,
-    });
-
-    await expect(
-      submitTreasuryUsdcTransfer({
-        serverWalletId: 'wallet-1',
-        serverWalletAddress: '0x1111111111111111111111111111111111111111',
-        recipientAddress: '0x2222222222222222222222222222222222222222',
-        usdcAmount: 1,
-        privyHashResolveOptions: { timeoutMs: 100, pollIntervalMs: 1 },
+    expect((mockSignAndSend.mock.calls[0][0] as { data: string }).data).toMatch(
+      /^0x/
+    );
+    expect(mockWaitForTransaction).toHaveBeenCalledWith(
+      'privy-tx-1',
+      expect.objectContaining({
+        timeoutMs: 30_000,
       })
-    ).resolves.toEqual(expect.objectContaining({ ok: true, txHash }));
-
-    expect(mockGetTransaction).toHaveBeenCalledWith({ id: 'privy-tx-1' });
+    );
   });
 
-  it('returns submittedPending when only Privy id is known after poll timeout', async () => {
-    mockSendTransaction.mockResolvedValue({
+  it('returns submittedPending when Privy poll times out (30s)', async () => {
+    const err = new MockPrivyTimeout('privy-tx-slow');
+    err.lastStatus = 'broadcasted';
+    mockSignAndSend.mockResolvedValue({
       transactionId: 'privy-tx-slow',
+      userOperationHash: null,
+      hash: '',
     });
-    mockGetTransaction.mockResolvedValue({
-      id: 'privy-tx-slow',
-      status: 'broadcasted',
-      transactionHash: null,
-    });
+    mockWaitForTransaction.mockRejectedValue(err);
 
     await expect(
       submitTreasuryUsdcTransfer({
@@ -136,6 +131,7 @@ describe('submitTreasuryUsdcTransfer', () => {
         ok: true,
         submittedPending: true,
         privyTransactionId: 'privy-tx-slow',
+        lastPrivyStatus: 'broadcasted',
       })
     );
   });
@@ -158,7 +154,7 @@ describe('submitTreasuryUsdcTransfer', () => {
       ok: false,
       error: expect.stringContaining('mismatch'),
     });
-    expect(mockSendTransaction).not.toHaveBeenCalled();
+    expect(mockSignAndSend).not.toHaveBeenCalled();
   });
 
   it('maps insufficient native gas errors to sponsorship troubleshooting text', () => {

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import {
   encodeFunctionData,
   erc20Abi,
@@ -6,13 +7,14 @@ import {
   parseAbiItem,
   parseUnits,
 } from 'viem';
+import { getPrivyClient } from '@/lib/api/privy';
 import {
-  extractPrivyTransactionId,
-  formatPrivyResponseForLog,
-  getPrivyClient,
-  resolvePrivyServerTransactionHash,
-} from '@/lib/api/privy';
-import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
+  PrivyRestApiError,
+  PrivyRestTransactionFailedError,
+  PrivyRestTransactionTimeoutError,
+  signAndSendTransaction,
+  waitForTransaction,
+} from '@/lib/privy-server-rest';
 import {
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
   POSTER_CHECKOUT_CHAIN,
@@ -22,15 +24,23 @@ export type TreasuryUsdcSubmitResult =
   | {
       ok: true;
       txHash: `0x${string}`;
-      /** Safe summary of Privy sendTransaction response for server logs only. */
+      /** Safe summary of Privy REST send for server logs. */
       privySendSummary?: Record<string, unknown>;
+      privyTransactionId: string;
+      userOperationHash?: string | null;
+      referenceId?: string;
+      /** Present when waitForTransaction returned (Privy poll confirmed). */
+      privyStatus?: string;
     }
   | {
       ok: true;
-      /** Privy accepted the send but no on-chain hash yet (poll timeout); reconcile later. */
+      /** Privy accepted the send but no on-chain hash after poll timeout; reconcile later. */
       submittedPending: true;
       privyTransactionId: string;
+      userOperationHash?: string | null;
+      referenceId?: string;
       privySendSummary?: Record<string, unknown>;
+      lastPrivyStatus?: string | null;
     }
   | { ok: false; error: string };
 
@@ -59,7 +69,7 @@ export function mapInsufficientNativeGasPrivyError(message: string): string {
     'Verify production NEXT_PUBLIC_PRIVY_APP_ID and PRIVY_APP_SECRET match the Privy app where Base gas sponsorship is enabled.',
     'Confirm Base (eip155:8453) is enabled for sponsorship and credits are available.',
     'Ensure privy_server_wallet_id and server_wallet_address match the Privy server wallet (no mismatch with treasury_wallet_address).',
-    'Confirm server sends via walletApi.ethereum.sendTransaction with sponsor: true (not a raw path that skips sponsorship).',
+    'Confirm server sends via Privy REST `eth_sendTransaction` with `sponsor: true` (see `lib/privy-server-rest.ts`).',
     'If issues persist, confirm your Privy plan supports TEE/native gas sponsorship for server wallets on Base.',
   ].join(' ');
 }
@@ -176,16 +186,13 @@ export async function submitTreasuryUsdcTransfer(params: {
   recipientAddress: `0x${string}`;
   /** Human-readable USDC amount (6 decimals). */
   usdcAmount: number;
-  /** Override Privy hash polling (e.g. tests). */
+  /** Override Privy poll (e.g. tests). */
   privyHashResolveOptions?: { timeoutMs?: number; pollIntervalMs?: number };
+  /** Optional Privy `reference_id` (default: random UUID). */
+  referenceId?: string;
+  /** When true, emit `withdraw_privy_*` logs for the admin withdraw route. */
+  withdrawTelemetry?: boolean;
 }): Promise<TreasuryUsdcSubmitResult> {
-  let fromBlock: bigint | null = null;
-  try {
-    fromBlock = await (await publicBaseClient()).getBlockNumber();
-  } catch {
-    fromBlock = null;
-  }
-
   const walletId = params.serverWalletId.trim();
   const expectedAddress = params.serverWalletAddress.trim().toLowerCase();
   if (!walletId || !expectedAddress) {
@@ -195,6 +202,12 @@ export async function submitTreasuryUsdcTransfer(params: {
         'Treasury transfer requires both privy_server_wallet_id and server_wallet_address.',
     };
   }
+
+  const referenceId = params.referenceId?.trim() || randomUUID();
+  const pollOpts = params.privyHashResolveOptions ?? {};
+  const timeoutMs = pollOpts.timeoutMs ?? 30_000;
+  const initialPollMs = pollOpts.pollIntervalMs ?? 500;
+  const logWithdraw = params.withdrawTelemetry === true;
 
   try {
     const privy = getPrivyClient();
@@ -213,85 +226,111 @@ export async function submitTreasuryUsdcTransfer(params: {
       };
     }
 
-    const transaction = {
+    const transferData = encodeFunctionData({
+      abi: erc20Abi,
+      functionName: 'transfer',
+      args: [
+        params.recipientAddress,
+        parseUnits(params.usdcAmount.toFixed(6), 6),
+      ],
+    });
+
+    const sent = await signAndSendTransaction({
+      walletId,
       to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-      chainId: POSTER_CHECKOUT_CHAIN.id,
-      data: encodeFunctionData({
-        abi: erc20Abi,
-        functionName: 'transfer',
-        args: [
-          params.recipientAddress,
-          parseUnits(params.usdcAmount.toFixed(6), 6),
-        ],
-      }),
-      value: '0x0' as const,
+      data: transferData,
+      value: '0x0',
+      sponsor: true,
+      referenceId,
+    });
+
+    const privySendSummary: Record<string, unknown> = {
+      transactionId: sent.transactionId,
+      userOperationHash: sent.userOperationHash,
+      hash: sent.hash,
+      referenceId,
     };
 
-    const sendResult = await privy.walletApi.ethereum.sendTransaction({
-      walletId,
-      caip2: SPEND_SERVER_WALLET_CAIP2,
-      sponsor: true,
-      transaction,
-    });
-
-    console.info('submitTreasuryUsdcTransfer send_transaction_success', {
-      step: 'send_transaction_success',
-      walletId,
-      privySendRawSummary: formatPrivyResponseForLog(sendResult),
-    });
-
-    const privySendSummary = formatPrivyResponseForLog(sendResult);
-
-    const resolvedHashRaw = await resolvePrivyServerTransactionHash(
-      sendResult,
-      params.privyHashResolveOptions ?? {}
-    );
-    const txHash = normalizeEvmTxHash(resolvedHashRaw);
-    if (txHash) {
-      console.info('submitTreasuryUsdcTransfer tx_hash_resolved', {
-        step: 'tx_hash_resolved',
+    if (logWithdraw) {
+      console.info('withdraw_privy_send_success', {
         walletId,
-        source: 'privy_resolve',
+        userOperationHash: sent.userOperationHash,
+        initialHash: sent.hash,
+        referenceId,
       });
-      return { ok: true, txHash, privySendSummary };
+      console.info('withdraw_privy_transaction_id', {
+        privyTransactionId: sent.transactionId,
+        referenceId,
+      });
     }
 
-    const fallbackHash = await findRecentTreasuryTransferHash({
-      serverWalletAddress: params.serverWalletAddress,
-      recipientAddress: params.recipientAddress,
-      usdcAmount: params.usdcAmount,
-      fromBlock,
+    console.info('submitTreasuryUsdcTransfer privy_rest_send', {
+      walletId,
+      transactionId: sent.transactionId,
+      userOperationHash: sent.userOperationHash,
+      hashEmpty: !sent.hash,
+      referenceId,
     });
 
-    if (fallbackHash) {
-      console.info('submitTreasuryUsdcTransfer tx_hash_resolved', {
-        step: 'tx_hash_resolved',
-        walletId,
-        source: 'chain_log_fallback',
+    try {
+      const waited = await waitForTransaction(sent.transactionId, {
+        timeoutMs,
+        initialPollMs,
+        maxPollMs: 2_000,
       });
-      return { ok: true, txHash: fallbackHash, privySendSummary };
-    }
 
-    const privyTransactionId = extractPrivyTransactionId(sendResult);
-    if (privyTransactionId) {
-      console.info('submitTreasuryUsdcTransfer tx_hash_pending_privy_id', {
-        step: 'tx_hash_pending',
-        walletId,
-        privyTransactionId,
-      });
+      if (logWithdraw) {
+        console.info('withdraw_privy_poll_confirmed', {
+          privyTransactionId: sent.transactionId,
+          privyStatus: waited.status,
+          transactionHash: waited.transactionHash,
+        });
+      }
+
       return {
         ok: true,
-        submittedPending: true,
-        privyTransactionId,
+        txHash: waited.transactionHash,
         privySendSummary,
+        privyTransactionId: sent.transactionId,
+        userOperationHash: sent.userOperationHash,
+        referenceId,
+        privyStatus: waited.status,
       };
+    } catch (pollErr) {
+      if (pollErr instanceof PrivyRestTransactionTimeoutError) {
+        const last = pollErr.lastStatus;
+        if (logWithdraw) {
+          console.warn('withdraw_privy_poll_timeout', {
+            privyTransactionId: pollErr.transactionId,
+            referenceId,
+            lastStatus: last ?? null,
+          });
+        }
+        return {
+          ok: true,
+          submittedPending: true,
+          privyTransactionId: sent.transactionId,
+          userOperationHash: sent.userOperationHash,
+          referenceId,
+          privySendSummary,
+          lastPrivyStatus: last ?? null,
+        };
+      }
+      if (pollErr instanceof PrivyRestTransactionFailedError) {
+        return {
+          ok: false,
+          error: `Privy transaction failed with status ${pollErr.status}.`,
+        };
+      }
+      throw pollErr;
     }
-
-    return {
-      ok: false,
-      error: 'USDC transfer hash was not returned by wallet provider.',
-    };
   } catch (e) {
+    if (e instanceof PrivyRestApiError) {
+      const rawMsg = e.message;
+      const msg = mapInsufficientNativeGasPrivyError(e.body || rawMsg);
+      console.error('submitTreasuryUsdcTransfer PrivyRestApiError:', e);
+      return { ok: false, error: msg };
+    }
     const rawMsg = e instanceof Error ? e.message : 'USDC transfer failed';
     const msg = mapInsufficientNativeGasPrivyError(rawMsg);
     console.error('submitTreasuryUsdcTransfer:', e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Treasury admin USDC withdrawals no longer use `walletApi.ethereum.sendTransaction`. They follow the Victus pattern: **Privy REST** `POST /v1/wallets/{walletId}/rpc` with `eth_sendTransaction`, `sponsor: true`, Base `eip155:8453`, then **poll** `GET /v1/transactions/{transactionId}` until the on-chain `transaction_hash` is available (30s timeout, exponential backoff).

## Behavior

- **Empty `hash` on send** is normal for sponsored UserOps; it is not treated as failure.
- **200** with `status: confirmed` when Privy poll succeeds and Base receipt wait succeeds; `admin_recovery` ledger is inserted only then.
- **202** with `status: submitted` if Privy poll times out (includes `privyTransactionId`, amount, destination) or if on-chain receipt wait times out (includes `txHash` when known).
- **Re-exports** in `lib/api/privy.ts` for `signAndSendTransaction`, `waitForTransaction`, `getPrivyRestTransaction` (implementation in `lib/privy-server-rest.ts`).

## Files

- `lib/privy-server-rest.ts` — REST client, `signAndSendTransaction`, `waitForTransaction`
- `lib/spend-treasury-usdc-transfer.ts` — treasury path uses REST + poll; optional `withdrawTelemetry` for admin logs
- `app/api/.../treasury/withdraw/route.ts` — response fields and `withdraw_privy_*` / `withdraw_confirmed` logging
- Tests updated/added for treasury transfer and route
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cc80628-0b66-42e1-86ee-c2a8ddbf1a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cc80628-0b66-42e1-86ee-c2a8ddbf1a53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

