### PR TITLE
fix(admin): align server wallet withdraw input and button

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -484,34 +484,32 @@ export default function SpendExperienceDetailPage() {
             </div>
           </div>
           <div className="mt-5 border-t border-neutral-100 pt-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-              <div className="min-w-0 flex-1 space-y-1.5">
-                <Label
-                  htmlFor="withdraw-destination"
-                  className="text-neutral-500"
-                >
-                  Withdraw to address
-                </Label>
-                <Input
-                  id="withdraw-destination"
-                  type="text"
-                  placeholder="0x…"
-                  autoComplete="off"
-                  spellCheck={false}
-                  value={withdrawDestination}
-                  onChange={(e) => setWithdrawDestination(e.target.value)}
-                  disabled={withdrawSubmitting}
-                  className="font-mono text-xs"
-                />
-                <p className="text-xs text-neutral-500">
-                  Withdraws the full Base USDC balance (6 decimals). Gas is
-                  sponsored.
-                </p>
-              </div>
+            <div className="flex flex-col gap-3 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-x-3 sm:gap-y-1.5">
+              <Label
+                htmlFor="withdraw-destination"
+                className="order-1 text-neutral-500 sm:col-start-1 sm:row-start-1"
+              >
+                Withdraw to address
+              </Label>
+              <Input
+                id="withdraw-destination"
+                type="text"
+                placeholder="0x…"
+                autoComplete="off"
+                spellCheck={false}
+                value={withdrawDestination}
+                onChange={(e) => setWithdrawDestination(e.target.value)}
+                disabled={withdrawSubmitting}
+                className="order-2 w-full font-mono text-xs sm:col-start-1 sm:row-start-2"
+              />
+              <p className="order-3 text-xs text-neutral-500 sm:col-start-1 sm:row-start-3">
+                Withdraws the full Base USDC balance (6 decimals). Gas is
+                sponsored.
+              </p>
               <Button
                 type="button"
                 variant="outline"
-                className="shrink-0"
+                className="order-4 w-full shrink-0 whitespace-nowrap sm:order-none sm:col-start-2 sm:row-start-2 sm:w-auto sm:self-end"
                 disabled={
                   withdrawSubmitting ||
                   treasuryData.serverWalletUsdcBalance === null ||


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The withdraw row used `sm:flex-row sm:items-end` with the label, input, and helper text in one flex child. That aligned the button to the bottom of the entire block, so it sat next to the helper line instead of the input.

## Changes

- Replace with a responsive grid from `sm:` up: `sm:grid-cols-[minmax(0,1fr)_auto]` so row 2 places the address input and withdraw button side by side; the helper stays on row 3 under the input column only.
- Button uses `whitespace-nowrap`, `sm:w-auto`, `sm:self-end`, and `shrink-0` so it keeps natural width and lines up with the input row.
- Below `sm`, stack with flex column order (full-width button on mobile for tap targets).

## Testing

- `yarn lint` (passes; existing unrelated warnings only).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c08bb3e2-949a-404d-b54a-9ec900168824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c08bb3e2-949a-404d-b54a-9ec900168824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

