### PR TITLE
debug: gated logs for sponsored spend USDC sendTransaction

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -315,23 +315,71 @@ export function SpendExperiencePage({
         'Switching to Base in your wallet'
       );
       const data = encodeUsdcTransferData(recipient, preview.usdcAmount);
-      // Client-side gas sponsorship requires Privy Dashboard → Gas sponsorship → Allow transactions from the client to be enabled for Base.
-      const { hash } = await withTimeout(
-        sendTransaction(
-          {
-            to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-            data,
-            value: 0n,
-            chainId: POSTER_CHECKOUT_CHAIN_ID,
+      const spendPaymentDebug = process.env.NODE_ENV !== 'production';
+      if (spendPaymentDebug) {
+        console.debug('[spend payment]', {
+          step: 'spend_payment_send_requested',
+          walletAddress,
+          evmWallet: {
+            address: evmWallet.address,
+            walletClientType: evmWallet.walletClientType,
           },
-          {
-            address: walletAddress,
+          chainId: POSTER_CHECKOUT_CHAIN_ID,
+          sponsor: true,
+          to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+          hasData: Boolean(data),
+          dataLength: data.length,
+          includesValueField: false,
+        });
+      }
+      // Client-side gas sponsorship requires Privy Dashboard → Gas sponsorship → Allow transactions from the client to be enabled for Base.
+      let hash: string;
+      try {
+        const result = await withTimeout(
+          sendTransaction(
+            {
+              to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+              data,
+              value: 0n,
+              chainId: POSTER_CHECKOUT_CHAIN_ID,
+            },
+            {
+              address: walletAddress,
+              sponsor: true,
+            } as Parameters<typeof sendTransaction>[1]
+          ),
+          WALLET_STEP_TIMEOUT_MS,
+          'Confirm the USDC payment in your wallet'
+        );
+        hash = result.hash;
+      } catch (sendErr) {
+        if (spendPaymentDebug) {
+          const message =
+            sendErr instanceof Error ? sendErr.message : String(sendErr);
+          const name =
+            sendErr instanceof Error ? sendErr.name : 'NonErrorThrown';
+          console.debug('[spend payment]', {
+            step: 'spend_payment_send_failed',
+            message,
+            name,
+            walletAddress,
+            evmWallet: {
+              address: evmWallet.address,
+              walletClientType: evmWallet.walletClientType,
+            },
             sponsor: true,
-          } as Parameters<typeof sendTransaction>[1]
-        ),
-        WALLET_STEP_TIMEOUT_MS,
-        'Confirm the USDC payment in your wallet'
-      );
+          });
+        }
+        throw sendErr;
+      }
+      if (spendPaymentDebug) {
+        console.debug('[spend payment]', {
+          step: 'spend_payment_send_success',
+          hash,
+          walletAddress,
+          sponsor: true,
+        });
+      }
       await paymentMutation.mutateAsync(hash);
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds temporary `console.debug` instrumentation in `sendUsdcPayment` (`components/spend/spend-experience-page.tsx`) for the Privy sponsored `sendTransaction` path:

- **`spend_payment_send_requested`** — wallet addresses, `walletClientType`, chain id, recipient (`to`), calldata presence/length, `includesValueField: false`, `sponsor: true`
- **`spend_payment_send_success`** — tx hash and wallet context
- **`spend_payment_send_failed`** — error message/name and wallet context when the send step throws

All logs are gated with `process.env.NODE_ENV !== "production"` so production bundles do not emit them. After QA, remove this block or keep the gate only as needed.

## Testing

- `yarn lint` — passes (existing warnings elsewhere)
- `yarn test` — fails on pre-existing suites (`location-search`, `user-menu`, `admin.test`), unrelated to this change
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-81bded0c-7e61-42be-b6ef-9e817f91e2ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-81bded0c-7e61-42be-b6ef-9e817f91e2ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

