### PR TITLE
fix(spend): sponsored USDC sendTransaction without value field

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -26,6 +26,13 @@ import {
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
 } from '@/lib/walletconnect-poster-direct-usdc';
 
+/** Privy supports `sponsor` at runtime for gas sponsorship; `@privy-io/react-auth` types omit it. */
+type PrivySendTransactionOptions = NonNullable<
+  Parameters<ReturnType<typeof useSendTransaction>['sendTransaction']>[1]
+> & {
+  sponsor?: boolean;
+};
+
 type SpendExperiencePageProps = {
   experienceId: string;
   initialExperience: SpendExperience;
@@ -345,11 +352,12 @@ export function SpendExperiencePage({
       // Client-side gas sponsorship requires Privy Dashboard → Gas sponsorship → Allow transactions from the client to be enabled for Base.
       let hash: string;
       try {
+        const sendOptions: PrivySendTransactionOptions = {
+          address: evmWallet.address,
+          sponsor: true,
+        };
         const result = await withTimeout(
-          sendTransaction(transactionRequest, {
-            address: evmWallet.address,
-            sponsor: true,
-          }),
+          sendTransaction(transactionRequest, sendOptions),
           WALLET_STEP_TIMEOUT_MS,
           'Confirm the USDC payment in your wallet'
         );

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -164,6 +164,10 @@ export function SpendExperiencePage({
   const evmWallet = useMemo(() => {
     if (!walletAddress) return null;
     const lower = walletAddress.toLowerCase();
+    const privyEmbedded = wallets.find(
+      (w) => w.walletClientType === 'privy' && w.address.toLowerCase() === lower
+    );
+    if (privyEmbedded) return privyEmbedded;
     return (
       wallets.find((w) => w.address.toLowerCase() === lower) ??
       wallets[0] ??
@@ -315,39 +319,37 @@ export function SpendExperiencePage({
         'Switching to Base in your wallet'
       );
       const data = encodeUsdcTransferData(recipient, preview.usdcAmount);
+      const transactionRequest = {
+        to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+        data,
+        chainId: POSTER_CHECKOUT_CHAIN_ID,
+      };
       const spendPaymentDebug = process.env.NODE_ENV !== 'production';
       if (spendPaymentDebug) {
         console.debug('[spend payment]', {
           step: 'spend_payment_send_requested',
           walletAddress,
-          evmWallet: {
-            address: evmWallet.address,
-            walletClientType: evmWallet.walletClientType,
-          },
+          evmWalletAddress: evmWallet.address,
+          evmWalletClientType: evmWallet.walletClientType,
           chainId: POSTER_CHECKOUT_CHAIN_ID,
           sponsor: true,
           to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
           hasData: Boolean(data),
           dataLength: data.length,
-          includesValueField: false,
+          includesValueField: Object.prototype.hasOwnProperty.call(
+            transactionRequest,
+            'value'
+          ),
         });
       }
       // Client-side gas sponsorship requires Privy Dashboard → Gas sponsorship → Allow transactions from the client to be enabled for Base.
       let hash: string;
       try {
         const result = await withTimeout(
-          sendTransaction(
-            {
-              to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-              data,
-              value: 0n,
-              chainId: POSTER_CHECKOUT_CHAIN_ID,
-            },
-            {
-              address: walletAddress,
-              sponsor: true,
-            } as Parameters<typeof sendTransaction>[1]
-          ),
+          sendTransaction(transactionRequest, {
+            address: evmWallet.address,
+            sponsor: true,
+          }),
           WALLET_STEP_TIMEOUT_MS,
           'Confirm the USDC payment in your wallet'
         );
@@ -363,10 +365,8 @@ export function SpendExperiencePage({
             message,
             name,
             walletAddress,
-            evmWallet: {
-              address: evmWallet.address,
-              walletClientType: evmWallet.walletClientType,
-            },
+            evmWalletAddress: evmWallet.address,
+            evmWalletClientType: evmWallet.walletClientType,
             sponsor: true,
           });
         }
@@ -377,6 +377,8 @@ export function SpendExperiencePage({
           step: 'spend_payment_send_success',
           hash,
           walletAddress,
+          evmWalletAddress: evmWallet.address,
+          evmWalletClientType: evmWallet.walletClientType,
           sponsor: true,
         });
       }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the client-side sponsored USDC payment on the spend experience flow so embedded wallets with USDC but no Base ETH can send the ERC-20 transfer with Privy gas sponsorship.

## Changes

- **Transaction request:** `sendTransaction` receives `{ to, data, chainId }` only — **`value` omitted** (no `value: 0n`).
- **Options:** **`address: evmWallet.address`** with **`sponsor: true`**. `@privy-io/react-auth` typings omit `sponsor`; options are typed via **`PrivySendTransactionOptions`** (official options intersected with `{ sponsor?: boolean }`) so `yarn build` / Vercel succeeds while runtime behavior is unchanged.
- **Wallet selection:** Prefer **Privy embedded** when `walletClientType === "privy"` and address matches `user.wallet.address`; otherwise prior fallback.
- **Debug logs:** Accurate `includesValueField`; `evmWalletAddress` / `evmWalletClientType`.

## Testing

- `yarn build` — completed successfully (compile + typecheck + lint warnings only).

## Follow-up

If production still reports **intrinsic gas too low**, add **`gas: 100000n`** to the transaction object after validating without `value`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-56f448fd-4f26-4eb5-bcb8-218488d6a6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56f448fd-4f26-4eb5-bcb8-218488d6a6df"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

