### PR TITLE
fix(spend): upgrade Privy react-auth for client gas sponsorship

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -26,13 +26,6 @@ import {
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
 } from '@/lib/walletconnect-poster-direct-usdc';
 
-/** Privy supports `sponsor` at runtime for gas sponsorship; `@privy-io/react-auth` types omit it. */
-type PrivySendTransactionOptions = NonNullable<
-  Parameters<ReturnType<typeof useSendTransaction>['sendTransaction']>[1]
-> & {
-  sponsor?: boolean;
-};
-
 type SpendExperiencePageProps = {
   experienceId: string;
   initialExperience: SpendExperience;
@@ -352,12 +345,11 @@ export function SpendExperiencePage({
       // Client-side gas sponsorship requires Privy Dashboard → Gas sponsorship → Allow transactions from the client to be enabled for Base.
       let hash: string;
       try {
-        const sendOptions: PrivySendTransactionOptions = {
-          address: evmWallet.address,
-          sponsor: true,
-        };
         const result = await withTimeout(
-          sendTransaction(transactionRequest, sendOptions),
+          sendTransaction(transactionRequest, {
+            address: evmWallet.address,
+            sponsor: true,
+          }),
           WALLET_STEP_TIMEOUT_MS,
           'Confirm the USDC payment in your wallet'
         );

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@creit.tech/stellar-wallets-kit": "^1.9.5",
     "@pinata/sdk": "^2.1.0",
     "@privy-io/chains": "^0.0.1",
-    "@privy-io/react-auth": "^2.21.4",
+    "@privy-io/react-auth": "^2.25.0",
     "@privy-io/server-auth": "1.32.2",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-icons": "^1.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2248,6 +2248,13 @@
   dependencies:
     zod "^3.24.3"
 
+"@privy-io/api-base@1.7.0":
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/@privy-io/api-base/-/api-base-1.7.0.tgz#83467ddc240800e3195f211540b9e264d41d4748"
+  integrity sha512-ji6ARQAAuW/FzRTgft9NCjRuouWX9t+J7JMmvLPsnXQJDFEV9mqh4sWXZhQ8ddTq/iDZ4z/yz1ORJqN8bYAi4Q==
+  dependencies:
+    zod "^3.24.3"
+
 "@privy-io/chains@0.0.2":
   version "0.0.2"
   resolved "https://registry.npmjs.org/@privy-io/chains/-/chains-0.0.2.tgz"
@@ -2263,10 +2270,10 @@
   resolved "https://registry.npmjs.org/@privy-io/ethereum/-/ethereum-0.0.2.tgz"
   integrity sha512-FnJ1dzgg/tij4jLeKHLlZM9uNk4WN+iIOkc8CG0FZKUQxqXH60Fs/dMF6Xbndd5CQkUO8LUU7FLom/405VKXpQ==
 
-"@privy-io/js-sdk-core@0.54.2":
-  version "0.54.2"
-  resolved "https://registry.npmjs.org/@privy-io/js-sdk-core/-/js-sdk-core-0.54.2.tgz"
-  integrity sha512-EDg10NFnbRd+pUbKbg7Cbg9qUq31hKg4trEq4CDhFbixfno0uOO924Dj1vbFzdVBOkFudHsoAmmgfSZ8shXGyQ==
+"@privy-io/js-sdk-core@0.55.0":
+  version "0.55.0"
+  resolved "https://registry.yarnpkg.com/@privy-io/js-sdk-core/-/js-sdk-core-0.55.0.tgz#c6b4aa6bfb7073e4bd56e20fb1a0213d3b61b572"
+  integrity sha512-halUc0CS0fKQY5fX7YOBpL1piBz5eg140rL+tjyL7yeBCjNkgf5DX6J4BWzRdr5AplRdMWRBUb1/6+g+pcm4Iw==
   dependencies:
     "@ethersproject/abstract-signer" "^5.7.0"
     "@ethersproject/bignumber" "^5.7.0"
@@ -2274,9 +2281,9 @@
     "@ethersproject/providers" "^5.7.2"
     "@ethersproject/transactions" "^5.7.0"
     "@ethersproject/units" "^5.7.0"
-    "@privy-io/api-base" "1.6.1"
+    "@privy-io/api-base" "1.7.0"
     "@privy-io/chains" "0.0.2"
-    "@privy-io/public-api" "2.44.2"
+    "@privy-io/public-api" "2.45.0"
     canonicalize "^2.0.0"
     eventemitter3 "^5.0.1"
     fetch-retry "^6.0.0"
@@ -2297,10 +2304,21 @@
     viem "^2"
     zod "^3.24.3"
 
-"@privy-io/react-auth@^2.21.4":
-  version "2.24.0"
-  resolved "https://registry.npmjs.org/@privy-io/react-auth/-/react-auth-2.24.0.tgz"
-  integrity sha512-ujG/4LZEBSXLZPzlcsiRx+mq3l6fUAGccHWtNbFMJK072uys2tQDrwDO2RPwlgWPMnQmu8XH7uaW80MG2TxivQ==
+"@privy-io/public-api@2.45.0":
+  version "2.45.0"
+  resolved "https://registry.yarnpkg.com/@privy-io/public-api/-/public-api-2.45.0.tgz#3a09bc710ac61f383b16a57d684151a268e96e2a"
+  integrity sha512-gEYclrdjirGqKrJBn1ZXkTuZTL/gK9FjPppoxDJ8/dX1JD4/vXahdt0AdgUfNUf70ZfMdVKYhyos1RkvSLFGYQ==
+  dependencies:
+    "@privy-io/api-base" "1.7.0"
+    bs58 "^5.0.0"
+    libphonenumber-js "^1.10.31"
+    viem "^2"
+    zod "^3.24.3"
+
+"@privy-io/react-auth@^2.25.0":
+  version "2.25.0"
+  resolved "https://registry.yarnpkg.com/@privy-io/react-auth/-/react-auth-2.25.0.tgz#4e403705d59aab9450e8c63e6a83279b4d4a5fa9"
+  integrity sha512-lcILJaXi2wYgxFsxbvSrIM1Cz8FAumMy90YS4R6wcBNWg79U6S6YTHKMa0U8xJPhJUoKrugAi/LTSifYdTCZjg==
   dependencies:
     "@base-org/account" "^1.1.0"
     "@coinbase/wallet-sdk" "4.3.2"
@@ -2309,11 +2327,11 @@
     "@heroicons/react" "^2.1.1"
     "@marsidev/react-turnstile" "^0.4.1"
     "@metamask/eth-sig-util" "^6.0.0"
-    "@privy-io/api-base" "1.6.1"
+    "@privy-io/api-base" "1.7.0"
     "@privy-io/chains" "0.0.2"
     "@privy-io/ethereum" "0.0.2"
-    "@privy-io/js-sdk-core" "0.54.2"
-    "@privy-io/public-api" "2.44.2"
+    "@privy-io/js-sdk-core" "0.55.0"
+    "@privy-io/public-api" "2.45.0"
     "@reown/appkit" "^1.7.11"
     "@scure/base" "^1.2.5"
     "@simplewebauthn/browser" "^9.0.1"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This change upgrades `@privy-io/react-auth` to **2.25.0** (latest stable **2.x** on npm at install time) so `useSendTransaction`’s `sendTransaction` path properly supports the **`sponsor: true`** option for Base USDC spend payments. The lockfile was regenerated with `yarn install`.

The custom `PrivySendTransactionOptions` type was removed because **2.25.0** ships typings that include `sponsor` on the second argument to `sendTransaction`.

The spend flow still calls `sendTransaction` with `{ to, data, chainId }` (no `value`), `{ address: evmWallet.address, sponsor: true }`, and keeps **non-production** `console.debug('[spend payment]', …)` logs.

## Why not Privy 3.x?

`@privy-io/react-auth` **3.22.x** declares a peer dependency on `@solana/kit` **>=3.0.3**. This app pins `@solana/kit` at **^2.3.3**, so upgrading to Privy 3 would require a coordinated Solana dependency migration. **2.25.0** is the latest stable line compatible with the current stack.

## Verification

- `yarn build` succeeds (typecheck + Next.js production build).
- **Manual QA** (Privy embedded wallet, enough USDC, **0 Base ETH**): please confirm sponsored send, unchanged user ETH balance, sponsorship credits decrease, and payment confirmation stores the tx hash. This environment cannot complete that wallet test.

## Notes

`yarn test` currently reports failures in unrelated suites (`location-search`, `user-menu`, `admin.test` email count); they were not introduced by this PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3e0e28d0-a9e9-4637-897c-179907e1994d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e0e28d0-a9e9-4637-897c-179907e1994d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

