### PR TITLE
fix(spend): sponsored USDC gas limit and hide pay CTA when complete

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -319,10 +319,12 @@ export function SpendExperiencePage({
         'Switching to Base in your wallet'
       );
       const data = encodeUsdcTransferData(recipient, preview.usdcAmount);
+      // Explicit gas avoids Privy/RPC preflight estimation errors in the sponsored ERC20 transfer modal.
       const transactionRequest = {
         to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
         data,
         chainId: POSTER_CHECKOUT_CHAIN_ID,
+        gas: 100000n,
       };
       const spendPaymentDebug = process.env.NODE_ENV !== 'production';
       if (spendPaymentDebug) {
@@ -427,6 +429,15 @@ export function SpendExperiencePage({
   const showSessionError = user && walletAddress && sessionError;
   const showWalletBlock = user && !walletAddress;
 
+  const receiptSession = receiptPayload?.session ?? session;
+  const receiptConversion = receiptPayload?.pointConversion;
+  const receiptPaymentHash = receiptPayload?.spendTransaction?.payment_tx_hash;
+
+  const isPaymentComplete =
+    elig?.status === 'payment_complete' ||
+    sessionStatus === 'payment_complete' ||
+    Boolean(receiptPaymentHash);
+
   const showPayDirectUsdc = elig?.status === 'ready_for_payment_own_usdc';
 
   const showConvert =
@@ -435,18 +446,14 @@ export function SpendExperiencePage({
     (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
 
   const showPay =
+    !isPaymentComplete &&
     (elig?.status === 'ready_for_payment' ||
       elig?.status === 'ready_for_payment_own_usdc' ||
       elig?.status === 'payment_failed') &&
     preview &&
     isEvmAddress(preview.receivingWalletAddress);
 
-  const receiptSession = receiptPayload?.session ?? session;
-  const receiptConversion = receiptPayload?.pointConversion;
-  const receiptPaymentHash = receiptPayload?.spendTransaction?.payment_tx_hash;
-
-  const displayReceipt =
-    elig?.status === 'payment_complete' || sessionStatus === 'payment_complete';
+  const displayReceipt = isPaymentComplete;
 
   const basescanUrl = (hash: string) =>
     `https://basescan.org/tx/${hash.trim()}`;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses two issues on the spend experience payment flow (`components/spend/spend-experience-page.tsx`).

### 1. Privy modal "Missing or invalid parameters"

The sponsored ERC20 transfer now includes an explicit `gas: 100000n` on the transaction request so Privy/RPC preflight estimation is less likely to fail while the sponsored path still succeeds. Added a short comment explaining why.

No `value` field was added; `sponsor: true` and `address: evmWallet.address` are unchanged.

### 2. Pay CTA visible after success

Introduced `isPaymentComplete` from eligibility status, session status, and `receiptPaymentHash` from the receipt query. `showPay` requires `!isPaymentComplete`, and `displayReceipt` uses the same boolean so the "Spend $X USDC" button hides once payment is complete while the receipt (and BaseScan link when present) stay visible.

## Testing

Lint/tests were not run in this environment (`yarn` not available on PATH). Please run `yarn lint` and `yarn test` locally if needed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c3838a1b-c219-4980-b11c-09737e410207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c3838a1b-c219-4980-b11c-09737e410207"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

