### PR TITLE
fix: remove unauthenticated POST /api/perks

### DIFF
--- a/app/api/perks/__tests__/route.test.ts
+++ b/app/api/perks/__tests__/route.test.ts
@@ -7,12 +7,8 @@ const mockEqUnlisted = vi.fn(() => ({ or: mockOr }))
 const mockEqActive = vi.fn(() => ({ eq: mockEqUnlisted }))
 const mockOrder = vi.fn(() => ({ eq: mockEqActive }))
 const mockSelectQuery = vi.fn(() => ({ order: mockOrder }))
-const mockSingle = vi.fn()
-const mockSelectInsert = vi.fn(() => ({ single: mockSingle }))
-const mockInsert = vi.fn(() => ({ select: mockSelectInsert }))
 const mockFrom = vi.fn(() => ({
   select: mockSelectQuery,
-  insert: mockInsert,
 }))
 
 vi.mock('@/lib/db/client', () => ({
@@ -21,7 +17,7 @@ vi.mock('@/lib/db/client', () => ({
   },
 }))
 
-import { GET, POST } from '../route'
+import { GET } from '../route'
 
 // Helper to create a mock NextRequest with search params
 function createMockGetRequest(searchParams?: Record<string, string>): NextRequest {
@@ -34,28 +30,17 @@ function createMockGetRequest(searchParams?: Record<string, string>): NextReques
   return new NextRequest(url, { method: 'GET' })
 }
 
-function createMockPostRequest(body: Record<string, unknown>): NextRequest {
-  return new NextRequest('http://localhost:3000/api/perks', {
-    method: 'POST',
-    body: JSON.stringify(body),
-    headers: { 'Content-Type': 'application/json' },
-  })
-}
-
 describe('Perks API Route', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     // Reset the chain so each test starts fresh
     mockFrom.mockReturnValue({
       select: mockSelectQuery,
-      insert: mockInsert,
     })
     mockSelectQuery.mockReturnValue({ order: mockOrder })
     mockOrder.mockReturnValue({ eq: mockEqActive })
     mockEqActive.mockReturnValue({ eq: mockEqUnlisted })
     mockEqUnlisted.mockReturnValue({ or: mockOr })
-    mockInsert.mockReturnValue({ select: mockSelectInsert })
-    mockSelectInsert.mockReturnValue({ single: mockSingle })
   })
 
   describe('GET /api/perks', () => {
@@ -148,71 +133,6 @@ describe('Perks API Route', () => {
       expect(response.status).toBe(500)
       expect(json.success).toBe(false)
       expect(json.error).toBe('Failed to fetch perks')
-    })
-  })
-
-  describe('POST /api/perks', () => {
-    it('should create a perk successfully', async () => {
-      const newPerk = {
-        title: 'New Perk',
-        description: 'A brand new perk',
-        points_threshold: 200,
-        type: 'discount',
-        is_active: true,
-      }
-      const createdPerk = {
-        id: 'perk-new',
-        ...newPerk,
-        created_at: '2024-01-01T00:00:00Z',
-      }
-
-      mockSingle.mockResolvedValueOnce({ data: createdPerk, error: null })
-
-      const request = createMockPostRequest(newPerk)
-      const response = await POST(request)
-      const json = await response.json()
-
-      expect(response.status).toBe(200)
-      expect(json.success).toBe(true)
-      expect(json.data.perk).toEqual(createdPerk)
-      expect(mockFrom).toHaveBeenCalledWith('perks')
-    })
-
-    it('should return 500 on database error during creation', async () => {
-      mockSingle.mockResolvedValueOnce({
-        data: null,
-        error: { message: 'Insert failed' },
-      })
-
-      const request = createMockPostRequest({
-        title: 'Perk',
-        description: 'desc',
-        points_threshold: 100,
-        type: 'discount',
-      })
-      const response = await POST(request)
-      const json = await response.json()
-
-      expect(response.status).toBe(500)
-      expect(json.success).toBe(false)
-      expect(json.error).toBe('Failed to create perk')
-    })
-
-    it('should return 500 when insert throws', async () => {
-      mockSingle.mockRejectedValueOnce(new Error('Unexpected insert error'))
-
-      const request = createMockPostRequest({
-        title: 'Perk',
-        description: 'desc',
-        points_threshold: 100,
-        type: 'discount',
-      })
-      const response = await POST(request)
-      const json = await response.json()
-
-      expect(response.status).toBe(500)
-      expect(json.success).toBe(false)
-      expect(json.error).toBe('Failed to create perk')
     })
   })
 })

--- a/app/api/perks/route.ts
+++ b/app/api/perks/route.ts
@@ -31,21 +31,3 @@ export async function GET(request: NextRequest) {
     return apiError("Failed to fetch perks", 500);
   }
 }
-
-// POST /api/perks
-export async function POST(request: NextRequest) {
-  try {
-    const perk = await request.json();
-    const { data, error } = await supabase
-      .from("perks")
-      .insert(perk)
-      .select()
-      .single();
-
-    if (error) throw error;
-    return apiSuccess({ perk: data });
-  } catch (error) {
-    console.error("POST /api/perks error:", error);
-    return apiError("Failed to create perk", 500);
-  }
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The public `POST /api/perks` handler accepted arbitrary JSON and inserted rows into `perks` with no authentication or validation.

## Changes

- Removed the `POST` export from `app/api/perks/route.ts`. The route now only exposes `GET` for listing perks (unchanged).
- Perk creation for admins remains at `POST /api/admin/perks` (see `app/api/admin/perks/route.ts`), which enforces `checkAdminPermission` on `x-user-email`.
- Updated `app/api/perks/__tests__/route.test.ts` to drop tests for the removed handler.

## Notes

- I could not run `yarn test` in this environment (Node/yarn not available in PATH). Please run `yarn test` and `yarn lint` locally or in CI.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-be6d0191-1201-4085-9341-6444011a1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-be6d0191-1201-4085-9341-6444011a1007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

