### PR TITLE
fix(security): verify Privy JWT for admin APIs

### DIFF
--- a/app/admin/checkpoints/page.tsx
+++ b/app/admin/checkpoints/page.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/components/ui/select';
 import type { Checkpoint, ChainType, CheckpointMode } from '@/lib/types';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import Image from 'next/image';
 import GradientPicker from '@/components/ui/gradient-picker';
 import FontPicker from '@/components/ui/font-picker';
@@ -288,7 +289,7 @@ function CheckpointCard({
 // ---------------------------------------------------------------------------
 
 export default function AdminCheckpointsPage() {
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
 
   // Admin auth
@@ -297,8 +298,11 @@ export default function AdminCheckpointsPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -306,7 +310,7 @@ export default function AdminCheckpointsPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
@@ -335,14 +339,15 @@ export default function AdminCheckpointsPage() {
   const { data: checkpoints = [], isLoading: checkpointsLoading } = useQuery<Checkpoint[]>({
     queryKey: ['admin-checkpoints'],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/checkpoints', {
-        headers: { 'x-user-email': user?.email?.address || '' },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to fetch checkpoints');
       const responseData = await response.json();
       return (responseData.data || responseData).checkpoints;
     },
-    enabled: !!isAdmin,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
 
   // Mutations
@@ -372,9 +377,10 @@ export default function AdminCheckpointsPage() {
         if (checkpointData.cta_url) fd.append('cta_url', checkpointData.cta_url);
         fd.append('partner_image', imageFile);
 
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch('/api/admin/checkpoints', {
           method: 'POST',
-          headers: { 'x-user-email': user?.email?.address || '' },
+          headers: auth,
           body: fd,
         });
         if (!response.ok) {
@@ -385,9 +391,10 @@ export default function AdminCheckpointsPage() {
         return rd.data || rd;
       }
 
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/checkpoints', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'x-user-email': user?.email?.address || '' },
+        headers: { 'Content-Type': 'application/json', ...auth },
         body: JSON.stringify(checkpointData),
       });
       if (!response.ok) {
@@ -442,15 +449,17 @@ export default function AdminCheckpointsPage() {
           fd.append(key, value === null ? '' : String(value));
         });
         fd.append('partner_image', imageFile);
+        const auth = await adminApiAuthHeaders(getAccessToken);
         response = await fetch(`/api/admin/checkpoints/${id}`, {
           method: 'PATCH',
-          headers: { 'x-user-email': user?.email?.address || '' },
+          headers: auth,
           body: fd,
         });
       } else {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         response = await fetch(`/api/admin/checkpoints/${id}`, {
           method: 'PATCH',
-          headers: { 'Content-Type': 'application/json', 'x-user-email': user?.email?.address || '' },
+          headers: { 'Content-Type': 'application/json', ...auth },
           body: JSON.stringify(updates),
         });
       }
@@ -473,9 +482,10 @@ export default function AdminCheckpointsPage() {
 
   const deleteCheckpointMutation = useMutation({
     mutationFn: async (id: string) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/checkpoints/${id}`, {
         method: 'DELETE',
-        headers: { 'x-user-email': user?.email?.address || '' },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to delete checkpoint');
     },

--- a/app/admin/events/page.tsx
+++ b/app/admin/events/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import type { DiceEvent } from '@/lib/dice';
 import Image from 'next/image';
 import {
@@ -56,12 +57,12 @@ function RewardTicketHoldersDialog({
   event,
   open,
   onOpenChange,
-  adminEmail,
+  getAccessToken,
 }: {
   event: DiceEvent | null;
   open: boolean;
   onOpenChange: (open: boolean) => void;
-  adminEmail: string | undefined;
+  getAccessToken: () => Promise<string | null | undefined>;
 }) {
   const [pointsPerHolder, setPointsPerHolder] = useState(100);
   const [awarding, setAwarding] = useState(false);
@@ -69,13 +70,6 @@ function RewardTicketHoldersDialog({
   const [error, setError] = useState<string | null>(null);
 
   const eventId = event?.id ?? '';
-  const headers = useMemo(
-    () =>
-      adminEmail
-        ? { 'Content-Type': 'application/json', 'x-user-email': adminEmail }
-        : { 'Content-Type': 'application/json' },
-    [adminEmail]
-  );
 
   const {
     data: preview,
@@ -84,9 +78,10 @@ function RewardTicketHoldersDialog({
   } = useQuery<TicketHoldersPreview>({
     queryKey: ['dice-ticket-holders', eventId],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const res = await fetch(
         `/api/admin/dice/events/${encodeURIComponent(eventId)}/ticket-holders`,
-        { headers: headers as HeadersInit }
+        { headers: auth }
       );
       if (!res.ok) {
         const j = await res.json().catch(() => ({}));
@@ -95,17 +90,18 @@ function RewardTicketHoldersDialog({
       const body = await res.json();
       return body.data ?? body;
     },
-    enabled: open && !!eventId && !!adminEmail,
+    enabled: open && !!eventId,
   });
 
   const handleAward = async () => {
-    if (!eventId || !adminEmail) return;
+    if (!eventId) return;
     setAwarding(true);
     setError(null);
     try {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const res = await fetch('/api/admin/dice/reward-ticket-holders', {
         method: 'POST',
-        headers: headers as HeadersInit,
+        headers: { 'Content-Type': 'application/json', ...auth },
         body: JSON.stringify({
           eventId,
           pointsPerHolder,
@@ -298,7 +294,7 @@ function RewardTicketHoldersDialog({
 }
 
 export default function AdminEventsPage() {
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
 
   const checkAdminStatus = useCallback(async () => {
     if (!user?.email?.address) return false;
@@ -306,8 +302,11 @@ export default function AdminEventsPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -316,7 +315,7 @@ export default function AdminEventsPage() {
       console.error('Error checking admin status:', error);
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
@@ -657,7 +656,7 @@ export default function AdminEventsPage() {
           event={rewardDialogEvent}
           open={rewardDialogOpen}
           onOpenChange={setRewardDialogOpen}
-          adminEmail={user?.email?.address}
+          getAccessToken={getAccessToken}
         />
       </div>
     </div>

--- a/app/admin/guides/[id]/page.tsx
+++ b/app/admin/guides/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import {
@@ -126,7 +127,7 @@ function computeSlugFollowsTitles(
 export default function AdminGuideEditPage() {
   const params = useParams();
   const id = typeof params.id === 'string' ? params.id : '';
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
@@ -136,8 +137,11 @@ export default function AdminGuideEditPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -145,7 +149,7 @@ export default function AdminGuideEditPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -165,22 +169,24 @@ export default function AdminGuideEditPage() {
   const { data: lists = [] } = useQuery<LocationListWithCount[]>({
     queryKey: ['admin-location-lists'],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/location-lists', {
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to load lists');
       const responseData = await response.json();
       const data = responseData.data || responseData;
       return data.lists ?? [];
     },
-    enabled: !!isAdmin,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
 
   const { data: detail, isLoading } = useQuery<AdminGuideDetail | null>({
     queryKey: ['admin-guide', id],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/guides/${id}`, {
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (response.status === 404) return null;
       if (!response.ok) throw new Error('Failed to load guide');
@@ -188,7 +194,7 @@ export default function AdminGuideEditPage() {
       const data = responseData.data || responseData;
       return data as AdminGuideDetail;
     },
-    enabled: !!isAdmin && !!id,
+    enabled: !!isAdmin && !!id && !!user?.email?.address,
   });
 
   const guide = detail?.guide ?? null;
@@ -372,11 +378,12 @@ export default function AdminGuideEditPage() {
         body.map_image_alt = null;
       }
 
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/guides/${id}`, {
         method: 'PATCH',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-email': adminEmail,
+          ...auth,
         },
         body: JSON.stringify(body),
       });
@@ -396,9 +403,10 @@ export default function AdminGuideEditPage() {
 
   const deleteMutation = useMutation({
     mutationFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/guides/${id}`, {
         method: 'DELETE',
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Delete failed');
       return response.json();
@@ -423,8 +431,9 @@ export default function AdminGuideEditPage() {
       return false;
     }
     try {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/guides/${id}/preview-link`, {
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -442,7 +451,7 @@ export default function AdminGuideEditPage() {
       toast.error(message);
       return false;
     }
-  }, [adminEmail, id]);
+  }, [user?.email?.address, id, getAccessToken]);
 
   const handleConfirmPreview = useCallback(async () => {
     setPreviewOpening(true);

--- a/app/admin/guides/page.tsx
+++ b/app/admin/guides/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { toast } from 'sonner';
 import { Eye, Loader2, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -12,7 +13,7 @@ import type { AdminGuideSummary } from '@/lib/db/guides';
 const GUIDES_ADMIN_KEY = ['admin-guides'] as const;
 
 export default function AdminGuidesListPage() {
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
@@ -22,8 +23,11 @@ export default function AdminGuidesListPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -31,7 +35,7 @@ export default function AdminGuidesListPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -51,15 +55,16 @@ export default function AdminGuidesListPage() {
   const { data: guides = [], isLoading } = useQuery<AdminGuideSummary[]>({
     queryKey: GUIDES_ADMIN_KEY,
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/guides', {
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to load guides');
       const responseData = await response.json();
       const data = responseData.data || responseData;
       return data.guides ?? [];
     },
-    enabled: !!isAdmin,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
 
   const openPreview = useCallback(
@@ -69,9 +74,10 @@ export default function AdminGuidesListPage() {
         return;
       }
       try {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch(
           `/api/admin/guides/${guideId}/preview-link`,
-          { headers: { 'x-user-email': adminEmail } }
+          { headers: auth }
         );
         const responseData = await response.json();
         const data = responseData.data || responseData;
@@ -91,16 +97,17 @@ export default function AdminGuidesListPage() {
         toast.error(message);
       }
     },
-    [adminEmail]
+    [getAccessToken, user?.email?.address]
   );
 
   const createMutation = useMutation({
     mutationFn: async (kind: 'city_guide' | 'editorial') => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/guides', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-email': adminEmail,
+          ...auth,
         },
         body: JSON.stringify({ kind }),
       });

--- a/app/admin/location-lists/page.tsx
+++ b/app/admin/location-lists/page.tsx
@@ -9,6 +9,7 @@ import {
   type FormEvent,
 } from 'react';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { z } from 'zod';
@@ -315,8 +316,11 @@ export default function AdminLocationListsPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       // Unwrap the apiSuccess wrapper
@@ -326,7 +330,7 @@ export default function AdminLocationListsPage() {
       console.error('Error checking admin status', error);
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -415,8 +419,9 @@ export default function AdminLocationListsPage() {
   >({
     queryKey: LISTS_KEY,
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/location-lists', {
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (!response.ok) {
         throw new Error('Failed to fetch location lists');
@@ -426,10 +431,8 @@ export default function AdminLocationListsPage() {
       const data = responseData.data || responseData;
       return data.lists ?? [];
     },
-    enabled: !!isAdmin,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
-
-  const {
     data: locationOptions = [],
     isLoading: locationOptionsLoading,
     isFetching: locationOptionsFetching,
@@ -441,10 +444,11 @@ export default function AdminLocationListsPage() {
       if (debouncedLocationSearch) {
         params.set('q', debouncedLocationSearch);
       }
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
         `/api/admin/location-lists/location-options?${params.toString()}`,
         {
-          headers: { 'x-user-email': adminEmail },
+          headers: auth,
         }
       );
       if (!response.ok) {
@@ -455,7 +459,7 @@ export default function AdminLocationListsPage() {
       const data = responseData.data || responseData;
       return data.locations ?? [];
     },
-    enabled: !!isAdmin,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
 
   const selectedList = useMemo(
@@ -488,10 +492,11 @@ export default function AdminLocationListsPage() {
     useQuery<LocationListLocation[]>({
       queryKey: listLocationsKey,
       queryFn: async () => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch(
           `/api/admin/location-lists/${selectedListId}/locations`,
           {
-            headers: { 'x-user-email': adminEmail },
+            headers: auth,
           }
         );
         if (!response.ok) {
@@ -502,16 +507,17 @@ export default function AdminLocationListsPage() {
         const data = responseData.data || responseData;
         return data.locations ?? [];
       },
-      enabled: !!selectedListId && !!isAdmin,
+      enabled: !!selectedListId && !!isAdmin && !!user?.email?.address,
     });
 
   const createListMutation = useMutation({
     mutationFn: async (payload: z.infer<typeof createListSchema>) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/location-lists', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-email': adminEmail,
+          ...auth,
         },
         body: JSON.stringify(payload),
       });
@@ -549,11 +555,12 @@ export default function AdminLocationListsPage() {
       listId: string;
       payload: z.infer<typeof updateListSchema>;
     }) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/location-lists/${listId}`, {
         method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-email': adminEmail,
+          ...auth,
         },
         body: JSON.stringify(payload),
       });
@@ -587,13 +594,14 @@ export default function AdminLocationListsPage() {
       listId: string;
       locationId: number;
     }) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
         `/api/admin/location-lists/${listId}/locations`,
         {
           method: 'POST',
           headers: {
             'Content-Type': 'application/json',
-            'x-user-email': adminEmail,
+            ...auth,
           },
           body: JSON.stringify({ locationId }),
         }
@@ -629,13 +637,12 @@ export default function AdminLocationListsPage() {
       listId: string;
       locationId: number;
     }) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
         `/api/admin/location-lists/${listId}/locations?locationId=${locationId}`,
         {
           method: 'DELETE',
-          headers: {
-            'x-user-email': adminEmail,
-          },
+          headers: auth,
         }
       );
 
@@ -668,9 +675,10 @@ export default function AdminLocationListsPage() {
 
   const deleteListMutation = useMutation({
     mutationFn: async (listId: string) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/location-lists/${listId}`, {
         method: 'DELETE',
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to delete list');
       return response.json();
@@ -697,7 +705,6 @@ export default function AdminLocationListsPage() {
       const response = await fetch('/api/admin/location-lists/csv-upload', {
         method: 'POST',
         headers: {
-          'x-user-email': adminEmail,
           Authorization: `Bearer ${token}`,
         },
         body: formData,
@@ -768,11 +775,12 @@ export default function AdminLocationListsPage() {
         throw new Error('Upload succeeded but no image URL was returned');
       }
 
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/locations', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-email': user?.email?.address || '',
+          ...auth,
         },
         body: JSON.stringify({
           place_id: placeId,
@@ -862,7 +870,6 @@ export default function AdminLocationListsPage() {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
-          'x-user-email': adminEmail,
         },
         body: JSON.stringify({
           placeId: payload.placeId,

--- a/app/admin/location-lists/page.tsx
+++ b/app/admin/location-lists/page.tsx
@@ -412,8 +412,6 @@ export default function AdminLocationListsPage() {
     });
   }, [user?.wallet?.address, user?.email?.address]);
 
-  const adminEmail = user?.email?.address || '';
-
   const { data: lists = [], isLoading: listsLoading } = useQuery<
     LocationListWithCount[]
   >({
@@ -433,6 +431,8 @@ export default function AdminLocationListsPage() {
     },
     enabled: !!isAdmin && !!user?.email?.address,
   });
+
+  const {
     data: locationOptions = [],
     isLoading: locationOptionsLoading,
     isFetching: locationOptionsFetching,

--- a/app/admin/locations/page.tsx
+++ b/app/admin/locations/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { Loader2, Trash2 } from 'lucide-react';
@@ -27,8 +28,11 @@ export default function AdminLocationsPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       // Unwrap the apiSuccess wrapper
@@ -38,7 +42,7 @@ export default function AdminLocationsPage() {
       console.error('Error checking admin status', error);
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -59,8 +63,9 @@ export default function AdminLocationsPage() {
   const { data: allLocations = [], isLoading: locationsLoading } = useQuery({
     queryKey: [...LOCATIONS_KEY, 'all'],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const res = await fetch(`/api/locations?includeHidden=true`, {
-        headers: { 'x-user-email': user?.email?.address || '' },
+        headers: auth,
       });
       if (!res.ok) throw new Error('Failed to fetch locations');
       const responseData = await res.json();
@@ -70,8 +75,6 @@ export default function AdminLocationsPage() {
     },
     enabled: !!isAdmin && !!user?.email?.address,
   });
-
-  // Filter client-side based on showApproved checkbox
   const filteredLocations = allLocations.filter((loc: Location) =>
     showApproved ? true : !loc.is_visible
   );
@@ -110,7 +113,6 @@ export default function AdminLocationsPage() {
         headers: {
           'Content-Type': 'application/json',
           Authorization: `Bearer ${token}`,
-          'x-user-email': user?.email?.address || '',
         },
         body: JSON.stringify({ isVisible }),
       });
@@ -137,7 +139,6 @@ export default function AdminLocationsPage() {
         method: 'DELETE',
         headers: {
           Authorization: `Bearer ${token}`,
-          'x-user-email': user?.email?.address || '',
         },
       });
       const body = await res.json().catch(() => ({}));

--- a/app/admin/perks/page.tsx
+++ b/app/admin/perks/page.tsx
@@ -24,20 +24,24 @@ import {
 import type { Perk, PerkDiscountCode } from "@/lib/types";
 import type { Tier } from "@/lib/types";
 import { usePrivy } from "@privy-io/react-auth";
+import { adminApiAuthHeaders } from "@/lib/admin-api-auth-headers";
 
 // Component to display discount code type for a perk
 function PerkCodeTypeInfo({
   perkId,
-  adminEmail,
+  getAccessToken,
+  isAdmin,
 }: {
   perkId: string;
-  adminEmail: string;
+  getAccessToken: () => Promise<string | null | undefined>;
+  isAdmin: boolean;
 }) {
   const { data: codes = [] } = useQuery<PerkDiscountCode[]>({
-    queryKey: ["perk-codes-preview", perkId, adminEmail],
+    queryKey: ["perk-codes-preview", perkId],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/perks/${perkId}/codes`, {
-        headers: { "x-user-email": adminEmail },
+        headers: auth,
       });
       if (!response.ok) return [];
       const responseData = await response.json();
@@ -45,7 +49,7 @@ function PerkCodeTypeInfo({
       const data = responseData.data || responseData;
       return data.codes ?? [];
     },
-    enabled: !!adminEmail,
+    enabled: !!perkId && !!isAdmin,
   });
 
   if (codes.length === 0) return null;
@@ -75,7 +79,7 @@ function PerkCodeTypeInfo({
 }
 
 export default function AdminPerksPage() {
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const [selectedTierId, setSelectedTierId] = useState<string>("");
 
@@ -86,8 +90,11 @@ export default function AdminPerksPage() {
       try {
         const response = await fetch("/api/admin/auth", {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({ email: user.email.address }),
+          headers: {
+            "Content-Type": "application/json",
+            ...(await adminApiAuthHeaders(getAccessToken)),
+          },
+          body: JSON.stringify({}),
         });
         const responseData = await response.json();
         // Unwrap the apiSuccess wrapper
@@ -97,7 +104,7 @@ export default function AdminPerksPage() {
         console.error("Error checking admin status:", error);
         return false;
       }
-    }, [user?.email?.address]);
+    }, [user?.email?.address, getAccessToken]);
     const [editingPerk, setEditingPerk] = useState<Perk | null>(null);
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [formData, setFormData] = useState<Partial<Perk>>({
@@ -151,10 +158,11 @@ export default function AdminPerksPage() {
 
     // Fetch all perks
     const { data: perks = [], isLoading: perksLoading } = useQuery({
-      queryKey: ["admin-perks", adminEmail],
+      queryKey: ["admin-perks", isAdmin],
       queryFn: async () => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch("/api/admin/perks?activeOnly=false", {
-          headers: { "x-user-email": adminEmail },
+          headers: auth,
         });
         if (!response.ok) throw new Error("Failed to fetch perks");
         const responseData = await response.json();
@@ -185,11 +193,12 @@ export default function AdminPerksPage() {
       mutationFn: async (
         perkData: Omit<Perk, "id" | "created_at" | "updated_at">,
       ) => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch("/api/admin/perks", {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "x-user-email": adminEmail,
+            ...auth,
           },
           body: JSON.stringify(perkData),
         });
@@ -219,11 +228,12 @@ export default function AdminPerksPage() {
         id: string;
         updates: Partial<Perk>;
       }) => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch(`/api/admin/perks/${id}`, {
           method: "PUT",
           headers: {
             "Content-Type": "application/json",
-            "x-user-email": adminEmail,
+            ...auth,
           },
           body: JSON.stringify(updates),
         });
@@ -247,9 +257,10 @@ export default function AdminPerksPage() {
     // Delete perk mutation
     const deletePerkMutation = useMutation({
       mutationFn: async (id: string) => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch(`/api/admin/perks/${id}`, {
           method: "DELETE",
-          headers: { "x-user-email": adminEmail },
+          headers: auth,
         });
         if (!response.ok) throw new Error("Failed to delete perk");
       },
@@ -274,11 +285,12 @@ export default function AdminPerksPage() {
         codes: string[];
         isUniversal: boolean;
       }) => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch(`/api/admin/perks/${perkId}/codes`, {
           method: "POST",
           headers: {
             "Content-Type": "application/json",
-            "x-user-email": adminEmail,
+            ...auth,
           },
           body: JSON.stringify({ codes, is_universal: isUniversal }),
         });
@@ -305,9 +317,10 @@ export default function AdminPerksPage() {
     // Delete discount code mutation
     const deleteCodeMutation = useMutation({
       mutationFn: async (codeId: string) => {
+        const auth = await adminApiAuthHeaders(getAccessToken);
         const response = await fetch(`/api/admin/perks/codes/${codeId}`, {
           method: "DELETE",
-          headers: { "x-user-email": adminEmail },
+          headers: auth,
         });
         if (!response.ok) throw new Error("Failed to delete discount code");
       },
@@ -489,7 +502,10 @@ export default function AdminPerksPage() {
 
     const loadPerkCodes = async (perkId: string) => {
       try {
-        const response = await fetch(`/api/admin/perks/${perkId}/codes`);
+        const auth = await adminApiAuthHeaders(getAccessToken);
+        const response = await fetch(`/api/admin/perks/${perkId}/codes`, {
+          headers: auth,
+        });
         if (!response.ok) throw new Error("Failed to fetch discount codes");
         const responseData = await response.json();
         // Unwrap the apiSuccess wrapper
@@ -1028,7 +1044,7 @@ export default function AdminPerksPage() {
                         </div>
                       )}
                       {perk.id && adminEmail && (
-                        <PerkCodeTypeInfo perkId={perk.id} adminEmail={adminEmail} />
+                        <PerkCodeTypeInfo perkId={perk.id} getAccessToken={getAccessToken} isAdmin={!!isAdmin} />
                       )}
                     </div>
                   </div>

--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useQuery } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import {
   Loader2,
   ArrowLeft,
@@ -164,7 +165,7 @@ function SessionPaymentCell({ payment }: { payment: SpendTransaction | null }) {
 export default function SpendExperienceDetailPage() {
   const params = useParams<{ experienceId: string }>();
   const experienceId = params.experienceId;
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
   const [withdrawDestination, setWithdrawDestination] = useState('');
@@ -175,8 +176,11 @@ export default function SpendExperienceDetailPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -184,7 +188,7 @@ export default function SpendExperienceDetailPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -199,22 +203,14 @@ export default function SpendExperienceDetailPage() {
     void verify();
   }, [user, checkAdminStatus]);
 
-  const adminEmail = user?.email?.address || '';
-
-  const headers = useMemo(
-    () => ({
-      'Content-Type': 'application/json',
-      'x-user-email': adminEmail,
-    }),
-    [adminEmail]
-  );
-
   const experienceQuery = useQuery<SpendExperience>({
-    queryKey: ['admin-spend-experience', experienceId, adminEmail],
+    queryKey: ['admin-spend-experience', experienceId, isAdmin],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const jsonHeaders = { 'Content-Type': 'application/json', ...auth };
       const response = await fetch(
         `/api/admin/spend-experiences/${experienceId}`,
-        { headers }
+        { headers: jsonHeaders }
       );
       if (!response.ok) throw new Error('Failed to load experience');
       const j = await response.json();
@@ -224,37 +220,41 @@ export default function SpendExperienceDetailPage() {
       if (!exp) throw new Error('Missing experience');
       return exp;
     },
-    enabled: Boolean(experienceId && isAdmin && adminEmail),
+    enabled: Boolean(experienceId && isAdmin && user?.email?.address),
   });
 
   const activityQuery = useQuery<ActivityPayload>({
-    queryKey: ['admin-spend-activity', experienceId, adminEmail],
+    queryKey: ['admin-spend-activity', experienceId, isAdmin],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const jsonHeaders = { 'Content-Type': 'application/json', ...auth };
       const response = await fetch(
         `/api/admin/spend-experiences/${experienceId}/activity`,
-        { headers }
+        { headers: jsonHeaders }
       );
       if (!response.ok) throw new Error('Failed to load activity');
       const j = await response.json();
       const data = j.data ?? j;
       return data as ActivityPayload;
     },
-    enabled: Boolean(experienceId && isAdmin && adminEmail),
+    enabled: Boolean(experienceId && isAdmin && user?.email?.address),
   });
 
   const treasuryQuery = useQuery<TreasuryPayload>({
-    queryKey: ['admin-spend-treasury', experienceId, adminEmail],
+    queryKey: ['admin-spend-treasury', experienceId, isAdmin],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const jsonHeaders = { 'Content-Type': 'application/json', ...auth };
       const response = await fetch(
         `/api/admin/spend-experiences/${experienceId}/treasury`,
-        { headers }
+        { headers: jsonHeaders }
       );
       if (!response.ok) throw new Error('Failed to load treasury');
       const j = await response.json();
       const data = j.data ?? j;
       return data as TreasuryPayload;
     },
-    enabled: Boolean(experienceId && isAdmin && adminEmail),
+    enabled: Boolean(experienceId && isAdmin && user?.email?.address),
   });
 
   const refetchAll = useCallback(() => {
@@ -271,11 +271,13 @@ export default function SpendExperienceDetailPage() {
     }
     setWithdrawSubmitting(true);
     try {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const jsonHeaders = { 'Content-Type': 'application/json', ...auth };
       const response = await fetch(
         `/api/admin/spend-experiences/${experienceId}/treasury/withdraw`,
         {
           method: 'POST',
-          headers,
+          headers: jsonHeaders,
           body: JSON.stringify({ destinationAddress: trimmed }),
         }
       );

--- a/app/admin/spend-experiences/[experienceId]/qr/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/qr/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { useQuery } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { Loader2, ArrowLeft } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import QRCode from 'qrcode';
@@ -15,7 +16,7 @@ import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
 export default function AdminSpendExperienceQrPage() {
   const params = useParams<{ experienceId: string }>();
   const experienceId = params.experienceId;
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
   const [qrDataUrl, setQrDataUrl] = useState<string | null>(null);
@@ -25,8 +26,11 @@ export default function AdminSpendExperienceQrPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -34,7 +38,7 @@ export default function AdminSpendExperienceQrPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -49,14 +53,13 @@ export default function AdminSpendExperienceQrPage() {
     void verify();
   }, [user, checkAdminStatus]);
 
-  const adminEmail = user?.email?.address || '';
-
   const { data, isLoading, error } = useQuery<SpendExperience>({
-    queryKey: ['admin-spend-experience', experienceId, adminEmail],
+    queryKey: ['admin-spend-experience', experienceId, isAdmin],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
         `/api/admin/spend-experiences/${experienceId}`,
-        { headers: { 'x-user-email': adminEmail } }
+        { headers: auth }
       );
       if (!response.ok) throw new Error('Failed to load experience');
       const j = await response.json();
@@ -66,7 +69,7 @@ export default function AdminSpendExperienceQrPage() {
       if (!exp) throw new Error('Missing experience');
       return exp;
     },
-    enabled: Boolean(experienceId && isAdmin && adminEmail),
+    enabled: Boolean(experienceId && isAdmin && user?.email?.address),
   });
 
   const scanUrl = useMemo(() => {

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -1,8 +1,9 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { toast } from 'sonner';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -25,7 +26,7 @@ type CreateSpendExperienceResponse = {
 };
 
 export default function AdminSpendExperiencesPage() {
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
@@ -43,8 +44,11 @@ export default function AdminSpendExperiencesPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -52,7 +56,7 @@ export default function AdminSpendExperiencesPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {
@@ -67,30 +71,21 @@ export default function AdminSpendExperiencesPage() {
     void verify();
   }, [user, checkAdminStatus]);
 
-  const adminEmail = user?.email?.address || '';
-
-  const headers = useMemo(
-    () => ({
-      'Content-Type': 'application/json',
-      'x-user-email': adminEmail,
-    }),
-    [adminEmail]
-  );
-
   const { data: spendExperiences = [], isLoading } = useQuery<
     SpendExperience[]
   >({
     queryKey: QUERY_KEY,
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/spend-experiences', {
-        headers: { 'x-user-email': adminEmail },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to load spend experiences');
       const responseData = await response.json();
       const data = responseData.data || responseData;
       return data.spendExperiences ?? [];
     },
-    enabled: !!isAdmin && !!adminEmail,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
 
   const closePanel = useCallback(() => {
@@ -111,10 +106,13 @@ export default function AdminSpendExperiencesPage() {
         end_time: datetimeLocalToIso(form.end_time_local),
       };
 
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const jsonHeaders = { 'Content-Type': 'application/json', ...auth };
+
       if (editing) {
         const response = await fetch(
           `/api/admin/spend-experiences/${encodeURIComponent(editing.id)}`,
-          { method: 'PATCH', headers, body: JSON.stringify(payload) }
+          { method: 'PATCH', headers: jsonHeaders, body: JSON.stringify(payload) }
         );
         const j = await response.json().catch(() => ({}));
         if (!response.ok) {
@@ -127,7 +125,7 @@ export default function AdminSpendExperiencesPage() {
       const response = await fetch('/api/admin/spend-experiences', {
         method: 'POST',
         headers: {
-          ...headers,
+          ...jsonHeaders,
           'Idempotency-Key': crypto.randomUUID(),
         },
         body: JSON.stringify(payload),

--- a/app/admin/users/page.tsx
+++ b/app/admin/users/page.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import {
   ArrowUpDown,
   Search,
@@ -91,7 +92,7 @@ interface PaginationInfo {
 }
 
 export default function AdminUsersPage() {
-  const { user, login } = usePrivy();
+  const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
@@ -116,13 +117,14 @@ export default function AdminUsersPage() {
     if (!user?.email?.address) return false;
 
     try {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/users', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          'x-user-email': user.email.address,
+          ...auth,
         },
-        body: JSON.stringify({ email: user.email.address }),
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       // Unwrap the apiSuccess wrapper
@@ -132,7 +134,7 @@ export default function AdminUsersPage() {
       console.error('Error checking admin status:', error);
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verifyAdmin = async () => {
@@ -153,12 +155,11 @@ export default function AdminUsersPage() {
   const { data: usersData, isLoading: usersLoading } = useQuery({
     queryKey: ['admin-users', currentPage, itemsPerPage],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
         `/api/admin/users?page=${currentPage}&limit=${itemsPerPage}`,
         {
-          headers: {
-            'x-user-email': user?.email?.address || '',
-          },
+          headers: auth,
         }
       );
       if (!response.ok) throw new Error('Failed to fetch users');
@@ -170,7 +171,7 @@ export default function AdminUsersPage() {
         pagination: data.pagination as PaginationInfo,
       };
     },
-    enabled: !!isAdmin,
+    enabled: !!isAdmin && !!user?.email?.address,
   });
 
   const users = useMemo(() => usersData?.users ?? [], [usersData?.users]);
@@ -185,10 +186,9 @@ export default function AdminUsersPage() {
   const { data: uploadHistory = [] } = useQuery({
     queryKey: ['upload-history'],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/points-upload', {
-        headers: {
-          'x-user-email': user?.email?.address || '',
-        },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to fetch upload history');
       const responseData = await response.json();
@@ -196,17 +196,16 @@ export default function AdminUsersPage() {
       const data = responseData.data || responseData;
       return data.uploads as UploadHistory[];
     },
-    enabled: !!isAdmin && showUploadHistory,
+    enabled: !!isAdmin && showUploadHistory && !!user?.email?.address,
   });
 
   // Fetch pending points
   const { data: pendingPointsData } = useQuery({
     queryKey: ['pending-points'],
     queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/pending-points', {
-        headers: {
-          'x-user-email': user?.email?.address || '',
-        },
+        headers: auth,
       });
       if (!response.ok) throw new Error('Failed to fetch pending points');
       const responseData = await response.json();
@@ -217,7 +216,7 @@ export default function AdminUsersPage() {
         summary: data.summary as PendingPointsSummary[],
       };
     },
-    enabled: !!isAdmin && showPendingPoints,
+    enabled: !!isAdmin && showPendingPoints && !!user?.email?.address,
   });
 
   // Upload mutation
@@ -226,11 +225,10 @@ export default function AdminUsersPage() {
       const formData = new FormData();
       formData.append('file', file);
 
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/points-upload', {
         method: 'POST',
-        headers: {
-          'x-user-email': user?.email?.address || '',
-        },
+        headers: auth,
         body: formData,
       });
 
@@ -335,10 +333,9 @@ export default function AdminUsersPage() {
       toast.info('Fetching all users for export...');
 
       // Fetch all users (using max limit of 1000)
+      const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(`/api/admin/users?page=1&limit=1000`, {
-        headers: {
-          'x-user-email': user?.email?.address || '',
-        },
+        headers: auth,
       });
 
       if (!response.ok) {

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,5 +1,4 @@
 import { NextRequest } from 'next/server';
-import { checkAdminPermission } from '@/lib/db/admin';
 import {
   getAnalyticsSummary,
   getAnalyticsTimeSeries,
@@ -8,28 +7,7 @@ import {
   getTopLocations,
 } from '@/lib/db/analytics';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { getPrivyClient } from '@/lib/api/privy';
-
-async function getAuthenticatedAdminEmail(
-  request: NextRequest
-): Promise<string | null> {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7).trim();
-  if (!token) return null;
-
-  try {
-    const privy = getPrivyClient();
-    const verifiedClaims = await privy.verifyAuthToken(token);
-    const user = await privy.getUser(verifiedClaims.userId);
-    const email = user.email?.address?.trim().toLowerCase();
-    if (!email) return null;
-    return checkAdminPermission(email) ? email : null;
-  } catch {
-    return null;
-  }
-}
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/auth/route.ts
+++ b/app/api/admin/auth/route.ts
@@ -1,13 +1,13 @@
 import { NextRequest } from 'next/server';
 import { apiSuccess, apiError } from '@/lib/api/response';
+import { getPrivyUserEmailFromRequest } from '@/lib/api/privy';
 import { checkAdminPermission } from '@/lib/db/admin';
 
 export async function POST(request: NextRequest) {
   try {
-    const { email } = await request.json();
-
+    const email = await getPrivyUserEmailFromRequest(request);
     if (!email) {
-      return apiError('Email is required', 400);
+      return apiError('Unauthorized', 403);
     }
 
     const isAdmin = checkAdminPermission(email);

--- a/app/api/admin/city-metrics/route.ts
+++ b/app/api/admin/city-metrics/route.ts
@@ -1,29 +1,7 @@
 import { NextRequest } from 'next/server';
-import { checkAdminPermission } from '@/lib/db/admin';
 import { getCityMetrics } from '@/lib/db/locations';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { getPrivyClient } from '@/lib/api/privy';
-
-async function getAuthenticatedAdminEmail(
-  request: NextRequest
-): Promise<string | null> {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7).trim();
-  if (!token) return null;
-
-  try {
-    const privy = getPrivyClient();
-    const verifiedClaims = await privy.verifyAuthToken(token);
-    const user = await privy.getUser(verifiedClaims.userId);
-    const email = user.email?.address?.trim().toLowerCase();
-    if (!email) return null;
-    return checkAdminPermission(email) ? email : null;
-  } catch {
-    return null;
-  }
-}
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export async function GET(request: NextRequest) {
   try {

--- a/app/api/admin/dice/events/[id]/ticket-holders/route.ts
+++ b/app/api/admin/dice/events/[id]/ticket-holders/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from 'next/server';
 import { supabase } from '@/lib/db/client';
-import { checkAdminPermission } from '@/lib/db/admin';
 import { getPlayersByEmails } from '@/lib/db/players';
 import { fetchEventTicketHolders } from '@/lib/dice/client';
 import { apiSuccess, apiError } from '@/lib/api/response';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 /**
  * GET /api/admin/dice/events/[id]/ticket-holders
@@ -14,8 +14,8 @@ export async function GET(
   { params }: { params: Promise<{ id: string }> }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email');
-    if (!checkAdminPermission(adminEmail || undefined)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 

--- a/app/api/admin/dice/reward-ticket-holders/route.ts
+++ b/app/api/admin/dice/reward-ticket-holders/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { supabase } from '@/lib/db/client';
-import { checkAdminPermission } from '@/lib/db/admin';
 import { getPlayersByEmails, updatePlayerPoints } from '@/lib/db/players';
 import { checkAndTrackTierProgression } from '@/lib/tier-progression';
 import { fetchEventTicketHolders } from '@/lib/dice/client';
 import { apiSuccess, apiError } from '@/lib/api/response';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 const rewardBodySchema = z.object({
   eventId: z.string().min(1, 'eventId is required'),
@@ -22,8 +22,8 @@ const rewardBodySchema = z.object({
  */
 export async function POST(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get('x-user-email');
-    if (!checkAdminPermission(adminEmail || undefined)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 

--- a/app/api/admin/guides/[id]/preview-link/route.ts
+++ b/app/api/admin/guides/[id]/preview-link/route.ts
@@ -1,11 +1,11 @@
 import { NextRequest } from 'next/server';
-import { checkAdminPermission } from '@/lib/db/admin';
 import { adminGetGuide } from '@/lib/db/guides';
 import {
   createGuidePreviewToken,
   isGuidePreviewSecretConfigured,
 } from '@/lib/guides/preview-token';
 import { apiSuccess, apiError } from '@/lib/api/response';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 function readHrefForGuide(
   slug: string,
@@ -18,7 +18,7 @@ function readHrefForGuide(
 
 /**
  * Returns a time-limited preview URL (with `?preview=…` token) for an unpublished or published guide.
- * Requires `x-user-email` for an admin. Signing uses `GUIDE_PREVIEW_SECRET` or, in production, a
+ * Requires a verified Privy admin session (`Authorization: Bearer`). Signing uses `GUIDE_PREVIEW_SECRET` or, in production, a
  * key derived from `PRIVY_APP_SECRET`.
  */
 export async function GET(
@@ -26,8 +26,8 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 

--- a/app/api/admin/guides/[id]/route.ts
+++ b/app/api/admin/guides/[id]/route.ts
@@ -1,6 +1,5 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
-import { checkAdminPermission } from '@/lib/db/admin';
 import {
   adminGetGuide,
   deleteGuide,
@@ -10,6 +9,7 @@ import {
 } from '@/lib/db/guides';
 import { editorialBlocksSchema } from '@/lib/guides/block-schema';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 const contributorSchema = z.object({
   position: z.number().int().min(0),
@@ -55,8 +55,8 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 
@@ -76,8 +76,8 @@ export async function PATCH(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 
@@ -135,8 +135,8 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 

--- a/app/api/admin/guides/route.ts
+++ b/app/api/admin/guides/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
-import { checkAdminPermission } from '@/lib/db/admin';
 import {
   adminListGuides,
   createGuide,
   ensureUniqueGuideSlug,
 } from '@/lib/db/guides';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 const createSchema = z.object({
   kind: z.enum(['city_guide', 'editorial']),
@@ -31,8 +31,8 @@ function slugify(value: string): string {
 
 export async function GET(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 
@@ -46,8 +46,8 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 

--- a/app/api/admin/location-lists/[listId]/locations/route.ts
+++ b/app/api/admin/location-lists/[listId]/locations/route.ts
@@ -1,12 +1,12 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { checkAdminPermission } from "@/lib/db/admin";
 import {
   addLocationToList,
   getLocationsForList,
   removeLocationFromList,
 } from "@/lib/db/location-lists";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api/response";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 
 const addSchema = z.object({
   locationId: z.coerce.number().int().positive(),
@@ -27,8 +27,8 @@ export async function GET(
   { params }: { params: { listId: string } },
 ) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 
@@ -45,8 +45,8 @@ export async function POST(
   { params }: { params: { listId: string } },
 ) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 
@@ -74,8 +74,8 @@ export async function DELETE(
   { params }: { params: { listId: string } },
 ) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 

--- a/app/api/admin/location-lists/[listId]/route.ts
+++ b/app/api/admin/location-lists/[listId]/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { checkAdminPermission } from "@/lib/db/admin";
 import { deleteLocationList, updateLocationList } from "@/lib/db/location-lists";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api/response";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 
 const colorRegex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 
@@ -18,8 +18,8 @@ export async function PUT(
   { params }: { params: { listId: string } },
 ) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 
@@ -57,8 +57,8 @@ export async function DELETE(
   { params }: { params: { listId: string } },
 ) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 

--- a/app/api/admin/location-lists/csv-upload/route.ts
+++ b/app/api/admin/location-lists/csv-upload/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest } from "next/server";
-import { checkAdminPermission } from "@/lib/db/admin";
 import { supabase } from "@/lib/db/client";
-import { getPrivyClient } from "@/lib/api/privy";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 import { apiSuccess, apiError } from "@/lib/api/response";
 import { trackLocationCreated, resolveServerIdentity } from "@/lib/analytics";
 import { lookup } from "node:dns/promises";
@@ -101,27 +100,6 @@ async function geocodeAddress(
     const center = data.features?.[0]?.center;
     if (!center || center.length < 2) return null;
     return [center[0], center[1]];
-  } catch {
-    return null;
-  }
-}
-
-async function getAuthenticatedAdminEmail(
-  request: NextRequest
-): Promise<string | null> {
-  const authHeader = request.headers.get("authorization");
-  if (!authHeader?.startsWith("Bearer ")) return null;
-
-  const token = authHeader.slice(7).trim();
-  if (!token) return null;
-
-  try {
-    const privy = getPrivyClient();
-    const verifiedClaims = await privy.verifyAuthToken(token);
-    const user = await privy.getUser(verifiedClaims.userId);
-    const email = user.email?.address?.trim().toLowerCase();
-    if (!email) return null;
-    return checkAdminPermission(email) ? email : null;
   } catch {
     return null;
   }

--- a/app/api/admin/location-lists/location-options/route.ts
+++ b/app/api/admin/location-lists/location-options/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import { LOCATION_OPTIONS_MAX_ROWS } from '@/lib/constants';
-import { checkAdminPermission } from '@/lib/db/admin';
 import { listLocationOptions } from '@/lib/db/locations';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 const querySchema = z.object({
   query: z.string().min(1).max(120).optional(),
@@ -17,8 +17,8 @@ const querySchema = z.object({
 
 export async function GET(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized', 403);
     }
 

--- a/app/api/admin/location-lists/route.ts
+++ b/app/api/admin/location-lists/route.ts
@@ -1,9 +1,9 @@
 import { NextRequest } from "next/server";
 import { z } from "zod";
-import { checkAdminPermission } from "@/lib/db/admin";
 import { createLocationList, getLocationLists } from "@/lib/db/location-lists";
 import { supabase } from "@/lib/db/client";
 import { apiSuccess, apiError, apiValidationError } from "@/lib/api/response";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 
 const colorRegex = /^#([0-9a-f]{3}|[0-9a-f]{6})$/i;
 
@@ -50,8 +50,8 @@ const ensureUniqueSlug = async (base: string): Promise<string> => {
 
 export async function GET(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 
@@ -65,8 +65,8 @@ export async function GET(request: NextRequest) {
 
 export async function POST(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get("x-user-email") || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized", 403);
     }
 

--- a/app/api/admin/locations/[locationId]/route.ts
+++ b/app/api/admin/locations/[locationId]/route.ts
@@ -1,9 +1,8 @@
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
-import { checkAdminPermission } from '@/lib/db/admin';
 import { deleteLocationById, updateLocationById } from '@/lib/db/locations';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
-import { getPrivyClient } from '@/lib/api/privy';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 const updateLocationSchema = z.object({
   name: z.string().min(1).optional(),
@@ -19,27 +18,6 @@ const updateLocationSchema = z.object({
   eventUrl: z.string().url().nullable().optional(),
   isVisible: z.boolean().optional(),
 });
-
-async function getAuthenticatedAdminEmail(
-  request: NextRequest
-): Promise<string | null> {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7).trim();
-  if (!token) return null;
-
-  try {
-    const privy = getPrivyClient();
-    const verifiedClaims = await privy.verifyAuthToken(token);
-    const user = await privy.getUser(verifiedClaims.userId);
-    const email = user.email?.address?.trim().toLowerCase();
-    if (!email) return null;
-    return checkAdminPermission(email) ? email : null;
-  } catch {
-    return null;
-  }
-}
 
 export async function PATCH(
   request: NextRequest,

--- a/app/api/admin/pending-points/route.ts
+++ b/app/api/admin/pending-points/route.ts
@@ -1,14 +1,14 @@
 import { NextRequest } from "next/server";
 import { supabase } from "@/lib/db/client";
-import { checkAdminPermission } from "@/lib/db/admin";
 import { apiSuccess, apiError } from "@/lib/api/response";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 
 // GET endpoint to fetch pending points
 export async function GET(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get("x-user-email");
+    const adminEmail = await getAuthenticatedAdminEmail(request);
 
-    if (!checkAdminPermission(adminEmail || undefined)) {
+    if (!adminEmail) {
       return apiError("Unauthorized - Admin access required", 403);
     }
 
@@ -50,9 +50,9 @@ export async function GET(request: NextRequest) {
 // DELETE endpoint to remove pending points
 export async function DELETE(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get("x-user-email");
+    const adminEmail = await getAuthenticatedAdminEmail(request);
 
-    if (!checkAdminPermission(adminEmail || undefined)) {
+    if (!adminEmail) {
       return apiError("Unauthorized - Admin access required", 403);
     }
 

--- a/app/api/admin/perks/[id]/codes/route.ts
+++ b/app/api/admin/perks/[id]/codes/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { getDiscountCodesByPerkId, createDiscountCodes } from '@/lib/db/perks';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { checkAdminPermission } from '@/lib/db/admin';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,8 +11,8 @@ export async function GET(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 
@@ -30,8 +30,8 @@ export async function POST(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 

--- a/app/api/admin/perks/[id]/route.ts
+++ b/app/api/admin/perks/[id]/route.ts
@@ -2,7 +2,7 @@ import { NextRequest } from 'next/server';
 import { updatePerk, deletePerk } from '@/lib/db/perks';
 import type { Perk } from '@/lib/types';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { checkAdminPermission } from '@/lib/db/admin';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,8 +12,8 @@ export async function PUT(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 
@@ -43,8 +43,8 @@ export async function DELETE(
   { params }: { params: { id: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 

--- a/app/api/admin/perks/codes/[codeId]/route.ts
+++ b/app/api/admin/perks/codes/[codeId]/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest } from 'next/server';
 import { deleteDiscountCode } from '@/lib/db/perks';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { checkAdminPermission } from '@/lib/db/admin';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,8 +11,8 @@ export async function DELETE(
   { params }: { params: { codeId: string } }
 ) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 

--- a/app/api/admin/perks/route.ts
+++ b/app/api/admin/perks/route.ts
@@ -2,15 +2,15 @@ import { NextRequest } from 'next/server';
 import { getAllPerks, createPerk } from '@/lib/db/perks';
 import type { Perk } from '@/lib/types';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { checkAdminPermission } from '@/lib/db/admin';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
 // GET /api/admin/perks - Get all perks
 export async function GET(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 
@@ -28,8 +28,8 @@ export async function GET(request: NextRequest) {
 // POST /api/admin/perks - Create a new perk
 export async function POST(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get('x-user-email') || undefined;
-    if (!checkAdminPermission(adminEmail)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 

--- a/app/api/admin/points-upload/route.ts
+++ b/app/api/admin/points-upload/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest } from "next/server";
 import { supabase } from "@/lib/db/client";
-import { checkAdminPermission } from "@/lib/db/admin";
 import { v4 as uuidv4 } from "uuid";
 import { apiSuccess, apiError } from "@/lib/api/response";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 
 interface CSVRow {
   email: string;
@@ -21,11 +21,9 @@ interface UploadResult {
 
 export async function POST(request: NextRequest) {
   try {
-    // Get email from header
-    const adminEmail = request.headers.get("x-user-email");
+    const adminEmail = await getAuthenticatedAdminEmail(request);
 
-    // Check admin permission
-    if (!checkAdminPermission(adminEmail || undefined)) {
+    if (!adminEmail) {
       return apiError("Unauthorized - Admin access required", 403);
     }
 
@@ -222,9 +220,9 @@ export async function POST(request: NextRequest) {
 // GET endpoint to fetch upload history
 export async function GET(request: NextRequest) {
   try {
-    const adminEmail = request.headers.get("x-user-email");
+    const adminEmail = await getAuthenticatedAdminEmail(request);
 
-    if (!checkAdminPermission(adminEmail || undefined)) {
+    if (!adminEmail) {
       return apiError("Unauthorized - Admin access required", 403);
     }
 

--- a/app/api/admin/users/route.ts
+++ b/app/api/admin/users/route.ts
@@ -1,15 +1,12 @@
 import { NextRequest } from "next/server";
 import { supabase } from "@/lib/db/client";
-import { checkAdminPermission } from "@/lib/db/admin";
 import { apiSuccess, apiError } from "@/lib/api/response";
+import { getAuthenticatedAdminEmail } from "@/lib/auth";
 
 export async function GET(request: NextRequest) {
   try {
-    // Get email from header (set by middleware or client)
-    const email = request.headers.get("x-user-email");
-
-    // Check admin permission
-    if (!checkAdminPermission(email || undefined)) {
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    if (!adminEmail) {
       return apiError("Unauthorized - Admin access required", 403);
     }
 
@@ -83,12 +80,11 @@ export async function GET(request: NextRequest) {
   }
 }
 
-// POST endpoint to check admin status
+// POST endpoint to check admin status (verified Privy session only)
 export async function POST(request: NextRequest) {
   try {
-    const { email } = await request.json();
-
-    const isAdmin = checkAdminPermission(email);
+    const adminEmail = await getAuthenticatedAdminEmail(request);
+    const isAdmin = Boolean(adminEmail);
 
     return apiSuccess({ isAdmin });
   } catch (error) {

--- a/app/api/locations/route.ts
+++ b/app/api/locations/route.ts
@@ -7,7 +7,8 @@ import {
 } from '@/lib/analytics';
 import { trackCityMilestone } from '@/lib/analytics/server';
 import { setUserProperties as setUserPropertiesServer } from '@/lib/analytics/server';
-import { checkAdminPermission } from '@/lib/db/admin';
+import { getPrivyUserEmailFromRequest } from '@/lib/api/privy';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 import {
   MAX_LOCATION_DESCRIPTION_LENGTH,
   MAX_LOCATIONS_PER_WEEK,
@@ -28,10 +29,10 @@ export async function GET(request: NextRequest) {
     const walletAddress = searchParams.get('walletAddress');
     const includeHidden = searchParams.get('includeHidden') === 'true';
 
-    // Only allow includeHidden if admin
+    // Only allow includeHidden if admin (verified Privy token)
     if (includeHidden) {
-      const adminEmail = request.headers.get('x-user-email');
-      if (!checkAdminPermission(adminEmail || undefined)) {
+      const adminEmail = await getAuthenticatedAdminEmail(request);
+      if (!adminEmail) {
         return apiError('Unauthorized', 403);
       }
     }
@@ -237,7 +238,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const creatorEmail = request.headers.get('x-user-email');
+    const creatorEmail = await getPrivyUserEmailFromRequest(request);
 
     // Resolve city from coordinates (and fall back to context JSON if present)
     const resolvedCity = resolveCityFromCoordinates(parsedLat, parsedLon);

--- a/app/api/perks/[id]/route.ts
+++ b/app/api/perks/[id]/route.ts
@@ -1,31 +1,9 @@
 import { NextRequest } from 'next/server';
 import { supabase } from '@/lib/db/client';
 import { apiSuccess, apiError } from '@/lib/api/response';
-import { checkAdminPermission } from '@/lib/db/admin';
-import { getPrivyClient } from '@/lib/api/privy';
+import { getAuthenticatedAdminEmail } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
-
-async function getAuthenticatedAdminEmail(
-  request: NextRequest
-): Promise<string | null> {
-  const authHeader = request.headers.get('authorization');
-  if (!authHeader?.startsWith('Bearer ')) return null;
-
-  const token = authHeader.slice(7).trim();
-  if (!token) return null;
-
-  try {
-    const privy = getPrivyClient();
-    const verifiedClaims = await privy.verifyAuthToken(token);
-    const user = await privy.getUser(verifiedClaims.userId);
-    const email = user.email?.address?.trim().toLowerCase();
-    if (!email) return null;
-    return checkAdminPermission(email) ? email : null;
-  } catch {
-    return null;
-  }
-}
 
 // GET /api/perks/[id]
 export async function GET(

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -13,6 +13,7 @@ import {
   mergeSearchBoxReverseFeatures,
 } from '@/lib/utils/location-autofill';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { toast } from 'sonner';
 import MapNav from '@/components/map/mapnav';
 import MapCard from '@/components/map/map-card';
@@ -167,7 +168,7 @@ export default function InteractiveMap({
   const effectiveGuideReturnHref =
     guideReturnHref ?? guideReturnPersistedRef.current;
 
-  const { user } = usePrivy();
+  const { user, getAccessToken } = usePrivy();
   const walletAddress = user?.wallet?.address;
   const [userUsername, setUserUsername] = useState<string | null>(null);
 
@@ -1160,14 +1161,20 @@ export default function InteractiveMap({
         }
       }
 
-      // Create location and award points
+      // Create location and award points (optional verified email for analytics)
+      let authHeaders: Record<string, string> = {};
+      if (user?.email?.address) {
+        try {
+          authHeaders = await adminApiAuthHeaders(getAccessToken);
+        } catch {
+          // Proceed without Bearer — location still created; server skips verified email
+        }
+      }
       const response = await fetch('/api/locations', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
-          ...(user?.email?.address
-            ? { 'x-user-email': user.email.address }
-            : {}),
+          ...authHeaders,
         },
         body: JSON.stringify({
           place_id: selectedMarker.place_id,

--- a/lib/admin-api-auth-headers.ts
+++ b/lib/admin-api-auth-headers.ts
@@ -1,0 +1,14 @@
+/**
+ * Builds `Authorization: Bearer` headers for browser calls to admin API routes
+ * that verify the Privy access token on the server.
+ */
+export async function adminApiAuthHeaders(
+  getAccessToken: () => Promise<string | null | undefined>
+): Promise<{ Authorization: string }> {
+  const token = await getAccessToken();
+  const trimmed = token?.trim();
+  if (!trimmed) {
+    throw new Error('Missing authorization token');
+  }
+  return { Authorization: `Bearer ${trimmed}` };
+}

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -249,11 +249,34 @@ export async function getPrivyUserIdFromRequest(
 ): Promise<string | null> {
   const authHeader = req.headers.get('authorization');
   if (!authHeader?.startsWith('Bearer ')) return null;
-  const token = authHeader.slice(7);
+  const token = authHeader.slice(7).trim();
+  if (!token) return null;
   try {
     const privy = getPrivyClient();
     const verifiedClaims = await privy.verifyAuthToken(token);
     return verifiedClaims.userId;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Verified login email from a Privy access token (`Authorization: Bearer`).
+ * Never trust client-supplied email headers for authorization.
+ */
+export async function getPrivyUserEmailFromRequest(
+  req: NextRequest
+): Promise<string | null> {
+  const authHeader = req.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7).trim();
+  if (!token) return null;
+  try {
+    const privy = getPrivyClient();
+    const verifiedClaims = await privy.verifyAuthToken(token);
+    const user = await privy.getUser(verifiedClaims.userId);
+    const email = user.email?.address?.trim().toLowerCase();
+    return email && email.length > 0 ? email : null;
   } catch {
     return null;
   }

--- a/lib/auth.test.ts
+++ b/lib/auth.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetPrivyUserEmailFromRequest = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  getPrivyUserEmailFromRequest: (...args: unknown[]) =>
+    mockGetPrivyUserEmailFromRequest(...args),
+}));
+
+import {
+  getUserFromRequest,
+  requireAdmin,
+  getAuthenticatedAdminEmail,
+} from './auth';
+
+describe('lib/auth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('getUserFromRequest returns email from verified Privy helper', async () => {
+    mockGetPrivyUserEmailFromRequest.mockResolvedValue('a@b.com');
+    const req = new NextRequest('http://localhost/');
+    await expect(getUserFromRequest(req)).resolves.toEqual({
+      email: 'a@b.com',
+    });
+  });
+
+  it('getUserFromRequest returns null when token invalid', async () => {
+    mockGetPrivyUserEmailFromRequest.mockResolvedValue(null);
+    const req = new NextRequest('http://localhost/');
+    await expect(getUserFromRequest(req)).resolves.toBeNull();
+  });
+
+  it('requireAdmin is valid only for allowlisted admin email', async () => {
+    mockGetPrivyUserEmailFromRequest.mockResolvedValue('dhurls99@gmail.com');
+    const req = new NextRequest('http://localhost/');
+    await expect(requireAdmin(req)).resolves.toEqual({
+      isValid: true,
+      user: { email: 'dhurls99@gmail.com' },
+    });
+  });
+
+  it('requireAdmin rejects non-admin verified email', async () => {
+    mockGetPrivyUserEmailFromRequest.mockResolvedValue('not@admin.com');
+    const req = new NextRequest('http://localhost/');
+    await expect(requireAdmin(req)).resolves.toEqual({
+      isValid: false,
+      user: { email: 'not@admin.com' },
+    });
+  });
+
+  it('getAuthenticatedAdminEmail returns null for non-admin', async () => {
+    mockGetPrivyUserEmailFromRequest.mockResolvedValue('x@y.com');
+    const req = new NextRequest('http://localhost/');
+    await expect(getAuthenticatedAdminEmail(req)).resolves.toBeNull();
+  });
+});

--- a/lib/auth.ts
+++ b/lib/auth.ts
@@ -1,25 +1,20 @@
 import { NextRequest } from 'next/server';
 import { checkAdminPermission } from '@/lib/db/admin';
+import { getPrivyUserEmailFromRequest } from '@/lib/api/privy';
 
 export { checkAdminPermission };
 
-// Extract user email from Privy token (simplified for now)
+/**
+ * Authenticated user (email from verified Privy JWT only).
+ */
 export async function getUserFromRequest(
   request: NextRequest
 ): Promise<{ email?: string } | null> {
-  try {
-    // For now, we'll use a simple approach - you can enhance this to properly verify Privy JWT tokens
-    const userEmail = request.headers.get('x-user-email'); // Frontend can send this after Privy auth
-
-    if (!userEmail) {
-      return null;
-    }
-
-    return { email: userEmail };
-  } catch (error) {
-    console.error('Error extracting user from request:', error);
+  const email = await getPrivyUserEmailFromRequest(request);
+  if (!email) {
     return null;
   }
+  return { email };
 }
 
 export async function requireAdmin(
@@ -36,4 +31,17 @@ export async function requireAdmin(
   }
 
   return { isValid: true, user: { email: user.email } };
+}
+
+/**
+ * Email of an admin user, or null if missing/invalid token or caller is not in {@link ADMIN_EMAILS}.
+ */
+export async function getAuthenticatedAdminEmail(
+  request: NextRequest
+): Promise<string | null> {
+  const email = await getPrivyUserEmailFromRequest(request);
+  if (!email || !checkAdminPermission(email)) {
+    return null;
+  }
+  return email;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin API routes previously treated `x-user-email` as proof of identity, which any client could spoof. This change removes that trust model and gates admin access on a verified Privy access token (`Authorization: Bearer`) plus the existing allowlist in `lib/db/admin.ts`.

## Follow-up fix

- **`app/admin/location-lists/page.tsx`**: Restored the missing `const {` before the second `useQuery` destructuring (syntax error from a bad merge) and removed an unused `adminEmail` variable that failed ESLint during `yarn build`.

## What changed (original)

- **`lib/api/privy.ts`**: Added `getPrivyUserEmailFromRequest()` (verify JWT → `getUser` → normalized email). `getPrivyUserIdFromRequest` now trims empty Bearer tokens.
- **`lib/auth.ts`**: `getUserFromRequest`, `requireAdmin`, and exported `getAuthenticatedAdminEmail` all derive identity from the verified Privy helper only.
- **Admin API routes**: Replaced `x-user-email` checks with `getAuthenticatedAdminEmail` (or existing `requireAdmin` now backed by JWT).
- **`/api/admin/auth` POST** and **`/api/admin/users` POST**: Admin check requires Bearer token; body email is no longer accepted as proof.
- **`/api/locations`**: `includeHidden=true` requires verified admin JWT; optional verified email on POST for analytics (no longer from spoofable header).
- **Admin UI + map**: New helper `lib/admin-api-auth-headers.ts`; fetches use `getAccessToken()` + `Authorization` header.
- **`lib/auth.test.ts`**: Unit coverage for auth helpers (mocked Privy email resolver).

## Testing

`yarn build` completed successfully in this environment (Node 18.19.1; `yarn install --ignore-engines` used due to WalletConnect engine constraint vs distro Node).

## Notes

- Admin clients must be logged in with Privy so `getAccessToken()` succeeds; unauthenticated calls correctly receive 403.
- Non-admin authenticated users still get 403 on admin routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d54419a8-bdc4-4ad4-ba08-8c6a8ab71cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d54419a8-bdc4-4ad4-ba08-8c6a8ab71cd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

