### PR TITLE
chore: add Cursor Cloud environment.json

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,3 @@
+{
+  "install": "yarn install --frozen-lockfile"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds [`.cursor/environment.json`](https://cursor.com/docs/cloud-agent/setup.md#the-environmentjson-spec) so **Cursor Cloud Agents** use a repo-defined **install** step. Per Cursor docs, this file takes precedence over personal/team dashboard environment settings when present, which keeps cloud setup versioned with the repo and matches **AGENTS.md** (Yarn 1, frozen lockfile).

## Changes

- **`install`:** `yarn install --frozen-lockfile`

## Notes

- If cloud installs still fail, the next checks are a committed in-sync `yarn.lock`, Cloud Agent **secrets** for private packages, and any native optional deps on the VM—not this file’s shape.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ceea0d49-3ae7-49bd-b1d9-f7ecb605942c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ceea0d49-3ae7-49bd-b1d9-f7ecb605942c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

