### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,10 +75,13 @@ Copy `.env.local.example` to `.env.local` for local config. The app runs without
 - Dynamic imports where code-splitting helps.
 - Small, focused components; document non-obvious decisions in code or PR.
 
-## Cursor Cloud / single-process setup
+## Cursor Cloud specific instructions
 
 - Only local process: Next.js dev server (`yarn dev`). Supabase, Privy, Mapbox, Mixpanel, RPCs are external; no Docker or local DB.
 - **Gotchas:** Optional `canvas` build warnings are safe to ignore. Use `yarn test` (Vitest); ignore docs that mention Jest. Lint may show known `<img>` vs `<Image />` warnings; they are non-blocking.
+- **Pre-existing test failures:** `components/location-search.test.tsx`, `components/layout/user-menu.test.tsx`, and `lib/db/__tests__/admin.test.ts` have known failures on `main`. Do not treat these as regressions unless your changes touch those files.
+- **Pre-commit hook:** `.husky/pre-commit` runs `yarn build`, which takes time. The build will produce `canvas` warnings — these are safe to ignore.
+- **Environment:** Copy `.env.local.example` → `.env.local`. The app renders pages without real credentials, but auth/database flows require valid Privy/Supabase keys.
 
 ## References
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `AGENTS.md` with a dedicated "Cursor Cloud specific instructions" section containing non-obvious setup notes discovered during dev environment setup:

- Document pre-existing test failures on `main` (`location-search.test.tsx`, `user-menu.test.tsx`, `admin.test.ts`) so future agents don't treat them as regressions
- Note that `.husky/pre-commit` runs `yarn build` (produces safe-to-ignore `canvas` warnings)
- Clarify `.env.local` setup and credential requirements

## Dev Environment Verification

The following were verified during setup:

| Check | Result |
|-------|--------|
| `yarn install` | OK (66s, warnings only) |
| `yarn lint` | OK (warnings only — known `<img>` vs `<Image />`) |
| `yarn test` | 960 passed / 17 pre-existing failures |
| `yarn dev` | Server starts on :3000, pages render |
| Browser navigation | Home → Perks → Interactive Map all load |

### Demo

[irl_dev_server_demo.mp4](https://cursor.com/agents/bc-dcac8b6a-b769-480b-ad47-10deedff377b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Firl_dev_server_demo.mp4)

[Homepage loaded](https://cursor.com/agents/bc-dcac8b6a-b769-480b-ad47-10deedff377b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage_loaded.webp)
[Perks page](https://cursor.com/agents/bc-dcac8b6a-b769-480b-ad47-10deedff377b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fperks_page.webp)
[Interactive map](https://cursor.com/agents/bc-dcac8b6a-b769-480b-ad47-10deedff377b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Finteractive_map.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dcac8b6a-b769-480b-ad47-10deedff377b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dcac8b6a-b769-480b-ad47-10deedff377b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

