### PR TITLE
style: align /spend/[id] pages with IRL mobile detail UI

### DIFF
--- a/app/spend/[id]/page.tsx
+++ b/app/spend/[id]/page.tsx
@@ -7,6 +7,7 @@ import { apiClient } from '@/lib/api/client';
 import type { SpendExperience, SpendItem } from '@/lib/types';
 import { SpendItemPage } from '@/components/spend/spend-item-page';
 import { SpendExperiencePage } from '@/components/spend/spend-experience-page';
+import { SpendPageShell } from '@/components/spend/spend-page-shell';
 
 type ResolveResponse =
   | { kind: 'spend_experience'; spendExperience: SpendExperience }
@@ -30,19 +31,23 @@ export default function SpendRoutePage() {
 
   if (isLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <Loader2 className="size-8 animate-spin text-neutral-500" />
-      </div>
+      <SpendPageShell>
+        <div className="flex min-h-[40vh] items-center justify-center rounded-2xl bg-white p-8">
+          <Loader2 className="size-8 animate-spin text-gray-400" />
+        </div>
+      </SpendPageShell>
     );
   }
 
   if (error || !data) {
     return (
-      <div className="flex min-h-screen items-center justify-center p-6">
-        <p className="text-center text-neutral-600">
-          This spend link is not available.
-        </p>
-      </div>
+      <SpendPageShell>
+        <div className="rounded-2xl bg-white p-8 text-center">
+          <p className="font-inktrap text-sm text-gray-600">
+            This spend link is not available.
+          </p>
+        </div>
+      </SpendPageShell>
     );
   }
 

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -5,7 +5,11 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy, useSendTransaction, useWallets } from '@privy-io/react-auth';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
-import { Button } from '@/components/ui/button';
+import {
+  SpendPageShell,
+  spendPrimaryCtaClass,
+} from '@/components/spend/spend-page-shell';
+import { cn } from '@/lib/utils';
 import type {
   PointConversion,
   SpendExperience,
@@ -142,9 +146,9 @@ function eligibilityToneClass(status: SpendEligibilityStatus): string {
     status === 'ready_for_payment_own_usdc' ||
     status === 'payment_complete'
   ) {
-    return 'text-sm text-emerald-800';
+    return 'text-sm font-inktrap text-emerald-800';
   }
-  return 'text-sm text-amber-900';
+  return 'text-sm font-inktrap text-amber-900';
 }
 
 /**
@@ -459,169 +463,214 @@ export function SpendExperiencePage({
     `https://basescan.org/tx/${hash.trim()}`;
 
   return (
-    <div className="container mx-auto max-w-lg p-6">
-      <h1 className="mb-2 text-2xl font-bold text-[#171717]">
-        {experience.title}
-      </h1>
-      {experience.description && (
-        <p className="mb-4 text-neutral-600">{experience.description}</p>
-      )}
+    <SpendPageShell>
+      <div className="rounded-2xl bg-white p-4">
+        <h1 className="mb-2 text-xl font-bold text-black font-inktrap">
+          {experience.title}
+        </h1>
+        {experience.description && (
+          <p className="text-sm leading-relaxed text-gray-600 font-inktrap">
+            {experience.description}
+          </p>
+        )}
+      </div>
 
-      <div className="mb-6 space-y-2 rounded-lg border border-neutral-200 bg-neutral-50 p-4 text-sm">
-        <div className="flex justify-between">
-          <span className="text-neutral-600">Status</span>
-          <span className="font-medium capitalize">{experience.status}</span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-neutral-600">Max USDC / user</span>
-          <span className="font-medium">
-            ${Number(experience.max_usdc_per_user).toFixed(2)}
-          </span>
-        </div>
-        <div className="flex justify-between">
-          <span className="text-neutral-600">Points per $1 USDC</span>
-          <span className="font-medium">
-            {Number(experience.points_to_usdc_rate).toLocaleString()} pts
-          </span>
+      <div className="rounded-2xl bg-white p-4">
+        <p className="mb-3 text-xs font-inktrap font-bold uppercase tracking-wide text-black">
+          Experience details
+        </p>
+        <div className="space-y-3 rounded-2xl border-2 border-gray-100 bg-gray-50/90 p-4 text-sm font-inktrap">
+          <div className="flex justify-between gap-2">
+            <span className="text-gray-600">Status</span>
+            <span className="font-semibold capitalize text-black">
+              {experience.status}
+            </span>
+          </div>
+          <div className="flex justify-between gap-2">
+            <span className="text-gray-600">Max USDC / user</span>
+            <span className="font-semibold text-black">
+              ${Number(experience.max_usdc_per_user).toFixed(2)}
+            </span>
+          </div>
+          <div className="flex justify-between gap-2">
+            <span className="text-gray-600">Points per $1 USDC</span>
+            <span className="font-semibold text-black">
+              {Number(experience.points_to_usdc_rate).toLocaleString()} pts
+            </span>
+          </div>
         </div>
       </div>
 
       {!user && (
-        <Button className="w-full" onClick={login}>
-          Log in to continue
-        </Button>
+        <div className="rounded-2xl bg-white p-4">
+          <button
+            type="button"
+            onClick={login}
+            className={cn(
+              spendPrimaryCtaClass,
+              'bg-black text-white hover:bg-gray-800'
+            )}
+          >
+            Log in to continue
+          </button>
+        </div>
       )}
 
       {showWalletBlock && (
-        <p className="text-sm text-amber-800">
-          {SPEND_ELIGIBILITY_MESSAGES.wallet_unavailable}
-        </p>
+        <div className="rounded-2xl border-2 border-amber-200 bg-amber-50/90 p-4">
+          <p className="text-sm font-inktrap text-amber-900">
+            {SPEND_ELIGIBILITY_MESSAGES.wallet_unavailable}
+          </p>
+        </div>
       )}
 
       {user && walletAddress && (
         <div className="space-y-4">
           {isFetching && (
-            <div className="flex items-center gap-2 text-sm text-neutral-600">
-              <Loader2 className="size-4 animate-spin" />
+            <div className="flex items-center gap-2 rounded-2xl bg-white p-4 text-sm text-gray-600 font-inktrap">
+              <Loader2 className="size-4 shrink-0 animate-spin" />
               Starting your session…
             </div>
           )}
 
           {showSessionError && !isFetching && (
-            <p className="text-sm text-red-800">
-              {SPEND_ELIGIBILITY_MESSAGES.experience_inactive}
-            </p>
+            <div className="rounded-2xl border-2 border-red-200 bg-red-50/90 p-4">
+              <p className="text-sm font-inktrap text-red-800">
+                {SPEND_ELIGIBILITY_MESSAGES.experience_inactive}
+              </p>
+            </div>
           )}
 
           {session && !isFetching && !showSessionError && (
             <>
               {previewLoading && (
-                <div className="flex items-center gap-2 text-sm text-neutral-600">
-                  <Loader2 className="size-4 animate-spin" />
+                <div className="flex items-center gap-2 rounded-2xl bg-white p-4 text-sm text-gray-600 font-inktrap">
+                  <Loader2 className="size-4 shrink-0 animate-spin" />
                   Checking your balance and event funds…
                 </div>
               )}
 
               {elig && !previewLoading && (
-                <div className="space-y-3">
+                <div className="space-y-4">
                   {preview && (
-                    <div className="space-y-2 rounded-lg border border-neutral-200 bg-white p-4 text-sm">
-                      {showPayDirectUsdc ? (
-                        <>
-                          <div className="flex justify-between">
-                            <span className="text-neutral-600">Pay</span>
-                            <span className="font-medium">
-                              ${preview.usdcAmount.toFixed(2)} USDC
-                            </span>
-                          </div>
-                          {preview.userUsdcBalance != null && (
-                            <div className="flex justify-between text-neutral-500">
-                              <span>Your wallet (Base)</span>
-                              <span>
-                                ${preview.userUsdcBalance.toFixed(2)} USDC
+                    <div className="rounded-2xl bg-white p-4">
+                      <p className="mb-3 text-xs font-inktrap font-bold uppercase tracking-wide text-black">
+                        {showPayDirectUsdc ? 'Payment' : 'Conversion'}
+                      </p>
+                      <div className="space-y-3 rounded-2xl border-2 border-gray-100 bg-gray-50/90 p-4 text-sm font-inktrap">
+                        {showPayDirectUsdc ? (
+                          <>
+                            <div className="flex justify-between gap-2">
+                              <span className="text-gray-600">Pay</span>
+                              <span className="font-semibold text-black">
+                                ${preview.usdcAmount.toFixed(2)} USDC
                               </span>
                             </div>
-                          )}
-                        </>
-                      ) : (
-                        <>
-                          <div className="flex justify-between">
-                            <span className="text-neutral-600">
-                              You will use
-                            </span>
-                            <span className="font-medium">
-                              {preview.pointsRequired.toLocaleString()} points
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-neutral-600">
-                              You will receive
-                            </span>
-                            <span className="font-medium">
-                              ${preview.usdcAmount.toFixed(2)} USDC
-                            </span>
-                          </div>
-                          {preview.userPointsBalance != null && (
-                            <div className="flex justify-between text-neutral-500">
-                              <span>Your points balance</span>
-                              <span>
-                                {Number(
-                                  preview.userPointsBalance
-                                ).toLocaleString()}
+                            {preview.userUsdcBalance != null && (
+                              <div className="flex justify-between gap-2 text-gray-600">
+                                <span>Your wallet (Base)</span>
+                                <span>
+                                  ${preview.userUsdcBalance.toFixed(2)} USDC
+                                </span>
+                              </div>
+                            )}
+                          </>
+                        ) : (
+                          <>
+                            <div className="flex justify-between gap-2">
+                              <span className="text-gray-600">You will use</span>
+                              <span className="font-semibold text-black">
+                                {preview.pointsRequired.toLocaleString()} points
                               </span>
                             </div>
-                          )}
-                        </>
-                      )}
+                            <div className="flex justify-between gap-2">
+                              <span className="text-gray-600">
+                                You will receive
+                              </span>
+                              <span className="font-semibold text-black">
+                                ${preview.usdcAmount.toFixed(2)} USDC
+                              </span>
+                            </div>
+                            {preview.userPointsBalance != null && (
+                              <div className="flex justify-between gap-2 text-gray-600">
+                                <span>Your points balance</span>
+                                <span>
+                                  {Number(
+                                    preview.userPointsBalance
+                                  ).toLocaleString()}
+                                </span>
+                              </div>
+                            )}
+                          </>
+                        )}
+                      </div>
                     </div>
                   )}
 
-                  <p className={eligibilityToneClass(elig.status)}>
-                    {elig.message}
-                  </p>
+                  <div className="rounded-2xl bg-white p-4">
+                    <p className={eligibilityToneClass(elig.status)}>
+                      {elig.message}
+                    </p>
+                  </div>
 
                   {showConvert && (
-                    <Button
-                      className="w-full"
-                      disabled={conversionMutation.isPending}
-                      onClick={() => conversionMutation.mutate()}
-                    >
-                      {conversionMutation.isPending ? (
-                        <>
-                          <Loader2 className="mr-2 size-4 animate-spin" />
-                          Converting…
-                        </>
-                      ) : (
-                        'Convert points to USDC'
-                      )}
-                    </Button>
+                    <div className="rounded-2xl bg-white p-4">
+                      <button
+                        type="button"
+                        className={cn(
+                          spendPrimaryCtaClass,
+                          'inline-flex items-center justify-center gap-2',
+                          conversionMutation.isPending
+                            ? 'bg-gray-100 text-gray-500'
+                            : 'bg-black text-white hover:bg-gray-800'
+                        )}
+                        disabled={conversionMutation.isPending}
+                        onClick={() => conversionMutation.mutate()}
+                      >
+                        {conversionMutation.isPending ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            Converting…
+                          </>
+                        ) : (
+                          'Convert points to USDC'
+                        )}
+                      </button>
+                    </div>
                   )}
 
                   {showPay && (
-                    <Button
-                      className="w-full"
-                      disabled={paymentMutation.isPending}
-                      onClick={() => void sendUsdcPayment()}
-                    >
-                      {paymentMutation.isPending ? (
-                        <>
-                          <Loader2 className="mr-2 size-4 animate-spin" />
-                          Pay with USDC…
-                        </>
-                      ) : (
-                        `Spend $${preview.usdcAmount.toFixed(2)} USDC`
-                      )}
-                    </Button>
+                    <div className="rounded-2xl bg-white p-4">
+                      <button
+                        type="button"
+                        className={cn(
+                          spendPrimaryCtaClass,
+                          'inline-flex items-center justify-center gap-2',
+                          paymentMutation.isPending
+                            ? 'bg-gray-100 text-gray-500'
+                            : 'bg-black text-white hover:bg-gray-800'
+                        )}
+                        disabled={paymentMutation.isPending}
+                        onClick={() => void sendUsdcPayment()}
+                      >
+                        {paymentMutation.isPending ? (
+                          <>
+                            <Loader2 className="size-4 animate-spin" />
+                            Pay with USDC…
+                          </>
+                        ) : (
+                          `Spend $${preview.usdcAmount.toFixed(2)} USDC`
+                        )}
+                      </button>
+                    </div>
                   )}
 
                   {displayReceipt && (
-                    <div className="space-y-3 rounded-lg border border-emerald-200 bg-emerald-50/80 p-4 text-sm text-[#171717]">
-                      <p className="font-semibold text-emerald-900">
-                        Payment complete
-                      </p>
+                    <div className="space-y-3 rounded-2xl border-2 border-green-200 bg-green-50/90 p-4 text-sm text-black font-inktrap">
+                      <p className="font-bold text-green-900">Payment complete</p>
                       <div className="flex justify-between gap-2">
-                        <span className="text-neutral-600">Amount</span>
-                        <span className="font-medium">
+                        <span className="text-gray-600">Amount</span>
+                        <span className="font-semibold">
                           $
                           {(
                             receiptConversion?.usdc_amount ??
@@ -632,8 +681,8 @@ export function SpendExperiencePage({
                         </span>
                       </div>
                       <div className="flex justify-between gap-2">
-                        <span className="text-neutral-600">Points used</span>
-                        <span className="font-medium">
+                        <span className="text-gray-600">Points used</span>
+                        <span className="font-semibold">
                           {Number(
                             receiptConversion?.points_deducted ??
                               (displayReceipt && !receiptConversion
@@ -643,8 +692,10 @@ export function SpendExperiencePage({
                         </span>
                       </div>
                       <div>
-                        <p className="text-xs text-neutral-600">Session</p>
-                        <p className="break-all font-mono text-xs">
+                        <p className="text-xs uppercase tracking-wide text-gray-600">
+                          Session
+                        </p>
+                        <p className="break-all font-mono text-xs text-gray-800">
                           {receiptSession?.id}
                         </p>
                       </div>
@@ -653,7 +704,7 @@ export function SpendExperiencePage({
                           href={basescanUrl(receiptPaymentHash)}
                           target="_blank"
                           rel="noreferrer"
-                          className="inline-flex items-center gap-1 text-sm font-medium text-emerald-900 underline"
+                          className="inline-flex items-center gap-1 text-sm font-semibold text-green-800 underline"
                         >
                           View payment on BaseScan
                           <ExternalLink className="size-3.5" />
@@ -667,6 +718,6 @@ export function SpendExperiencePage({
           )}
         </div>
       )}
-    </div>
+    </SpendPageShell>
   );
 }

--- a/components/spend/spend-item-page.tsx
+++ b/components/spend/spend-item-page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { Button } from '@/components/ui/button';
+import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import {
   useSpendItem,
@@ -12,6 +12,11 @@ import {
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import { usePrivy } from '@privy-io/react-auth';
 import type { SpendRedemption } from '@/lib/types';
+import {
+  SpendPageShell,
+  spendPrimaryCtaClass,
+} from '@/components/spend/spend-page-shell';
+import { cn } from '@/lib/utils';
 
 type SpendItemPageProps = {
   itemId: string;
@@ -82,97 +87,142 @@ export function SpendItemPage({ itemId }: SpendItemPageProps) {
 
   if (itemLoading) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        Loading...
-      </div>
+      <SpendPageShell>
+        <div className="flex min-h-[40vh] items-center justify-center rounded-2xl bg-white p-8">
+          <Loader2 className="size-8 animate-spin text-gray-400" />
+        </div>
+      </SpendPageShell>
     );
   }
 
   if (!item) {
     return (
-      <div className="flex min-h-screen items-center justify-center">
-        <p>Item not found</p>
-      </div>
+      <SpendPageShell>
+        <div className="rounded-2xl bg-white p-8 text-center">
+          <p className="font-inktrap text-sm text-gray-600">Item not found</p>
+        </div>
+      </SpendPageShell>
     );
   }
 
   return (
-    <div className="container mx-auto max-w-lg p-6">
+    <SpendPageShell>
       {item.image_url && (
-        <div className="mb-6">
-          <Image
-            src={item.image_url}
-            alt={item.name}
-            width={600}
-            height={400}
-            className="w-full rounded-lg object-cover"
-          />
+        <div className="overflow-hidden rounded-2xl bg-white p-2">
+          <div className="relative aspect-[3/2] w-full overflow-hidden rounded-xl bg-gray-100">
+            <Image
+              src={item.image_url}
+              alt={item.name}
+              fill
+              className="object-cover"
+              sizes="(max-width: 512px) 100vw, 512px"
+            />
+          </div>
         </div>
       )}
 
-      <h1 className="mb-2 text-2xl font-bold">{item.name}</h1>
+      <div className="rounded-2xl bg-white p-4">
+        <h1 className="mb-2 text-xl font-bold text-black font-inktrap">
+          {item.name}
+        </h1>
+        {item.description && (
+          <p className="mb-4 text-sm leading-relaxed text-gray-600 font-inktrap">
+            {item.description}
+          </p>
+        )}
 
-      {item.description && (
-        <p className="mb-4 text-gray-600">{item.description}</p>
-      )}
-
-      <div className="mb-6 space-y-2 rounded-lg bg-gray-50 p-4">
-        <div className="flex justify-between text-sm">
-          <span className="text-gray-600">Cost</span>
-          <span className="font-semibold">
-            {item.points_cost.toLocaleString()} points
-          </span>
-        </div>
-        {walletAddress && (
-          <div className="flex justify-between text-sm">
-            <span className="text-gray-600">Your Balance</span>
-            <span className="font-semibold">
-              {currentPoints.toLocaleString()} points
+        <div className="space-y-3 rounded-2xl border-2 border-gray-100 bg-gray-50/90 p-4">
+          <div className="flex justify-between gap-2 text-sm font-inktrap">
+            <span className="text-gray-600">Cost</span>
+            <span className="font-semibold text-black">
+              {item.points_cost.toLocaleString()} points
             </span>
           </div>
-        )}
+          {walletAddress && (
+            <div className="flex justify-between gap-2 text-sm font-inktrap">
+              <span className="text-gray-600">Your balance</span>
+              <span className="font-semibold text-black">
+                {currentPoints.toLocaleString()} points
+              </span>
+            </div>
+          )}
+        </div>
       </div>
 
       {!user ? (
-        <Button className="w-full" onClick={login}>
-          Login to Get Drink Ticket
-        </Button>
+        <div className="rounded-2xl bg-white p-4">
+          <button
+            type="button"
+            onClick={login}
+            className={cn(spendPrimaryCtaClass, 'bg-black text-white hover:bg-gray-800')}
+          >
+            Login to get drink ticket
+          </button>
+        </div>
       ) : (
         <>
-          <Button
-            className="mb-6 w-full"
-            onClick={() => void handleGetTicket()}
-            disabled={createMutation.isPending}
-          >
-            {createMutation.isPending ? 'Creating...' : 'Get Drink Ticket'}
-          </Button>
+          <div className="rounded-2xl bg-white p-4">
+            <button
+              type="button"
+              className={cn(
+                spendPrimaryCtaClass,
+                createMutation.isPending
+                  ? 'bg-gray-100 text-gray-500'
+                  : 'bg-black text-white hover:bg-gray-800'
+              )}
+              onClick={() => void handleGetTicket()}
+              disabled={createMutation.isPending}
+            >
+              {createMutation.isPending ? (
+                <span className="inline-flex items-center gap-2">
+                  <Loader2 className="size-4 animate-spin" />
+                  Creating…
+                </span>
+              ) : (
+                'Get drink ticket'
+              )}
+            </button>
+          </div>
 
           {pending.length > 0 && (
-            <div className="mb-4">
-              <h2 className="mb-2 text-sm font-semibold text-gray-700">
+            <div className="rounded-2xl bg-white p-4">
+              <p className="mb-3 text-xs font-inktrap font-bold uppercase tracking-wide text-black">
                 Pending – verify at the bar
-              </h2>
-              <ul className="space-y-2">
+              </p>
+              <ul className="space-y-3">
                 {pending.map((r) => (
                   <li
                     key={r.id}
-                    className="flex items-center justify-between gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3"
+                    className="flex flex-col gap-3 rounded-2xl border-2 border-orange-200 bg-orange-50/90 p-4 sm:flex-row sm:items-center sm:justify-between"
                   >
-                    <span className="text-sm">
+                    <span className="text-sm text-gray-800 font-inktrap">
                       {r.points_spent} points – not yet verified
                     </span>
-                    <Button
-                      size="sm"
+                    <button
+                      type="button"
+                      className={cn(
+                        spendPrimaryCtaClass,
+                        'shrink-0 px-6 py-2 sm:w-auto',
+                        verifyMutation.isPending ||
+                          currentPoints < r.points_spent
+                          ? 'bg-gray-100 text-gray-500'
+                          : 'bg-black text-white hover:bg-gray-800'
+                      )}
                       onClick={() => void handleVerify(r.id!)}
                       disabled={
                         verifyMutation.isPending ||
                         currentPoints < r.points_spent
                       }
                     >
-                      {verifyMutation.isPending
-                        ? 'Verifying...'
-                        : 'Verify at bar'}
-                    </Button>
+                      {verifyMutation.isPending ? (
+                        <span className="inline-flex items-center gap-2">
+                          <Loader2 className="size-4 animate-spin" />
+                          Verifying…
+                        </span>
+                      ) : (
+                        'Verify at bar'
+                      )}
+                    </button>
                   </li>
                 ))}
               </ul>
@@ -180,15 +230,15 @@ export function SpendItemPage({ itemId }: SpendItemPageProps) {
           )}
 
           {verified.length > 0 && (
-            <div>
-              <h2 className="mb-2 text-sm font-semibold text-gray-700">
+            <div className="rounded-2xl bg-white p-4">
+              <p className="mb-3 text-xs font-inktrap font-bold uppercase tracking-wide text-black">
                 Verified
-              </h2>
-              <ul className="space-y-2">
+              </p>
+              <ul className="space-y-3">
                 {verified.map((r) => (
                   <li
                     key={r.id}
-                    className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-3 text-sm text-gray-600"
+                    className="flex items-center justify-between gap-2 rounded-2xl border-2 border-green-200 bg-green-50/90 p-4 text-sm font-inktrap text-gray-800"
                   >
                     <span>
                       {r.points_spent} points
@@ -196,7 +246,7 @@ export function SpendItemPage({ itemId }: SpendItemPageProps) {
                         ? ` · ${new Date(r.fulfilled_at).toLocaleDateString()}`
                         : ''}
                     </span>
-                    <span className="font-medium text-green-700">Verified</span>
+                    <span className="font-semibold text-green-800">Verified</span>
                   </li>
                 ))}
               </ul>
@@ -204,6 +254,6 @@ export function SpendItemPage({ itemId }: SpendItemPageProps) {
           )}
         </>
       )}
-    </div>
+    </SpendPageShell>
   );
 }

--- a/components/spend/spend-page-shell.tsx
+++ b/components/spend/spend-page-shell.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import Header from '@/components/layout/header';
+
+/** Matches perk / rewards mobile detail screens (IRL Production v2). */
+export const SPEND_PAGE_GRADIENT =
+  'linear-gradient(0deg, #61BFD1 0%, #1BA351 33.66%, #FFE600 62.5%, #EE91B7 100%)';
+
+/** Primary action: black pill, same as `/perks/[perkId]`. */
+export const spendPrimaryCtaClass =
+  'w-full rounded-full py-3 font-inktrap text-sm font-medium transition-colors disabled:pointer-events-none disabled:opacity-50';
+
+type SpendPageShellProps = {
+  children: React.ReactNode;
+  backHref?: string;
+  backLabel?: string;
+};
+
+export function SpendPageShell({
+  children,
+  backHref = '/',
+  backLabel = 'Back',
+}: SpendPageShellProps) {
+  return (
+    <div
+      style={{ background: SPEND_PAGE_GRADIENT }}
+      className="min-h-screen p-4 pb-0 font-grotesk"
+    >
+      <div className="mx-auto min-h-screen max-w-lg">
+        <Header />
+
+        <div className="mb-4 px-0 pt-16">
+          <div className="rounded-2xl bg-white p-4">
+            <Link
+              href={backHref}
+              className="flex items-center text-sm font-inktrap text-gray-600 transition-opacity hover:opacity-80"
+            >
+              <ArrowLeft className="mr-1 h-4 w-4 shrink-0" />
+              {backLabel}
+            </Link>
+          </div>
+        </div>
+
+        <div className="space-y-4 px-0 pb-8">{children}</div>
+
+        <div className="py-6">
+          {/* Match perks detail: decorative footer mark */}
+          <img
+            src="/irl-bottom-logo.svg"
+            alt="IRL"
+            className="h-auto w-full"
+          />
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `/spend/[id]` (both legacy spend items and spend pilot experiences) to match the same visual language as other mobile detail flows (e.g. perk detail): brand gradient background, glass `Header`, white `rounded-2xl` cards, Inktrap typography, and black pill primary actions.

## Changes

- New `SpendPageShell` (`components/spend/spend-page-shell.tsx`) with the same gradient as `/perks/[perkId]`, back link, and bottom IRL mark.
- Refactored `SpendItemPage` and `SpendExperiencePage` to use the shell and card layout; UX and copy behavior are unchanged aside from minor label casing for consistency.
- Route-level loading and “link not available” states use the shell so the experience is consistent end-to-end.

## Notes

The linked Figma file did not load in the agent environment; implementation follows existing in-repo patterns from the perks detail page, which should align with IRL Production v2.

## Testing

- Lint/tests not run locally (yarn unavailable in agent container). CI should validate.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d44d60ca-1add-430f-8041-3e92fd88a13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d44d60ca-1add-430f-8041-3e92fd88a13d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

