### PR TITLE
fix: configure Cursor cloud Node environment

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:22-bookworm
+
+RUN corepack enable \
+  && corepack prepare yarn@1.22.22 --activate

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,7 @@
 {
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": ".."
+  },
   "install": "yarn install --frozen-lockfile"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a repo-managed Cursor Cloud Dockerfile based on Node 22
- Activate Yarn 1.22.22 via Corepack before the install step runs
- Keep the environment install command as `yarn install --frozen-lockfile`

## Testing
- Not run locally: current Cloud image does not have node/npm/yarn installed before this environment config is applied
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-732af936-d640-42b6-a859-32a0520ab386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-732af936-d640-42b6-a859-32a0520ab386"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

