### PR TITLE
fix(spend): consistent conversion card surface and post-conversion balances

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -148,6 +148,16 @@ function eligibilityToneClass(status: SpendEligibilityStatus): string {
   return 'body-small font-grotesk text-amber-900';
 }
 
+/** After a points→USDC conversion (or that path through payment), balances reflect deducted points and funded USDC. */
+function isPostPointsConversionFlow(status: SpendEligibilityStatus): boolean {
+  return (
+    status === 'ready_for_payment' ||
+    status === 'conversion_in_progress' ||
+    status === 'payment_failed' ||
+    status === 'payment_complete'
+  );
+}
+
 /**
  * Spend pilot: opens from QR at `/spend/{experienceId}`; creates/returns a session when authed.
  */
@@ -441,6 +451,10 @@ export function SpendExperiencePage({
 
   const showPayDirectUsdc = elig?.status === 'ready_for_payment_own_usdc';
 
+  const postPointsConversion =
+    Boolean(elig?.status && isPostPointsConversionFlow(elig.status)) &&
+    !showPayDirectUsdc;
+
   const showConvert =
     elig?.status === 'eligible' &&
     preview &&
@@ -540,7 +554,7 @@ export function SpendExperiencePage({
                 {elig && !previewLoading && (
                   <div className="space-y-4">
                     {preview && (
-                      <div className="space-y-3 rounded-sm border border-[#ededed] bg-white p-4">
+                      <div className="space-y-3 rounded-sm border border-[#ededed] bg-[#fafafa] p-4">
                         {showPayDirectUsdc ? (
                           <>
                             <div className="flex justify-between gap-4">
@@ -583,15 +597,34 @@ export function SpendExperiencePage({
                             {preview.userPointsBalance != null && (
                               <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
                                 <span className="body-small font-grotesk text-[#757575]">
-                                  Your points balance
+                                  {postPointsConversion
+                                    ? 'Points remaining'
+                                    : 'Your points balance'}
                                 </span>
-                                <span className="body-medium font-grotesk text-[#171717]">
+                                <span
+                                  className={
+                                    postPointsConversion
+                                      ? 'body-medium font-grotesk font-semibold text-[#171717]'
+                                      : 'body-medium font-grotesk text-[#171717]'
+                                  }
+                                >
                                   {Number(
                                     preview.userPointsBalance
                                   ).toLocaleString()}
                                 </span>
                               </div>
                             )}
+                            {postPointsConversion &&
+                              preview.userUsdcBalance != null && (
+                                <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
+                                  <span className="body-small font-grotesk text-[#757575]">
+                                    USDC balance
+                                  </span>
+                                  <span className="body-medium font-grotesk font-semibold text-[#171717]">
+                                    ${preview.userUsdcBalance.toFixed(2)} USDC
+                                  </span>
+                                </div>
+                              )}
                           </>
                         )}
                       </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Matched the spend conversion summary card background to the experience details block (`#fafafa`) so nested cards no longer read as a different gray/white against the frosted shell.
- After a points-based conversion path (`ready_for_payment`, `conversion_in_progress`, `payment_failed`, `payment_complete`), the points row is labeled **Points remaining** and a **USDC balance** row is shown when the preview includes on-chain wallet USDC.

## Notes

- USDC and remaining points come from the existing conversion preview payload (`userUsdcBalance`, `userPointsBalance` from the server after points are deducted).

## Testing

- `yarn lint` (existing warnings only)
- Pre-commit `yarn build` succeeded on commit
- `yarn test` still shows known failures in `location-search` and `user-menu` (unchanged files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-810341d8-4df3-42ee-98d3-458d19f79f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-810341d8-4df3-42ee-98d3-458d19f79f0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

