### PR TITLE
feat: hide status/USDC details for unauthenticated spend experience view

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -485,32 +485,34 @@ export function SpendExperiencePage({
           )}
         </div>
 
-        <div className="space-y-3 rounded-sm border border-[#ededed] bg-[#fafafa] p-4">
-          <div className="flex justify-between gap-4">
-            <span className="body-small font-grotesk text-[#757575]">
-              Status
-            </span>
-            <span className="body-medium font-grotesk font-semibold capitalize text-[#171717]">
-              {experience.status}
-            </span>
+        {user && (
+          <div className="space-y-3 rounded-sm border border-[#ededed] bg-[#fafafa] p-4">
+            <div className="flex justify-between gap-4">
+              <span className="body-small font-grotesk text-[#757575]">
+                Status
+              </span>
+              <span className="body-medium font-grotesk font-semibold capitalize text-[#171717]">
+                {experience.status}
+              </span>
+            </div>
+            <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
+              <span className="body-small font-grotesk text-[#757575]">
+                Max USDC / user
+              </span>
+              <span className="body-medium font-grotesk font-semibold text-[#171717]">
+                ${Number(experience.max_usdc_per_user).toFixed(2)}
+              </span>
+            </div>
+            <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
+              <span className="body-small font-grotesk text-[#757575]">
+                Points per $1 USDC
+              </span>
+              <span className="body-medium font-grotesk font-semibold text-[#171717]">
+                {Number(experience.points_to_usdc_rate).toLocaleString()} pts
+              </span>
+            </div>
           </div>
-          <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
-            <span className="body-small font-grotesk text-[#757575]">
-              Max USDC / user
-            </span>
-            <span className="body-medium font-grotesk font-semibold text-[#171717]">
-              ${Number(experience.max_usdc_per_user).toFixed(2)}
-            </span>
-          </div>
-          <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
-            <span className="body-small font-grotesk text-[#757575]">
-              Points per $1 USDC
-            </span>
-            <span className="body-medium font-grotesk font-semibold text-[#171717]">
-              {Number(experience.points_to_usdc_rate).toLocaleString()} pts
-            </span>
-          </div>
-        </div>
+        )}
 
         {!user && (
           <SpendPrimaryButton onClick={login}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

On the `/spend/:id` page, the unauthenticated view previously showed a details card with **Status**, **Max USDC / user**, and **Points per $1 USDC** fields before the "Log in to continue" CTA.

This change wraps that details card in `{user && (...)}` so it is only rendered for authenticated users. Unauthenticated visitors now see only the experience title, description, and the "Log in to continue" button.

## Changes

- `components/spend/spend-experience-page.tsx`: Wrapped the Status / Max USDC / Points info block in a `{user && ...}` guard.

## Testing

- ✅ `yarn lint` — no new errors (pre-existing `<img>` warnings only)
- ✅ `yarn build` — production build succeeds
- ✅ `yarn test` — no new failures (pre-existing failures in unrelated files)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7a1af9c6-988e-4a58-a059-72378d19d3cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a1af9c6-988e-4a58-a059-72378d19d3cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

