### PR TITLE
feat: hide conversion preview rows and show dynamic message post-conversion

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -578,24 +578,35 @@ export function SpendExperiencePage({
                           </>
                         ) : (
                           <>
-                            <div className="flex justify-between gap-4">
-                              <span className="body-small font-grotesk text-[#757575]">
-                                You will use
-                              </span>
-                              <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                                {preview.pointsRequired.toLocaleString()} points
-                              </span>
-                            </div>
-                            <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
-                              <span className="body-small font-grotesk text-[#757575]">
-                                You will receive
-                              </span>
-                              <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                                ${preview.usdcAmount.toFixed(2)} USDC
-                              </span>
-                            </div>
+                            {!postPointsConversion && (
+                              <>
+                                <div className="flex justify-between gap-4">
+                                  <span className="body-small font-grotesk text-[#757575]">
+                                    You will use
+                                  </span>
+                                  <span className="body-medium font-grotesk font-semibold text-[#171717]">
+                                    {preview.pointsRequired.toLocaleString()}{' '}
+                                    points
+                                  </span>
+                                </div>
+                                <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
+                                  <span className="body-small font-grotesk text-[#757575]">
+                                    You will receive
+                                  </span>
+                                  <span className="body-medium font-grotesk font-semibold text-[#171717]">
+                                    ${preview.usdcAmount.toFixed(2)} USDC
+                                  </span>
+                                </div>
+                              </>
+                            )}
                             {preview.userPointsBalance != null && (
-                              <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
+                              <div
+                                className={
+                                  postPointsConversion
+                                    ? 'flex justify-between gap-4'
+                                    : 'flex justify-between gap-4 border-t border-[#ededed] pt-3'
+                                }
+                              >
                                 <span className="body-small font-grotesk text-[#757575]">
                                   {postPointsConversion
                                     ? 'Points remaining'
@@ -631,7 +642,9 @@ export function SpendExperiencePage({
                     )}
 
                     <p className={eligibilityToneClass(elig.status)}>
-                      {elig.message}
+                      {elig.status === 'ready_for_payment' && preview
+                        ? `${preview.pointsRequired.toLocaleString()} points were converted to ${preview.usdcAmount.toFixed(2)} USDC.`
+                        : elig.message}
                     </p>
 
                     {showConvert && (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

After points are converted to USDC, the spend UI now:

- **Hides** the "You will use" and "You will receive" rows — they are irrelevant once conversion is done.
- **Removes the stray top border** from the "Points remaining" row so it renders cleanly as the first item in the summary card.
- **Replaces** the static "Your points were converted to USDC." message with a dynamic, data-driven message: e.g. **"10 points were converted to 1.00 USDC."**

## Changes

- `components/spend/spend-experience-page.tsx` — wrap the two preview rows in `{!postPointsConversion && …}`, conditionally apply the border class on the points-balance row, and compute the eligibility message dynamically when `status === 'ready_for_payment'`.

## Testing

- ✅ `yarn lint` — no new errors or warnings
- ✅ `yarn test` — all spend-related tests pass; pre-existing failures in `location-search`, `user-menu`, and `admin` test files are unchanged and unrelated to this diff.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3f44dc9a-73df-4acd-93fc-1e18fc73ceef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3f44dc9a-73df-4acd-93fc-1e18fc73ceef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

