### PR TITLE
feat: remove Status, Max USDC/user, and Points per $1 USDC from spend experience page

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -485,35 +485,6 @@ export function SpendExperiencePage({
           )}
         </div>
 
-        {user && (
-          <div className="space-y-3 rounded-sm border border-[#ededed] bg-[#fafafa] p-4">
-            <div className="flex justify-between gap-4">
-              <span className="body-small font-grotesk text-[#757575]">
-                Status
-              </span>
-              <span className="body-medium font-grotesk font-semibold capitalize text-[#171717]">
-                {experience.status}
-              </span>
-            </div>
-            <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
-              <span className="body-small font-grotesk text-[#757575]">
-                Max USDC / user
-              </span>
-              <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                ${Number(experience.max_usdc_per_user).toFixed(2)}
-              </span>
-            </div>
-            <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
-              <span className="body-small font-grotesk text-[#757575]">
-                Points per $1 USDC
-              </span>
-              <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                {Number(experience.points_to_usdc_rate).toLocaleString()} pts
-              </span>
-            </div>
-          </div>
-        )}
-
         {!user && (
           <SpendPrimaryButton onClick={login}>
             Log in to continue


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Removes the three info rows (Status, Max USDC / user, Points per $1 USDC) from the authenticated UX on the `spend/:id` page (`SpendExperiencePage`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-684d41be-4606-4fa1-8659-5b5af768b621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-684d41be-4606-4fa1-8659-5b5af768b621"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

