### PR TITLE
fix: prevent Vercel timeout on USDC conversion confirm route

### DIFF
--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -13,6 +13,7 @@ import {
 import { spendConversionConfirmBodySchema } from '@/lib/schemas/spend-session';
 
 export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
 
 type RouteParams = { params: { sessionId: string } };
 

--- a/lib/spend-treasury-usdc-transfer.test.ts
+++ b/lib/spend-treasury-usdc-transfer.test.ts
@@ -103,7 +103,7 @@ describe('submitTreasuryUsdcTransfer', () => {
     expect(mockWaitForTransaction).toHaveBeenCalledWith(
       'privy-tx-1',
       expect.objectContaining({
-        timeoutMs: 30_000,
+        timeoutMs: 10_000,
       })
     );
   });

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -205,7 +205,10 @@ export async function submitTreasuryUsdcTransfer(params: {
 
   const referenceId = params.referenceId?.trim() || randomUUID();
   const pollOpts = params.privyHashResolveOptions ?? {};
-  const timeoutMs = pollOpts.timeoutMs ?? 30_000;
+  // 10 s keeps total function time well within Vercel's 15 s default limit;
+  // if Privy hasn't confirmed by then we return submittedPending and the
+  // resume flow resolves the hash asynchronously.
+  const timeoutMs = pollOpts.timeoutMs ?? 10_000;
   const initialPollMs = pollOpts.pollIntervalMs ?? 500;
   const logWithdraw = params.withdrawTelemetry === true;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The `/api/spend-sessions/[sessionId]/conversion/confirm` route was intermittently hitting Vercel's default **15-second** function timeout. This happened because `submitTreasuryUsdcTransfer` polls the Privy REST API for up to **30 seconds** waiting for on-chain confirmation. When the transaction was slow to confirm, Vercel killed the function mid-poll — **after** the USDC had already been sent — resulting in a hard 504 error to the user even though the transfer succeeded.

## Root Cause

Two compounding issues:

1. The route had no `maxDuration` export, so Vercel enforced the default 15 s limit.
2. `submitTreasuryUsdcTransfer`'s default Privy poll timeout (30 s) exceeded that 15 s limit, so the graceful `submittedPending` fallback path never had a chance to fire — Vercel killed the function first.

The code already handles slow transactions correctly (returns `submittedPending: true`, stores `pending:{privyTransactionId}` in the DB, and the resume flow resolves the hash asynchronously) — but that path was unreachable under the old configuration.

## Fix

### `app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts`
- Added `export const maxDuration = 60` so Vercel allows up to 60 s for this route.

### `lib/spend-treasury-usdc-transfer.ts`
- Lowered the default Privy poll timeout from **30 s → 10 s**.  
  Base transactions typically confirm in 2–5 s. If Privy hasn't returned a confirmed status within 10 s, the function returns `submittedPending: true` and the existing resume flow handles the rest — without blocking the HTTP response. This also acts as a defence-in-depth safety net: even if `maxDuration` were reverted, the function would still return gracefully before Vercel's 15 s cutoff.

### `lib/spend-treasury-usdc-transfer.test.ts`
- Updated test assertion for the new default `timeoutMs` (10_000).

## Testing

✅ `yarn test lib/spend-treasury-usdc-transfer.test.ts` — all 4 tests pass  
✅ No lint errors on changed files
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e446f08d-551d-4960-bc67-c78a7321dece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e446f08d-551d-4960-bc67-c78a7321dece"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

