### PR TITLE
Add /venue-network redirect to Airtable form

### DIFF
--- a/app/venue-network/page.tsx
+++ b/app/venue-network/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function VenueNetworkPage() {
+  redirect('https://airtable.com/app6NdM2sO6HCxGv2/pagHBO8wciWJ5g8mp/form');
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a new App Router page at `/venue-network` that server-redirects visitors to the venue network intake form on Airtable.

## Implementation

- `app/venue-network/page.tsx` uses `redirect()` from `next/navigation`, matching the existing pattern used by `/tour`.

## Testing

- `yarn lint` and pre-commit `next build` completed successfully on this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c4dcbed8-d516-4ce3-bc53-4d25ce006264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c4dcbed8-d516-4ce3-bc53-4d25ce006264"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

