### PR TITLE
fix(admin): send Privy Bearer token for admin auth check on analytics and city metrics

### DIFF
--- a/app/admin/analytics/page.tsx
+++ b/app/admin/analytics/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import {
   Loader2,
   Users,
@@ -199,8 +200,11 @@ export default function AdminAnalyticsPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -208,7 +212,7 @@ export default function AdminAnalyticsPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {

--- a/app/admin/city-metrics/page.tsx
+++ b/app/admin/city-metrics/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { Loader2, MapPin, TrendingUp, Globe, ArrowUpDown } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 
@@ -34,8 +35,11 @@ export default function AdminCityMetricsPage() {
     try {
       const response = await fetch('/api/admin/auth', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ email: user.email.address }),
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
       });
       const responseData = await response.json();
       const data = responseData.data || responseData;
@@ -43,7 +47,7 @@ export default function AdminCityMetricsPage() {
     } catch {
       return false;
     }
-  }, [user?.email?.address]);
+  }, [user?.email?.address, getAccessToken]);
 
   useEffect(() => {
     const verify = async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`/admin/analytics` (and `/admin/city-metrics`) showed "Unauthorized: You don't have admin access" for users who are allowlisted in `ADMIN_EMAILS`, including accounts that are correctly signed in with Privy.

## Root cause

`POST /api/admin/auth` resolves the user only via `getPrivyUserEmailFromRequest`, which requires `Authorization: Bearer <Privy access token>`. The analytics and city-metrics pages posted `{ email }` in the JSON body instead; the server never reads that body for authorization, so the check failed every time.

## Change

Align these pages with the rest of the admin UI (e.g. locations, checkpoints): use `adminApiAuthHeaders(getAccessToken)` on the `/api/admin/auth` request.

## Files

- `app/admin/analytics/page.tsx`
- `app/admin/city-metrics/page.tsx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1b9d64ba-e1ad-491d-a42d-fdadc479f976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1b9d64ba-e1ad-491d-a42d-fdadc479f976"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

