### PR TITLE
feat(spend): snapshot spend_rail and rail wallet on spend sessions (IRL-9)

### DIFF
--- a/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
@@ -9,6 +9,10 @@ const mockAssert = vi.fn();
 const mockTrack = vi.fn();
 const mockResolve = vi.fn();
 
+const { mockEnsureStellar } = vi.hoisted(() => ({
+  mockEnsureStellar: vi.fn(),
+}));
+
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
@@ -31,6 +35,10 @@ vi.mock('@/lib/analytics/server', () => ({
   resolveServerIdentity: (...a: unknown[]) => mockResolve(...a),
 }));
 
+vi.mock('@/lib/privy/stellar-rail-wallet', () => ({
+  ensureStellarRailUserWallet: (...a: unknown[]) => mockEnsureStellar(...a),
+}));
+
 import { POST } from '../route';
 
 const experience = {
@@ -39,6 +47,7 @@ const experience = {
   description: null,
   event_id: 'evt-1',
   status: 'active' as const,
+  spend_rail: 'base_usdc' as const,
   points_to_usdc_rate: 1000,
   max_usdc_per_user: 5,
   treasury_wallet_address: '0x1111111111111111111111111111111111111111',
@@ -55,6 +64,8 @@ const session = {
   spend_experience_id: 'exp-uuid',
   user_id: 'privy-1',
   wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+  spend_rail: 'base_usdc' as const,
+  rail_user_wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
   status: 'created' as const,
   qr_token_hash: null,
   created_at: '2026-06-01T00:00:00.000Z',
@@ -87,6 +98,10 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
     mockAssert.mockReturnValue({ ok: true });
     mockCreateOrGet.mockResolvedValue({ session, created: true });
     mockResolve.mockReturnValue('privy-1');
+    mockEnsureStellar.mockResolvedValue({
+      address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      provisioned: false,
+    });
   });
 
   it('returns 404 when experience not found', async () => {
@@ -125,6 +140,46 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
     expect(j.data.session).toEqual(session);
     expect(j.data.created).toBe(true);
     expect(mockTrack).toHaveBeenCalled();
+    expect(mockEnsureStellar).not.toHaveBeenCalled();
+    expect(mockCreateOrGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        walletAddress: wallet,
+        spendRail: 'base_usdc',
+        railUserWalletAddress: wallet,
+      })
+    );
+  });
+
+  it('snapshots Stellar rail wallet when experience is stellar_usdc', async () => {
+    const stellarExp = { ...experience, spend_rail: 'stellar_usdc' as const };
+    const stellarSession = {
+      ...session,
+      spend_rail: 'stellar_usdc' as const,
+      rail_user_wallet_address:
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    };
+    mockGetExperience.mockResolvedValue(stellarExp);
+    mockCreateOrGet.mockResolvedValue({
+      session: stellarSession,
+      created: true,
+    });
+
+    const res = await POST(postRequest({ walletAddress: wallet }), {
+      params: { experienceId: 'exp-uuid' },
+    });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(mockEnsureStellar).toHaveBeenCalledWith('privy-1');
+    expect(mockCreateOrGet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spendRail: 'stellar_usdc',
+        railUserWalletAddress:
+          'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      })
+    );
+    expect(j.data.session.rail_user_wallet_address).toBe(
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+    );
   });
 
   it('returns 401 when wallet not owned', async () => {

--- a/app/api/spend-experiences/[experienceId]/sessions/route.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/route.ts
@@ -5,6 +5,7 @@ import {
 } from '@/lib/api/privy';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { createOrGetSpendSession } from '@/lib/db/spend-sessions';
+import { ensureStellarRailUserWallet } from '@/lib/privy/stellar-rail-wallet';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { createSpendSessionBodySchema } from '@/lib/schemas/spend-session';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
@@ -61,22 +62,33 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   }
 
   try {
+    const trimmedWallet = walletAddress.trim();
+    let railUserWalletAddress: string;
+    if (experience.spend_rail === 'stellar_usdc') {
+      const stellar = await ensureStellarRailUserWallet(auth.userId);
+      railUserWalletAddress = stellar.address;
+    } else {
+      railUserWalletAddress = trimmedWallet;
+    }
+
     const { session, created } = await createOrGetSpendSession({
       spendExperience: experience,
       userId: auth.userId,
-      walletAddress: walletAddress.trim(),
+      walletAddress: trimmedWallet,
+      spendRail: experience.spend_rail,
+      railUserWalletAddress,
     });
 
     if (created) {
       const distinctId = resolveServerIdentity({
         privyUserId: auth.userId,
-        walletAddress: walletAddress.trim().toLowerCase(),
+        walletAddress: trimmedWallet.toLowerCase(),
       });
       trackSpendSessionCreated(distinctId, {
         spend_experience_id: experienceId,
         event_id: experience.event_id,
         user_id: auth.userId,
-        wallet_address: walletAddress.trim().toLowerCase(),
+        wallet_address: trimmedWallet.toLowerCase(),
         spend_session_id: session.id,
         created: true,
       });

--- a/app/api/spend-sessions/[sessionId]/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/__tests__/route.test.ts
@@ -26,6 +26,8 @@ const session = {
   spend_experience_id: 'exp-1',
   user_id: 'privy-1',
   wallet_address: '0xabc',
+  spend_rail: 'base_usdc' as const,
+  rail_user_wallet_address: '0xabc',
   status: 'created' as const,
   qr_token_hash: null,
   created_at: '2026-01-01T00:00:00.000Z',

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -34,6 +34,8 @@ const session = {
   spend_experience_id: 'exp-1',
   user_id: 'privy-1',
   wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  spend_rail: 'base_usdc' as const,
+  rail_user_wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
   status: 'created' as const,
   qr_token_hash: null,
   created_at: '2026-01-01T00:00:00.000Z',

--- a/app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts
@@ -51,6 +51,8 @@ const session = {
   spend_experience_id: 'exp-1',
   user_id: 'privy-1',
   wallet_address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+  spend_rail: 'base_usdc' as const,
+  rail_user_wallet_address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
   status: 'created' as const,
   qr_token_hash: null,
   created_at: '2026-01-01T00:00:00.000Z',

--- a/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
@@ -38,6 +38,8 @@ const session = {
   spend_experience_id: 'exp-1',
   user_id: 'privy-1',
   wallet_address: '0xabc',
+  spend_rail: 'base_usdc' as const,
+  rail_user_wallet_address: '0xabc',
   status: 'created' as const,
   qr_token_hash: null,
   created_at: '2026-01-01T00:00:00.000Z',

--- a/app/api/stellar-wallet/route.ts
+++ b/app/api/stellar-wallet/route.ts
@@ -1,11 +1,9 @@
 import { NextRequest } from 'next/server';
-import {
-  createOrUpdatePlayerForStellar,
-  getPlayerByEmail,
-} from '@/lib/db/players';
+import { getPlayerByEmail } from '@/lib/db/players';
 import { apiSuccess, apiError } from '@/lib/api/response';
 import { getPrivyClient, verifyCallerIdentity } from '@/lib/api/privy';
 import { captureHandledException } from '@/lib/monitoring/capture-handled-exception';
+import { ensureStellarRailUserWallet } from '@/lib/privy/stellar-rail-wallet';
 
 /**
  * GET - Get Stellar wallet for a user
@@ -89,59 +87,16 @@ export async function POST(req: NextRequest) {
   }
 
   try {
-    const privy = getPrivyClient();
-
-    // Check if user already has a Stellar wallet
-    const user = await privy.getUser(privyUserId);
-    const existingStellarWallet = user.linkedAccounts?.find(
-      (account) =>
-        account.type === 'wallet' &&
-        'chainType' in account &&
-        account.chainType === 'stellar'
-    );
-
-    if (existingStellarWallet && 'address' in existingStellarWallet) {
-      // Ensure wallet is saved to database (in case it wasn't previously)
-      const email = user.email?.address ?? undefined;
-      const walletId =
-        'id' in existingStellarWallet ? existingStellarWallet.id : undefined;
-      await createOrUpdatePlayerForStellar(
-        existingStellarWallet.address,
-        email,
-        walletId ?? undefined
-      );
-
-      return apiSuccess(
-        {
-          address: existingStellarWallet.address,
-          walletId:
-            'id' in existingStellarWallet
-              ? existingStellarWallet.id
-              : undefined,
-        },
-        'Stellar wallet already exists'
-      );
-    }
-
-    // Create a new Stellar wallet (Tier 2 - server-managed)
-    // Note: Stellar wallets are created server-side without direct user ownership
-    // The wallet address is stored in our database linked to the user
-    const wallet = await privy.walletApi.create({
-      chainType: 'stellar',
-    });
-
-    // Get user's email for account linking
-    const email = user.email?.address ?? undefined;
-
-    // Save to database (creates player or links wallet to existing player by email)
-    await createOrUpdatePlayerForStellar(wallet.address, email, wallet.id);
+    const result = await ensureStellarRailUserWallet(privyUserId);
 
     return apiSuccess(
       {
-        address: wallet.address,
-        walletId: wallet.id,
+        address: result.address,
+        walletId: result.walletId,
       },
-      'Stellar wallet created successfully'
+      result.provisioned
+        ? 'Stellar wallet created successfully'
+        : 'Stellar wallet already exists'
     );
   } catch (error) {
     console.error('Error creating Stellar wallet:', error);

--- a/database/snapshot-spend-rail-on-spend-sessions.sql
+++ b/database/snapshot-spend-rail-on-spend-sessions.sql
@@ -1,0 +1,61 @@
+-- IRL-9: Snapshot spend_rail and rail_user_wallet_address on spend_sessions.
+-- spend_rail matches parent experience at insert; CHECK + BEFORE UPDATE keep it immutable.
+-- Depends on: spend_experiences.spend_rail (IRL-7), spend_sessions base table.
+
+ALTER TABLE spend_sessions
+  ADD COLUMN IF NOT EXISTS spend_rail TEXT;
+
+ALTER TABLE spend_sessions
+  ADD COLUMN IF NOT EXISTS rail_user_wallet_address TEXT;
+
+UPDATE spend_sessions ss
+SET spend_rail = se.spend_rail
+FROM spend_experiences se
+WHERE ss.spend_experience_id = se.id
+  AND ss.spend_rail IS NULL;
+
+UPDATE spend_sessions
+SET spend_rail = 'base_usdc'
+WHERE spend_rail IS NULL;
+
+-- Historical spend pilot: Base-only; rail user wallet matches verified EVM wallet_address
+UPDATE spend_sessions
+SET rail_user_wallet_address = wallet_address
+WHERE rail_user_wallet_address IS NULL;
+
+ALTER TABLE spend_sessions
+  ALTER COLUMN spend_rail SET NOT NULL;
+
+ALTER TABLE spend_sessions
+  ALTER COLUMN rail_user_wallet_address SET NOT NULL;
+
+ALTER TABLE spend_sessions DROP CONSTRAINT IF EXISTS spend_sessions_spend_rail_check;
+ALTER TABLE spend_sessions ADD CONSTRAINT spend_sessions_spend_rail_check
+  CHECK (spend_rail IN ('base_usdc', 'stellar_usdc'));
+
+COMMENT ON COLUMN spend_sessions.spend_rail IS
+  'Spend rail copied from spend_experiences at session creation (base_usdc | stellar_usdc). Immutable after insert.';
+
+COMMENT ON COLUMN spend_sessions.rail_user_wallet_address IS
+  'Rail-specific user wallet snapshotted at session creation (EVM for base_usdc; Stellar G-address for stellar_usdc).';
+
+CREATE OR REPLACE FUNCTION enforce_spend_sessions_spend_rail_immutable()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.spend_rail IS DISTINCT FROM OLD.spend_rail THEN
+    RAISE EXCEPTION
+      'spend_rail cannot be changed after the spend session is created (was %, attempted %)',
+      OLD.spend_rail,
+      NEW.spend_rail;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS spend_sessions_spend_rail_immutable ON spend_sessions;
+CREATE TRIGGER spend_sessions_spend_rail_immutable
+  BEFORE UPDATE ON spend_sessions
+  FOR EACH ROW
+  EXECUTE FUNCTION enforce_spend_sessions_spend_rail_immutable();

--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -1,6 +1,7 @@
 import { supabase } from './client';
 import type {
   PointConversion,
+  SpendRail,
   SpendSession,
   SpendTransaction,
 } from '@/lib/types';
@@ -10,6 +11,8 @@ const SESSION_COLS = `
   spend_experience_id,
   user_id,
   wallet_address,
+  spend_rail,
+  rail_user_wallet_address,
   status,
   qr_token_hash,
   created_at,
@@ -59,12 +62,19 @@ function toNum(v: unknown): number {
   return NaN;
 }
 
+function normalizeSpendRail(value: unknown): SpendRail {
+  if (value === 'stellar_usdc') return 'stellar_usdc';
+  return 'base_usdc';
+}
+
 function rowToSession(row: Record<string, unknown>): SpendSession {
   return {
     id: String(row.id),
     spend_experience_id: String(row.spend_experience_id),
     user_id: String(row.user_id),
     wallet_address: String(row.wallet_address),
+    spend_rail: normalizeSpendRail(row.spend_rail),
+    rail_user_wallet_address: String(row.rail_user_wallet_address),
     status: row.status as SpendSession['status'],
     qr_token_hash: row.qr_token_hash == null ? null : String(row.qr_token_hash),
     created_at: String(row.created_at),

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -3,6 +3,7 @@ import { computeSpendSessionExpiresAt } from '@/lib/spend-experience-guard';
 import type {
   PointConversion,
   SpendExperience,
+  SpendRail,
   SpendSession,
   SpendSessionStatus,
   SpendTransaction,
@@ -13,6 +14,8 @@ const SESSION_COLS = `
   spend_experience_id,
   user_id,
   wallet_address,
+  spend_rail,
+  rail_user_wallet_address,
   status,
   qr_token_hash,
   created_at,
@@ -62,12 +65,19 @@ function toNum(v: unknown): number {
   return NaN;
 }
 
+function normalizeSpendRail(value: unknown): SpendRail {
+  if (value === 'stellar_usdc') return 'stellar_usdc';
+  return 'base_usdc';
+}
+
 function rowToSession(row: Record<string, unknown>): SpendSession {
   return {
     id: String(row.id),
     spend_experience_id: String(row.spend_experience_id),
     user_id: String(row.user_id),
     wallet_address: String(row.wallet_address),
+    spend_rail: normalizeSpendRail(row.spend_rail),
+    rail_user_wallet_address: String(row.rail_user_wallet_address),
     status: row.status as SpendSession['status'],
     qr_token_hash: row.qr_token_hash == null ? null : String(row.qr_token_hash),
     created_at: String(row.created_at),
@@ -195,6 +205,8 @@ type CreateSessionInput = {
   spendExperience: SpendExperience;
   userId: string;
   walletAddress: string;
+  spendRail: SpendRail;
+  railUserWalletAddress: string;
   now?: Date;
 };
 
@@ -215,6 +227,8 @@ export async function createOrGetSpendSession(
     spend_experience_id: input.spendExperience.id,
     user_id: input.userId,
     wallet_address: input.walletAddress,
+    spend_rail: input.spendRail,
+    rail_user_wallet_address: input.railUserWalletAddress,
     status: 'created' as SpendSessionStatus,
     expires_at: expiresAt,
   };

--- a/lib/privy/__tests__/stellar-rail-wallet.test.ts
+++ b/lib/privy/__tests__/stellar-rail-wallet.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetUser = vi.fn();
+const mockWalletCreate = vi.fn();
+const mockGetPlayerByEmail = vi.fn();
+const mockCreateOrUpdatePlayerForStellar = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  getPrivyClient: () => ({
+    getUser: (...a: unknown[]) => mockGetUser(...a),
+    walletApi: {
+      create: (...a: unknown[]) => mockWalletCreate(...a),
+    },
+  }),
+}));
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerByEmail: (...a: unknown[]) => mockGetPlayerByEmail(...a),
+  createOrUpdatePlayerForStellar: (...a: unknown[]) =>
+    mockCreateOrUpdatePlayerForStellar(...a),
+}));
+
+import { ensureStellarRailUserWallet } from '../stellar-rail-wallet';
+
+describe('ensureStellarRailUserWallet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns canonical player stellar_wallet_address when present', async () => {
+    mockGetUser.mockResolvedValue({
+      email: { address: 'u@test.com' },
+      linkedAccounts: [],
+    });
+    mockGetPlayerByEmail.mockResolvedValue({
+      stellar_wallet_address: 'GDBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      stellar_wallet_id: 'wid-db',
+    });
+
+    const r = await ensureStellarRailUserWallet('privy-x');
+    expect(r).toEqual({
+      address: 'GDBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      walletId: 'wid-db',
+      provisioned: false,
+    });
+    expect(mockWalletCreate).not.toHaveBeenCalled();
+  });
+
+  it('uses linked Privy Stellar and syncs player when DB has no canonical row', async () => {
+    mockGetUser.mockResolvedValue({
+      email: { address: 'u@test.com' },
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: 'GLINKBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          id: 'lid',
+        },
+      ],
+    });
+    mockGetPlayerByEmail.mockResolvedValue({
+      stellar_wallet_address: null,
+    });
+
+    const r = await ensureStellarRailUserWallet('privy-x');
+    expect(r.address).toBe('GLINKBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB');
+    expect(r.walletId).toBe('lid');
+    expect(r.provisioned).toBe(false);
+    expect(mockCreateOrUpdatePlayerForStellar).toHaveBeenCalledWith(
+      'GLINKBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      'u@test.com',
+      'lid'
+    );
+    expect(mockWalletCreate).not.toHaveBeenCalled();
+  });
+
+  it('creates a Privy Stellar wallet when none exists', async () => {
+    mockGetUser.mockResolvedValue({
+      email: { address: 'u@test.com' },
+      linkedAccounts: [],
+    });
+    mockGetPlayerByEmail.mockResolvedValue(null);
+    mockWalletCreate.mockResolvedValue({
+      address: 'GNEWBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      id: 'new-id',
+    });
+
+    const r = await ensureStellarRailUserWallet('privy-x');
+    expect(r).toEqual({
+      address: 'GNEWBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      walletId: 'new-id',
+      provisioned: true,
+    });
+    expect(mockWalletCreate).toHaveBeenCalledWith({ chainType: 'stellar' });
+    expect(mockCreateOrUpdatePlayerForStellar).toHaveBeenCalledWith(
+      'GNEWBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      'u@test.com',
+      'new-id'
+    );
+  });
+});

--- a/lib/privy/stellar-rail-wallet.ts
+++ b/lib/privy/stellar-rail-wallet.ts
@@ -1,0 +1,74 @@
+import { getPrivyClient } from '@/lib/api/privy';
+import {
+  createOrUpdatePlayerForStellar,
+  getPlayerByEmail,
+} from '@/lib/db/players';
+
+export type EnsureStellarRailUserWalletResult = {
+  address: string;
+  walletId?: string;
+  /** True when a new Privy Stellar wallet was created in this call. */
+  provisioned: boolean;
+};
+
+/**
+ * Resolves the canonical Stellar account for spend flows (same order as GET /api/stellar-wallet),
+ * or creates a Privy-managed Stellar wallet and persists it (same semantics as POST /api/stellar-wallet).
+ */
+export async function ensureStellarRailUserWallet(
+  privyUserId: string
+): Promise<EnsureStellarRailUserWalletResult> {
+  const privy = getPrivyClient();
+  const user = await privy.getUser(privyUserId);
+
+  const email = user.email?.address;
+  if (email) {
+    const player = await getPlayerByEmail(email);
+    if (player?.stellar_wallet_address) {
+      return {
+        address: player.stellar_wallet_address,
+        walletId: player.stellar_wallet_id ?? undefined,
+        provisioned: false,
+      };
+    }
+  }
+
+  const existingStellarWallet = user.linkedAccounts?.find(
+    (account) =>
+      account.type === 'wallet' &&
+      'chainType' in account &&
+      account.chainType === 'stellar'
+  );
+
+  if (existingStellarWallet && 'address' in existingStellarWallet) {
+    const walletIdRaw =
+      'id' in existingStellarWallet ? existingStellarWallet.id : undefined;
+    const walletId =
+      walletIdRaw === null || walletIdRaw === undefined
+        ? undefined
+        : String(walletIdRaw);
+    await createOrUpdatePlayerForStellar(
+      existingStellarWallet.address,
+      email,
+      walletId
+    );
+
+    return {
+      address: existingStellarWallet.address,
+      walletId,
+      provisioned: false,
+    };
+  }
+
+  const wallet = await privy.walletApi.create({
+    chainType: 'stellar',
+  });
+
+  await createOrUpdatePlayerForStellar(wallet.address, email, wallet.id);
+
+  return {
+    address: wallet.address,
+    walletId: wallet.id,
+    provisioned: true,
+  };
+}

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -36,6 +36,8 @@ const sess = (over: Partial<SpendSession> = {}): SpendSession => ({
   spend_experience_id: 'e1',
   user_id: 'u1',
   wallet_address: '0x3333333333333333333333333333333333333333',
+  spend_rail: 'base_usdc',
+  rail_user_wallet_address: '0x3333333333333333333333333333333333333333',
   status: 'created',
   qr_token_hash: null,
   created_at: '2026-06-01T12:00:00.000Z',

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -57,6 +57,8 @@ const baseSession: SpendSession = {
   spend_experience_id: 'exp-1',
   user_id: 'user-1',
   wallet_address: '0x1111111111111111111111111111111111111111',
+  spend_rail: 'base_usdc',
+  rail_user_wallet_address: '0x1111111111111111111111111111111111111111',
   /** Stale or partial-write state: conversion row exists but session not advanced yet. */
   status: 'created',
   qr_token_hash: null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -320,6 +320,14 @@ export type SpendSession = {
   spend_experience_id: string;
   user_id: string;
   wallet_address: string;
+  /** Copied from the parent experience at session creation. Immutable in DB. */
+  spend_rail: SpendRail;
+  /**
+   * Rail-specific user wallet at session creation: verified EVM for `base_usdc`,
+   * canonical Stellar account for `stellar_usdc` (see GET /api/stellar-wallet order;
+   * Stellar may be auto-provisioned on create).
+   */
+  rail_user_wallet_address: string;
   status: SpendSessionStatus;
   qr_token_hash: string | null;
   created_at: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-9: immutable `spend_rail` and `rail_user_wallet_address` on `spend_sessions`, set at creation.

## Changes

- **Migration** (`database/snapshot-spend-rail-on-spend-sessions.sql`): Adds `spend_rail` (CHECK `base_usdc` \| `stellar_usdc`) and `rail_user_wallet_address`; backfills from joined experience and `wallet_address` for legacy rows; `BEFORE UPDATE` trigger blocks `spend_rail` changes (same pattern as spend experiences).
- **Session create**: Copies `spend_rail` from the parent experience; Base snapshots verified EVM `wallet_address`; Stellar calls `ensureStellarRailUserWallet` (canonical DB address → linked Privy → `walletApi.create` + `createOrUpdatePlayerForStellar`), aligned with GET/POST `/api/stellar-wallet`.
- **Types and DB**: `SpendSession` extended; `SESSION_COLS` and `rowToSession` in `lib/db/spend-sessions.ts` and `lib/db/spend-admin.ts`.
- **Refactor**: POST `/api/stellar-wallet` delegates to the shared helper.

## Verification

- Vitest on touched suites; production build passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-9](https://linear.app/irlenergy/issue/IRL-9/snapshot-spend-rail-and-rail-user-wallet-on-spend-sessions)

<div><a href="https://cursor.com/agents/bc-5bc34374-0c76-4327-8dd6-7d6aed00e52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5bc34374-0c76-4327-8dd6-7d6aed00e52d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

