### PR TITLE
feat(db): spend wallet readiness operations (IRL-5)

### DIFF
--- a/database/spend-wallet-readiness-operations.sql
+++ b/database/spend-wallet-readiness-operations.sql
@@ -1,0 +1,89 @@
+-- IRL-5: Idempotent wallet readiness ledger row per spend session (Stellar activation / trustline, etc.).
+-- Depends on: spend_sessions (including IRL-9 spend_rail / rail_user_wallet_address), treasury_transactions.
+
+CREATE TABLE IF NOT EXISTS spend_wallet_readiness_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    spend_session_id UUID NOT NULL REFERENCES spend_sessions(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL,
+    spend_rail TEXT NOT NULL
+        CHECK (spend_rail IN ('base_usdc', 'stellar_usdc')),
+    rail_user_wallet_address TEXT NOT NULL,
+    status VARCHAR(32) NOT NULL DEFAULT 'pending'
+        CHECK (status IN (
+            'pending',
+            'completed',
+            'failed',
+            'needs_review'
+        )),
+    step_metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+    sanitized_error_category TEXT,
+    sanitized_error_code TEXT,
+    internal_diagnostics JSONB,
+    idempotency_key TEXT NOT NULL,
+    sponsor_treasury_transaction_id UUID
+        REFERENCES treasury_transactions(id) ON DELETE SET NULL,
+    trustline_treasury_transaction_id UUID
+        REFERENCES treasury_transactions(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT spend_wallet_readiness_operations_idempotency_key_unique
+        UNIQUE (idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spend_wallet_readiness_operations_session
+    ON spend_wallet_readiness_operations (spend_session_id);
+
+CREATE INDEX IF NOT EXISTS idx_spend_wallet_readiness_operations_user
+    ON spend_wallet_readiness_operations (user_id);
+
+COMMENT ON TABLE spend_wallet_readiness_operations IS
+    'Per-session idempotent wallet readiness (e.g. Stellar sponsor + USDC trustline); one row per idempotency_key.';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.rail_user_wallet_address IS
+    'Rail user wallet snapshotted for this operation (same normalization as spend_sessions.rail_user_wallet_address).';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.step_metadata IS
+    'Structured per-step state for orchestration (JSON).';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.sanitized_error_category IS
+    'User-safe error grouping for product copy (no raw chain errors).';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.sanitized_error_code IS
+    'Stable user-safe error code for analytics and support.';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.internal_diagnostics IS
+    'Server-only diagnostic payload (JSON); not for client display.';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.idempotency_key IS
+    'Deterministic v1 key: wallet_readiness:{spend_session_id}. Unique for retry safety.';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.sponsor_treasury_transaction_id IS
+    'Optional treasury row for account sponsorship / activation step.';
+
+COMMENT ON COLUMN spend_wallet_readiness_operations.trustline_treasury_transaction_id IS
+    'Optional treasury row for USDC trustline (or related) step.';
+
+CREATE OR REPLACE FUNCTION set_spend_wallet_readiness_operations_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS spend_wallet_readiness_operations_updated_at
+    ON spend_wallet_readiness_operations;
+CREATE TRIGGER spend_wallet_readiness_operations_updated_at
+    BEFORE UPDATE ON spend_wallet_readiness_operations
+    FOR EACH ROW
+    EXECUTE FUNCTION set_spend_wallet_readiness_operations_updated_at();
+
+ALTER TABLE spend_wallet_readiness_operations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access spend_wallet_readiness_operations"
+    ON spend_wallet_readiness_operations
+    FOR ALL
+    USING (true)
+    WITH CHECK (true);

--- a/lib/db/__tests__/spend-wallet-readiness.test.ts
+++ b/lib/db/__tests__/spend-wallet-readiness.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSingle, mockMaybeSingle, mockFrom, mockInsert } = vi.hoisted(() => {
+  const single = vi.fn();
+  const maybeSingle = vi.fn(() => Promise.resolve({ data: null, error: null }));
+  const queryBuilder = {
+    select: vi.fn(() => queryBuilder),
+    eq: vi.fn(() => queryBuilder),
+    maybeSingle,
+    single,
+  };
+
+  const insert = vi.fn(() => ({
+    select: vi.fn(() => ({ single })),
+  }));
+
+  const from = vi.fn(() => ({
+    ...queryBuilder,
+    insert,
+    update: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        select: vi.fn(() => ({ single })),
+      })),
+    })),
+  }));
+
+  return {
+    mockSingle: single,
+    mockMaybeSingle: maybeSingle,
+    mockFrom: from,
+    mockInsert: insert,
+  };
+});
+
+vi.mock('@/lib/db/client', () => ({
+  supabase: {
+    from: (...args: unknown[]) => mockFrom(...args),
+  },
+}));
+
+import {
+  getSpendWalletReadinessByIdempotencyKey,
+  insertPendingSpendWalletReadinessOrGet,
+  spendWalletReadinessIdempotencyKey,
+} from '../spend-wallet-readiness';
+
+const sessionId = '770e8400-e29b-41d4-a716-446655440000';
+const readinessRow = {
+  id: '880e8400-e29b-41d4-a716-446655440001',
+  spend_session_id: sessionId,
+  user_id: 'user-1',
+  spend_rail: 'stellar_usdc',
+  rail_user_wallet_address:
+    'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+  status: 'pending',
+  step_metadata: {},
+  sanitized_error_category: null,
+  sanitized_error_code: null,
+  internal_diagnostics: null,
+  idempotency_key: spendWalletReadinessIdempotencyKey(sessionId),
+  sponsor_treasury_transaction_id: null,
+  trustline_treasury_transaction_id: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+describe('spendWalletReadinessIdempotencyKey', () => {
+  it('uses the v1 wallet_readiness prefix', () => {
+    expect(spendWalletReadinessIdempotencyKey(sessionId)).toBe(
+      `wallet_readiness:${sessionId}`
+    );
+  });
+});
+
+describe('insertPendingSpendWalletReadinessOrGet', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns created row on first insert', async () => {
+    mockSingle.mockResolvedValueOnce({ data: readinessRow, error: null });
+
+    const result = await insertPendingSpendWalletReadinessOrGet({
+      spendSessionId: sessionId,
+      userId: 'user-1',
+      spendRail: 'stellar_usdc',
+      railUserWalletAddress: readinessRow.rail_user_wallet_address,
+    });
+
+    expect(mockFrom).toHaveBeenCalledWith('spend_wallet_readiness_operations');
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spend_session_id: sessionId,
+        idempotency_key: spendWalletReadinessIdempotencyKey(sessionId),
+      })
+    );
+    expect(result.created).toBe(true);
+    expect(result.row.id).toBe(readinessRow.id);
+    expect(result.row.idempotency_key).toBe(
+      spendWalletReadinessIdempotencyKey(sessionId)
+    );
+  });
+
+  it('returns existing row when idempotency unique constraint fires', async () => {
+    mockSingle.mockResolvedValueOnce({
+      data: null,
+      error: { code: '23505', message: 'duplicate key value' },
+    });
+    mockMaybeSingle.mockResolvedValueOnce({
+      data: readinessRow,
+      error: null,
+    });
+
+    const result = await insertPendingSpendWalletReadinessOrGet({
+      spendSessionId: sessionId,
+      userId: 'user-1',
+      spendRail: 'stellar_usdc',
+      railUserWalletAddress: readinessRow.rail_user_wallet_address,
+    });
+
+    expect(result.created).toBe(false);
+    expect(result.row).toEqual(
+      expect.objectContaining({
+        id: readinessRow.id,
+        spend_session_id: sessionId,
+      })
+    );
+  });
+});
+
+describe('getSpendWalletReadinessByIdempotencyKey', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('maps DB row to SpendWalletReadinessOperation', async () => {
+    const maybeSingle = vi.fn().mockResolvedValue({
+      data: readinessRow,
+      error: null,
+    });
+    mockFrom.mockReturnValueOnce({
+      select: vi.fn().mockReturnValue({
+        eq: vi.fn().mockReturnValue({ maybeSingle }),
+      }),
+    });
+
+    const row = await getSpendWalletReadinessByIdempotencyKey(
+      spendWalletReadinessIdempotencyKey(sessionId)
+    );
+
+    expect(row?.spend_rail).toBe('stellar_usdc');
+    expect(row?.step_metadata).toEqual({});
+    expect(row?.internal_diagnostics).toBeNull();
+  });
+});

--- a/lib/db/spend-wallet-readiness.ts
+++ b/lib/db/spend-wallet-readiness.ts
@@ -1,0 +1,202 @@
+import { supabase } from './client';
+import { normalizeSpendRail } from './spend-rail';
+import type {
+  SpendRail,
+  SpendWalletReadinessOperation,
+  SpendWalletReadinessStatus,
+} from '@/lib/types';
+
+export const WALLET_READINESS_COLS = `
+  id,
+  spend_session_id,
+  user_id,
+  spend_rail,
+  rail_user_wallet_address,
+  status,
+  step_metadata,
+  sanitized_error_category,
+  sanitized_error_code,
+  internal_diagnostics,
+  idempotency_key,
+  sponsor_treasury_transaction_id,
+  trustline_treasury_transaction_id,
+  created_at,
+  updated_at
+`;
+
+function parseJsonObject(value: unknown): Record<string, unknown> | null {
+  if (value == null) return null;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
+export function rowToSpendWalletReadinessOperation(
+  row: Record<string, unknown>
+): SpendWalletReadinessOperation {
+  const step = parseJsonObject(row.step_metadata);
+  const internal = parseJsonObject(row.internal_diagnostics);
+  return {
+    id: String(row.id),
+    spend_session_id: String(row.spend_session_id),
+    user_id: String(row.user_id),
+    spend_rail: normalizeSpendRail(row.spend_rail),
+    rail_user_wallet_address: String(row.rail_user_wallet_address),
+    status: row.status as SpendWalletReadinessStatus,
+    step_metadata: step ?? {},
+    sanitized_error_category:
+      row.sanitized_error_category == null
+        ? null
+        : String(row.sanitized_error_category),
+    sanitized_error_code:
+      row.sanitized_error_code == null
+        ? null
+        : String(row.sanitized_error_code),
+    internal_diagnostics: internal,
+    idempotency_key: String(row.idempotency_key),
+    sponsor_treasury_transaction_id:
+      row.sponsor_treasury_transaction_id == null
+        ? null
+        : String(row.sponsor_treasury_transaction_id),
+    trustline_treasury_transaction_id:
+      row.trustline_treasury_transaction_id == null
+        ? null
+        : String(row.trustline_treasury_transaction_id),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+/** v1 deterministic idempotency key: one readiness row per spend session. */
+export function spendWalletReadinessIdempotencyKey(
+  spendSessionId: string
+): string {
+  return `wallet_readiness:${spendSessionId}`;
+}
+
+export async function getSpendWalletReadinessBySessionId(
+  spendSessionId: string
+): Promise<SpendWalletReadinessOperation | null> {
+  const { data, error } = await supabase
+    .from('spend_wallet_readiness_operations')
+    .select(WALLET_READINESS_COLS)
+    .eq('spend_session_id', spendSessionId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendWalletReadinessBySessionId error:', error);
+    throw new Error(error.message || 'Failed to load wallet readiness');
+  }
+  if (!data) return null;
+  return rowToSpendWalletReadinessOperation(data as Record<string, unknown>);
+}
+
+export async function getSpendWalletReadinessByIdempotencyKey(
+  idempotencyKey: string
+): Promise<SpendWalletReadinessOperation | null> {
+  const { data, error } = await supabase
+    .from('spend_wallet_readiness_operations')
+    .select(WALLET_READINESS_COLS)
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendWalletReadinessByIdempotencyKey error:', error);
+    throw new Error(error.message || 'Failed to load wallet readiness');
+  }
+  if (!data) return null;
+  return rowToSpendWalletReadinessOperation(data as Record<string, unknown>);
+}
+
+export type InsertSpendWalletReadinessPendingInput = {
+  spendSessionId: string;
+  userId: string;
+  spendRail: SpendRail;
+  /** Same convention as `spend_sessions.rail_user_wallet_address` (trimmed). */
+  railUserWalletAddress: string;
+  status?: SpendWalletReadinessStatus;
+  stepMetadata?: Record<string, unknown>;
+};
+
+/**
+ * Inserts a pending readiness row or returns the existing row for the same
+ * idempotency key (unique constraint on `idempotency_key`).
+ */
+export async function insertPendingSpendWalletReadinessOrGet(
+  input: InsertSpendWalletReadinessPendingInput
+): Promise<{ row: SpendWalletReadinessOperation; created: boolean }> {
+  const idempotency_key = spendWalletReadinessIdempotencyKey(
+    input.spendSessionId
+  );
+  const rail = input.railUserWalletAddress.trim();
+  const insertRow = {
+    spend_session_id: input.spendSessionId,
+    user_id: input.userId,
+    spend_rail: input.spendRail,
+    rail_user_wallet_address: rail,
+    status: input.status ?? ('pending' as const),
+    step_metadata: input.stepMetadata ?? {},
+    idempotency_key,
+  };
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('spend_wallet_readiness_operations')
+    .insert(insertRow)
+    .select(WALLET_READINESS_COLS)
+    .single();
+
+  if (!insertError && inserted) {
+    return {
+      row: rowToSpendWalletReadinessOperation(
+        inserted as Record<string, unknown>
+      ),
+      created: true,
+    };
+  }
+
+  if (
+    insertError?.code === '23505' ||
+    insertError?.message?.includes('duplicate')
+  ) {
+    const existing =
+      await getSpendWalletReadinessByIdempotencyKey(idempotency_key);
+    if (existing) {
+      return { row: existing, created: false };
+    }
+  }
+
+  console.error('insertPendingSpendWalletReadinessOrGet error:', insertError);
+  throw new Error(
+    insertError?.message || 'Failed to insert wallet readiness operation'
+  );
+}
+
+export async function updateSpendWalletReadinessFields(
+  id: string,
+  patch: Partial<
+    Pick<
+      SpendWalletReadinessOperation,
+      | 'status'
+      | 'step_metadata'
+      | 'sanitized_error_category'
+      | 'sanitized_error_code'
+      | 'internal_diagnostics'
+      | 'sponsor_treasury_transaction_id'
+      | 'trustline_treasury_transaction_id'
+    >
+  >
+): Promise<SpendWalletReadinessOperation> {
+  const { data, error } = await supabase
+    .from('spend_wallet_readiness_operations')
+    .update(patch)
+    .eq('id', id)
+    .select(WALLET_READINESS_COLS)
+    .single();
+
+  if (error || !data) {
+    console.error('updateSpendWalletReadinessFields:', error);
+    throw new Error(error?.message || 'Failed to update wallet readiness');
+  }
+  return rowToSpendWalletReadinessOperation(data as Record<string, unknown>);
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -424,3 +424,32 @@ export type TreasuryTransaction = {
   created_at: string;
   updated_at: string;
 };
+
+/** Wallet readiness lifecycle for rail setup (e.g. Stellar account + trustline). */
+export type SpendWalletReadinessStatus =
+  | 'pending'
+  | 'completed'
+  | 'failed'
+  | 'needs_review';
+
+/**
+ * Idempotent per-session wallet readiness operation (v1 idempotency key
+ * `wallet_readiness:{spend_session_id}`).
+ */
+export type SpendWalletReadinessOperation = {
+  id: string;
+  spend_session_id: string;
+  user_id: string;
+  spend_rail: SpendRail;
+  rail_user_wallet_address: string;
+  status: SpendWalletReadinessStatus;
+  step_metadata: Record<string, unknown>;
+  sanitized_error_category: string | null;
+  sanitized_error_code: string | null;
+  internal_diagnostics: Record<string, unknown> | null;
+  idempotency_key: string;
+  sponsor_treasury_transaction_id: string | null;
+  trustline_treasury_transaction_id: string | null;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-5: idempotent per-session wallet readiness storage and typed DB access, without wiring conversion flows.

## Changes

- **Migration** `database/spend-wallet-readiness-operations.sql`: new `spend_wallet_readiness_operations` table with `spend_session_id` FK, `user_id`, `spend_rail`, `rail_user_wallet_address`, lifecycle `status`, `step_metadata` and `internal_diagnostics` JSONB, sanitized error columns, required `idempotency_key` with unique constraint (`wallet_readiness:{spend_session_id}`), nullable `sponsor_treasury_transaction_id` and `trustline_treasury_transaction_id` FKs to `treasury_transactions`, `created_at` / `updated_at` (BEFORE UPDATE trigger), RLS enabled with service-role full-access policy aligned with other spend ledger tables.
- **Types** in `lib/types.ts`: `SpendWalletReadinessStatus`, `SpendWalletReadinessOperation`.
- **Helpers** in `lib/db/spend-wallet-readiness.ts`: idempotency key helper, fetch by session or idempotency key, insert-or-get on unique conflict, and `updateSpendWalletReadinessFields`.
- **Tests** `lib/db/__tests__/spend-wallet-readiness.test.ts`: idempotency key format and duplicate-insert handling with mocked Supabase.

## Verification

- `yarn test lib/db/__tests__/spend-wallet-readiness.test.ts`
- `yarn lint` (existing warnings only)
- Pre-commit `yarn build` passed

Assumes IRL-7/IRL-9 session rail columns are already present on `spend_sessions`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-5](https://linear.app/irlenergy/issue/IRL-5/create-wallet-readiness-operation-table)

<div><a href="https://cursor.com/agents/bc-80f9d243-5683-4c6f-a5f0-11e188db34f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-80f9d243-5683-4c6f-a5f0-11e188db34f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

