### PR TITLE
feat(spend): centralized spend rail configuration (IRL-8)

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -70,6 +70,26 @@ SENTRY_IGNORE_ERRORS=
 # Key that signs the fungible-token claim transaction (server pays fees)
 REWARDS_TOKEN_OWNER_SECRET_KEY=
 
+# --- Spend rails (IRL Spend: Base USDC + Stellar USDC) ---
+# Kill switches (default: Base on, Stellar off). When false or required vars are missing/invalid, new sessions and new money movement are blocked for that rail.
+# SPEND_RAIL_BASE_USDC_ENABLED=true
+# SPEND_RAIL_STELLAR_USDC_ENABLED=false
+#
+# Base USDC — treasury (Privy server wallet), receiving (settlement), optional overrides:
+# SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS=0x...
+# SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS=0x...
+# SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID=...
+# SPEND_RAIL_BASE_USDC_USDC_CONTRACT=0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913
+# SPEND_RAIL_BASE_USDC_RPC_URL=https://mainnet.base.org
+# NEXT_PUBLIC_SPEND_RAIL_BASE_USDC_EXPLORER_TX_URL_TEMPLATE=https://basescan.org/tx/{txHash}
+#
+# Stellar USDC — receiving (G… strkey); optional separate treasury; network for explorer defaults:
+# SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS=G...
+# SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS=G...
+# NEXT_PUBLIC_STELLAR_NETWORK=PUBLIC
+# NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE=https://stellar.expert/explorer/public/tx/{txHash}
+# Optional Horizon override (validated only when set): NEXT_PUBLIC_STELLAR_HORIZON_URL=
+
 # Claim NFT (WalletCon NFT on Base — see lib/walletcon-nft.ts): mock "mint open" for local UI testing.
 # When set to "true", GET /api/claim-nft returns canMint: true, hasClaimed: false so the claim button appears.
 # Do not set in production.

--- a/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
@@ -182,7 +182,7 @@ describe('PATCH /api/admin/spend-experiences/[experienceId]', () => {
 
     expect(res.status).toBe(200);
     expect(mockGetFundingStatus).toHaveBeenCalledWith({
-      walletAddress: existing.server_wallet_address,
+      walletAddress: '0x4444444444444444444444444444444444444444',
       minUsdcRequired: existing.max_usdc_per_user,
     });
     expect(mockUpdateSpendExperience).toHaveBeenCalledWith('exp-1', {

--- a/app/api/admin/spend-experiences/[experienceId]/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/route.ts
@@ -7,6 +7,7 @@ import { updateSpendExperienceRequestSchema } from '@/lib/schemas/spend-experien
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
 import { getServerWalletFundingStatus } from '@/lib/spend-server-wallet';
+import { getSpendTreasuryWalletAddress } from '@/lib/spend-rail-config';
 
 interface RouteParams {
   params: { experienceId: string };
@@ -58,16 +59,18 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     }
 
     if (validation.data.status === 'active') {
-      const funding = await getServerWalletFundingStatus({
-        walletAddress: existing.server_wallet_address,
-        minUsdcRequired:
-          validation.data.max_usdc_per_user ?? existing.max_usdc_per_user,
-      });
-      if (!funding.isFunded) {
-        return apiError(
-          'Server wallet must be funded with at least max_usdc_per_user USDC before activation.',
-          400
-        );
+      if (existing.spend_rail === 'base_usdc') {
+        const funding = await getServerWalletFundingStatus({
+          walletAddress: getSpendTreasuryWalletAddress('base_usdc'),
+          minUsdcRequired:
+            validation.data.max_usdc_per_user ?? existing.max_usdc_per_user,
+        });
+        if (!funding.isFunded) {
+          return apiError(
+            'Server wallet must be funded with at least max_usdc_per_user USDC before activation.',
+            400
+          );
+        }
       }
     }
 

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts
@@ -91,7 +91,7 @@ describe('GET /api/admin/spend-experiences/[experienceId]/treasury', () => {
     expect(res.status).toBe(200);
     expect(mockFetchBalance).toHaveBeenCalledWith(
       expect.objectContaining({
-        server_wallet_address: '0x3333333333333333333333333333333333333333',
+        spend_rail: 'base_usdc',
       })
     );
     expect(j.data.serverWalletUsdcBalance).toBe(123.45);

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
@@ -6,9 +6,13 @@ import { requireAdmin } from '@/lib/auth';
 import type { TreasuryTransaction } from '@/lib/types';
 import {
   fetchServerWalletUsdcBalanceSafe,
-  getSpendServerWalletAddress,
   spendServerWalletFundingMetadata,
 } from '@/lib/spend-server-wallet';
+import {
+  getSpendBaseTreasuryPrivyTransferConfig,
+  getSpendReceivingWalletAddress,
+  getSpendTreasuryWalletAddress,
+} from '@/lib/spend-rail-config';
 
 interface RouteParams {
   params: { experienceId: string };
@@ -35,7 +39,7 @@ function ledgerTotalsFromRows(rows: TreasuryTransaction[]): {
 
 /**
  * GET /api/admin/spend-experiences/{experienceId}/treasury
- * Server wallet address, live USDC balance, optional ledger (PRD §12).
+ * Global rail treasury wallet (Base USDC), live USDC balance when applicable, optional ledger (PRD §12).
  */
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {
@@ -49,7 +53,11 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       return apiError('Spend experience not found', 404);
     }
 
-    const serverWalletAddress = getSpendServerWalletAddress(experience).trim();
+    const rail = experience.spend_rail;
+    const treasuryWalletAddress = getSpendTreasuryWalletAddress(rail).trim();
+    const receivingWalletAddress = getSpendReceivingWalletAddress(rail).trim();
+    const privyCfg =
+      rail === 'base_usdc' ? getSpendBaseTreasuryPrivyTransferConfig() : null;
 
     const [serverWalletUsdcBalance, ledger] = await Promise.all([
       fetchServerWalletUsdcBalanceSafe(experience),
@@ -64,14 +72,15 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 
     return apiSuccess({
       spendExperienceId: experience.id,
-      serverWalletAddress,
-      privyServerWalletId: experience.privy_server_wallet_id,
-      serverWalletChain: experience.server_wallet_chain,
-      serverWalletCreatedAt: experience.server_wallet_created_at,
+      spendRail: rail,
+      serverWalletAddress: treasuryWalletAddress,
+      privyServerWalletId: privyCfg?.walletId ?? null,
+      serverWalletChain: rail === 'base_usdc' ? funding.chain : null,
+      serverWalletCreatedAt: null,
       serverWalletUsdcBalance,
       funding,
-      treasuryWalletAddress: serverWalletAddress,
-      receivingWalletAddress: serverWalletAddress,
+      treasuryWalletAddress,
+      receivingWalletAddress,
       treasuryUsdcBalance: serverWalletUsdcBalance,
       ledger,
       ledgerTotals,

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -82,6 +82,8 @@ const experience = {
   updated_at: '2026-04-01T00:00:00Z',
 };
 
+const CONFIG_TREASURY = '0x4444444444444444444444444444444444444444' as const;
+
 describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -92,8 +94,8 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
     mockGetSpendExperienceById.mockResolvedValue(experience);
     mockFetchBalance.mockResolvedValue(2.0001);
     mockGetTransferConfig.mockReturnValue({
-      walletId: 'privy-wallet-1',
-      address: '0x3333333333333333333333333333333333333333' as `0x${string}`,
+      walletId: 'wallet_e1',
+      address: CONFIG_TREASURY,
     });
     mockSubmitTransfer.mockResolvedValue({
       ok: true,
@@ -110,8 +112,8 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
     mockWaitReceipt.mockResolvedValue(undefined);
     mockInsertLedger.mockResolvedValue(undefined);
     mockPrivyGetWallet.mockResolvedValue({
-      id: 'privy-wallet-1',
-      address: experience.server_wallet_address,
+      id: 'wallet_e1',
+      address: CONFIG_TREASURY,
     });
   });
 
@@ -125,7 +127,7 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
         method: 'POST',
         headers,
         body: JSON.stringify({
-          destinationAddress: experience.server_wallet_address,
+          destinationAddress: CONFIG_TREASURY,
         }),
       }
     );
@@ -140,7 +142,7 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
     headers.set('x-user-email', 'admin@example.com');
-    const dest = '0x4444444444444444444444444444444444444444';
+    const dest = '0x5555555555555555555555555555555555555555';
     const req = new NextRequest(
       'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
       {
@@ -171,7 +173,7 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
     headers.set('x-user-email', 'admin@example.com');
-    const dest = '0x4444444444444444444444444444444444444444';
+    const dest = '0x5555555555555555555555555555555555555555';
     const req = new NextRequest(
       'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
       {
@@ -199,7 +201,7 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
     const headers = new Headers();
     headers.set('Content-Type', 'application/json');
     headers.set('x-user-email', 'admin@example.com');
-    const dest = '0x4444444444444444444444444444444444444444';
+    const dest = '0x5555555555555555555555555555555555555555';
     const req = new NextRequest(
       'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
       {

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -36,6 +36,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError('Spend experience not found', 404);
     }
 
+    if (experience.spend_rail !== 'base_usdc') {
+      return apiError(
+        'USDC withdrawals are only supported for Base USDC experiences.',
+        400
+      );
+    }
+
     const walletConfig = getSpendServerWalletTransferConfig(experience);
     if (!walletConfig) {
       return apiError(

--- a/app/api/admin/spend-experiences/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/__tests__/route.test.ts
@@ -198,7 +198,7 @@ describe('POST /api/admin/spend-experiences', () => {
       })
     );
     expect(j.data.funding.serverWalletAddress).toBe(
-      '0x9999999999999999999999999999999999999999'
+      '0x4444444444444444444444444444444444444444'
     );
   });
 

--- a/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
@@ -151,37 +151,50 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
   });
 
   it('snapshots Stellar rail wallet when experience is stellar_usdc', async () => {
-    const stellarExp = { ...experience, spend_rail: 'stellar_usdc' as const };
-    const stellarSession = {
-      ...session,
-      spend_rail: 'stellar_usdc' as const,
-      rail_user_wallet_address:
-        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-    };
-    mockGetExperience.mockResolvedValue(stellarExp);
-    mockCreateOrGet.mockResolvedValue({
-      session: stellarSession,
-      created: true,
-    });
-
-    const res = await POST(postRequest({ walletAddress: wallet }), {
-      params: { experienceId: 'exp-uuid' },
-    });
-    const j = await res.json();
-    expect(res.status).toBe(200);
-    expect(mockEnsureStellar).toHaveBeenCalledWith('privy-1');
-    expect(mockCreateOrGet).toHaveBeenCalledWith(
-      expect.objectContaining({
-        spendExperience: expect.objectContaining({
-          spend_rail: 'stellar_usdc',
-        }),
-        railUserWalletAddress:
+    const prevEnabled = process.env.SPEND_RAIL_STELLAR_USDC_ENABLED;
+    const prevRecv = process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS;
+    const prevNet = process.env.NEXT_PUBLIC_STELLAR_NETWORK;
+    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS =
+      'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    try {
+      const stellarExp = { ...experience, spend_rail: 'stellar_usdc' as const };
+      const stellarSession = {
+        ...session,
+        spend_rail: 'stellar_usdc' as const,
+        rail_user_wallet_address:
           'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-      })
-    );
-    expect(j.data.session.rail_user_wallet_address).toBe(
-      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
-    );
+      };
+      mockGetExperience.mockResolvedValue(stellarExp);
+      mockCreateOrGet.mockResolvedValue({
+        session: stellarSession,
+        created: true,
+      });
+
+      const res = await POST(postRequest({ walletAddress: wallet }), {
+        params: { experienceId: 'exp-uuid' },
+      });
+      const j = await res.json();
+      expect(res.status).toBe(200);
+      expect(mockEnsureStellar).toHaveBeenCalledWith('privy-1');
+      expect(mockCreateOrGet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          spendExperience: expect.objectContaining({
+            spend_rail: 'stellar_usdc',
+          }),
+          railUserWalletAddress:
+            'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+        })
+      );
+      expect(j.data.session.rail_user_wallet_address).toBe(
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
+      );
+    } finally {
+      process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = prevEnabled;
+      process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = prevRecv;
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = prevNet;
+    }
   });
 
   it('returns 401 when wallet not owned', async () => {

--- a/app/api/spend-experiences/[experienceId]/sessions/route.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/route.ts
@@ -7,6 +7,7 @@ import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { createOrGetSpendSession } from '@/lib/db/spend-sessions';
 import { ensureStellarRailUserWallet } from '@/lib/privy/stellar-rail-wallet';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
+import { assertSpendRailAllowsNewSessions } from '@/lib/spend-rail-config';
 import { createSpendSessionBodySchema } from '@/lib/schemas/spend-session';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import {
@@ -59,6 +60,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   const gate = assertSpendExperienceOpenForSessions(experience);
   if (!gate.ok) {
     return apiError(gate.error, gate.httpStatus);
+  }
+
+  const railGate = assertSpendRailAllowsNewSessions(experience.spend_rail);
+  if (!railGate.ok) {
+    return apiError(railGate.error, 400);
   }
 
   try {

--- a/app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts
@@ -88,8 +88,8 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/preview', () => {
       preview: {
         pointsRequired: 5000,
         usdcAmount: 5,
-        receivingWalletAddress: experience.receiving_wallet_address,
-        treasuryWalletAddress: experience.treasury_wallet_address,
+        receivingWalletAddress: '0x2222222222222222222222222222222222222222',
+        treasuryWalletAddress: '0x4444444444444444444444444444444444444444',
         userPointsBalance: 6000,
         treasuryUsdcBalance: 100,
       },

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { buildSpendEligibilityPreview } from '@/lib/spend-conversion-preview';
 import type {
   SpendExperience,
@@ -253,5 +253,75 @@ describe('buildSpendEligibilityPreview', () => {
       now,
     });
     expect(r.status).toBe('ready_for_payment_own_usdc');
+  });
+
+  describe('stellar_usdc rail', () => {
+    const prev: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const k of [
+        'SPEND_RAIL_STELLAR_USDC_ENABLED',
+        'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
+        'NEXT_PUBLIC_STELLAR_NETWORK',
+      ]) {
+        prev[k] = process.env[k];
+      }
+      process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+      process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS =
+        'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+      process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    });
+
+    afterEach(() => {
+      for (const [k, v] of Object.entries(prev)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    });
+
+    it('allows ready_for_payment_own_usdc without Base treasury funding', () => {
+      const r = buildSpendEligibilityPreview({
+        session: sess({ spend_rail: 'stellar_usdc' }),
+        spendExperience: exp({ spend_rail: 'stellar_usdc' }),
+        player: player(0),
+        pointConversion: null,
+        spendTransaction: null,
+        fundedConversionForOtherSession: null,
+        treasuryUsdcBalance: null,
+        userUsdcBalance: 10,
+        now,
+      });
+      expect(r.status).toBe('ready_for_payment_own_usdc');
+    });
+
+    it('returns conversion_unsupported when points would fund but rail has no Privy treasury path', () => {
+      const r = buildSpendEligibilityPreview({
+        session: sess({ spend_rail: 'stellar_usdc' }),
+        spendExperience: exp({ spend_rail: 'stellar_usdc' }),
+        player: player(6000),
+        pointConversion: null,
+        spendTransaction: null,
+        fundedConversionForOtherSession: null,
+        treasuryUsdcBalance: 100,
+        userUsdcBalance: null,
+        now,
+      });
+      expect(r.status).toBe('conversion_unsupported');
+    });
+
+    it('returns insufficient_points when user lacks points and own USDC', () => {
+      const r = buildSpendEligibilityPreview({
+        session: sess({ spend_rail: 'stellar_usdc' }),
+        spendExperience: exp({ spend_rail: 'stellar_usdc' }),
+        player: player(100),
+        pointConversion: null,
+        spendTransaction: null,
+        fundedConversionForOtherSession: null,
+        treasuryUsdcBalance: 100,
+        userUsdcBalance: null,
+        now,
+      });
+      expect(r.status).toBe('insufficient_points');
+    });
   });
 });

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -79,7 +79,7 @@ describe('buildSpendEligibilityPreview', () => {
       '0x4444444444444444444444444444444444444444'
     );
     expect(r.preview?.receivingWalletAddress).toBe(
-      '0x4444444444444444444444444444444444444444'
+      '0x2222222222222222222222222222222222222222'
     );
   });
 

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -2,14 +2,19 @@ import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
-import {
-  fetchServerWalletUsdcBalanceSafe,
-  getSpendServerWalletAddress,
-} from '@/lib/spend-server-wallet';
+import { fetchServerWalletUsdcBalanceSafe } from '@/lib/spend-server-wallet';
 import {
   fetchUsdcBalanceOnBase,
   isEvmAddress,
 } from '@/lib/walletconnect-poster-direct-usdc';
+import {
+  getSpendRailBaseRpcUrl,
+  getSpendRailBaseUsdcContractAddress,
+  getSpendRailOperationalDiagnostics,
+  getSpendReceivingWalletAddress,
+  getSpendTreasuryWalletAddress,
+  supportsSpendRailBasePrivyTreasuryFunding,
+} from '@/lib/spend-rail-config';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import type {
   PointConversion,
@@ -101,8 +106,12 @@ export function buildSpendEligibilityPreview(
   const basePreview = (): SpendConversionPreview => ({
     pointsRequired,
     usdcAmount,
-    receivingWalletAddress: getSpendServerWalletAddress(spendExperience),
-    treasuryWalletAddress: getSpendServerWalletAddress(spendExperience),
+    receivingWalletAddress: getSpendReceivingWalletAddress(
+      spendExperience.spend_rail
+    ),
+    treasuryWalletAddress: getSpendTreasuryWalletAddress(
+      spendExperience.spend_rail
+    ),
     userPointsBalance:
       player?.total_points != null ? Number(player.total_points) : null,
     userUsdcBalance,
@@ -114,6 +123,23 @@ export function buildSpendEligibilityPreview(
       status: 'session_expired',
       message: SPEND_ELIGIBILITY_MESSAGES.session_expired,
       preview: null,
+    };
+  }
+
+  const railDiag = getSpendRailOperationalDiagnostics(session.spend_rail);
+  if (!railDiag.operational) {
+    return {
+      status: 'rail_unavailable',
+      message: SPEND_ELIGIBILITY_MESSAGES.rail_unavailable,
+      preview: basePreview(),
+    };
+  }
+
+  if (!supportsSpendRailBasePrivyTreasuryFunding(spendExperience.spend_rail)) {
+    return {
+      status: 'conversion_unsupported',
+      message: SPEND_ELIGIBILITY_MESSAGES.conversion_unsupported,
+      preview: basePreview(),
     };
   }
 
@@ -217,7 +243,10 @@ export async function fetchUserUsdcBalanceSafe(
   const trimmed = walletAddress.trim();
   if (!isEvmAddress(trimmed)) return null;
   try {
-    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`);
+    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`, {
+      rpcUrl: getSpendRailBaseRpcUrl(),
+      usdcContract: getSpendRailBaseUsdcContractAddress(),
+    });
   } catch (e) {
     console.error('fetchUserUsdcBalanceSafe:', e);
     return null;

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -135,14 +135,6 @@ export function buildSpendEligibilityPreview(
     };
   }
 
-  if (!supportsSpendRailBasePrivyTreasuryFunding(spendExperience.spend_rail)) {
-    return {
-      status: 'conversion_unsupported',
-      message: SPEND_ELIGIBILITY_MESSAGES.conversion_unsupported,
-      preview: basePreview(),
-    };
-  }
-
   const gate = assertSpendExperienceOpenForSessions(spendExperience, now);
   if (!gate.ok) {
     return {
@@ -205,6 +197,19 @@ export function buildSpendEligibilityPreview(
 
   const balance =
     player?.total_points != null ? Number(player.total_points) : 0;
+
+  /** Points→USDC via Privy treasury exists only on `base_usdc` today. */
+  if (
+    !supportsSpendRailBasePrivyTreasuryFunding(spendExperience.spend_rail) &&
+    balance >= pointsRequired
+  ) {
+    return {
+      status: 'conversion_unsupported',
+      message: SPEND_ELIGIBILITY_MESSAGES.conversion_unsupported,
+      preview: basePreview(),
+    };
+  }
+
   if (balance < pointsRequired) {
     return {
       status: 'insufficient_points',

--- a/lib/spend-eligibility-messages.ts
+++ b/lib/spend-eligibility-messages.ts
@@ -8,6 +8,8 @@ export type SpendEligibilityStatus =
   | 'conversion_in_progress'
   | 'experience_inactive'
   | 'session_expired'
+  | 'rail_unavailable'
+  | 'conversion_unsupported'
   | 'treasury_insufficient'
   | 'wallet_unavailable'
   | 'ready_for_payment'
@@ -28,6 +30,10 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
   experience_inactive:
     'This spend experience is inactive or outside its active window.',
   session_expired: 'This spend session has expired. Scan the event QR again.',
+  rail_unavailable:
+    'This payment network is temporarily unavailable. Please try again later or ask an event host.',
+  conversion_unsupported:
+    'Points conversion is not available on this payment network yet. Please ask an event host.',
   treasury_insufficient:
     'The event wallet is temporarily out of USDC. Please try again later or ask an event host.',
   wallet_unavailable:

--- a/lib/spend-ledger-explorer-url.ts
+++ b/lib/spend-ledger-explorer-url.ts
@@ -1,41 +1,11 @@
-import type { SpendRail } from '@/lib/types';
-
 const EVM_TX_HASH_RE = /^0x[a-fA-F0-9]{64}$/;
 
-/** `0x` + 64 hex digits (trimmed). Used for BaseScan links and payment hash gates. */
+/** `0x` + 64 hex digits (trimmed). Used for explorer links and payment hash gates. */
 export function isLedgerCanonicalEvmTxHash(value: string): boolean {
   return EVM_TX_HASH_RE.test(value.trim());
 }
 
-export function spendLedgerNetworkLabel(spendRail: SpendRail): string {
-  return spendRail === 'stellar_usdc' ? 'Stellar' : 'Base';
-}
-
-/**
- * Explorer URL for a ledger tx hash, or null for `pending:` / unknown shapes.
- * EVM-shaped hashes use BaseScan (treasury paths are Base today even when the experience rail is Stellar).
- */
-export function explorerTxUrlForSpendLedger(
-  spendRail: SpendRail,
-  txHash: string | null | undefined
-): string | null {
-  const raw = txHash?.trim();
-  if (!raw || raw.toLowerCase().startsWith('pending:')) {
-    return null;
-  }
-
-  if (isLedgerCanonicalEvmTxHash(raw)) {
-    return `https://basescan.org/tx/${raw.toLowerCase()}`;
-  }
-
-  if (spendRail === 'stellar_usdc') {
-    const env = process.env.NEXT_PUBLIC_STELLAR_NETWORK?.toUpperCase();
-    const base =
-      env === 'TESTNET' || env === 'FUTURENET'
-        ? 'https://stellar.expert/explorer/testnet'
-        : 'https://stellar.expert/explorer/public';
-    return `${base}/tx/${encodeURIComponent(raw)}`;
-  }
-
-  return null;
-}
+export {
+  spendLedgerNetworkLabel,
+  formatExplorerTxUrlForSpendLedger as explorerTxUrlForSpendLedger,
+} from '@/lib/spend-rail-config';

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -31,9 +31,10 @@ vi.mock('@/lib/spend-payment-verify', () => ({
   verifySpendUsdcPaymentTx: vi.fn(),
 }));
 
-vi.mock('@/lib/spend-server-wallet', () => ({
-  getSpendServerWalletAddress: () =>
+vi.mock('@/lib/spend-rail-config', () => ({
+  getSpendReceivingWalletAddress: () =>
     '0x2222222222222222222222222222222222222222',
+  isSpendRailOperational: () => true,
 }));
 
 vi.mock('@/lib/analytics/server', () => ({

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -19,7 +19,10 @@ import {
 } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
-import { getSpendServerWalletAddress } from '@/lib/spend-server-wallet';
+import {
+  getSpendReceivingWalletAddress,
+  isSpendRailOperational,
+} from '@/lib/spend-rail-config';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import type {
   SpendExperience,
@@ -179,6 +182,15 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
+  if (spendExperience.spend_rail !== 'base_usdc') {
+    return {
+      ok: false,
+      error:
+        'USDC payment verification on this network is not available in this release.',
+      httpStatus: 400,
+    };
+  }
+
   const pointConversion = await getPointConversionBySessionId(session.id);
   const fundedConversion =
     pointConversion?.status === 'funded' ? pointConversion : null;
@@ -213,7 +225,9 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  const receiving = getSpendServerWalletAddress(spendExperience).trim();
+  const receiving = getSpendReceivingWalletAddress(
+    spendExperience.spend_rail
+  ).trim();
   if (!isEvmAddress(receiving)) {
     return {
       ok: false,
@@ -267,6 +281,15 @@ export async function runSpendPaymentConfirm(input: {
   }
 
   let spendTx = await getSpendTransactionBySessionId(session.id);
+
+  if (!spendTx && !isSpendRailOperational(session.spend_rail)) {
+    return {
+      ok: false,
+      error:
+        'This payment network is temporarily unavailable. Please try again later.',
+      httpStatus: 400,
+    };
+  }
 
   if (spendTx?.status === 'confirmed') {
     const fresh = await getSpendSessionById(session.id);

--- a/lib/spend-payment-verify.ts
+++ b/lib/spend-payment-verify.ts
@@ -5,10 +5,11 @@ import {
   http,
   parseUnits,
 } from 'viem';
+import { POSTER_CHECKOUT_CHAIN } from '@/lib/walletconnect-poster-direct-usdc';
 import {
-  POSTER_CHECKOUT_CHAIN,
-  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-} from '@/lib/walletconnect-poster-direct-usdc';
+  getSpendRailBaseRpcUrl,
+  getSpendRailBaseUsdcContractAddress,
+} from '@/lib/spend-rail-config';
 
 export type SpendPaymentTxVerifyResult =
   | { ok: true }
@@ -24,7 +25,7 @@ export async function verifySpendUsdcPaymentTx(params: {
   /** Human-readable USDC (must match on-chain 6-decimal amount). */
   expectedUsdcAmount: number;
 }): Promise<SpendPaymentTxVerifyResult> {
-  const rpcUrl = process.env.NEXT_PUBLIC_BASE_RPC?.trim();
+  const rpcUrl = getSpendRailBaseRpcUrl().trim();
   if (!rpcUrl) {
     return { ok: false, reason: 'RPC not configured' };
   }
@@ -52,7 +53,7 @@ export async function verifySpendUsdcPaymentTx(params: {
   const expectedRaw = parseUnits(params.expectedUsdcAmount.toFixed(6), 6);
   const fromLower = params.expectedFrom.toLowerCase();
   const toLower = params.expectedTo.toLowerCase();
-  const usdcLower = POSTER_CHECKOUT_USDC_ADDRESS_BASE.toLowerCase();
+  const usdcLower = getSpendRailBaseUsdcContractAddress().toLowerCase();
 
   for (const log of receipt.logs) {
     if (log.address.toLowerCase() !== usdcLower) {

--- a/lib/spend-rail-config/index.test.ts
+++ b/lib/spend-rail-config/index.test.ts
@@ -1,0 +1,179 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  assertSpendRailAllowsNewSessions,
+  formatExplorerTxUrlForSpendLedger,
+  getSpendRailOperationalDiagnostics,
+  getSpendRailPublicMetadata,
+  getSpendReceivingWalletAddress,
+  getSpendTreasuryWalletAddress,
+  spendLedgerNetworkLabel,
+} from '@/lib/spend-rail-config/index';
+
+const VALID_STELLAR =
+  'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+describe('spendLedgerNetworkLabel', () => {
+  it('maps rails to snapshot labels', () => {
+    expect(spendLedgerNetworkLabel('base_usdc')).toBe('Base');
+    expect(spendLedgerNetworkLabel('stellar_usdc')).toBe('Stellar');
+  });
+});
+
+describe('getSpendRailPublicMetadata', () => {
+  it('includes enabled flag and safe fields', () => {
+    const meta = getSpendRailPublicMetadata('base_usdc');
+    expect(meta.rail).toBe('base_usdc');
+    expect(meta.displayName).toBe('Base USDC');
+    expect(meta.assetSymbol).toBe('USDC');
+    expect(typeof meta.enabled).toBe('boolean');
+    expect(meta.explorerTxUrlTemplate).toContain('{txHash}');
+  });
+});
+
+describe('formatExplorerTxUrlForSpendLedger', () => {
+  it('returns null for pending placeholders', () => {
+    expect(
+      formatExplorerTxUrlForSpendLedger('base_usdc', 'pending:privy-tx-123')
+    ).toBeNull();
+  });
+
+  it('applies Base template for EVM hashes (any rail)', () => {
+    const h =
+      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    expect(formatExplorerTxUrlForSpendLedger('base_usdc', h)).toBe(
+      'https://basescan.org/tx/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    );
+    expect(formatExplorerTxUrlForSpendLedger('stellar_usdc', h)).toContain(
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    );
+  });
+
+  it('uses stellar template for non-EVM hash on stellar rail', () => {
+    const h =
+      'deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef';
+    const url = formatExplorerTxUrlForSpendLedger('stellar_usdc', h);
+    expect(url).toMatch(
+      /^https:\/\/stellar\.expert\/explorer\/(public|testnet)\/tx\//
+    );
+  });
+});
+
+describe('getSpendRailOperationalDiagnostics — base_usdc', () => {
+  const prev: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of [
+      'SPEND_RAIL_BASE_USDC_ENABLED',
+      'SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS',
+      'SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS',
+      'SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID',
+      'NEXT_PUBLIC_SPEND_RAIL_BASE_USDC_EXPLORER_TX_URL_TEMPLATE',
+    ]) {
+      prev[k] = process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('marks rail unavailable when kill switch is off', () => {
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'false';
+    process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS =
+      '0x1111111111111111111111111111111111111111';
+    process.env.SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS =
+      '0x2222222222222222222222222222222222222222';
+    process.env.SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID = 'w1';
+    const d = getSpendRailOperationalDiagnostics('base_usdc');
+    expect(d.operational).toBe(false);
+    expect(d.unavailableReasons.some((r) => r.includes('disabled'))).toBe(true);
+    expect(assertSpendRailAllowsNewSessions('base_usdc').ok).toBe(false);
+  });
+
+  it('marks rail unavailable when treasury address invalid', () => {
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS = 'not-an-addr';
+    process.env.SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS =
+      '0x2222222222222222222222222222222222222222';
+    process.env.SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID = 'w1';
+    const d = getSpendRailOperationalDiagnostics('base_usdc');
+    expect(d.operational).toBe(false);
+    expect(
+      d.unavailableReasons.some((r) => r.includes('TREASURY_WALLET'))
+    ).toBe(true);
+  });
+
+  it('rejects explorer template without placeholder', () => {
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS =
+      '0x1111111111111111111111111111111111111111';
+    process.env.SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS =
+      '0x2222222222222222222222222222222222222222';
+    process.env.SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID = 'w1';
+    process.env.NEXT_PUBLIC_SPEND_RAIL_BASE_USDC_EXPLORER_TX_URL_TEMPLATE =
+      'https://basescan.org/tx/';
+    const d = getSpendRailOperationalDiagnostics('base_usdc');
+    expect(d.operational).toBe(false);
+    expect(d.unavailableReasons.some((r) => r.includes('{txHash}'))).toBe(true);
+  });
+});
+
+describe('getSpendRailOperationalDiagnostics — stellar_usdc', () => {
+  const prev: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of [
+      'SPEND_RAIL_STELLAR_USDC_ENABLED',
+      'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
+      'NEXT_PUBLIC_STELLAR_NETWORK',
+      'NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE',
+    ]) {
+      prev[k] = process.env[k];
+    }
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(prev)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('happy path when enabled with valid receiving and network', () => {
+    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    delete process.env
+      .NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE;
+    const d = getSpendRailOperationalDiagnostics('stellar_usdc');
+    expect(d.operational).toBe(true);
+    expect(getSpendReceivingWalletAddress('stellar_usdc')).toBe(VALID_STELLAR);
+  });
+
+  it('unavailable when receiving invalid', () => {
+    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = 'bad';
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    const d = getSpendRailOperationalDiagnostics('stellar_usdc');
+    expect(d.operational).toBe(false);
+  });
+
+  it('unavailable when network env missing', () => {
+    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
+    process.env.NEXT_PUBLIC_STELLAR_NETWORK = '';
+    const d = getSpendRailOperationalDiagnostics('stellar_usdc');
+    expect(d.operational).toBe(false);
+  });
+});
+
+describe('getSpendTreasuryWalletAddress', () => {
+  it('resolves base treasury from env', () => {
+    expect(getSpendTreasuryWalletAddress('base_usdc').toLowerCase()).toBe(
+      '0x4444444444444444444444444444444444444444'
+    );
+  });
+});

--- a/lib/spend-rail-config/index.ts
+++ b/lib/spend-rail-config/index.ts
@@ -1,0 +1,367 @@
+import {
+  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+  isEvmAddress,
+} from '@/lib/walletconnect-poster-direct-usdc';
+import { stellarWalletAddressSchema } from '@/lib/schemas/player';
+import type { SpendRail } from '@/lib/types';
+import type {
+  SpendRailOperationalDiagnostics,
+  SpendRailPublicMetadata,
+} from '@/lib/spend-rail-config/types';
+
+export type {
+  SpendRailPublicMetadata,
+  SpendRailOperationalDiagnostics,
+} from '@/lib/spend-rail-config/types';
+
+const DEFAULT_BASE_RPC = 'https://mainnet.base.org';
+
+function trimEnv(key: string): string {
+  return (process.env[key] ?? '').trim();
+}
+
+function parseBool(value: string | undefined, defaultValue: boolean): boolean {
+  if (value == null || value.trim() === '') return defaultValue;
+  const v = value.trim().toLowerCase();
+  if (['1', 'true', 'yes', 'on'].includes(v)) return true;
+  if (['0', 'false', 'no', 'off'].includes(v)) return false;
+  return defaultValue;
+}
+
+function stellarExplorerTemplateFromNetwork(networkUpper: string): string {
+  const base =
+    networkUpper === 'TESTNET' || networkUpper === 'FUTURENET'
+      ? 'https://stellar.expert/explorer/testnet'
+      : 'https://stellar.expert/explorer/public';
+  return `${base}/tx/{txHash}`;
+}
+
+type ParsedBase = {
+  enabled: boolean;
+  treasuryAddress: string | null;
+  receivingAddress: string | null;
+  privyServerWalletId: string | null;
+  usdcContract: string;
+  rpcUrl: string;
+  explorerTxUrlTemplate: string;
+};
+
+type ParsedStellar = {
+  enabled: boolean;
+  receivingAddress: string | null;
+  /** Optional; when unset, treasury display/fallback uses `receivingAddress`. */
+  treasuryAddress: string | null;
+  stellarNetworkUpper: string;
+  explorerTxUrlTemplate: string;
+};
+
+type ParsedRails = {
+  base: ParsedBase;
+  stellar: ParsedStellar;
+};
+
+function parseRailsConfig(): ParsedRails {
+  const baseEnabled = parseBool(process.env.SPEND_RAIL_BASE_USDC_ENABLED, true);
+  const treasuryAddress =
+    trimEnv('SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS') || null;
+  const receivingAddress =
+    trimEnv('SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS') || null;
+  const privyServerWalletId =
+    trimEnv('SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID') || null;
+  const usdcContract =
+    trimEnv('SPEND_RAIL_BASE_USDC_USDC_CONTRACT') ||
+    POSTER_CHECKOUT_USDC_ADDRESS_BASE;
+  const rpcUrl =
+    trimEnv('SPEND_RAIL_BASE_USDC_RPC_URL') ||
+    trimEnv('NEXT_PUBLIC_BASE_RPC') ||
+    DEFAULT_BASE_RPC;
+  const explorerTemplateRaw = trimEnv(
+    'NEXT_PUBLIC_SPEND_RAIL_BASE_USDC_EXPLORER_TX_URL_TEMPLATE'
+  );
+  const explorerTxUrlTemplate =
+    explorerTemplateRaw.length > 0
+      ? explorerTemplateRaw
+      : 'https://basescan.org/tx/{txHash}';
+
+  const stellarEnabled = parseBool(
+    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED,
+    false
+  );
+  const stellarReceiving =
+    trimEnv('SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS') || null;
+  const stellarTreasury =
+    trimEnv('SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS') || null;
+  const stellarNetworkRaw = trimEnv('NEXT_PUBLIC_STELLAR_NETWORK');
+  const stellarNetworkUpper = stellarNetworkRaw.toUpperCase();
+  const stellarExplorerOverride = trimEnv(
+    'NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE'
+  );
+  const stellarExplorerTxUrlTemplate =
+    stellarExplorerOverride.length > 0
+      ? stellarExplorerOverride
+      : stellarExplorerTemplateFromNetwork(stellarNetworkUpper);
+
+  return {
+    base: {
+      enabled: baseEnabled,
+      treasuryAddress,
+      receivingAddress,
+      privyServerWalletId,
+      usdcContract,
+      rpcUrl,
+      explorerTxUrlTemplate,
+    },
+    stellar: {
+      enabled: stellarEnabled,
+      receivingAddress: stellarReceiving,
+      treasuryAddress: stellarTreasury,
+      stellarNetworkUpper,
+      explorerTxUrlTemplate: stellarExplorerTxUrlTemplate,
+    },
+  };
+}
+
+function validateExplorerTemplate(template: string, label: string): string[] {
+  if (!template.includes('{txHash}')) {
+    return [`${label} explorer template must include {txHash} placeholder`];
+  }
+  return [];
+}
+
+function collectBaseOperationalReasons(parsed: ParsedBase): string[] {
+  const reasons: string[] = [];
+  if (!parsed.enabled) {
+    reasons.push('base_usdc rail is disabled (SPEND_RAIL_BASE_USDC_ENABLED)');
+    return reasons;
+  }
+  if (!parsed.treasuryAddress) {
+    reasons.push('SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS is missing');
+  } else if (!isEvmAddress(parsed.treasuryAddress)) {
+    reasons.push(
+      'SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS is not a valid EVM address'
+    );
+  }
+  if (!parsed.receivingAddress) {
+    reasons.push('SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS is missing');
+  } else if (!isEvmAddress(parsed.receivingAddress)) {
+    reasons.push(
+      'SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS is not a valid EVM address'
+    );
+  }
+  if (!parsed.privyServerWalletId) {
+    reasons.push('SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID is missing');
+  }
+  if (!isEvmAddress(parsed.usdcContract)) {
+    reasons.push(
+      'SPEND_RAIL_BASE_USDC_USDC_CONTRACT is not a valid EVM address'
+    );
+  }
+  reasons.push(
+    ...validateExplorerTemplate(parsed.explorerTxUrlTemplate, 'Base')
+  );
+  if (!parsed.rpcUrl) {
+    reasons.push('Base RPC URL resolved empty');
+  }
+  return reasons;
+}
+
+function collectStellarOperationalReasons(parsed: ParsedStellar): string[] {
+  const reasons: string[] = [];
+  if (!parsed.enabled) {
+    reasons.push(
+      'stellar_usdc rail is disabled (SPEND_RAIL_STELLAR_USDC_ENABLED)'
+    );
+    return reasons;
+  }
+  if (!trimEnv('NEXT_PUBLIC_STELLAR_NETWORK')) {
+    reasons.push(
+      'NEXT_PUBLIC_STELLAR_NETWORK is missing (required for Stellar spend rail)'
+    );
+  }
+  if (!parsed.receivingAddress) {
+    reasons.push('SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS is missing');
+  } else {
+    const stellarCheck = stellarWalletAddressSchema.safeParse(
+      parsed.receivingAddress
+    );
+    if (!stellarCheck.success) {
+      reasons.push(
+        'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS is not a valid Stellar public key'
+      );
+    }
+  }
+  if (parsed.treasuryAddress) {
+    const t = stellarWalletAddressSchema.safeParse(parsed.treasuryAddress);
+    if (!t.success) {
+      reasons.push(
+        'SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS is not a valid Stellar public key'
+      );
+    }
+  }
+  reasons.push(
+    ...validateExplorerTemplate(parsed.explorerTxUrlTemplate, 'Stellar')
+  );
+  return reasons;
+}
+
+/** Optional Stellar server URL used elsewhere in the app; validated only when set (IRL-8). */
+export function getOptionalStellarHorizonUrlForSpendEnv(): {
+  value: string | null;
+  valid: boolean;
+  reason: string | null;
+} {
+  const v = trimEnv('NEXT_PUBLIC_STELLAR_HORIZON_URL');
+  if (!v) return { value: null, valid: true, reason: null };
+  try {
+    // eslint-disable-next-line no-new -- URL validates shape
+    new URL(v);
+    return { value: v, valid: true, reason: null };
+  } catch {
+    return {
+      value: v,
+      valid: false,
+      reason: 'NEXT_PUBLIC_STELLAR_HORIZON_URL is not a valid URL',
+    };
+  }
+}
+
+export function getSpendRailOperationalDiagnostics(
+  spendRail: SpendRail
+): SpendRailOperationalDiagnostics {
+  const parsed = parseRailsConfig();
+  const reasons =
+    spendRail === 'stellar_usdc'
+      ? collectStellarOperationalReasons(parsed.stellar)
+      : collectBaseOperationalReasons(parsed.base);
+  const horizon = getOptionalStellarHorizonUrlForSpendEnv();
+  if (spendRail === 'stellar_usdc' && !horizon.valid && horizon.reason) {
+    reasons.push(horizon.reason);
+  }
+  return {
+    operational: reasons.length === 0,
+    unavailableReasons: reasons,
+  };
+}
+
+export function isSpendRailOperational(spendRail: SpendRail): boolean {
+  return getSpendRailOperationalDiagnostics(spendRail).operational;
+}
+
+export function assertSpendRailAllowsNewSessions(
+  spendRail: SpendRail
+): { ok: true } | { ok: false; error: string } {
+  const { operational } = getSpendRailOperationalDiagnostics(spendRail);
+  if (operational) return { ok: true };
+  return {
+    ok: false,
+    error:
+      'This payment network is temporarily unavailable. Please try again later.',
+  };
+}
+
+/** Treasury funding via Privy server wallet + Base USDC exists only for `base_usdc` today. */
+export function supportsSpendRailBasePrivyTreasuryFunding(
+  spendRail: SpendRail
+): boolean {
+  return spendRail === 'base_usdc';
+}
+
+export function getSpendRailPublicMetadata(
+  spendRail: SpendRail
+): SpendRailPublicMetadata {
+  const parsed = parseRailsConfig();
+  if (spendRail === 'stellar_usdc') {
+    const s = parsed.stellar;
+    return {
+      rail: 'stellar_usdc',
+      displayName: 'Stellar USDC',
+      networkLabel: 'Stellar',
+      assetSymbol: 'USDC',
+      enabled: s.enabled,
+      receivingWalletAddress: s.receivingAddress,
+      explorerTxUrlTemplate: s.explorerTxUrlTemplate,
+    };
+  }
+  const b = parsed.base;
+  return {
+    rail: 'base_usdc',
+    displayName: 'Base USDC',
+    networkLabel: 'Base',
+    assetSymbol: 'USDC',
+    enabled: b.enabled,
+    receivingWalletAddress: b.receivingAddress,
+    explorerTxUrlTemplate: b.explorerTxUrlTemplate,
+  };
+}
+
+export function spendLedgerNetworkLabel(spendRail: SpendRail): string {
+  return getSpendRailPublicMetadata(spendRail).networkLabel;
+}
+
+/**
+ * Builds an explorer URL from rail templates. EVM-shaped hashes always use the
+ * Base USDC template (on-chain activity may be on Base even when the session rail is Stellar).
+ */
+export function formatExplorerTxUrlForSpendLedger(
+  spendRail: SpendRail,
+  txHash: string | null | undefined
+): string | null {
+  const raw = txHash?.trim();
+  if (!raw || raw.toLowerCase().startsWith('pending:')) {
+    return null;
+  }
+
+  const parsed = parseRailsConfig();
+  const evmHash = /^0x[a-fA-F0-9]{64}$/.test(raw);
+  if (evmHash) {
+    const tpl = parsed.base.explorerTxUrlTemplate;
+    return tpl.replace('{txHash}', raw.toLowerCase());
+  }
+
+  if (spendRail === 'stellar_usdc') {
+    const tpl = parsed.stellar.explorerTxUrlTemplate;
+    return tpl.replace('{txHash}', encodeURIComponent(raw));
+  }
+
+  return null;
+}
+
+export function getSpendTreasuryWalletAddress(spendRail: SpendRail): string {
+  const parsed = parseRailsConfig();
+  if (spendRail === 'stellar_usdc') {
+    const s = parsed.stellar;
+    return s.treasuryAddress?.trim() || s.receivingAddress?.trim() || '';
+  }
+  return parsed.base.treasuryAddress?.trim() ?? '';
+}
+
+export function getSpendReceivingWalletAddress(spendRail: SpendRail): string {
+  const parsed = parseRailsConfig();
+  if (spendRail === 'stellar_usdc') {
+    return parsed.stellar.receivingAddress?.trim() ?? '';
+  }
+  return parsed.base.receivingAddress?.trim() ?? '';
+}
+
+export type SpendBaseTreasuryPrivyTransferConfig = {
+  walletId: string;
+  address: `0x${string}`;
+};
+
+export function getSpendBaseTreasuryPrivyTransferConfig(): SpendBaseTreasuryPrivyTransferConfig | null {
+  const parsed = parseRailsConfig().base;
+  if (!parsed.enabled) return null;
+  const walletId = parsed.privyServerWalletId?.trim();
+  const addr = parsed.treasuryAddress?.trim();
+  if (!walletId || !addr || !isEvmAddress(addr)) return null;
+  return { walletId, address: addr as `0x${string}` };
+}
+
+export function getSpendRailBaseRpcUrl(): string {
+  return parseRailsConfig().base.rpcUrl;
+}
+
+export function getSpendRailBaseUsdcContractAddress(): `0x${string}` {
+  const raw = parseRailsConfig().base.usdcContract.trim();
+  return raw as `0x${string}`;
+}

--- a/lib/spend-rail-config/types.ts
+++ b/lib/spend-rail-config/types.ts
@@ -1,0 +1,28 @@
+import type { SpendRail } from '@/lib/types';
+
+export type SpendRailPublicMetadata = {
+  rail: SpendRail;
+  /** Human-readable rail label for UI. */
+  displayName: string;
+  /** Short network label stored on ledger rows (e.g. Base, Stellar). */
+  networkLabel: string;
+  assetSymbol: string;
+  /** Kill switch: when false, new sessions and new money movement are blocked. */
+  enabled: boolean;
+  /**
+   * Global receiving/settlement destination for this rail (safe to expose publicly).
+   * EVM 0x-hex for Base; `G…` strkey for Stellar.
+   */
+  receivingWalletAddress: string | null;
+  /**
+   * Template for explorer links; replace `{txHash}` with the normalized hash
+   * (lowercase for EVM; URI-encoded for Stellar non-EVM hashes).
+   */
+  explorerTxUrlTemplate: string | null;
+};
+
+export type SpendRailOperationalDiagnostics = {
+  operational: boolean;
+  /** Non-empty when operational is false; safe for server logs/tests only. */
+  unavailableReasons: string[];
+};

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -2,6 +2,13 @@ import {
   fetchUsdcBalanceOnBase,
   isEvmAddress,
 } from '@/lib/walletconnect-poster-direct-usdc';
+import {
+  getSpendBaseTreasuryPrivyTransferConfig,
+  getSpendRailBaseRpcUrl,
+  getSpendRailBaseUsdcContractAddress,
+  getSpendTreasuryWalletAddress,
+  supportsSpendRailBasePrivyTreasuryFunding,
+} from '@/lib/spend-rail-config';
 import type { SpendExperience } from '@/lib/types';
 
 export const SPEND_SERVER_WALLET_CHAIN = 'base-mainnet';
@@ -27,28 +34,22 @@ export type SpendServerWalletTransferConfig = {
   address: `0x${string}`;
 };
 
+/**
+ * Global treasury (funding) wallet for the experience rail — from spend rail env config.
+ */
 export function getSpendServerWalletAddress(
-  experience: Pick<
-    SpendExperience,
-    'server_wallet_address' | 'treasury_wallet_address'
-  >
+  experience: Pick<SpendExperience, 'spend_rail'>
 ): string {
-  return (
-    experience.server_wallet_address?.trim() ||
-    experience.treasury_wallet_address.trim()
-  );
+  return getSpendTreasuryWalletAddress(experience.spend_rail);
 }
 
 export function spendServerWalletFundingMetadata(
-  experience: Pick<
-    SpendExperience,
-    'server_wallet_address' | 'treasury_wallet_address' | 'max_usdc_per_user'
-  >,
+  experience: Pick<SpendExperience, 'spend_rail' | 'max_usdc_per_user'>,
   usdcBalance: number | null
 ): SpendServerWalletFundingMetadata {
   const minimumUsdc = Number(experience.max_usdc_per_user);
   return {
-    serverWalletAddress: getSpendServerWalletAddress(experience),
+    serverWalletAddress: getSpendTreasuryWalletAddress(experience.spend_rail),
     chain: SPEND_SERVER_WALLET_CHAIN,
     minimumUsdc,
     usdcBalance,
@@ -57,33 +58,34 @@ export function spendServerWalletFundingMetadata(
 }
 
 export function getSpendServerWalletTransferConfig(
-  experience: Pick<
-    SpendExperience,
-    | 'privy_server_wallet_id'
-    | 'server_wallet_address'
-    | 'treasury_wallet_address'
-  >
+  experience: Pick<SpendExperience, 'spend_rail'>
 ): SpendServerWalletTransferConfig | null {
-  const walletId = experience.privy_server_wallet_id?.trim();
-  const serverAddr = experience.server_wallet_address?.trim();
-  if (!walletId || !serverAddr || !isEvmAddress(serverAddr)) {
+  if (!supportsSpendRailBasePrivyTreasuryFunding(experience.spend_rail)) {
     return null;
   }
-
-  return { walletId, address: serverAddr as `0x${string}` };
+  const cfg = getSpendBaseTreasuryPrivyTransferConfig();
+  if (!cfg) return null;
+  return { walletId: cfg.walletId, address: cfg.address };
 }
 
 async function fetchUsdcBalanceSafe(
+  spendRail: SpendExperience['spend_rail'],
   walletAddress: string | null | undefined,
   logContext: string
 ): Promise<number | null> {
+  if (spendRail !== 'base_usdc') {
+    return null;
+  }
   const trimmed = walletAddress?.trim();
   if (!trimmed || !isEvmAddress(trimmed)) {
     return null;
   }
 
   try {
-    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`);
+    return await fetchUsdcBalanceOnBase(trimmed as `0x${string}`, {
+      rpcUrl: getSpendRailBaseRpcUrl(),
+      usdcContract: getSpendRailBaseUsdcContractAddress(),
+    });
   } catch (error) {
     console.error(`${logContext}:`, error);
     return null;
@@ -95,6 +97,7 @@ export async function getServerWalletFundingStatus(params: {
   minUsdcRequired: number;
 }): Promise<{ usdcBalance: number | null; isFunded: boolean }> {
   const usdcBalance = await fetchUsdcBalanceSafe(
+    'base_usdc',
     params.walletAddress,
     'getServerWalletFundingStatus'
   );
@@ -106,13 +109,11 @@ export async function getServerWalletFundingStatus(params: {
 }
 
 export function fetchServerWalletUsdcBalanceSafe(
-  experience: Pick<
-    SpendExperience,
-    'server_wallet_address' | 'treasury_wallet_address'
-  >
+  experience: Pick<SpendExperience, 'spend_rail'>
 ): Promise<number | null> {
   return fetchUsdcBalanceSafe(
-    getSpendServerWalletAddress(experience),
+    experience.spend_rail,
+    getSpendTreasuryWalletAddress(experience.spend_rail),
     'fetchServerWalletUsdcBalanceSafe'
   );
 }

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -9,16 +9,17 @@ import {
 } from 'viem';
 import { getPrivyClient } from '@/lib/api/privy';
 import {
+  getSpendRailBaseRpcUrl,
+  getSpendRailBaseUsdcContractAddress,
+} from '@/lib/spend-rail-config';
+import {
   PrivyRestApiError,
   PrivyRestTransactionFailedError,
   PrivyRestTransactionTimeoutError,
   signAndSendTransaction,
   waitForTransaction,
 } from '@/lib/privy-server-rest';
-import {
-  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-  POSTER_CHECKOUT_CHAIN,
-} from '@/lib/walletconnect-poster-direct-usdc';
+import { POSTER_CHECKOUT_CHAIN } from '@/lib/walletconnect-poster-direct-usdc';
 
 export type TreasuryUsdcSubmitResult =
   | {
@@ -75,7 +76,7 @@ export function mapInsufficientNativeGasPrivyError(message: string): string {
 }
 
 function rpcUrl(): string {
-  return process.env.NEXT_PUBLIC_BASE_RPC?.trim() || 'https://mainnet.base.org';
+  return getSpendRailBaseRpcUrl().trim() || 'https://mainnet.base.org';
 }
 
 async function publicBaseClient() {
@@ -140,7 +141,7 @@ async function findRecentTreasuryTransferHash(params: {
     const maxFrom = chunkTo - (MAX_LOG_BLOCK_SPAN - 1n);
     const fromBlock = maxFrom > scanFrom ? maxFrom : scanFrom;
     const logs = await publicClient.getLogs({
-      address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+      address: getSpendRailBaseUsdcContractAddress(),
       event: TRANSFER_EVENT,
       args: {
         from: params.serverWalletAddress,
@@ -240,7 +241,7 @@ export async function submitTreasuryUsdcTransfer(params: {
 
     const sent = await signAndSendTransaction({
       walletId,
-      to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+      to: getSpendRailBaseUsdcContractAddress(),
       data: transferData,
       value: '0x0',
       sponsor: true,

--- a/lib/walletconnect-poster-direct-usdc.ts
+++ b/lib/walletconnect-poster-direct-usdc.ts
@@ -49,14 +49,21 @@ export function encodeUsdcTransferData(
  * Returns the balance as a human-readable number (e.g. 1.23 for 1.23 USDC).
  */
 export async function fetchUsdcBalanceOnBase(
-  walletAddress: `0x${string}`
+  walletAddress: `0x${string}`,
+  options?: {
+    rpcUrl?: string;
+    usdcContract?: `0x${string}`;
+  }
 ): Promise<number> {
+  const rpcUrl =
+    options?.rpcUrl ?? process.env.NEXT_PUBLIC_BASE_RPC?.trim() ?? undefined;
   const client = createPublicClient({
     chain: base,
-    transport: http(),
+    transport: rpcUrl ? http(rpcUrl) : http(),
   });
+  const contract = options?.usdcContract ?? POSTER_CHECKOUT_USDC_ADDRESS_BASE;
   const raw = await client.readContract({
-    address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+    address: contract,
     abi: erc20Abi,
     functionName: 'balanceOf',
     args: [walletAddress],

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -1,14 +1,23 @@
 // Vitest test setup file
-import '@testing-library/jest-dom'
-import { vi, beforeAll, afterAll, afterEach } from 'vitest'
-import { server } from './mocks/server'
+import '@testing-library/jest-dom';
+import { vi, beforeAll, afterAll, afterEach } from 'vitest';
+import { server } from './mocks/server';
 
 // MSW server lifecycle and console error suppression
-const originalError = console.error
+const originalError = console.error;
 
 beforeAll(() => {
+  process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'true';
+  process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS =
+    '0x4444444444444444444444444444444444444444';
+  process.env.SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS =
+    '0x2222222222222222222222222222222222222222';
+  process.env.SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID = 'wallet_e1';
+  process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'false';
+  process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'TESTNET';
+
   // Start MSW server
-  server.listen({ onUnhandledRequest: 'warn' })
+  server.listen({ onUnhandledRequest: 'warn' });
 
   // Suppress common React warnings in tests
   console.error = (...args: unknown[]) => {
@@ -17,26 +26,26 @@ beforeAll(() => {
       (args[0].includes('Warning: ReactDOM.render') ||
         args[0].includes('Warning: validateDOMNesting'))
     ) {
-      return
+      return;
     }
-    originalError.call(console, ...args)
-  }
-})
+    originalError.call(console, ...args);
+  };
+});
 
 // Reset handlers after each test to ensure test isolation
 afterEach(() => {
-  server.resetHandlers()
-})
+  server.resetHandlers();
+});
 
 // Close server and restore console after all tests
 afterAll(() => {
-  server.close()
-  console.error = originalError
-})
+  server.close();
+  console.error = originalError;
+});
 
 // Mock NextResponse for testing - use importOriginal to keep NextRequest
 vi.mock('next/server', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('next/server')>()
+  const actual = await importOriginal<typeof import('next/server')>();
   return {
     ...actual,
     NextResponse: {
@@ -45,12 +54,12 @@ vi.mock('next/server', async (importOriginal) => {
           status: init?.status || 200,
           json: async () => data,
           body: JSON.stringify(data),
-        }
-        return response
+        };
+        return response;
       }),
     },
-  }
-})
+  };
+});
 
 // Mock Next.js router
 vi.mock('next/navigation', () => ({
@@ -63,15 +72,15 @@ vi.mock('next/navigation', () => ({
       pathname: '/',
       query: {},
       asPath: '/',
-    }
+    };
   },
   usePathname() {
-    return '/'
+    return '/';
   },
   useSearchParams() {
-    return new URLSearchParams()
+    return new URLSearchParams();
   },
-}))
+}));
 
 // Mock Supabase client
 vi.mock('@/lib/db/client', () => ({
@@ -99,7 +108,7 @@ vi.mock('@/lib/db/client', () => ({
       delete: vi.fn(),
     })),
   },
-}))
+}));
 
 // Mock Privy
 vi.mock('@privy-io/react-auth', () => ({
@@ -111,7 +120,7 @@ vi.mock('@privy-io/react-auth', () => ({
     ready: true,
   })),
   PrivyProvider: ({ children }: { children: React.ReactNode }) => children,
-}))
+}));
 
 // Mock Mapbox GL
 vi.mock('mapbox-gl', () => ({
@@ -121,6 +130,6 @@ vi.mock('mapbox-gl', () => ({
   GeolocateControl: vi.fn(),
   NavigationControl: vi.fn(),
   FullscreenControl: vi.fn(),
-}))
+}));
 
 // react-map-gl is mocked via alias in vitest.config.ts


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements centralized spend rail configuration (IRL-8): env-driven Base and Stellar USDC rails, validation, kill switches, explorer templates, and global treasury/receiving resolution.

## Follow-up fix

Eligibility no longer treats `supportsSpendRailBasePrivyTreasuryFunding` as a global gate. `conversion_unsupported` applies only when the user would rely on the points→Privy treasury path (enough points, not enough wallet USDC). Stellar users with sufficient embedded USDC can reach `ready_for_payment_own_usdc` again.

## Deploy note

Set `SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS`, `SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS`, and `SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID` in each environment, or the Base rail is unavailable for new sessions until configured.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-8](https://linear.app/irlenergy/issue/IRL-8/implement-centralized-spend-rail-configuration)

<div><a href="https://cursor.com/agents/bc-8546b300-5f73-4465-a04f-9eaa34e71b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8546b300-5f73-4465-a04f-9eaa34e71b34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

