### PR TITLE
feat(spend): expose public rail metadata to admin and user surfaces (IRL-13)

### DIFF
--- a/app/admin/spend-experiences/form-state.ts
+++ b/app/admin/spend-experiences/form-state.ts
@@ -1,10 +1,16 @@
-import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+import type {
+  SpendExperience,
+  SpendExperienceStatus,
+  SpendRail,
+} from '@/lib/types';
 
 export type SpendExperienceFormState = {
   title: string;
   description: string;
   event_id: string;
   status: SpendExperienceStatus;
+  /** Immutable after create; only used when creating a new experience. */
+  spend_rail: SpendRail;
   points_to_usdc_rate: string;
   max_usdc_per_user: string;
   start_time_local: string;
@@ -33,6 +39,7 @@ export function experienceToForm(e: SpendExperience): SpendExperienceFormState {
     description: e.description ?? '',
     event_id: e.event_id ?? '',
     status: e.status,
+    spend_rail: e.spend_rail,
     points_to_usdc_rate: String(e.points_to_usdc_rate),
     max_usdc_per_user: String(e.max_usdc_per_user),
     start_time_local: isoToDatetimeLocalValue(e.start_time),
@@ -47,6 +54,7 @@ export function emptySpendExperienceForm(): SpendExperienceFormState {
     description: '',
     event_id: '',
     status: 'draft',
+    spend_rail: 'base_usdc',
     points_to_usdc_rate: '1000',
     max_usdc_per_user: '5',
     start_time_local: isoToDatetimeLocalValue(start),

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -17,8 +17,10 @@ import {
 import { SpendExperienceFormPanel } from './spend-experience-form-panel';
 import { SpendExperienceList } from './spend-experience-list';
 import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
+import type { SpendRailCatalogEntry } from '@/lib/spend-rail-config/types';
 
 const QUERY_KEY = ['admin-spend-experiences'] as const;
+const RAILS_CATALOG_QUERY_KEY = ['admin-spend-rails-catalog'] as const;
 
 type CreateSpendExperienceResponse = {
   spendExperience: SpendExperience;
@@ -88,6 +90,21 @@ export default function AdminSpendExperiencesPage() {
     enabled: !!isAdmin && !!user?.email?.address,
   });
 
+  const { data: railCatalog = [] } = useQuery<SpendRailCatalogEntry[]>({
+    queryKey: RAILS_CATALOG_QUERY_KEY,
+    queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch('/api/admin/spend-rails/catalog', {
+        headers: auth,
+      });
+      if (!response.ok) throw new Error('Failed to load spend rail catalog');
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return data.rails ?? [];
+    },
+    enabled: !!isAdmin && !!user?.email?.address,
+  });
+
   const closePanel = useCallback(() => {
     setPanelOpen(false);
     setEditing(null);
@@ -104,6 +121,7 @@ export default function AdminSpendExperiencesPage() {
         max_usdc_per_user: Number(form.max_usdc_per_user),
         start_time: datetimeLocalToIso(form.start_time_local),
         end_time: datetimeLocalToIso(form.end_time_local),
+        ...(editing ? {} : { spend_rail: form.spend_rail }),
       };
 
       const auth = await adminApiAuthHeaders(getAccessToken);
@@ -112,7 +130,11 @@ export default function AdminSpendExperiencesPage() {
       if (editing) {
         const response = await fetch(
           `/api/admin/spend-experiences/${encodeURIComponent(editing.id)}`,
-          { method: 'PATCH', headers: jsonHeaders, body: JSON.stringify(payload) }
+          {
+            method: 'PATCH',
+            headers: jsonHeaders,
+            body: JSON.stringify(payload),
+          }
         );
         const j = await response.json().catch(() => ({}));
         if (!response.ok) {
@@ -241,6 +263,7 @@ export default function AdminSpendExperiencesPage() {
         editing={editing}
         form={form}
         setForm={setForm}
+        railCatalog={railCatalog}
         isSaving={saveMutation.isPending}
         onClose={closePanel}
         onSubmit={saveMutation.mutate}

--- a/app/admin/spend-experiences/spend-experience-form-panel.tsx
+++ b/app/admin/spend-experiences/spend-experience-form-panel.tsx
@@ -12,6 +12,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+import type { SpendRailCatalogEntry } from '@/lib/spend-rail-config/types';
 import type { SpendExperienceFormState } from './form-state';
 
 export type SpendExperienceFormPanelProps = {
@@ -19,6 +20,7 @@ export type SpendExperienceFormPanelProps = {
   editing: SpendExperience | null;
   form: SpendExperienceFormState;
   setForm: Dispatch<SetStateAction<SpendExperienceFormState>>;
+  railCatalog: SpendRailCatalogEntry[];
   isSaving: boolean;
   onClose: () => void;
   onSubmit: () => void;
@@ -50,11 +52,16 @@ export function SpendExperienceFormPanel({
   editing,
   form,
   setForm,
+  railCatalog,
   isSaving,
   onClose,
   onSubmit,
 }: SpendExperienceFormPanelProps) {
   if (!open) return null;
+
+  const selectedCatalogRow = editing
+    ? railCatalog.find((r) => r.rail === editing.spend_rail)
+    : railCatalog.find((r) => r.rail === form.spend_rail);
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -112,6 +119,91 @@ export function SpendExperienceFormPanel({
               placeholder="External event id if linked"
             />
           </div>
+          {!editing && (
+            <div className="space-y-2">
+              <Label>Payment network</Label>
+              {railCatalog.length === 0 ? (
+                <p className="text-sm text-neutral-500">
+                  Loading payment networks…
+                </p>
+              ) : (
+                <Select
+                  value={form.spend_rail}
+                  onValueChange={(v) =>
+                    setForm((f) => ({
+                      ...f,
+                      spend_rail: v as SpendExperienceFormState['spend_rail'],
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Select network" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {railCatalog.map((row) => (
+                      <SelectItem
+                        key={row.rail}
+                        value={row.rail}
+                        disabled={!row.allowsNewSpendWork}
+                      >
+                        {row.displayName} — {row.networkLabel} ·{' '}
+                        {row.assetSymbol}
+                        {!row.allowsNewSpendWork ? ' (unavailable)' : ''}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+              {selectedCatalogRow && !selectedCatalogRow.allowsNewSpendWork && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950">
+                  <p className="font-medium">This network is not ready</p>
+                  <ul className="mt-1 list-inside list-disc space-y-0.5">
+                    {selectedCatalogRow.adminUnavailableReasons.map(
+                      (reason) => (
+                        <li key={reason}>{reason}</li>
+                      )
+                    )}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+          {editing && selectedCatalogRow && (
+            <div className="space-y-2">
+              <Label>Payment network</Label>
+              <p className="text-sm text-neutral-700">
+                {selectedCatalogRow.displayName} —{' '}
+                {selectedCatalogRow.networkLabel} ·{' '}
+                {selectedCatalogRow.assetSymbol}
+              </p>
+              {!selectedCatalogRow.allowsNewSpendWork && (
+                <div className="rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-950">
+                  <p className="font-medium">Operational issues detected</p>
+                  <ul className="mt-1 list-inside list-disc space-y-0.5">
+                    {selectedCatalogRow.adminUnavailableReasons.map(
+                      (reason) => (
+                        <li key={reason}>{reason}</li>
+                      )
+                    )}
+                  </ul>
+                </div>
+              )}
+            </div>
+          )}
+          {(selectedCatalogRow?.receivingWalletAddress ?? '') !== '' && (
+            <div className="space-y-2">
+              <Label>Receiving wallet (read-only)</Label>
+              <Input
+                readOnly
+                className="font-mono text-xs"
+                value={selectedCatalogRow?.receivingWalletAddress ?? ''}
+              />
+              <p className="text-xs text-neutral-500">
+                Global settlement address for this payment network. Shown for
+                verification only.
+              </p>
+            </div>
+          )}
           <div className="space-y-2">
             <Label>Status</Label>
             <Select

--- a/app/api/admin/spend-rails/catalog/__tests__/route.test.ts
+++ b/app/api/admin/spend-rails/catalog/__tests__/route.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const { mockListCatalog } = vi.hoisted(() => ({
+  mockListCatalog: vi.fn(),
+}));
+
+const mockRequireAdmin = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/spend-rail-config', () => ({
+  listSpendRailCatalog: mockListCatalog,
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/admin/spend-rails/catalog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockListCatalog.mockReturnValue([
+      {
+        rail: 'base_usdc',
+        displayName: 'Base USDC',
+        networkLabel: 'Base',
+        assetSymbol: 'USDC',
+        explorerTxUrlTemplate: 'https://basescan.org/tx/{txHash}',
+        allowsNewSpendWork: true,
+        adminUnavailableReasons: [],
+        receivingWalletAddress: '0x2222222222222222222222222222222222222222',
+      },
+    ]);
+  });
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await GET(
+      new NextRequest('http://localhost:3000/api/admin/spend-rails/catalog')
+    );
+    expect(res.status).toBe(403);
+    expect(mockListCatalog).not.toHaveBeenCalled();
+  });
+
+  it('returns catalog rows when admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'a@b.com' },
+    });
+    const res = await GET(
+      new NextRequest('http://localhost:3000/api/admin/spend-rails/catalog')
+    );
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(mockListCatalog).toHaveBeenCalled();
+    expect(j.data.rails).toHaveLength(1);
+    expect(j.data.rails[0].rail).toBe('base_usdc');
+    expect(j.data.rails[0].receivingWalletAddress).toContain('0x2222');
+  });
+});

--- a/app/api/admin/spend-rails/catalog/route.ts
+++ b/app/api/admin/spend-rails/catalog/route.ts
@@ -1,0 +1,24 @@
+import { NextRequest } from 'next/server';
+import { requireAdmin } from '@/lib/auth';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { listSpendRailCatalog } from '@/lib/spend-rail-config';
+
+export const dynamic = 'force-dynamic';
+
+/**
+ * GET /api/admin/spend-rails/catalog
+ * Public (non-secret) rail metadata for admin pickers and read-only wallet display.
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    return apiSuccess({ rails: listSpendRailCatalog() });
+  } catch (error) {
+    console.error('GET spend rails catalog:', error);
+    return apiError('Failed to load spend rail catalog', 500);
+  }
+}

--- a/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
@@ -139,6 +139,7 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
     expect(res.status).toBe(200);
     expect(j.data.session).toEqual(session);
     expect(j.data.created).toBe(true);
+    expect(j.data.spendRailSummary.rail).toBe('base_usdc');
     expect(mockTrack).toHaveBeenCalled();
     expect(mockEnsureStellar).not.toHaveBeenCalled();
     expect(mockCreateOrGet).toHaveBeenCalledWith(
@@ -190,6 +191,7 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
       expect(j.data.session.rail_user_wallet_address).toBe(
         'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF'
       );
+      expect(j.data.spendRailSummary.rail).toBe('stellar_usdc');
     } finally {
       process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = prevEnabled;
       process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = prevRecv;

--- a/app/api/spend-experiences/[experienceId]/sessions/route.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/route.ts
@@ -10,6 +10,7 @@ import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-gua
 import { assertSpendRailAllowsNewSessions } from '@/lib/spend-rail-config';
 import { createSpendSessionBodySchema } from '@/lib/schemas/spend-session';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 import {
   trackSpendSessionCreated,
   resolveServerIdentity,
@@ -100,7 +101,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     }
 
     return apiSuccess(
-      { session, spendExperience: experience, created },
+      {
+        session,
+        spendExperience: experience,
+        created,
+        spendRailSummary: getSpendRailClientSummary(experience.spend_rail),
+      },
       created ? 'Spend session created' : 'Spend session returned'
     );
   } catch (e) {

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -137,6 +137,10 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
       (json as { data: { spendExperience: { spend_rail: string } } }).data
         .spendExperience.spend_rail
     ).toBe('base_usdc');
+    expect(
+      (json as { data: { spendRailSummary: { rail: string } } }).data
+        .spendRailSummary.rail
+    ).toBe('base_usdc');
   });
 
   it('captures handled conversion failures when requested by domain logic', async () => {

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -11,6 +11,7 @@ import {
   runSpendConversionConfirm,
 } from '@/lib/spend-conversion-confirm';
 import { spendConversionConfirmBodySchema } from '@/lib/schemas/spend-session';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
@@ -115,6 +116,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         pointsRequired,
         usdcAmount,
       },
+      spendRailSummary: getSpendRailClientSummary(spendExperience.spend_rail),
       resumed: result.resumed,
     });
   } catch (e) {

--- a/app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/preview/__tests__/route.test.ts
@@ -126,6 +126,13 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/preview', () => {
     const j = await res.json();
     expect(res.status).toBe(200);
     expect(j.data.eligibility.status).toBe('eligible');
+    expect(j.data.spendRailSummary).toMatchObject({
+      rail: 'base_usdc',
+      displayName: 'Base USDC',
+      networkLabel: 'Base',
+      assetSymbol: 'USDC',
+    });
+    expect(j.data.spendRailSummary.explorerTxUrlTemplate).toContain('{txHash}');
     expect(mockTrackPreview).toHaveBeenCalled();
   });
 

--- a/app/api/spend-sessions/[sessionId]/conversion/preview/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/preview/route.ts
@@ -18,6 +18,7 @@ import {
   resolveServerIdentity,
 } from '@/lib/analytics/server';
 import { spendConversionPreviewBodySchema } from '@/lib/schemas/spend-session';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 
 export const dynamic = 'force-dynamic';
 
@@ -136,6 +137,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return apiSuccess({
       eligibility,
       spendExperience,
+      spendRailSummary: getSpendRailClientSummary(responseSession.spend_rail),
       session: {
         id: responseSession.id,
         status: responseSession.status,

--- a/app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts
@@ -48,6 +48,7 @@ describe('POST /api/spend-sessions/[sessionId]/payment/confirm', () => {
         id: 'sess-1',
         user_id: 'privy-1',
         wallet_address: '0xabcdef0123456789012345678901234567890abc',
+        spend_rail: 'base_usdc',
       },
       spendExperience: { id: 'exp-1' },
       usdcAmount: 5,
@@ -81,6 +82,10 @@ describe('POST /api/spend-sessions/[sessionId]/payment/confirm', () => {
     expect(res.status).toBe(200);
     expect(j.data.spendTransaction.id).toBe('tx-1');
     expect(j.data.session.status).toBe('payment_complete');
+    expect(j.data.spendRailSummary).toMatchObject({
+      rail: 'base_usdc',
+      displayName: 'Base USDC',
+    });
   });
 
   it('returns 400 for invalid paymentTxHash', async () => {

--- a/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
@@ -10,6 +10,7 @@ import {
   runSpendPaymentConfirm,
 } from '@/lib/spend-payment-confirm';
 import { spendPaymentConfirmBodySchema } from '@/lib/schemas/spend-session';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 
 export const dynamic = 'force-dynamic';
 
@@ -17,7 +18,7 @@ type RouteParams = { params: { sessionId: string } };
 
 /**
  * POST /api/spend-sessions/{sessionId}/payment/confirm
- * Verifies on-chain Base USDC transfer from the session wallet to the experience receiving wallet.
+ * Verifies on-chain USDC transfer from the session wallet to the configured receiving wallet for the session rail.
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const sessionId = params.sessionId;
@@ -88,6 +89,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
     return apiSuccess({
       spendTransaction: result.spendTransaction,
+      spendRailSummary: getSpendRailClientSummary(session.spend_rail),
       session: {
         id: result.session.id,
         status: result.session.status,

--- a/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
@@ -70,5 +70,6 @@ describe('GET /api/spend-sessions/[sessionId]/receipt', () => {
     expect(res.status).toBe(200);
     expect(j.data.session).toEqual(session);
     expect(j.data.eligibility.status).toBe('eligible');
+    expect(j.data.spendRailSummary.rail).toBe('base_usdc');
   });
 });

--- a/app/api/spend-sessions/[sessionId]/receipt/route.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/route.ts
@@ -12,6 +12,7 @@ import {
   resolveServerIdentity,
   trackSpendReceiptViewed,
 } from '@/lib/analytics/server';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 
 export const dynamic = 'force-dynamic';
 
@@ -82,6 +83,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       pointConversion,
       spendTransaction,
       eligibility,
+      spendRailSummary: getSpendRailClientSummary(session.spend_rail),
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Failed to load receipt state';

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -20,6 +20,11 @@ import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
+import type { SpendRailClientSummary } from '@/lib/spend-rail-config/types';
+import {
+  formatSpendPaymentExplorerUrl,
+  spendPaymentExplorerLinkLabel,
+} from '@/lib/spend-rail-explorer-url-client';
 import {
   encodeUsdcTransferData,
   isEvmAddress,
@@ -36,6 +41,7 @@ type SessionResponse = {
   session: SpendSession;
   spendExperience: SpendExperience;
   created: boolean;
+  spendRailSummary: SpendRailClientSummary;
 };
 
 type ConversionPreviewResponse = {
@@ -54,6 +60,7 @@ type ConversionPreviewResponse = {
   };
   spendExperience: SpendExperience;
   session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
+  spendRailSummary: SpendRailClientSummary;
 };
 
 type ConversionConfirmResponse = {
@@ -66,11 +73,13 @@ type ConversionConfirmResponse = {
     pointsRequired: number;
     usdcAmount: number;
   };
+  spendRailSummary: SpendRailClientSummary;
   resumed: boolean;
 };
 
 type PaymentConfirmResponse = {
   spendTransaction: SpendTransaction;
+  spendRailSummary: SpendRailClientSummary;
   session: Pick<SpendSession, 'id' | 'status' | 'expires_at' | 'completed_at'>;
   resumed: boolean;
 };
@@ -81,6 +90,7 @@ type ReceiptResponse = {
   pointConversion: PointConversion | null;
   spendTransaction: SpendTransaction | null;
   eligibility: ConversionPreviewResponse['eligibility'];
+  spendRailSummary: SpendRailClientSummary;
 };
 
 const WALLET_STEP_TIMEOUT_MS = 180_000;
@@ -438,6 +448,14 @@ export function SpendExperiencePage({
   const session = sessionPayload?.session;
   const elig = previewPayload?.eligibility;
   const preview = elig?.preview;
+  const spendRailSummary: SpendRailClientSummary | null =
+    previewPayload?.spendRailSummary ??
+    sessionPayload?.spendRailSummary ??
+    receiptPayload?.spendRailSummary ??
+    null;
+  const resolvedSpendRail = spendRailSummary?.rail ?? experience.spend_rail;
+  const walletNetworkLabel = spendRailSummary?.networkLabel ?? 'Base';
+  const assetSymbol = spendRailSummary?.assetSymbol ?? 'USDC';
   const showSessionError = user && walletAddress && sessionError;
   const showWalletBlock = user && !walletAddress;
 
@@ -461,18 +479,24 @@ export function SpendExperiencePage({
     preview &&
     (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
 
-  const showPay =
+  const showBaseWalletPay =
     !isPaymentComplete &&
     (elig?.status === 'ready_for_payment' ||
       elig?.status === 'ready_for_payment_own_usdc' ||
       elig?.status === 'payment_failed') &&
     preview &&
+    resolvedSpendRail === 'base_usdc' &&
     isEvmAddress(preview.receivingWalletAddress);
 
   const displayReceipt = isPaymentComplete;
 
-  const basescanUrl = (hash: string) =>
-    `https://basescan.org/tx/${hash.trim()}`;
+  const paymentExplorerUrl = formatSpendPaymentExplorerUrl(
+    spendRailSummary?.explorerTxUrlTemplate,
+    receiptPaymentHash
+  );
+  const paymentExplorerLabel = spendPaymentExplorerLinkLabel(
+    spendRailSummary?.explorerTxUrlTemplate
+  );
 
   return (
     <SpendPageShell>
@@ -536,16 +560,17 @@ export function SpendExperiencePage({
                                 Pay
                               </span>
                               <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                                ${preview.usdcAmount.toFixed(2)} USDC
+                                ${preview.usdcAmount.toFixed(2)} {assetSymbol}
                               </span>
                             </div>
                             {preview.userUsdcBalance != null && (
                               <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
                                 <span className="body-small font-grotesk text-[#757575]">
-                                  Your wallet (Base)
+                                  Your wallet ({walletNetworkLabel})
                                 </span>
                                 <span className="body-medium font-grotesk text-[#171717]">
-                                  ${preview.userUsdcBalance.toFixed(2)} USDC
+                                  ${preview.userUsdcBalance.toFixed(2)}{' '}
+                                  {assetSymbol}
                                 </span>
                               </div>
                             )}
@@ -568,7 +593,8 @@ export function SpendExperiencePage({
                                     You will receive
                                   </span>
                                   <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                                    ${preview.usdcAmount.toFixed(2)} USDC
+                                    ${preview.usdcAmount.toFixed(2)}{' '}
+                                    {assetSymbol}
                                   </span>
                                 </div>
                               </>
@@ -603,10 +629,11 @@ export function SpendExperiencePage({
                               preview.userUsdcBalance != null && (
                                 <div className="flex justify-between gap-4 border-t border-[#ededed] pt-3">
                                   <span className="body-small font-grotesk text-[#757575]">
-                                    USDC balance
+                                    {assetSymbol} balance
                                   </span>
                                   <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                                    ${preview.userUsdcBalance.toFixed(2)} USDC
+                                    ${preview.userUsdcBalance.toFixed(2)}{' '}
+                                    {assetSymbol}
                                   </span>
                                 </div>
                               )}
@@ -617,7 +644,7 @@ export function SpendExperiencePage({
 
                     <p className={eligibilityToneClass(elig.status)}>
                       {elig.status === 'ready_for_payment' && preview
-                        ? `${preview.pointsRequired.toLocaleString()} points were converted to ${preview.usdcAmount.toFixed(2)} USDC.`
+                        ? `${preview.pointsRequired.toLocaleString()} points were converted to ${preview.usdcAmount.toFixed(2)} ${assetSymbol}.`
                         : elig.message}
                     </p>
 
@@ -628,18 +655,18 @@ export function SpendExperiencePage({
                       >
                         {conversionMutation.isPending
                           ? 'Converting…'
-                          : 'Convert points to USDC'}
+                          : `Convert points to ${assetSymbol}`}
                       </SpendPrimaryButton>
                     )}
 
-                    {showPay && (
+                    {showBaseWalletPay && (
                       <SpendPrimaryButton
                         pending={paymentMutation.isPending}
                         onClick={() => void sendUsdcPayment()}
                       >
                         {paymentMutation.isPending
-                          ? 'Pay with USDC…'
-                          : `Spend $${preview.usdcAmount.toFixed(2)} USDC`}
+                          ? `Pay with ${assetSymbol}…`
+                          : `Spend $${preview.usdcAmount.toFixed(2)} ${assetSymbol}`}
                       </SpendPrimaryButton>
                     )}
 
@@ -659,7 +686,7 @@ export function SpendExperiencePage({
                               preview?.usdcAmount ??
                               0
                             ).toFixed(2)}{' '}
-                            USDC
+                            {assetSymbol}
                           </span>
                         </div>
                         <div className="flex justify-between gap-2">
@@ -681,14 +708,14 @@ export function SpendExperiencePage({
                             {receiptSession?.id}
                           </p>
                         </div>
-                        {receiptPaymentHash && (
+                        {receiptPaymentHash && paymentExplorerUrl && (
                           <a
-                            href={basescanUrl(receiptPaymentHash)}
+                            href={paymentExplorerUrl}
                             target="_blank"
                             rel="noreferrer"
                             className="inline-flex items-center gap-1 body-medium font-grotesk font-semibold text-emerald-900 underline"
                           >
-                            View payment on BaseScan
+                            {paymentExplorerLabel}
                             <ExternalLink className="size-3.5 shrink-0" />
                           </a>
                         )}

--- a/lib/spend-rail-config/admin-curated-unavailable-reasons.test.ts
+++ b/lib/spend-rail-config/admin-curated-unavailable-reasons.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { mapSpendRailOperationalReasonToAdminCurated } from '@/lib/spend-rail-config/admin-curated-unavailable-reasons';
+
+describe('mapSpendRailOperationalReasonToAdminCurated', () => {
+  it('maps Privy server wallet diagnostic without exposing secrets in output', () => {
+    const out = mapSpendRailOperationalReasonToAdminCurated(
+      'SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID is missing'
+    );
+    expect(out).toMatch(/signing wallet/i);
+    expect(out.toLowerCase()).not.toContain('privy');
+  });
+
+  it('maps disabled rails', () => {
+    expect(
+      mapSpendRailOperationalReasonToAdminCurated(
+        'base_usdc rail is disabled (SPEND_RAIL_BASE_USDC_ENABLED)'
+      )
+    ).toContain('Base USDC');
+    expect(
+      mapSpendRailOperationalReasonToAdminCurated(
+        'stellar_usdc rail is disabled (SPEND_RAIL_STELLAR_USDC_ENABLED)'
+      )
+    ).toContain('Stellar USDC');
+  });
+});

--- a/lib/spend-rail-config/admin-curated-unavailable-reasons.ts
+++ b/lib/spend-rail-config/admin-curated-unavailable-reasons.ts
@@ -1,0 +1,61 @@
+/**
+ * Maps internal operational diagnostic strings to short, admin-safe copy.
+ * Never forwards env var names or signer identifiers to clients.
+ */
+export function mapSpendRailOperationalReasonToAdminCurated(
+  reason: string
+): string {
+  const s = reason;
+  const lower = s.toLowerCase();
+
+  if (lower.includes('base_usdc rail is disabled')) {
+    return 'Base USDC is turned off in configuration.';
+  }
+  if (lower.includes('stellar_usdc rail is disabled')) {
+    return 'Stellar USDC is turned off in configuration.';
+  }
+  if (lower.includes('privy_server_wallet_id')) {
+    return 'The backend signing wallet is not configured.';
+  }
+  if (lower.includes('treasury_wallet_address')) {
+    if (lower.includes('missing')) {
+      return 'Treasury wallet is not configured.';
+    }
+    return 'Treasury wallet address is not valid.';
+  }
+  if (lower.includes('receiving_wallet_address')) {
+    if (lower.includes('missing')) {
+      return 'Receiving wallet is not configured.';
+    }
+    return 'Receiving wallet address is not valid.';
+  }
+  if (lower.includes('stellar_usdc_receiving')) {
+    if (lower.includes('missing')) {
+      return 'Receiving wallet is not configured.';
+    }
+    return 'Receiving wallet address is not valid.';
+  }
+  if (lower.includes('treasury_address') && lower.includes('not a valid')) {
+    return 'Treasury wallet address is not valid.';
+  }
+  if (lower.includes('usdc_contract')) {
+    return 'USDC token contract configuration is not valid.';
+  }
+  if (lower.includes('base') && lower.includes('explorer template')) {
+    return 'Block explorer link template for Base is not valid.';
+  }
+  if (lower.includes('stellar') && lower.includes('explorer template')) {
+    return 'Block explorer link template for Stellar is not valid.';
+  }
+  if (lower.includes('rpc url resolved empty')) {
+    return 'Base network RPC endpoint is not configured.';
+  }
+  if (lower.includes('stellar_network') || lower.includes('stellar network')) {
+    return 'Stellar network is not configured.';
+  }
+  if (lower.includes('horizon_url')) {
+    return 'Stellar API endpoint URL is not valid.';
+  }
+
+  return 'Additional configuration is required for this payment network.';
+}

--- a/lib/spend-rail-config/index.ts
+++ b/lib/spend-rail-config/index.ts
@@ -4,7 +4,10 @@ import {
 } from '@/lib/walletconnect-poster-direct-usdc';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import type { SpendRail } from '@/lib/types';
+import { mapSpendRailOperationalReasonToAdminCurated } from '@/lib/spend-rail-config/admin-curated-unavailable-reasons';
 import type {
+  SpendRailCatalogEntry,
+  SpendRailClientSummary,
   SpendRailOperationalDiagnostics,
   SpendRailPublicMetadata,
 } from '@/lib/spend-rail-config/types';
@@ -12,6 +15,8 @@ import type {
 export type {
   SpendRailPublicMetadata,
   SpendRailOperationalDiagnostics,
+  SpendRailClientSummary,
+  SpendRailCatalogEntry,
 } from '@/lib/spend-rail-config/types';
 
 const DEFAULT_BASE_RPC = 'https://mainnet.base.org';
@@ -264,6 +269,60 @@ export function supportsSpendRailBasePrivyTreasuryFunding(
   spendRail: SpendRail
 ): boolean {
   return spendRail === 'base_usdc';
+}
+
+/** Stable ordering for admin catalog and pickers. */
+export const SPEND_RAILS_CATALOG_ORDER: SpendRail[] = [
+  'base_usdc',
+  'stellar_usdc',
+];
+
+function dedupeStrings(values: string[]): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const v of values) {
+    if (seen.has(v)) continue;
+    seen.add(v);
+    out.push(v);
+  }
+  return out;
+}
+
+export function getSpendRailClientSummary(
+  spendRail: SpendRail
+): SpendRailClientSummary {
+  const m = getSpendRailPublicMetadata(spendRail);
+  return {
+    rail: m.rail,
+    displayName: m.displayName,
+    networkLabel: m.networkLabel,
+    assetSymbol: m.assetSymbol,
+    explorerTxUrlTemplate: m.explorerTxUrlTemplate,
+  };
+}
+
+export function getSpendRailCatalogEntry(
+  spendRail: SpendRail
+): SpendRailCatalogEntry {
+  const summary = getSpendRailClientSummary(spendRail);
+  const diag = getSpendRailOperationalDiagnostics(spendRail);
+  const allowsNewSpendWork = diag.operational;
+  const meta = getSpendRailPublicMetadata(spendRail);
+  const adminUnavailableReasons = allowsNewSpendWork
+    ? []
+    : dedupeStrings(
+        diag.unavailableReasons.map(mapSpendRailOperationalReasonToAdminCurated)
+      );
+  return {
+    ...summary,
+    allowsNewSpendWork,
+    adminUnavailableReasons,
+    receivingWalletAddress: meta.receivingWalletAddress,
+  };
+}
+
+export function listSpendRailCatalog(): SpendRailCatalogEntry[] {
+  return SPEND_RAILS_CATALOG_ORDER.map(getSpendRailCatalogEntry);
 }
 
 export function getSpendRailPublicMetadata(

--- a/lib/spend-rail-config/types.ts
+++ b/lib/spend-rail-config/types.ts
@@ -26,3 +26,21 @@ export type SpendRailOperationalDiagnostics = {
   /** Non-empty when operational is false; safe for server logs/tests only. */
   unavailableReasons: string[];
 };
+
+/** Client-safe rail labels for spend flows (no secrets). */
+export type SpendRailClientSummary = {
+  rail: SpendRail;
+  displayName: string;
+  networkLabel: string;
+  assetSymbol: string;
+  explorerTxUrlTemplate: string | null;
+};
+
+/** Admin rail catalog row: public metadata plus operational flags and curated reasons. */
+export type SpendRailCatalogEntry = SpendRailClientSummary & {
+  /** True when the rail passes operational diagnostics (new sessions allowed if policy permits). */
+  allowsNewSpendWork: boolean;
+  /** Curated, non-secret reasons when `allowsNewSpendWork` is false. */
+  adminUnavailableReasons: string[];
+  receivingWalletAddress: string | null;
+};

--- a/lib/spend-rail-explorer-url-client.test.ts
+++ b/lib/spend-rail-explorer-url-client.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatSpendPaymentExplorerUrl,
+  spendPaymentExplorerLinkLabel,
+} from '@/lib/spend-rail-explorer-url-client';
+
+describe('formatSpendPaymentExplorerUrl', () => {
+  it('returns null for pending placeholders', () => {
+    expect(
+      formatSpendPaymentExplorerUrl(
+        'https://basescan.org/tx/{txHash}',
+        'pending:privy-1'
+      )
+    ).toBeNull();
+  });
+
+  it('lowercases EVM hashes', () => {
+    const h =
+      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    expect(
+      formatSpendPaymentExplorerUrl('https://basescan.org/tx/{txHash}', h)
+    ).toBe(
+      'https://basescan.org/tx/0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+    );
+  });
+
+  it('encodes non-EVM hashes for Stellar-style templates', () => {
+    const tpl = 'https://stellar.expert/explorer/public/tx/{txHash}';
+    const h = 'abc def';
+    expect(formatSpendPaymentExplorerUrl(tpl, h)).toContain('abc%20def');
+  });
+});
+
+describe('spendPaymentExplorerLinkLabel', () => {
+  it('extracts hostname from template', () => {
+    expect(
+      spendPaymentExplorerLinkLabel('https://basescan.org/tx/{txHash}')
+    ).toBe('View payment on basescan.org');
+  });
+
+  it('falls back when template is unusable', () => {
+    expect(spendPaymentExplorerLinkLabel(null)).toBe(
+      'View payment transaction'
+    );
+  });
+});

--- a/lib/spend-rail-explorer-url-client.ts
+++ b/lib/spend-rail-explorer-url-client.ts
@@ -1,0 +1,40 @@
+/**
+ * Builds a payment transaction explorer URL using a server-provided template.
+ * Safe for client bundles (no env reads). Mirrors server substitution rules for spend payments.
+ */
+export function formatSpendPaymentExplorerUrl(
+  explorerTxUrlTemplate: string | null | undefined,
+  txHash: string | null | undefined
+): string | null {
+  const raw = txHash?.trim();
+  if (!raw || raw.toLowerCase().startsWith('pending:')) {
+    return null;
+  }
+  const tpl = explorerTxUrlTemplate?.trim();
+  if (!tpl || !tpl.includes('{txHash}')) {
+    return null;
+  }
+  const evmHash = /^0x[a-fA-F0-9]{64}$/.test(raw);
+  if (evmHash) {
+    return tpl.replace('{txHash}', raw.toLowerCase());
+  }
+  return tpl.replace('{txHash}', encodeURIComponent(raw));
+}
+
+/** Derives a short link label from an explorer URL template (hostname only). */
+export function spendPaymentExplorerLinkLabel(
+  explorerTxUrlTemplate: string | null | undefined
+): string {
+  const tpl = explorerTxUrlTemplate?.trim();
+  if (!tpl || !tpl.includes('{txHash}')) {
+    return 'View payment transaction';
+  }
+  try {
+    const prefix = tpl.split('{txHash}')[0];
+    const u = new URL(prefix.endsWith('/') ? prefix.slice(0, -1) : prefix);
+    const host = u.hostname.replace(/^www\./, '');
+    return host ? `View payment on ${host}` : 'View payment transaction';
+  } catch {
+    return 'View payment transaction';
+  }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Delivers client-safe spend rail metadata for the admin spend experience form and the user spend flow, without exposing server-only diagnostics or secrets (IRL-13).

## Changes

- **`lib/spend-rail-config`**: Curated admin unavailable reasons from operational diagnostics; types `SpendRailClientSummary` and `SpendRailCatalogEntry`; helpers `getSpendRailClientSummary`, `getSpendRailCatalogEntry`, and `listSpendRailCatalog`.
- **`GET /api/admin/spend-rails/catalog`**: Admin-authenticated catalog for the rail picker and read-only receiving wallet display.
- **Spend APIs**: `spendRailSummary` on conversion preview and confirm, payment confirm, receipt, and spend experience session routes (rail id, labels, asset symbol, explorer URL template only).
- **Admin spend experiences UI**: Fetches catalog from the API; create flow selects payment network with disabled options when a rail is not operational; shows curated reasons and read-only receiving address; edit flow shows immutable rail and the same fields.
- **`components/spend/spend-experience-page.tsx`**: Metadata-driven network and asset copy plus receipt explorer links using **`lib/spend-rail-explorer-url-client`** (template from API, no client env reads). Embedded-wallet USDC payment remains limited to `base_usdc`.

## Verification

- `yarn lint` passes.
- Vitest for touched spend routes, admin catalog, spend-rail-config, and explorer URL helpers passes. Repository-wide `yarn test` still includes unrelated failures present on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-13](https://linear.app/irlenergy/issue/IRL-13/expose-public-spend-rail-metadata-to-admin-and-user-surfaces)

<div><a href="https://cursor.com/agents/bc-ace1c64e-5c82-49ca-90b8-dd7c808b8a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ace1c64e-5c82-49ca-90b8-dd7c808b8a86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

