### PR TITLE
IRL-12: Admin spend experience payment network (immutable on edit)

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -404,13 +404,8 @@ export default function SpendExperienceDetailPage() {
         <section className="mb-8 rounded-lg border border-amber-200 bg-amber-50 p-5 text-sm text-amber-950">
           <div className="flex flex-wrap items-start justify-between gap-3">
             <div>
-              <h2 className="font-semibold">
-                Fund server wallet before activation
-              </h2>
-              <p className="mt-1">
-                Send at least {fmtUsdc(funding.minimumUsdc)} USDC on Base now,
-                and enough USDC for expected redemptions.
-              </p>
+              <h2 className="font-semibold">{funding.fundingCalloutTitle}</h2>
+              <p className="mt-1">{funding.fundingCalloutBody}</p>
               <code className="mt-3 block break-all rounded bg-white/70 p-2 text-xs text-neutral-900">
                 {funding.serverWalletAddress}
               </code>

--- a/app/admin/spend-experiences/form-state.test.ts
+++ b/app/admin/spend-experiences/form-state.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import {
+  emptySpendExperienceForm,
+  experienceToForm,
+  SPEND_RAIL_ADMIN_LABEL,
+} from './form-state';
+import type { SpendExperience } from '@/lib/types';
+
+describe('spend experience form state', () => {
+  it('defaults spend_rail to base_usdc for new forms', () => {
+    const f = emptySpendExperienceForm();
+    expect(f.spend_rail).toBe('base_usdc');
+  });
+
+  it('maps spend_rail from an experience', () => {
+    const e = {
+      id: 'x',
+      title: 'T',
+      description: null,
+      event_id: null,
+      status: 'draft' as const,
+      spend_rail: 'stellar_usdc' as const,
+      points_to_usdc_rate: 1000,
+      max_usdc_per_user: 5,
+      treasury_wallet_address: 'G' + 'A'.repeat(55),
+      receiving_wallet_address: 'G' + 'B'.repeat(55),
+      privy_server_wallet_id: null,
+      server_wallet_address: null,
+      server_wallet_chain: null,
+      server_wallet_created_at: null,
+      spend_create_idempotency_key: null,
+      start_time: '2026-05-01T12:00:00.000Z',
+      end_time: '2026-05-08T12:00:00.000Z',
+      created_by: null,
+      created_at: '2026-04-01T00:00:00.000Z',
+      updated_at: '2026-04-01T00:00:00.000Z',
+    } satisfies SpendExperience;
+    expect(experienceToForm(e).spend_rail).toBe('stellar_usdc');
+  });
+
+  it('uses aligned admin labels', () => {
+    expect(SPEND_RAIL_ADMIN_LABEL.base_usdc).toBe('Base USDC');
+    expect(SPEND_RAIL_ADMIN_LABEL.stellar_usdc).toBe('Stellar USDC');
+  });
+});

--- a/app/admin/spend-experiences/form-state.ts
+++ b/app/admin/spend-experiences/form-state.ts
@@ -1,10 +1,21 @@
-import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+import type {
+  SpendExperience,
+  SpendExperienceStatus,
+  SpendRail,
+} from '@/lib/types';
+
+/** Admin UI labels — aligned with `getSpendRailPublicMetadata` display names. */
+export const SPEND_RAIL_ADMIN_LABEL: Record<SpendRail, string> = {
+  base_usdc: 'Base USDC',
+  stellar_usdc: 'Stellar USDC',
+};
 
 export type SpendExperienceFormState = {
   title: string;
   description: string;
   event_id: string;
   status: SpendExperienceStatus;
+  spend_rail: SpendRail;
   points_to_usdc_rate: string;
   max_usdc_per_user: string;
   start_time_local: string;
@@ -33,6 +44,7 @@ export function experienceToForm(e: SpendExperience): SpendExperienceFormState {
     description: e.description ?? '',
     event_id: e.event_id ?? '',
     status: e.status,
+    spend_rail: e.spend_rail,
     points_to_usdc_rate: String(e.points_to_usdc_rate),
     max_usdc_per_user: String(e.max_usdc_per_user),
     start_time_local: isoToDatetimeLocalValue(e.start_time),
@@ -47,6 +59,7 @@ export function emptySpendExperienceForm(): SpendExperienceFormState {
     description: '',
     event_id: '',
     status: 'draft',
+    spend_rail: 'base_usdc',
     points_to_usdc_rate: '1000',
     max_usdc_per_user: '5',
     start_time_local: isoToDatetimeLocalValue(start),

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -17,8 +17,10 @@ import {
 import { SpendExperienceFormPanel } from './spend-experience-form-panel';
 import { SpendExperienceList } from './spend-experience-list';
 import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
+import type { SpendRailsAvailabilityClientPayload } from '@/lib/admin/spend-rail-availability-public';
 
 const QUERY_KEY = ['admin-spend-experiences'] as const;
+const RAIL_AVAILABILITY_QUERY_KEY = ['admin-spend-rails-availability'] as const;
 
 type CreateSpendExperienceResponse = {
   spendExperience: SpendExperience;
@@ -88,10 +90,38 @@ export default function AdminSpendExperiencesPage() {
     enabled: !!isAdmin && !!user?.email?.address,
   });
 
+  const {
+    data: railAvailability,
+    isLoading: railAvailabilityLoading,
+    isError: railAvailabilityError,
+  } = useQuery<SpendRailsAvailabilityClientPayload>({
+    queryKey: RAIL_AVAILABILITY_QUERY_KEY,
+    queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch('/api/admin/spend-rails/availability', {
+        headers: auth,
+      });
+      if (!response.ok) throw new Error('Failed to load rail availability');
+      const responseData = await response.json();
+      const data = responseData.data ?? responseData;
+      return data as SpendRailsAvailabilityClientPayload;
+    },
+    enabled: !!isAdmin && !!user?.email?.address,
+  });
+
   const closePanel = useCallback(() => {
     setPanelOpen(false);
     setEditing(null);
   }, []);
+
+  const readApiErrorMessage = useCallback(
+    (body: Record<string, unknown>, fallback: string) => {
+      if (typeof body.error === 'string') return body.error;
+      if (typeof body.message === 'string') return body.message;
+      return fallback;
+    },
+    []
+  );
 
   const saveMutation = useMutation<CreateSpendExperienceResponse, Error>({
     mutationFn: async () => {
@@ -112,15 +142,32 @@ export default function AdminSpendExperiencesPage() {
       if (editing) {
         const response = await fetch(
           `/api/admin/spend-experiences/${encodeURIComponent(editing.id)}`,
-          { method: 'PATCH', headers: jsonHeaders, body: JSON.stringify(payload) }
+          {
+            method: 'PATCH',
+            headers: jsonHeaders,
+            body: JSON.stringify(payload),
+          }
         );
-        const j = await response.json().catch(() => ({}));
+        const j = (await response.json().catch(() => ({}))) as Record<
+          string,
+          unknown
+        >;
         if (!response.ok) {
-          throw new Error(j.error || j.message || 'Update failed');
+          throw new Error(readApiErrorMessage(j, 'Update failed'));
         }
-        const spendExperience = j.data?.spendExperience ?? j.spendExperience;
+        const dataWrap = j.data as
+          | { spendExperience?: SpendExperience }
+          | undefined;
+        const spendExperience =
+          dataWrap?.spendExperience ??
+          (j as { spendExperience?: SpendExperience }).spendExperience;
+        if (!spendExperience) {
+          throw new Error(readApiErrorMessage(j, 'Update failed'));
+        }
         return { spendExperience } satisfies CreateSpendExperienceResponse;
       }
+
+      const createPayload = { ...payload, spend_rail: form.spend_rail };
 
       const response = await fetch('/api/admin/spend-experiences', {
         method: 'POST',
@@ -128,11 +175,14 @@ export default function AdminSpendExperiencesPage() {
           ...jsonHeaders,
           'Idempotency-Key': crypto.randomUUID(),
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify(createPayload),
       });
-      const j = await response.json().catch(() => ({}));
+      const j = (await response.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
       if (!response.ok) {
-        throw new Error(j.error || j.message || 'Create failed');
+        throw new Error(readApiErrorMessage(j, 'Create failed'));
       }
       return (j.data ?? j) as CreateSpendExperienceResponse;
     },
@@ -150,6 +200,36 @@ export default function AdminSpendExperiencesPage() {
     },
     onError: (e: Error) => toast.error(e.message),
   });
+
+  const handleSave = useCallback(() => {
+    if (!editing) {
+      if (railAvailabilityLoading) {
+        toast.error('Still loading payment network status. Please wait.');
+        return;
+      }
+      if (railAvailabilityError || !railAvailability) {
+        toast.error(
+          'Could not verify payment network status. Try refreshing the page.'
+        );
+        return;
+      }
+      const row = railAvailability.rails[form.spend_rail];
+      if (!row.operational) {
+        toast.error(
+          row.unavailableReason ?? 'Selected payment network is unavailable.'
+        );
+        return;
+      }
+    }
+    saveMutation.mutate();
+  }, [
+    editing,
+    form.spend_rail,
+    railAvailability,
+    railAvailabilityError,
+    railAvailabilityLoading,
+    saveMutation,
+  ]);
 
   const openCreate = useCallback(() => {
     setEditing(null);
@@ -202,12 +282,10 @@ export default function AdminSpendExperiencesPage() {
     <div className="mx-auto max-w-3xl p-6 font-grotesk">
       {createdFunding && (
         <section className="mb-6 rounded-lg border border-amber-200 bg-amber-50 p-4 text-sm text-amber-950">
-          <div className="font-semibold">Fund the server wallet</div>
-          <p className="mt-1">
-            Send at least ${createdFunding.minimumUsdc.toFixed(2)} USDC on Base
-            to activate this spend experience. Fund enough USDC for expected
-            redemptions.
-          </p>
+          <div className="font-semibold">
+            {createdFunding.fundingCalloutTitle}
+          </div>
+          <p className="mt-1">{createdFunding.fundingCalloutBody}</p>
           <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center">
             <code className="flex-1 break-all rounded bg-white/80 px-2 py-1 text-xs">
               {createdFunding.serverWalletAddress}
@@ -220,7 +298,7 @@ export default function AdminSpendExperiencesPage() {
                 void navigator.clipboard.writeText(
                   createdFunding.serverWalletAddress
                 );
-                toast.success('Server wallet copied');
+                toast.success('Treasury address copied');
               }}
             >
               Copy
@@ -242,8 +320,10 @@ export default function AdminSpendExperiencesPage() {
         form={form}
         setForm={setForm}
         isSaving={saveMutation.isPending}
+        spendRailAvailability={railAvailability ?? null}
+        spendRailAvailabilityLoading={railAvailabilityLoading}
         onClose={closePanel}
-        onSubmit={saveMutation.mutate}
+        onSubmit={handleSave}
       />
     </div>
   );

--- a/app/admin/spend-experiences/spend-experience-form-panel.tsx
+++ b/app/admin/spend-experiences/spend-experience-form-panel.tsx
@@ -11,8 +11,14 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { SpendExperience, SpendExperienceStatus } from '@/lib/types';
+import type {
+  SpendExperience,
+  SpendExperienceStatus,
+  SpendRail,
+} from '@/lib/types';
+import type { SpendRailsAvailabilityClientPayload } from '@/lib/admin/spend-rail-availability-public';
 import type { SpendExperienceFormState } from './form-state';
+import { SPEND_RAIL_ADMIN_LABEL } from './form-state';
 
 export type SpendExperienceFormPanelProps = {
   open: boolean;
@@ -20,6 +26,8 @@ export type SpendExperienceFormPanelProps = {
   form: SpendExperienceFormState;
   setForm: Dispatch<SetStateAction<SpendExperienceFormState>>;
   isSaving: boolean;
+  spendRailAvailability: SpendRailsAvailabilityClientPayload | null;
+  spendRailAvailabilityLoading: boolean;
   onClose: () => void;
   onSubmit: () => void;
 };
@@ -51,10 +59,14 @@ export function SpendExperienceFormPanel({
   form,
   setForm,
   isSaving,
+  spendRailAvailability,
+  spendRailAvailabilityLoading,
   onClose,
   onSubmit,
 }: SpendExperienceFormPanelProps) {
   if (!open) return null;
+
+  const rails = spendRailAvailability?.rails;
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -113,6 +125,63 @@ export function SpendExperienceFormPanel({
             />
           </div>
           <div className="space-y-2">
+            <Label htmlFor="se-rail">Payment network</Label>
+            {editing ? (
+              <div
+                id="se-rail"
+                className="rounded-md border border-neutral-200 bg-neutral-50 px-3 py-2 text-sm text-neutral-900"
+              >
+                {SPEND_RAIL_ADMIN_LABEL[editing.spend_rail]}
+                <p className="mt-1 text-xs text-neutral-500">
+                  Cannot be changed after creation.
+                </p>
+              </div>
+            ) : (
+              <>
+                <Select
+                  value={form.spend_rail}
+                  onValueChange={(v) =>
+                    setForm((f) => ({ ...f, spend_rail: v as SpendRail }))
+                  }
+                  disabled={spendRailAvailabilityLoading}
+                >
+                  <SelectTrigger id="se-rail">
+                    <SelectValue placeholder="Select payment network" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {(['base_usdc', 'stellar_usdc'] as const).map((rail) => {
+                      const row = rails?.[rail];
+                      const unavailable = Boolean(row && !row.operational);
+                      return (
+                        <SelectItem
+                          key={rail}
+                          value={rail}
+                          disabled={unavailable}
+                        >
+                          {SPEND_RAIL_ADMIN_LABEL[rail]}
+                          {unavailable ? ' (unavailable)' : ''}
+                        </SelectItem>
+                      );
+                    })}
+                  </SelectContent>
+                </Select>
+                {spendRailAvailabilityLoading && (
+                  <p className="text-xs text-neutral-500">
+                    Checking operational status…
+                  </p>
+                )}
+                {!spendRailAvailabilityLoading &&
+                  rails &&
+                  !rails[form.spend_rail].operational && (
+                    <p className="text-sm text-amber-800">
+                      {rails[form.spend_rail].unavailableReason ??
+                        'This payment network is unavailable.'}
+                    </p>
+                  )}
+              </>
+            )}
+          </div>
+          <div className="space-y-2">
             <Label>Status</Label>
             <Select
               value={form.status}
@@ -167,17 +236,34 @@ export function SpendExperienceFormPanel({
               />
             </div>
           </div>
-          {editing?.server_wallet_address && (
-            <div className="rounded-lg border border-blue-100 bg-blue-50 p-3 text-sm">
-              <div className="font-medium text-blue-950">
-                Privy server wallet
+          {editing?.spend_rail === 'base_usdc' &&
+            editing.server_wallet_address && (
+              <div className="rounded-lg border border-blue-100 bg-blue-50 p-3 text-sm">
+                <div className="font-medium text-blue-950">
+                  Privy server wallet (Base)
+                </div>
+                <p className="mt-1 text-blue-900">
+                  Backend-managed on Base for this experience. Admins do not
+                  edit wallet addresses.
+                </p>
+                <code className="mt-2 block break-all text-xs text-blue-950">
+                  {editing.server_wallet_address}
+                </code>
               </div>
-              <p className="mt-1 text-blue-900">
-                Backend-managed on Base. Admins do not edit wallet addresses.
+            )}
+          {editing?.spend_rail === 'stellar_usdc' && (
+            <div className="rounded-lg border border-violet-100 bg-violet-50 p-3 text-sm text-violet-950">
+              <div className="font-medium">Stellar USDC</div>
+              <p className="mt-1 text-violet-900">
+                Funding uses the global Stellar treasury from platform
+                configuration. User accounts and trustlines are managed on
+                Stellar (not Base).
               </p>
-              <code className="mt-2 block break-all text-xs text-blue-950">
-                {editing.server_wallet_address}
-              </code>
+              {editing.treasury_wallet_address ? (
+                <code className="mt-2 block break-all text-xs">
+                  Treasury: {editing.treasury_wallet_address}
+                </code>
+              ) : null}
             </div>
           )}
           <div className="grid gap-4 sm:grid-cols-2">

--- a/app/admin/spend-experiences/spend-experience-list.tsx
+++ b/app/admin/spend-experiences/spend-experience-list.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import { Loader2, Pencil, Plus, QrCode } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import type { SpendExperience } from '@/lib/types';
+import { SPEND_RAIL_ADMIN_LABEL } from './form-state';
 
 export type SpendExperienceListProps = {
   experiences: SpendExperience[];
@@ -55,6 +56,8 @@ export function SpendExperienceList({
                 <div className="font-medium text-[#171717]">{exp.title}</div>
                 <div className="text-sm text-neutral-500">
                   <span className="capitalize">{exp.status}</span>
+                  {' · '}
+                  {SPEND_RAIL_ADMIN_LABEL[exp.spend_rail]}
                   {' · '}
                   {exp.points_to_usdc_rate} pts / $1 · max $
                   {exp.max_usdc_per_user} USDC

--- a/app/api/admin/spend-rails/availability/__tests__/route.test.ts
+++ b/app/api/admin/spend-rails/availability/__tests__/route.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+import { GET } from '../route';
+
+describe('GET /api/admin/spend-rails/availability', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-rails/availability',
+      { method: 'GET', headers: new Headers({ 'x-user-email': 'u@x.com' }) }
+    );
+    const res = await GET(req);
+    const j = await res.json();
+    expect(res.status).toBe(403);
+    expect(j.success).toBe(false);
+  });
+
+  it('returns rails payload for admin', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/spend-rails/availability',
+      { method: 'GET', headers: new Headers({ 'x-user-email': 'admin@x.com' }) }
+    );
+    const res = await GET(req);
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.success).toBe(true);
+    expect(j.data.rails.base_usdc.operational).toBeTypeOf('boolean');
+    expect(
+      j.data.rails.base_usdc.unavailableReason === null ||
+        typeof j.data.rails.base_usdc.unavailableReason === 'string'
+    ).toBe(true);
+    expect(j.data.rails.stellar_usdc.operational).toBeTypeOf('boolean');
+    expect(
+      j.data.rails.stellar_usdc.unavailableReason === null ||
+        typeof j.data.rails.stellar_usdc.unavailableReason === 'string'
+    ).toBe(true);
+  });
+});

--- a/app/api/admin/spend-rails/availability/route.ts
+++ b/app/api/admin/spend-rails/availability/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest } from 'next/server';
+import { apiSuccess, apiError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+import { buildSpendRailsAvailabilityClientPayload } from '@/lib/admin/spend-rail-availability-public';
+
+/** GET /api/admin/spend-rails/availability — per-rail operational status for admin UI (browser-safe). */
+export async function GET(request: NextRequest) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    return apiSuccess(buildSpendRailsAvailabilityClientPayload());
+  } catch (error) {
+    console.error('admin spend rails availability:', error);
+    return apiError('Failed to load spend rail availability', 500);
+  }
+}

--- a/lib/admin/spend-rail-availability-public.test.ts
+++ b/lib/admin/spend-rail-availability-public.test.ts
@@ -32,4 +32,26 @@ describe('spendRailDiagnosticsToPublicUnavailableReason', () => {
     expect(msg).toBe('Required configuration for this network is incomplete.');
     expect(msg).not.toMatch(/SPEND_RAIL/);
   });
+
+  it('maps invalid Stellar Horizon URL diagnostics to the Horizon message, not wallet copy', () => {
+    expect(
+      spendRailDiagnosticsToPublicUnavailableReason({
+        operational: false,
+        unavailableReasons: [
+          'NEXT_PUBLIC_STELLAR_HORIZON_URL is not a valid URL',
+        ],
+      })
+    ).toBe('The Stellar Horizon URL setting is invalid.');
+  });
+
+  it('maps invalid Stellar public key diagnostics to the wallet message', () => {
+    expect(
+      spendRailDiagnosticsToPublicUnavailableReason({
+        operational: false,
+        unavailableReasons: [
+          'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS is not a valid Stellar public key',
+        ],
+      })
+    ).toBe('A configured wallet address for this network is invalid.');
+  });
 });

--- a/lib/admin/spend-rail-availability-public.test.ts
+++ b/lib/admin/spend-rail-availability-public.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { spendRailDiagnosticsToPublicUnavailableReason } from './spend-rail-availability-public';
+
+describe('spendRailDiagnosticsToPublicUnavailableReason', () => {
+  it('returns null when operational', () => {
+    expect(
+      spendRailDiagnosticsToPublicUnavailableReason({
+        operational: true,
+        unavailableReasons: [],
+      })
+    ).toBeNull();
+  });
+
+  it('maps disabled rails to a public message', () => {
+    expect(
+      spendRailDiagnosticsToPublicUnavailableReason({
+        operational: false,
+        unavailableReasons: [
+          'stellar_usdc rail is disabled (SPEND_RAIL_STELLAR_USDC_ENABLED)',
+        ],
+      })
+    ).toBe('This payment network is turned off in platform settings.');
+  });
+
+  it('maps missing configuration without echoing env keys', () => {
+    const msg = spendRailDiagnosticsToPublicUnavailableReason({
+      operational: false,
+      unavailableReasons: [
+        'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS is missing',
+      ],
+    });
+    expect(msg).toBe('Required configuration for this network is incomplete.');
+    expect(msg).not.toMatch(/SPEND_RAIL/);
+  });
+});

--- a/lib/admin/spend-rail-availability-public.ts
+++ b/lib/admin/spend-rail-availability-public.ts
@@ -26,14 +26,14 @@ export function spendRailDiagnosticsToPublicUnavailableReason(
   if (r.some((x) => /missing/i.test(x))) {
     return 'Required configuration for this network is incomplete.';
   }
+  if (r.some((x) => /HORIZON_URL/i.test(x))) {
+    return 'The Stellar Horizon URL setting is invalid.';
+  }
   if (r.some((x) => /not a valid/i.test(x))) {
     return 'A configured wallet address for this network is invalid.';
   }
   if (r.some((x) => /explorer template/i.test(x))) {
     return 'Transaction explorer settings for this network are misconfigured.';
-  }
-  if (r.some((x) => /Horizon URL/i.test(x))) {
-    return 'The Stellar Horizon URL setting is invalid.';
   }
   if (r.some((x) => /RPC URL/i.test(x))) {
     return 'Base RPC configuration is invalid.';

--- a/lib/admin/spend-rail-availability-public.ts
+++ b/lib/admin/spend-rail-availability-public.ts
@@ -26,10 +26,12 @@ export function spendRailDiagnosticsToPublicUnavailableReason(
   if (r.some((x) => /missing/i.test(x))) {
     return 'Required configuration for this network is incomplete.';
   }
-  if (r.some((x) => /HORIZON_URL/i.test(x))) {
+  if (r.some((x) => /STELLAR_HORIZON_URL/i.test(x))) {
     return 'The Stellar Horizon URL setting is invalid.';
   }
-  if (r.some((x) => /not a valid/i.test(x))) {
+  if (
+    r.some((x) => /not a valid/i.test(x) && !/STELLAR_HORIZON_URL/i.test(x))
+  ) {
     return 'A configured wallet address for this network is invalid.';
   }
   if (r.some((x) => /explorer template/i.test(x))) {

--- a/lib/admin/spend-rail-availability-public.ts
+++ b/lib/admin/spend-rail-availability-public.ts
@@ -1,0 +1,60 @@
+import { getSpendRailOperationalDiagnostics } from '@/lib/spend-rail-config';
+import type { SpendRailOperationalDiagnostics } from '@/lib/spend-rail-config/types';
+import type { SpendRail } from '@/lib/types';
+
+export type SpendRailAvailabilityClientRow = {
+  operational: boolean;
+  /** Short admin-facing summary when `operational` is false (no secrets). */
+  unavailableReason: string | null;
+};
+
+export type SpendRailsAvailabilityClientPayload = {
+  rails: Record<SpendRail, SpendRailAvailabilityClientRow>;
+};
+
+/**
+ * Maps internal diagnostics to browser-safe copy (no env values, keys, or URLs).
+ */
+export function spendRailDiagnosticsToPublicUnavailableReason(
+  diagnostics: SpendRailOperationalDiagnostics
+): string | null {
+  if (diagnostics.operational) return null;
+  const r = diagnostics.unavailableReasons;
+  if (r.some((x) => /disabled/i.test(x))) {
+    return 'This payment network is turned off in platform settings.';
+  }
+  if (r.some((x) => /missing/i.test(x))) {
+    return 'Required configuration for this network is incomplete.';
+  }
+  if (r.some((x) => /not a valid/i.test(x))) {
+    return 'A configured wallet address for this network is invalid.';
+  }
+  if (r.some((x) => /explorer template/i.test(x))) {
+    return 'Transaction explorer settings for this network are misconfigured.';
+  }
+  if (r.some((x) => /Horizon URL/i.test(x))) {
+    return 'The Stellar Horizon URL setting is invalid.';
+  }
+  if (r.some((x) => /RPC URL/i.test(x))) {
+    return 'Base RPC configuration is invalid.';
+  }
+  return 'This payment network is not operational right now.';
+}
+
+export function buildSpendRailsAvailabilityClientPayload(): SpendRailsAvailabilityClientPayload {
+  const base = getSpendRailOperationalDiagnostics('base_usdc');
+  const stellar = getSpendRailOperationalDiagnostics('stellar_usdc');
+  return {
+    rails: {
+      base_usdc: {
+        operational: base.operational,
+        unavailableReason: spendRailDiagnosticsToPublicUnavailableReason(base),
+      },
+      stellar_usdc: {
+        operational: stellar.operational,
+        unavailableReason:
+          spendRailDiagnosticsToPublicUnavailableReason(stellar),
+      },
+    },
+  };
+}

--- a/lib/spend-server-wallet.test.ts
+++ b/lib/spend-server-wallet.test.ts
@@ -1,0 +1,57 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { spendServerWalletFundingMetadata } from './spend-server-wallet';
+
+const VALID_STELLAR =
+  'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+describe('spendServerWalletFundingMetadata', () => {
+  it('includes Base-specific funding copy and chain for base_usdc', () => {
+    const m = spendServerWalletFundingMetadata(
+      { spend_rail: 'base_usdc', max_usdc_per_user: 5 },
+      null
+    );
+    expect(m.spendRail).toBe('base_usdc');
+    expect(m.chain).toBe('base-mainnet');
+    expect(m.paymentNetworkDisplayName).toBe('Base USDC');
+    expect(m.fundingNetworkLabel).toBe('Base');
+    expect(m.fundingCalloutTitle).toBe('Fund the server wallet');
+    expect(m.fundingCalloutBody).toContain('Base');
+    expect(m.fundingCalloutBody).not.toMatch(/Privy/i);
+  });
+
+  const prevStellar: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const k of [
+      'SPEND_RAIL_STELLAR_USDC_ENABLED',
+      'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
+      'SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS',
+    ]) {
+      prevStellar[k] = process.env[k];
+    }
+    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+    process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
+    delete process.env.SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS;
+  });
+
+  afterEach(() => {
+    for (const [k, v] of Object.entries(prevStellar)) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  });
+
+  it('includes Stellar treasury copy for stellar_usdc', () => {
+    const m = spendServerWalletFundingMetadata(
+      { spend_rail: 'stellar_usdc', max_usdc_per_user: 3 },
+      null
+    );
+    expect(m.spendRail).toBe('stellar_usdc');
+    expect(m.chain).toBe('stellar');
+    expect(m.paymentNetworkDisplayName).toBe('Stellar USDC');
+    expect(m.fundingNetworkLabel).toBe('Stellar');
+    expect(m.fundingCalloutTitle).toBe('Fund the Stellar treasury');
+    expect(m.fundingCalloutBody).toContain('Stellar');
+    expect(m.fundingCalloutBody).not.toContain('Base');
+  });
+});

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -6,6 +6,7 @@ import {
   getSpendBaseTreasuryPrivyTransferConfig,
   getSpendRailBaseRpcUrl,
   getSpendRailBaseUsdcContractAddress,
+  getSpendRailPublicMetadata,
   getSpendTreasuryWalletAddress,
   supportsSpendRailBasePrivyTreasuryFunding,
 } from '@/lib/spend-rail-config';
@@ -23,10 +24,16 @@ export type SpendServerWalletMetadata = {
 
 export type SpendServerWalletFundingMetadata = {
   serverWalletAddress: string;
+  /** Technical network tag (Base mainnet CAIP-style id for Base; `stellar` for Stellar). */
   chain: string;
   minimumUsdc: number;
   usdcBalance: number | null;
   funded: boolean;
+  spendRail: SpendExperience['spend_rail'];
+  paymentNetworkDisplayName: string;
+  fundingNetworkLabel: string;
+  fundingCalloutTitle: string;
+  fundingCalloutBody: string;
 };
 
 export type SpendServerWalletTransferConfig = {
@@ -43,17 +50,49 @@ export function getSpendServerWalletAddress(
   return getSpendTreasuryWalletAddress(experience.spend_rail);
 }
 
+function fundingCalloutCopy(
+  experience: Pick<SpendExperience, 'spend_rail' | 'max_usdc_per_user'>
+): Pick<
+  SpendServerWalletFundingMetadata,
+  | 'fundingCalloutTitle'
+  | 'fundingCalloutBody'
+  | 'paymentNetworkDisplayName'
+  | 'fundingNetworkLabel'
+  | 'chain'
+> {
+  const meta = getSpendRailPublicMetadata(experience.spend_rail);
+  const minStr = Number(experience.max_usdc_per_user).toFixed(2);
+  if (experience.spend_rail === 'base_usdc') {
+    return {
+      chain: SPEND_SERVER_WALLET_CHAIN,
+      paymentNetworkDisplayName: meta.displayName,
+      fundingNetworkLabel: meta.networkLabel,
+      fundingCalloutTitle: 'Fund the server wallet',
+      fundingCalloutBody: `Send at least $${minStr} USDC on ${meta.networkLabel} to activate this spend experience. Fund enough USDC for expected redemptions.`,
+    };
+  }
+  return {
+    chain: 'stellar',
+    paymentNetworkDisplayName: meta.displayName,
+    fundingNetworkLabel: meta.networkLabel,
+    fundingCalloutTitle: 'Fund the Stellar treasury',
+    fundingCalloutBody: `Send at least $${minStr} USDC on the ${meta.networkLabel} network (${meta.displayName}) to the treasury address below. This funds user conversions; add enough for expected redemptions.`,
+  };
+}
+
 export function spendServerWalletFundingMetadata(
   experience: Pick<SpendExperience, 'spend_rail' | 'max_usdc_per_user'>,
   usdcBalance: number | null
 ): SpendServerWalletFundingMetadata {
   const minimumUsdc = Number(experience.max_usdc_per_user);
+  const callout = fundingCalloutCopy(experience);
   return {
     serverWalletAddress: getSpendTreasuryWalletAddress(experience.spend_rail),
-    chain: SPEND_SERVER_WALLET_CHAIN,
     minimumUsdc,
     usdcBalance,
     funded: usdcBalance !== null && usdcBalance >= minimumUsdc,
+    spendRail: experience.spend_rail,
+    ...callout,
   };
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin spend experience create flow adds a required **Payment network** select (via `GET /api/admin/spend-rails/catalog` on `main`), defaulting to Base USDC. The edit flow shows the rail read-only; PATCH still omits `spend_rail`. POST includes `spend_rail` on create.

Merged latest `main` (includes catalog-based rail picker and related spend-rail work). Conflicts resolved by **using the catalog API for the form** while keeping IRL-12-specific behavior: submit guards from catalog rows, clearer API validation toasts, rail-aware post-create funding banner, and rail-specific wallet/treasury copy in the edit panel.

## Note on `/api/admin/spend-rails/availability`

The branch still includes the older availability route and tests from IRL-12; the **admin list page now relies on the catalog endpoint** from `main` (richer rows: `allowsNewSpendWork`, `adminUnavailableReasons`, receiving wallet). Consider a follow-up to remove or consolidate the availability route if product wants a single admin rail API.

## Tests

Targeted Vitest for form state, spend-experiences admin route, spend-rails catalog, and spend-rails availability after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-12](https://linear.app/irlenergy/issue/IRL-12/update-admin-form-with-immutable-payment-network-selection)

<div><a href="https://cursor.com/agents/bc-3e149ec8-6ef4-43ab-99f4-3199e01f0f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3e149ec8-6ef4-43ab-99f4-3199e01f0f83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

