### PR TITLE
fix(spend): enforce rail availability on admin and user spend APIs (IRL-10)

### DIFF
--- a/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/__tests__/route.test.ts
@@ -22,6 +22,10 @@ vi.mock('@/lib/spend-server-wallet', () => ({
     mockGetFundingStatus(...args),
 }));
 
+vi.mock('@/lib/analytics/server', () => ({
+  trackSpendPilotRailMutationBlocked: vi.fn(),
+}));
+
 import { PATCH, GET } from '../route';
 
 const existing = {
@@ -121,6 +125,29 @@ describe('PATCH /api/admin/spend-experiences/[experienceId]', () => {
     expect(res.status).toBe(404);
     expect(j.success).toBe(false);
     expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when updating spend mechanics while rail is not operational', async () => {
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSpendExperienceById.mockResolvedValue(existing);
+    const prev = process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'false';
+    try {
+      const res = await PATCH(
+        patchRequest({ max_usdc_per_user: 10 }, 'admin@example.com'),
+        { params: { experienceId: 'exp-1' } }
+      );
+      const j = await res.json();
+      expect(res.status).toBe(400);
+      expect(j.success).toBe(false);
+      expect(mockUpdateSpendExperience).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+      else process.env.SPEND_RAIL_BASE_USDC_ENABLED = prev;
+    }
   });
 
   it('returns 400 when merged window is invalid', async () => {

--- a/app/api/admin/spend-experiences/[experienceId]/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/route.ts
@@ -3,14 +3,35 @@ import {
   getSpendExperienceById,
   updateSpendExperience,
 } from '@/lib/db/spend-experiences';
+import { z } from 'zod';
 import { updateSpendExperienceRequestSchema } from '@/lib/schemas/spend-experience';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
 import { getServerWalletFundingStatus } from '@/lib/spend-server-wallet';
-import { getSpendTreasuryWalletAddress } from '@/lib/spend-rail-config';
+import {
+  getSpendTreasuryWalletAddress,
+  assertSpendRailAllowsMutatingSpendWork,
+} from '@/lib/spend-rail-config';
+import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
 
 interface RouteParams {
   params: { experienceId: string };
+}
+
+type UpdateSpendExperiencePatch = z.infer<
+  typeof updateSpendExperienceRequestSchema
+>;
+
+function spendExperiencePatchAffectsSpendMechanics(
+  data: UpdateSpendExperiencePatch
+): boolean {
+  return (
+    data.status !== undefined ||
+    data.max_usdc_per_user !== undefined ||
+    data.points_to_usdc_rate !== undefined ||
+    data.start_time !== undefined ||
+    data.end_time !== undefined
+  );
 }
 
 /** GET /api/admin/spend-experiences/{experienceId} */
@@ -50,6 +71,25 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     const validation = updateSpendExperienceRequestSchema.safeParse(raw);
     if (!validation.success) {
       return apiValidationError(validation.error);
+    }
+
+    if (spendExperiencePatchAffectsSpendMechanics(validation.data)) {
+      const railGate = assertSpendRailAllowsMutatingSpendWork(
+        existing.spend_rail
+      );
+      if (!railGate.ok) {
+        trackSpendPilotRailMutationBlocked(
+          adminCheck.user?.email ?? 'admin_server',
+          {
+            mutation: 'admin_spend_experience_update',
+            ...railGate.analytics,
+            spend_experience_id: existing.id,
+            event_id: existing.event_id,
+            admin_actor: adminCheck.user?.email ?? null,
+          }
+        );
+        return apiError(railGate.error, 400);
+      }
     }
 
     const nextStart = validation.data.start_time ?? existing.start_time;

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/__tests__/route.test.ts
@@ -57,6 +57,10 @@ vi.mock('@/lib/db/treasury-transactions', () => ({
     mockInsertLedger(...args),
 }));
 
+vi.mock('@/lib/analytics/server', () => ({
+  trackSpendPilotRailMutationBlocked: vi.fn(),
+}));
+
 import { POST } from '../route';
 
 const experience = {
@@ -115,6 +119,33 @@ describe('POST /api/admin/spend-experiences/[experienceId]/treasury/withdraw', (
       id: 'wallet_e1',
       address: CONFIG_TREASURY,
     });
+  });
+
+  it('returns 400 when spend rail is not operational', async () => {
+    const prev = process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'false';
+    try {
+      const headers = new Headers();
+      headers.set('Content-Type', 'application/json');
+      headers.set('x-user-email', 'admin@example.com');
+      const dest = '0x5555555555555555555555555555555555555555';
+      const req = new NextRequest(
+        'http://localhost:3000/api/admin/spend-experiences/exp-1/treasury/withdraw',
+        {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ destinationAddress: dest }),
+        }
+      );
+      const res = await POST(req, { params: { experienceId: 'exp-1' } });
+      const j = await res.json();
+      expect(res.status).toBe(400);
+      expect(j.success).toBe(false);
+      expect(mockSubmitTransfer).not.toHaveBeenCalled();
+    } finally {
+      if (prev === undefined) delete process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+      else process.env.SPEND_RAIL_BASE_USDC_ENABLED = prev;
+    }
   });
 
   it('returns 400 when destination equals server wallet', async () => {

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -10,6 +10,8 @@ import {
   getSpendServerWalletAddress,
   getSpendServerWalletTransferConfig,
 } from '@/lib/spend-server-wallet';
+import { assertSpendRailAllowsMutatingSpendWork } from '@/lib/spend-rail-config';
+import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
 import {
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
@@ -34,6 +36,23 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const experience = await getSpendExperienceById(params.experienceId);
     if (!experience) {
       return apiError('Spend experience not found', 404);
+    }
+
+    const railGate = assertSpendRailAllowsMutatingSpendWork(
+      experience.spend_rail
+    );
+    if (!railGate.ok) {
+      trackSpendPilotRailMutationBlocked(
+        adminCheck.user?.email ?? 'admin_server',
+        {
+          mutation: 'admin_treasury_withdraw',
+          ...railGate.analytics,
+          spend_experience_id: experience.id,
+          event_id: experience.event_id,
+          admin_actor: adminCheck.user?.email ?? null,
+        }
+      );
+      return apiError(railGate.error, 400);
     }
 
     if (experience.spend_rail !== 'base_usdc') {

--- a/app/api/admin/spend-experiences/route.ts
+++ b/app/api/admin/spend-experiences/route.ts
@@ -15,8 +15,9 @@ import {
 import {
   getSpendRailOperationalDiagnostics,
   getSpendRailPublicMetadata,
-  isSpendRailOperational,
+  assertSpendRailAllowsMutatingSpendWork,
 } from '@/lib/spend-rail-config';
+import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
 
 function createIdempotencyKey(request: NextRequest): string {
   return (
@@ -74,7 +75,16 @@ export async function POST(request: NextRequest) {
     }
 
     const spendRail = validation.data.spend_rail;
-    if (!isSpendRailOperational(spendRail)) {
+    const railGate = assertSpendRailAllowsMutatingSpendWork(spendRail);
+    if (!railGate.ok) {
+      trackSpendPilotRailMutationBlocked(
+        adminCheck.user?.email ?? 'admin_server',
+        {
+          mutation: 'admin_spend_experience_create',
+          ...railGate.analytics,
+          admin_actor: adminCheck.user?.email ?? null,
+        }
+      );
       const meta = getSpendRailPublicMetadata(spendRail);
       const { unavailableReasons } =
         getSpendRailOperationalDiagnostics(spendRail);

--- a/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
@@ -7,6 +7,7 @@ const mockGetExperience = vi.fn();
 const mockCreateOrGet = vi.fn();
 const mockAssert = vi.fn();
 const mockTrack = vi.fn();
+const mockTrackRailBlocked = vi.fn();
 const mockResolve = vi.fn();
 
 const { mockEnsureStellar } = vi.hoisted(() => ({
@@ -32,6 +33,8 @@ vi.mock('@/lib/spend-experience-guard', () => ({
 
 vi.mock('@/lib/analytics/server', () => ({
   trackSpendSessionCreated: (...a: unknown[]) => mockTrack(...a),
+  trackSpendPilotRailMutationBlocked: (...a: unknown[]) =>
+    mockTrackRailBlocked(...a),
   resolveServerIdentity: (...a: unknown[]) => mockResolve(...a),
 }));
 
@@ -205,5 +208,33 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
       params: { experienceId: 'exp-uuid' },
     });
     expect(res.status).toBe(401);
+  });
+
+  it('returns 400 when spend rail is not operational and does not create a session', async () => {
+    const prev = process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'false';
+    try {
+      const res = await POST(postRequest({ walletAddress: wallet }), {
+        params: { experienceId: 'exp-uuid' },
+      });
+      const j = await res.json();
+      expect(res.status).toBe(400);
+      expect(j.success).toBe(false);
+      expect(mockCreateOrGet).not.toHaveBeenCalled();
+      expect(mockTrack).not.toHaveBeenCalled();
+      expect(mockTrackRailBlocked).toHaveBeenCalledWith(
+        'privy-1',
+        expect.objectContaining({
+          mutation: 'spend_session_create',
+          spend_rail: 'base_usdc',
+          rail_operational: false,
+          spend_experience_id: 'exp-uuid',
+          user_id: 'privy-1',
+        })
+      );
+    } finally {
+      if (prev === undefined) delete process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+      else process.env.SPEND_RAIL_BASE_USDC_ENABLED = prev;
+    }
   });
 });

--- a/app/api/spend-experiences/[experienceId]/sessions/route.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/route.ts
@@ -7,11 +7,12 @@ import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { createOrGetSpendSession } from '@/lib/db/spend-sessions';
 import { ensureStellarRailUserWallet } from '@/lib/privy/stellar-rail-wallet';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
-import { assertSpendRailAllowsNewSessions } from '@/lib/spend-rail-config';
+import { assertSpendRailAllowsMutatingSpendWork } from '@/lib/spend-rail-config';
 import { createSpendSessionBodySchema } from '@/lib/schemas/spend-session';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 import {
+  trackSpendPilotRailMutationBlocked,
   trackSpendSessionCreated,
   resolveServerIdentity,
 } from '@/lib/analytics/server';
@@ -63,8 +64,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return apiError(gate.error, gate.httpStatus);
   }
 
-  const railGate = assertSpendRailAllowsNewSessions(experience.spend_rail);
+  const railGate = assertSpendRailAllowsMutatingSpendWork(
+    experience.spend_rail
+  );
   if (!railGate.ok) {
+    const distinctId = resolveServerIdentity({
+      privyUserId: auth.userId,
+      walletAddress: walletAddress.trim().toLowerCase(),
+    });
+    trackSpendPilotRailMutationBlocked(distinctId, {
+      mutation: 'spend_session_create',
+      ...railGate.analytics,
+      spend_experience_id: experienceId,
+      event_id: experience.event_id,
+      user_id: auth.userId,
+      wallet_address: walletAddress.trim().toLowerCase(),
+    });
     return apiError(railGate.error, 400);
   }
 

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -50,6 +50,8 @@ export const ANALYTICS_EVENTS = {
   SPEND_PAYMENT_COMPLETED: 'spend_payment_completed',
   SPEND_PAYMENT_FAILED: 'spend_payment_failed',
   SPEND_RECEIPT_VIEWED: 'spend_receipt_viewed',
+  /** Spend rail disabled/misconfigured blocked a mutating API path (IRL-10). */
+  SPEND_PILOT_RAIL_MUTATION_BLOCKED: 'spend_pilot_rail_mutation_blocked',
 } as const;
 
 export type AnalyticsEventName =

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -14,6 +14,7 @@ import type {
   SpendPilotSessionEventProperties,
   SpendPilotConversionEventProperties,
   SpendPilotPaymentEventProperties,
+  SpendPilotRailMutationBlockedProperties,
 } from './types';
 import { ANALYTICS_EVENTS } from './events';
 import { resolveDistinctId, type IdentityInput } from './identity';
@@ -356,4 +357,15 @@ export function trackSpendReceiptViewed(
   properties: SpendPilotPaymentEventProperties
 ): void {
   trackEvent(distinctId, ANALYTICS_EVENTS.SPEND_RECEIPT_VIEWED, properties);
+}
+
+export function trackSpendPilotRailMutationBlocked(
+  distinctId: string,
+  properties: SpendPilotRailMutationBlockedProperties
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPEND_PILOT_RAIL_MUTATION_BLOCKED,
+    properties
+  );
 }

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -181,3 +181,26 @@ export interface SpendPilotPaymentEventProperties {
   spend_transaction_id?: string;
   payment_tx_hash?: string | null;
 }
+
+/** Server-only: mutating spend blocked because the session rail is not operational. */
+export interface SpendPilotRailMutationBlockedProperties {
+  mutation:
+    | 'spend_session_create'
+    | 'conversion_confirm'
+    | 'conversion_resume'
+    | 'payment_confirm_new_tx'
+    | 'admin_spend_experience_create'
+    | 'admin_spend_experience_update'
+    | 'admin_treasury_withdraw';
+  spend_rail: string;
+  rail_operational: false;
+  /** Curated, non-secret reason labels (see spend-rail-config admin mapping). */
+  unavailable_reason_codes: string[];
+  spend_experience_id?: string;
+  spend_session_id?: string;
+  event_id?: string | null;
+  user_id?: string;
+  wallet_address?: string;
+  point_conversion_id?: string;
+  admin_actor?: string | null;
+}

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -35,10 +35,15 @@ import type {
 } from '@/lib/types';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import {
+  assertSpendRailAllowsMutatingSpendWork,
+  isSpendRailOperational,
+} from '@/lib/spend-rail-config';
+import {
   resolveServerIdentity,
   trackSpendConversionCompleted,
   trackSpendConversionConfirmed,
   trackSpendConversionFailed,
+  trackSpendPilotRailMutationBlocked,
   trackSpendTreasuryInsufficientFunds,
 } from '@/lib/analytics/server';
 import type { SpendPilotConversionEventProperties } from '@/lib/analytics/types';
@@ -181,6 +186,10 @@ export async function tryFinalizePendingSpendConversion(input: {
   distinctId: string;
   baseAnalytics: SpendPilotConversionEventProperties;
 }): Promise<PointConversion | null> {
+  if (!isSpendRailOperational(input.session.spend_rail)) {
+    return null;
+  }
+
   const pointConversion =
     input.pointConversion ??
     (await getPointConversionBySessionId(input.session.id));
@@ -351,6 +360,20 @@ export async function runSpendConversionConfirm(
   }
 
   if (eligibility.status !== 'eligible') {
+    if (eligibility.status === 'rail_unavailable') {
+      const rg = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+      if (!rg.ok) {
+        trackSpendPilotRailMutationBlocked(distinctId, {
+          mutation: 'conversion_confirm',
+          ...rg.analytics,
+          spend_experience_id: spendExperience.id,
+          event_id: spendExperience.event_id,
+          user_id: authUserId,
+          wallet_address: normalizedWallet,
+          spend_session_id: session.id,
+        });
+      }
+    }
     return {
       ok: false,
       httpStatus: 400,
@@ -566,6 +589,27 @@ async function fundOrResumeUsdc(input: {
     distinctId,
     baseAnalytics,
   } = input;
+
+  const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+  if (!railGate.ok) {
+    trackSpendPilotRailMutationBlocked(distinctId, {
+      mutation: 'conversion_resume',
+      ...railGate.analytics,
+      spend_experience_id: spendExperience.id,
+      event_id: spendExperience.event_id,
+      user_id: session.user_id,
+      wallet_address: normalizedWallet,
+      spend_session_id: session.id,
+      point_conversion_id: pointConversion.id,
+    });
+    return {
+      error: {
+        ok: false,
+        httpStatus: 400,
+        error: railGate.error,
+      },
+    };
+  }
 
   const serverWallet = getSpendServerWalletTransferConfig(spendExperience);
   if (!serverWallet) {

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -240,6 +240,68 @@ describe('buildSpendEligibilityPreview', () => {
     expect(r.status).toBe('payment_complete');
   });
 
+  it('returns payment_complete when spend is confirmed even if Base rail is disabled', () => {
+    const prev = process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'false';
+    try {
+      const conv: PointConversion = {
+        id: 'c1',
+        spend_experience_id: 'e1',
+        spend_session_id: 's1',
+        user_id: 'u1',
+        points_deducted: 5000,
+        usdc_amount: 5,
+        status: 'funded',
+        spend_rail: 'base_usdc',
+        network: 'Base',
+        asset_symbol: 'USDC',
+        treasury_wallet_address: '0x1',
+        user_wallet_address: '0x3',
+        funding_tx_hash: '0xabc',
+        explorer_tx_url: null,
+        idempotency_key: null,
+        created_at: '',
+        completed_at: '',
+        failed_reason: null,
+        updated_at: '',
+      };
+      const r = buildSpendEligibilityPreview({
+        session: sess({ status: 'payment_complete' }),
+        spendExperience: exp(),
+        player: player(1000),
+        pointConversion: conv,
+        spendTransaction: {
+          id: 't1',
+          spend_experience_id: 'e1',
+          spend_session_id: 's1',
+          user_id: 'u1',
+          usdc_amount: 5,
+          spend_rail: 'base_usdc',
+          network: 'Base',
+          asset_symbol: 'USDC',
+          from_wallet_address: '0x3',
+          to_wallet_address: '0x2',
+          status: 'confirmed',
+          payment_tx_hash: '0x' + 'a'.repeat(64),
+          explorer_tx_url: null,
+          idempotency_key: 'k',
+          created_at: '',
+          completed_at: '',
+          failed_reason: null,
+          updated_at: '',
+        },
+        fundedConversionForOtherSession: null,
+        treasuryUsdcBalance: 100,
+        userUsdcBalance: null,
+        now,
+      });
+      expect(r.status).toBe('payment_complete');
+    } finally {
+      if (prev === undefined) delete process.env.SPEND_RAIL_BASE_USDC_ENABLED;
+      else process.env.SPEND_RAIL_BASE_USDC_ENABLED = prev;
+    }
+  });
+
   it('returns ready_for_payment_own_usdc when wallet has enough USDC (no conversion)', () => {
     const r = buildSpendEligibilityPreview({
       session: sess(),

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -127,7 +127,13 @@ export function buildSpendEligibilityPreview(
   }
 
   const railDiag = getSpendRailOperationalDiagnostics(session.spend_rail);
-  if (!railDiag.operational) {
+  /** Confirmed on-chain payment: receipt/read paths stay accurate if the rail is later disabled. */
+  const completedPaymentReadBypass =
+    !railDiag.operational &&
+    spendTransaction?.status === 'confirmed' &&
+    !!(spendTransaction.payment_tx_hash ?? '').trim();
+
+  if (!railDiag.operational && !completedPaymentReadBypass) {
     return {
       status: 'rail_unavailable',
       message: SPEND_ELIGIBILITY_MESSAGES.rail_unavailable,

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -118,20 +118,20 @@ export function buildSpendEligibilityPreview(
     treasuryUsdcBalance,
   });
 
-  if (now > new Date(session.expires_at)) {
-    return {
-      status: 'session_expired',
-      message: SPEND_ELIGIBILITY_MESSAGES.session_expired,
-      preview: null,
-    };
-  }
-
   const railDiag = getSpendRailOperationalDiagnostics(session.spend_rail);
   /** Confirmed on-chain payment: receipt/read paths stay accurate if the rail is later disabled. */
   const completedPaymentReadBypass =
     !railDiag.operational &&
     spendTransaction?.status === 'confirmed' &&
     !!(spendTransaction.payment_tx_hash ?? '').trim();
+
+  if (now > new Date(session.expires_at) && !completedPaymentReadBypass) {
+    return {
+      status: 'session_expired',
+      message: SPEND_ELIGIBILITY_MESSAGES.session_expired,
+      preview: null,
+    };
+  }
 
   if (!railDiag.operational && !completedPaymentReadBypass) {
     return {
@@ -142,7 +142,7 @@ export function buildSpendEligibilityPreview(
   }
 
   const gate = assertSpendExperienceOpenForSessions(spendExperience, now);
-  if (!gate.ok) {
+  if (!gate.ok && !completedPaymentReadBypass) {
     return {
       status: 'experience_inactive',
       message: SPEND_ELIGIBILITY_MESSAGES.experience_inactive,

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -2,12 +2,15 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const mockGetPointConversion = vi.fn();
 const mockFetchUserUsdc = vi.fn();
+const mockGetSpendTransaction = vi.fn();
+const mockRailGate = vi.fn(() => ({ ok: true as const }));
 
 vi.mock('@/lib/db/spend-sessions', () => ({
   getPointConversionBySessionId: (...a: unknown[]) =>
     mockGetPointConversion(...a),
   getSpendSessionById: vi.fn(),
-  getSpendTransactionBySessionId: vi.fn(),
+  getSpendTransactionBySessionId: (...a: unknown[]) =>
+    mockGetSpendTransaction(...a),
   insertSpendTransactionSubmitted: vi.fn(),
   updateSpendSessionStatus: vi.fn(),
   updateSpendTransactionFields: vi.fn(),
@@ -34,16 +37,20 @@ vi.mock('@/lib/spend-payment-verify', () => ({
 vi.mock('@/lib/spend-rail-config', () => ({
   getSpendReceivingWalletAddress: () =>
     '0x2222222222222222222222222222222222222222',
-  isSpendRailOperational: () => true,
+  assertSpendRailAllowsMutatingSpendWork: (...a: unknown[]) =>
+    mockRailGate(...a),
 }));
 
 vi.mock('@/lib/analytics/server', () => ({
   trackSpendPaymentCompleted: vi.fn(),
   trackSpendPaymentConfirmed: vi.fn(),
   trackSpendPaymentFailed: vi.fn(),
+  trackSpendPilotRailMutationBlocked: vi.fn(),
 }));
 
 import { runSpendPaymentConfirm } from '@/lib/spend-payment-confirm';
+import * as analytics from '@/lib/analytics/server';
+import * as spendSessions from '@/lib/db/spend-sessions';
 import type {
   PointConversion,
   SpendExperience,
@@ -121,6 +128,8 @@ describe('runSpendPaymentConfirm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockFetchUserUsdc.mockResolvedValue(10);
+    mockRailGate.mockReturnValue({ ok: true as const });
+    mockGetSpendTransaction.mockResolvedValue(null);
   });
 
   it('rejects direct USDC payment while a points conversion is still in progress', async () => {
@@ -142,5 +151,51 @@ describe('runSpendPaymentConfirm', () => {
     if (result.ok) throw new Error('expected failure');
     expect(result.httpStatus).toBe(400);
     expect(result.error).toMatch(/conversion is still in progress/i);
+  });
+
+  it('returns 400 and does not insert when rail blocks new payment tx (HTTP 400 per spend API convention)', async () => {
+    mockGetPointConversion.mockResolvedValue(inProgressConversion('funded'));
+    mockRailGate.mockReturnValue({
+      ok: false as const,
+      error:
+        'This payment network is temporarily unavailable. Please try again later.',
+      analytics: {
+        spend_rail: 'base_usdc',
+        rail_operational: false as const,
+        unavailable_reason_codes: ['Base USDC is turned off in configuration.'],
+      },
+    });
+
+    const session = {
+      ...baseSession,
+      status: 'conversion_complete' as const,
+    };
+
+    const result = await runSpendPaymentConfirm({
+      session,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      paymentTxHash: validHash,
+      usdcAmount: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.httpStatus).toBe(400);
+    expect(result.error).toMatch(/temporarily unavailable/i);
+    expect(analytics.trackSpendPilotRailMutationBlocked).toHaveBeenCalledWith(
+      'd1',
+      expect.objectContaining({
+        mutation: 'payment_confirm_new_tx',
+        spend_rail: 'base_usdc',
+        rail_operational: false,
+        spend_session_id: session.id,
+      })
+    );
+    expect(
+      spendSessions.insertSpendTransactionSubmitted
+    ).not.toHaveBeenCalled();
   });
 });

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -20,8 +20,8 @@ import {
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
 import {
+  assertSpendRailAllowsMutatingSpendWork,
   getSpendReceivingWalletAddress,
-  isSpendRailOperational,
 } from '@/lib/spend-rail-config';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import type {
@@ -33,6 +33,7 @@ import {
   trackSpendPaymentCompleted,
   trackSpendPaymentConfirmed,
   trackSpendPaymentFailed,
+  trackSpendPilotRailMutationBlocked,
 } from '@/lib/analytics/server';
 import type { SpendPilotPaymentEventProperties } from '@/lib/analytics/types';
 
@@ -282,13 +283,25 @@ export async function runSpendPaymentConfirm(input: {
 
   let spendTx = await getSpendTransactionBySessionId(session.id);
 
-  if (!spendTx && !isSpendRailOperational(session.spend_rail)) {
-    return {
-      ok: false,
-      error:
-        'This payment network is temporarily unavailable. Please try again later.',
-      httpStatus: 400,
-    };
+  if (!spendTx) {
+    const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+    if (!railGate.ok) {
+      trackSpendPilotRailMutationBlocked(distinctId, {
+        mutation: 'payment_confirm_new_tx',
+        ...railGate.analytics,
+        spend_experience_id: spendExperience.id,
+        event_id: spendExperience.event_id,
+        user_id: authUserId,
+        wallet_address: normalizedWallet,
+        spend_session_id: session.id,
+        point_conversion_id: fundedConversion?.id,
+      });
+      return {
+        ok: false,
+        error: railGate.error,
+        httpStatus: 400,
+      };
+    }
   }
 
   if (spendTx?.status === 'confirmed') {

--- a/lib/spend-rail-config/index.test.ts
+++ b/lib/spend-rail-config/index.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
+  assertSpendRailAllowsMutatingSpendWork,
   assertSpendRailAllowsNewSessions,
   formatExplorerTxUrlForSpendLedger,
   getSpendRailOperationalDiagnostics,
@@ -91,6 +92,21 @@ describe('getSpendRailOperationalDiagnostics — base_usdc', () => {
     expect(d.operational).toBe(false);
     expect(d.unavailableReasons.some((r) => r.includes('disabled'))).toBe(true);
     expect(assertSpendRailAllowsNewSessions('base_usdc').ok).toBe(false);
+  });
+
+  it('assertSpendRailAllowsMutatingSpendWork includes safe analytics when blocked', () => {
+    process.env.SPEND_RAIL_BASE_USDC_ENABLED = 'false';
+    process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS =
+      '0x1111111111111111111111111111111111111111';
+    process.env.SPEND_RAIL_BASE_USDC_RECEIVING_WALLET_ADDRESS =
+      '0x2222222222222222222222222222222222222222';
+    process.env.SPEND_RAIL_BASE_USDC_PRIVY_SERVER_WALLET_ID = 'w1';
+    const gate = assertSpendRailAllowsMutatingSpendWork('base_usdc');
+    expect(gate.ok).toBe(false);
+    if (gate.ok) throw new Error('expected block');
+    expect(gate.analytics.spend_rail).toBe('base_usdc');
+    expect(gate.analytics.rail_operational).toBe(false);
+    expect(gate.analytics.unavailable_reason_codes.length).toBeGreaterThan(0);
   });
 
   it('marks rail unavailable when treasury address invalid', () => {

--- a/lib/spend-rail-config/index.ts
+++ b/lib/spend-rail-config/index.ts
@@ -252,16 +252,54 @@ export function isSpendRailOperational(spendRail: SpendRail): boolean {
   return getSpendRailOperationalDiagnostics(spendRail).operational;
 }
 
-export function assertSpendRailAllowsNewSessions(
+/** Safe analytics payload when mutating spend work is blocked (no secrets). */
+export type SpendRailMutationBlockAnalytics = {
+  spend_rail: SpendRail;
+  rail_operational: false;
+  unavailable_reason_codes: string[];
+};
+
+export function spendRailMutationBlockAnalytics(
   spendRail: SpendRail
-): { ok: true } | { ok: false; error: string } {
+): SpendRailMutationBlockAnalytics {
+  const diag = getSpendRailOperationalDiagnostics(spendRail);
+  return {
+    spend_rail: spendRail,
+    rail_operational: false,
+    unavailable_reason_codes: dedupeStrings(
+      diag.unavailableReasons.map(mapSpendRailOperationalReasonToAdminCurated)
+    ),
+  };
+}
+
+const SPEND_RAIL_MUTATION_BLOCKED_USER_MESSAGE =
+  'This payment network is temporarily unavailable. Please try again later.';
+
+/**
+ * Blocks user- or admin-initiated spend work that must not run when the rail is
+ * disabled or misconfigured (sessions, conversion funding, new payment rows, etc.).
+ * Read-only flows (e.g. confirmed receipts) use separate rules in eligibility builders.
+ */
+export function assertSpendRailAllowsMutatingSpendWork(
+  spendRail: SpendRail
+):
+  | { ok: true }
+  | { ok: false; error: string; analytics: SpendRailMutationBlockAnalytics } {
   const { operational } = getSpendRailOperationalDiagnostics(spendRail);
   if (operational) return { ok: true };
   return {
     ok: false,
-    error:
-      'This payment network is temporarily unavailable. Please try again later.',
+    error: SPEND_RAIL_MUTATION_BLOCKED_USER_MESSAGE,
+    analytics: spendRailMutationBlockAnalytics(spendRail),
   };
+}
+
+export function assertSpendRailAllowsNewSessions(
+  spendRail: SpendRail
+): { ok: true } | { ok: false; error: string } {
+  const gate = assertSpendRailAllowsMutatingSpendWork(spendRail);
+  if (gate.ok) return { ok: true };
+  return { ok: false, error: gate.error };
 }
 
 /** Treasury funding via Privy server wallet + Base USDC exists only for `base_usdc` today. */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Enforces spend rail availability and immutability rules from IRL-10: disabled or misconfigured rails block mutating user spend and selected admin operations; completed on-chain payments still surface as `payment_complete` in eligibility when the rail is later off.

## What changed

- **`lib/spend-rail-config`**: Added `assertSpendRailAllowsMutatingSpendWork` and `spendRailMutationBlockAnalytics` (curated reason codes only). `assertSpendRailAllowsNewSessions` delegates to the same guard.
- **Session create**: Returns **400** with the same user message when the rail is off; emits **`spend_pilot_rail_mutation_blocked`** with `spend_rail` and `unavailable_reason_codes` (no new session row, including idempotent paths).
- **Conversion**: `tryFinalizePendingSpendConversion` returns early when the rail is non-operational. `fundOrResumeUsdc` blocks resume funding when the rail is off and tracks analytics. `runSpendConversionConfirm` tracks when eligibility is **`rail_unavailable`**.
- **Payment confirm**: When there is no existing spend transaction row, blocks with **400** and tracks **`payment_confirm_new_tx`** on the rail-blocked path; in-progress and confirmed rows behave as before.
- **Eligibility**: If the spend transaction is **confirmed** with a payment hash, **`payment_complete`** is still returned when the global rail is disabled so receipt reads stay accurate.
- **Admin**: Create tracks analytics on rail block. **PATCH** blocks mechanics-affecting updates (`status`, caps, rates, window times) when the experience rail is not operational. **Treasury withdraw** requires an operational rail before transfer.

## Tests

Route and unit tests cover disabled-rail session POST, admin PATCH mechanics, treasury withdraw, payment confirm new-tx block, and eligibility with Base disabled after confirmed payment.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-10](https://linear.app/irlenergy/issue/IRL-10/update-admin-and-spend-apis-for-rail-availability-rules)

<div><a href="https://cursor.com/agents/bc-05fcf882-2027-4cc8-a6c5-1c12051d3ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05fcf882-2027-4cc8-a6c5-1c12051d3ed2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

