### PR TITLE
feat(spend): payment rail interface, statuses, errors, registry (IRL-15)

### DIFF
--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -143,4 +143,32 @@ describe('runSpendPaymentConfirm', () => {
     expect(result.httpStatus).toBe(400);
     expect(result.error).toMatch(/conversion is still in progress/i);
   });
+
+  it('rejects user-signed payment confirm for stellar_usdc via spend payment rail', async () => {
+    const stellarExperience = {
+      ...baseExperience,
+      spend_rail: 'stellar_usdc' as const,
+    };
+    const stellarSession = {
+      ...baseSession,
+      spend_rail: 'stellar_usdc' as const,
+    };
+
+    const result = await runSpendPaymentConfirm({
+      session: stellarSession,
+      spendExperience: stellarExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      paymentTxHash: validHash,
+      usdcAmount: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.httpStatus).toBe(400);
+    expect(result.error).toBe(
+      'USDC payment verification on this network is not available in this release.'
+    );
+  });
 });

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -19,6 +19,7 @@ import {
 } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
+import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
 import {
   getSpendReceivingWalletAddress,
   isSpendRailOperational,
@@ -182,11 +183,13 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  if (spendExperience.spend_rail !== 'base_usdc') {
+  const spendPaymentRail = getSpendPaymentRail(spendExperience.spend_rail);
+  const userSignedConfirmGate =
+    spendPaymentRail.assertUserSignedOnchainPaymentConfirmSupported();
+  if (!userSignedConfirmGate.ok) {
     return {
       ok: false,
-      error:
-        'USDC payment verification on this network is not available in this release.',
+      error: userSignedConfirmGate.error.userMessage,
       httpStatus: 400,
     };
   }

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -1,0 +1,76 @@
+import type { SpendRail, SpendWalletReadinessStatus } from '@/lib/types';
+import {
+  okSpendRail,
+  spendPaymentRailExplorerUrl,
+  type SpendPaymentRail,
+  type SpendRailResult,
+} from '@/lib/spend/payment-rails/spend-payment-rail';
+import type {
+  SpendPaymentRailReconcileContext,
+  SpendPaymentRailSessionContext,
+  SpendRailFundingOperationStatus,
+  SpendRailPaymentOperationStatus,
+} from '@/lib/spend/payment-rails/types';
+
+/**
+ * Base USDC rail: user-signed EVM flows today; additional orchestration moves behind this
+ * object in IRL-14 / follow-on issues.
+ */
+export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
+  const spendRail: SpendRail = 'base_usdc';
+
+  return {
+    spendRail,
+
+    async getTreasurySpendableBalance(): Promise<
+      SpendRailResult<number | null>
+    > {
+      return okSpendRail(null);
+    },
+
+    async runWalletReadinessOrchestration(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>> {
+      void ctx;
+      return okSpendRail({ status: 'completed' });
+    },
+
+    async initiateUserFunding(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
+      void ctx;
+      return okSpendRail({ status: 'pending' });
+    },
+
+    async preparePayment(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
+      void ctx;
+      return okSpendRail({ status: 'prepared' });
+    },
+
+    async confirmPayment(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
+      void ctx;
+      return okSpendRail({ status: 'submitted' });
+    },
+
+    explorerUrlForLedgerTx(
+      txReference: string | null | undefined
+    ): string | null {
+      return spendPaymentRailExplorerUrl(spendRail, txReference);
+    },
+
+    async reconcilePendingOperations(
+      ctx: SpendPaymentRailReconcileContext
+    ): Promise<SpendRailResult<void>> {
+      void ctx;
+      return okSpendRail(undefined);
+    },
+
+    assertUserSignedOnchainPaymentConfirmSupported(): SpendRailResult<void> {
+      return okSpendRail(undefined);
+    },
+  };
+}

--- a/lib/spend/payment-rails/errors.ts
+++ b/lib/spend/payment-rails/errors.ts
@@ -1,0 +1,128 @@
+/**
+ * Sanitized analytics identifiers for spend rails (snake_case, stable, no secrets).
+ * Downstream analytics (e.g. IRL-23) should reference these constants only.
+ */
+export const SPEND_RAIL_ANALYTICS_CODES = {
+  wallet_unavailable: 'spend_rail_wallet_unavailable',
+  treasury_insufficient_funds: 'spend_rail_treasury_insufficient_funds',
+  wallet_readiness_failed: 'spend_rail_wallet_readiness_failed',
+  funding_failed: 'spend_rail_funding_failed',
+  payment_failed: 'spend_rail_payment_failed',
+  network_unavailable: 'spend_rail_network_unavailable',
+  invalid_receiving_wallet: 'spend_rail_invalid_receiving_wallet',
+  duplicate_request: 'spend_rail_duplicate_request',
+  rail_operation_not_supported: 'spend_rail_operation_not_supported',
+} as const;
+
+export type SpendRailAnalyticsCode =
+  (typeof SPEND_RAIL_ANALYTICS_CODES)[keyof typeof SPEND_RAIL_ANALYTICS_CODES];
+
+export type SpendRailErrorCategory =
+  | 'wallet_unavailable'
+  | 'treasury_insufficient_funds'
+  | 'wallet_readiness_failed'
+  | 'funding_failed'
+  | 'payment_failed'
+  | 'network_unavailable'
+  | 'invalid_receiving_wallet'
+  | 'duplicate_request'
+  | 'rail_operation_not_supported';
+
+/**
+ * Categorized rail error safe for API responses (user copy) and analytics (sanitized code).
+ */
+export type SpendRailError = {
+  category: SpendRailErrorCategory;
+  userMessage: string;
+  analyticsCode: SpendRailAnalyticsCode;
+};
+
+const err = (
+  category: SpendRailErrorCategory,
+  userMessage: string,
+  analyticsCode: SpendRailAnalyticsCode
+): SpendRailError => ({ category, userMessage, analyticsCode });
+
+/** User wallet is missing or cannot be used for this operation. */
+export const spendRailErrorWalletUnavailable = (): SpendRailError =>
+  err(
+    'wallet_unavailable',
+    'Your wallet is not available for this step. Reconnect your wallet and try again.',
+    SPEND_RAIL_ANALYTICS_CODES.wallet_unavailable
+  );
+
+/** Treasury cannot cover the requested funding amount. */
+export const spendRailErrorTreasuryInsufficientFunds = (): SpendRailError =>
+  err(
+    'treasury_insufficient_funds',
+    'This experience cannot fund your balance right now. Please try again later.',
+    SPEND_RAIL_ANALYTICS_CODES.treasury_insufficient_funds
+  );
+
+/** Server-driven wallet readiness (e.g. account prep) did not complete successfully. */
+export const spendRailErrorWalletReadinessFailed = (): SpendRailError =>
+  err(
+    'wallet_readiness_failed',
+    'Your wallet could not be set up for payments on this network. Please try again or contact support.',
+    SPEND_RAIL_ANALYTICS_CODES.wallet_readiness_failed
+  );
+
+/** Treasury → user funding failed or could not be verified. */
+export const spendRailErrorFundingFailed = (): SpendRailError =>
+  err(
+    'funding_failed',
+    'Funding your balance did not complete. You can try again from the start of the flow.',
+    SPEND_RAIL_ANALYTICS_CODES.funding_failed
+  );
+
+/** Payment submission or on-chain verification failed. */
+export const spendRailErrorPaymentFailed = (): SpendRailError =>
+  err(
+    'payment_failed',
+    'Payment could not be verified. If funds left your wallet, contact support with your transaction hash.',
+    SPEND_RAIL_ANALYTICS_CODES.payment_failed
+  );
+
+/** Upstream network or provider unavailable. */
+export const spendRailErrorNetworkUnavailable = (): SpendRailError =>
+  err(
+    'network_unavailable',
+    'This payment network is temporarily unavailable. Please try again later.',
+    SPEND_RAIL_ANALYTICS_CODES.network_unavailable
+  );
+
+/** Configured receiving/settlement address is invalid for the rail. */
+export const spendRailErrorInvalidReceivingWallet = (): SpendRailError =>
+  err(
+    'invalid_receiving_wallet',
+    'Invalid receiving wallet configuration.',
+    SPEND_RAIL_ANALYTICS_CODES.invalid_receiving_wallet
+  );
+
+/** Idempotent replay detected a conflicting in-flight request. */
+export const spendRailErrorDuplicateRequest = (): SpendRailError =>
+  err(
+    'duplicate_request',
+    'This request was already processed. Please refresh and continue.',
+    SPEND_RAIL_ANALYTICS_CODES.duplicate_request
+  );
+
+/**
+ * Operation is not implemented for this rail in the current release (non-leaky copy for clients).
+ */
+export const spendRailErrorRailOperationNotSupported = (): SpendRailError =>
+  err(
+    'rail_operation_not_supported',
+    'USDC payment verification on this network is not available in this release.',
+    SPEND_RAIL_ANALYTICS_CODES.rail_operation_not_supported
+  );
+
+export function isSpendRailError(value: unknown): value is SpendRailError {
+  if (!value || typeof value !== 'object') return false;
+  const v = value as Record<string, unknown>;
+  return (
+    typeof v.category === 'string' &&
+    typeof v.userMessage === 'string' &&
+    typeof v.analyticsCode === 'string'
+  );
+}

--- a/lib/spend/payment-rails/index.ts
+++ b/lib/spend/payment-rails/index.ts
@@ -1,0 +1,36 @@
+export {
+  SPEND_RAIL_ANALYTICS_CODES,
+  spendRailErrorDuplicateRequest,
+  spendRailErrorFundingFailed,
+  spendRailErrorInvalidReceivingWallet,
+  spendRailErrorNetworkUnavailable,
+  spendRailErrorPaymentFailed,
+  spendRailErrorRailOperationNotSupported,
+  spendRailErrorTreasuryInsufficientFunds,
+  spendRailErrorWalletReadinessFailed,
+  spendRailErrorWalletUnavailable,
+  isSpendRailError,
+  type SpendRailAnalyticsCode,
+  type SpendRailError,
+  type SpendRailErrorCategory,
+} from '@/lib/spend/payment-rails/errors';
+
+export { getSpendPaymentRail } from '@/lib/spend/payment-rails/registry';
+
+export {
+  errSpendRail,
+  okSpendRail,
+  spendPaymentRailExplorerUrl,
+  type SpendPaymentRail,
+  type SpendRailResult,
+} from '@/lib/spend/payment-rails/spend-payment-rail';
+
+export {
+  isTerminalSpendRailFundingStatus,
+  isTerminalSpendRailPaymentStatus,
+  type SpendPaymentRailReconcileContext,
+  type SpendPaymentRailSessionContext,
+  type SpendRailFundingOperationStatus,
+  type SpendRailPaymentOperationStatus,
+  type SpendWalletReadinessStatus,
+} from '@/lib/spend/payment-rails/types';

--- a/lib/spend/payment-rails/payment-rails.test.ts
+++ b/lib/spend/payment-rails/payment-rails.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'vitest';
+import {
+  SPEND_RAIL_ANALYTICS_CODES,
+  spendRailErrorDuplicateRequest,
+  spendRailErrorFundingFailed,
+  spendRailErrorInvalidReceivingWallet,
+  spendRailErrorNetworkUnavailable,
+  spendRailErrorPaymentFailed,
+  spendRailErrorRailOperationNotSupported,
+  spendRailErrorTreasuryInsufficientFunds,
+  spendRailErrorWalletReadinessFailed,
+  spendRailErrorWalletUnavailable,
+} from '@/lib/spend/payment-rails/errors';
+import { getSpendPaymentRail } from '@/lib/spend/payment-rails/registry';
+import {
+  isTerminalSpendRailFundingStatus,
+  isTerminalSpendRailPaymentStatus,
+} from '@/lib/spend/payment-rails/types';
+
+describe('SPEND_RAIL_ANALYTICS_CODES', () => {
+  it('uses snake_case stable identifiers', () => {
+    for (const code of Object.values(SPEND_RAIL_ANALYTICS_CODES)) {
+      expect(code).toMatch(/^spend_rail_[a-z0-9_]+$/);
+    }
+  });
+});
+
+describe('spend rail error catalog', () => {
+  const cases = [
+    ['wallet', spendRailErrorWalletUnavailable, 'wallet_unavailable'],
+    [
+      'treasury',
+      spendRailErrorTreasuryInsufficientFunds,
+      'treasury_insufficient_funds',
+    ],
+    [
+      'readiness',
+      spendRailErrorWalletReadinessFailed,
+      'wallet_readiness_failed',
+    ],
+    ['funding', spendRailErrorFundingFailed, 'funding_failed'],
+    ['payment', spendRailErrorPaymentFailed, 'payment_failed'],
+    ['network', spendRailErrorNetworkUnavailable, 'network_unavailable'],
+    [
+      'receiving',
+      spendRailErrorInvalidReceivingWallet,
+      'invalid_receiving_wallet',
+    ],
+    ['duplicate', spendRailErrorDuplicateRequest, 'duplicate_request'],
+    [
+      'unsupported',
+      spendRailErrorRailOperationNotSupported,
+      'rail_operation_not_supported',
+    ],
+  ] as const;
+
+  it.each(cases)(
+    '%s exposes user message and analytics code',
+    (_label, fn, category) => {
+      const e = fn();
+      expect(e.category).toBe(category);
+      expect(e.userMessage.length).toBeGreaterThan(10);
+      expect(e.analyticsCode).toBe(
+        SPEND_RAIL_ANALYTICS_CODES[
+          category as keyof typeof SPEND_RAIL_ANALYTICS_CODES
+        ]
+      );
+    }
+  );
+});
+
+describe('isTerminalSpendRailFundingStatus', () => {
+  it('is true only for terminal funding statuses', () => {
+    expect(isTerminalSpendRailFundingStatus('confirmed')).toBe(true);
+    expect(isTerminalSpendRailFundingStatus('failed')).toBe(true);
+    expect(isTerminalSpendRailFundingStatus('needs_review')).toBe(true);
+    expect(isTerminalSpendRailFundingStatus('pending')).toBe(false);
+    expect(isTerminalSpendRailFundingStatus('submitted')).toBe(false);
+  });
+});
+
+describe('isTerminalSpendRailPaymentStatus', () => {
+  it('is true only for terminal payment statuses', () => {
+    expect(isTerminalSpendRailPaymentStatus('confirmed')).toBe(true);
+    expect(isTerminalSpendRailPaymentStatus('failed')).toBe(true);
+    expect(isTerminalSpendRailPaymentStatus('needs_review')).toBe(true);
+    expect(isTerminalSpendRailPaymentStatus('prepared')).toBe(false);
+    expect(isTerminalSpendRailPaymentStatus('submitted')).toBe(false);
+  });
+});
+
+describe('getSpendPaymentRail', () => {
+  it('returns typed Base rail with user-signed payment confirm supported', () => {
+    const rail = getSpendPaymentRail('base_usdc');
+    expect(rail.spendRail).toBe('base_usdc');
+    expect(rail.assertUserSignedOnchainPaymentConfirmSupported().ok).toBe(true);
+  });
+
+  it('returns typed Stellar rail that rejects user-signed confirm with catalog error', () => {
+    const rail = getSpendPaymentRail('stellar_usdc');
+    expect(rail.spendRail).toBe('stellar_usdc');
+    const gate = rail.assertUserSignedOnchainPaymentConfirmSupported();
+    expect(gate.ok).toBe(false);
+    if (gate.ok) throw new Error('expected failure');
+    expect(gate.error.analyticsCode).toBe(
+      SPEND_RAIL_ANALYTICS_CODES.rail_operation_not_supported
+    );
+    expect(gate.error.userMessage).toContain('not available in this release');
+  });
+
+  it('marks Stellar orchestration entrypoints as unsupported except explorer URL helper', async () => {
+    const rail = getSpendPaymentRail('stellar_usdc');
+    const ctx = { spendSessionId: 's1' };
+
+    await expect(rail.getTreasurySpendableBalance()).resolves.toMatchObject({
+      ok: false,
+    });
+    await expect(
+      rail.runWalletReadinessOrchestration(ctx)
+    ).resolves.toMatchObject({
+      ok: false,
+    });
+    await expect(rail.initiateUserFunding(ctx)).resolves.toMatchObject({
+      ok: false,
+    });
+    await expect(rail.preparePayment(ctx)).resolves.toMatchObject({
+      ok: false,
+    });
+    await expect(rail.confirmPayment(ctx)).resolves.toMatchObject({
+      ok: false,
+    });
+    await expect(
+      rail.reconcilePendingOperations({ spendSessionId: 's1' })
+    ).resolves.toMatchObject({ ok: false });
+
+    expect(rail.explorerUrlForLedgerTx(null)).toBeNull();
+  });
+});

--- a/lib/spend/payment-rails/registry.ts
+++ b/lib/spend/payment-rails/registry.ts
@@ -1,0 +1,17 @@
+import type { SpendRail } from '@/lib/types';
+import { createBaseUsdcSpendPaymentRail } from '@/lib/spend/payment-rails/base-usdc-rail';
+import { createStellarUsdcSpendPaymentRail } from '@/lib/spend/payment-rails/stellar-usdc-rail';
+import type { SpendPaymentRail } from '@/lib/spend/payment-rails/spend-payment-rail';
+
+const registry: Record<SpendRail, SpendPaymentRail> = {
+  base_usdc: createBaseUsdcSpendPaymentRail(),
+  stellar_usdc: createStellarUsdcSpendPaymentRail(),
+};
+
+/**
+ * Supported entrypoint for spend flow code to branch on `spend_rail` instead of ad hoc string
+ * checks (see `getSpendPaymentRail(session.spend_rail)` or experience rail).
+ */
+export function getSpendPaymentRail(spendRail: SpendRail): SpendPaymentRail {
+  return registry[spendRail];
+}

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -1,0 +1,99 @@
+import type { SpendRail } from '@/lib/types';
+import { explorerTxUrlForSpendLedger } from '@/lib/spend-ledger-explorer-url';
+import type { SpendRailError } from '@/lib/spend/payment-rails/errors';
+import type {
+  SpendPaymentRailReconcileContext,
+  SpendPaymentRailSessionContext,
+  SpendRailFundingOperationStatus,
+  SpendRailPaymentOperationStatus,
+  SpendWalletReadinessStatus,
+} from '@/lib/spend/payment-rails/types';
+
+export type SpendRailResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: SpendRailError };
+
+/**
+ * Orchestration surface for spend payment rails (Base user-signed flows vs Stellar
+ * backend-controlled flows). Differences are expressed through method availability and
+ * rail-private implementation types — not through a public custody field.
+ *
+ * Several methods are structural placeholders for IRL-14 / IRL-19 / IRL-20; IRL-15 wires
+ * registry + typing + shared errors only. Call production money movement only through
+ * existing library paths until those issues land.
+ */
+export interface SpendPaymentRail {
+  readonly spendRail: SpendRail;
+
+  /**
+   * Treasury USDC (or rail asset) spendable balance when the rail can resolve it server-side.
+   * `null` means unknown / not loaded at this boundary (not an error).
+   */
+  getTreasurySpendableBalance(): Promise<SpendRailResult<number | null>>;
+
+  /**
+   * Coarse wallet readiness orchestration (e.g. sponsored account + trustline). Base USDC
+   * treats readiness as **completed** at this boundary because session wallets are verified EVM
+   * up front; Stellar returns **not supported** until IRL-21 implements readiness behind the rail.
+   */
+  runWalletReadinessOrchestration(
+    ctx: SpendPaymentRailSessionContext
+  ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>>;
+
+  /**
+   * Treasury → user funding at the rail operation layer. Real orchestration moves in IRL-14 /
+   * conversion refactors; Base returns a neutral pending placeholder, Stellar is unsupported.
+   */
+  initiateUserFunding(
+    ctx: SpendPaymentRailSessionContext
+  ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>>;
+
+  /**
+   * Prepare a payment action (idempotent descriptor). Unsupported on both rails at IRL-15
+   * except for typing; IRL-19 will implement descriptors.
+   */
+  preparePayment(
+    ctx: SpendPaymentRailSessionContext
+  ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>>;
+
+  /**
+   * Confirm payment after prepare/submit. Unsupported at IRL-15 except for typing;
+   * user-signed Base confirmation stays in `lib/spend-payment-confirm.ts` until extracted.
+   */
+  confirmPayment(
+    ctx: SpendPaymentRailSessionContext
+  ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>>;
+
+  /** Canonical explorer URL for a ledger transaction reference, when known. */
+  explorerUrlForLedgerTx(txReference: string | null | undefined): string | null;
+
+  /**
+   * Reconcile stale pending/submitted operations (cron). IRL-15: successful no-op on Base;
+   * unsupported outcome on Stellar until reconciliation is rail-backed.
+   */
+  reconcilePendingOperations(
+    ctx: SpendPaymentRailReconcileContext
+  ): Promise<SpendRailResult<void>>;
+
+  /**
+   * Whether this rail accepts **user-submitted** on-chain payment hashes for confirmation
+   * in the spend pilot API. Base USDC: supported. Stellar v1 (server-controlled): not supported.
+   */
+  assertUserSignedOnchainPaymentConfirmSupported(): SpendRailResult<void>;
+}
+
+export function okSpendRail<T>(value: T): SpendRailResult<T> {
+  return { ok: true, value };
+}
+
+export function errSpendRail(error: SpendRailError): SpendRailResult<never> {
+  return { ok: false, error };
+}
+
+/** Shared explorer helper so rails stay aligned with `lib/spend-ledger-explorer-url.ts`. */
+export function spendPaymentRailExplorerUrl(
+  spendRail: SpendRail,
+  txReference: string | null | undefined
+): string | null {
+  return explorerTxUrlForSpendLedger(spendRail, txReference);
+}

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -1,0 +1,82 @@
+import type { SpendRail } from '@/lib/types';
+import {
+  errSpendRail,
+  spendPaymentRailExplorerUrl,
+  type SpendPaymentRail,
+  type SpendRailResult,
+} from '@/lib/spend/payment-rails/spend-payment-rail';
+import { spendRailErrorRailOperationNotSupported } from '@/lib/spend/payment-rails/errors';
+import type {
+  SpendPaymentRailReconcileContext,
+  SpendPaymentRailSessionContext,
+  SpendRailFundingOperationStatus,
+  SpendRailPaymentOperationStatus,
+  SpendWalletReadinessStatus,
+} from '@/lib/spend/payment-rails/types';
+
+const unsupported = (): SpendRailResult<never> =>
+  errSpendRail(spendRailErrorRailOperationNotSupported());
+
+/**
+ * Stellar USDC rail: registered for typing and shared errors; orchestration methods return
+ * categorized "not supported in this release" until IRL-19 / IRL-21 / IRL-14-style extraction.
+ */
+export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
+  const spendRail: SpendRail = 'stellar_usdc';
+  const notSupported = unsupported;
+
+  return {
+    spendRail,
+
+    async getTreasurySpendableBalance(): Promise<
+      SpendRailResult<number | null>
+    > {
+      return notSupported();
+    },
+
+    async runWalletReadinessOrchestration(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>> {
+      void ctx;
+      return notSupported();
+    },
+
+    async initiateUserFunding(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
+      void ctx;
+      return notSupported();
+    },
+
+    async preparePayment(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
+      void ctx;
+      return notSupported();
+    },
+
+    async confirmPayment(
+      ctx: SpendPaymentRailSessionContext
+    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
+      void ctx;
+      return notSupported();
+    },
+
+    explorerUrlForLedgerTx(
+      txReference: string | null | undefined
+    ): string | null {
+      return spendPaymentRailExplorerUrl(spendRail, txReference);
+    },
+
+    async reconcilePendingOperations(
+      ctx: SpendPaymentRailReconcileContext
+    ): Promise<SpendRailResult<void>> {
+      void ctx;
+      return notSupported();
+    },
+
+    assertUserSignedOnchainPaymentConfirmSupported(): SpendRailResult<void> {
+      return notSupported();
+    },
+  };
+}

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -1,0 +1,68 @@
+import type { SpendWalletReadinessStatus } from '@/lib/types';
+
+/**
+ * Re-export for rail-layer code that should stay aligned with persisted readiness rows
+ * (`SpendWalletReadinessOperation.status` in `lib/types.ts`).
+ */
+export type { SpendWalletReadinessStatus };
+
+/**
+ * Funding operation lifecycle at the **rail orchestration layer** (not DB enum alignment;
+ * see IRL-20 / conversion refactor for persistence).
+ *
+ * **confirmed** means on-chain (or network-appropriate) finality consistent with existing
+ * treasury ledger confirmation semantics; verification lives in rail implementations.
+ */
+export type SpendRailFundingOperationStatus =
+  | 'pending'
+  | 'submitted'
+  | 'confirmed'
+  | 'failed'
+  | 'needs_review';
+
+/**
+ * Payment operation lifecycle at the **rail orchestration layer** (not `spend_transactions.status`;
+ * DB alignment is deferred).
+ *
+ * **confirmed** means on-chain (or network-appropriate) evidence consistent with spend payment
+ * ledger confirmation semantics; verification lives in rail implementations.
+ */
+export type SpendRailPaymentOperationStatus =
+  | 'prepared'
+  | 'submitted'
+  | 'confirmed'
+  | 'failed'
+  | 'needs_review';
+
+export type SpendPaymentRailSessionContext = {
+  spendSessionId: string;
+  spendExperienceId?: string;
+};
+
+/**
+ * Inputs for reconciliation passes (e.g. cron). IRL-15 defines shape only; behavior is no-op
+ * until reconciliation is centralized on rails.
+ */
+export type SpendPaymentRailReconcileContext = {
+  spendSessionId: string;
+  /** ISO timestamp — rows older than this may be candidates for reconciliation. */
+  olderThanIso?: string;
+};
+
+/** Terminal funding states for orchestration branching in new code. */
+export function isTerminalSpendRailFundingStatus(
+  status: SpendRailFundingOperationStatus
+): boolean {
+  return (
+    status === 'confirmed' || status === 'failed' || status === 'needs_review'
+  );
+}
+
+/** Terminal payment states for orchestration branching in new code. */
+export function isTerminalSpendRailPaymentStatus(
+  status: SpendRailPaymentOperationStatus
+): boolean {
+  return (
+    status === 'confirmed' || status === 'failed' || status === 'needs_review'
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-15: adds `lib/spend/payment-rails/` with a `SpendPaymentRail` orchestration surface, rail-layer funding and payment status unions (separate from persisted DB enums), a shared error catalog with stable `spend_rail_*` analytics codes, and `getSpendPaymentRail()` registry entries for `base_usdc` and `stellar_usdc`.

## Integration

`runSpendPaymentConfirm` gates user-submitted on-chain payment confirmation through `getSpendPaymentRail(spendExperience.spend_rail).assertUserSignedOnchainPaymentConfirmSupported()` instead of an ad hoc `spend_rail !== 'base_usdc'` check. User-facing copy and HTTP 400 behavior for unsupported rails are unchanged.

## Tests

- `lib/spend/payment-rails/payment-rails.test.ts`: error catalog, terminal status helpers, registry wiring (Base supports user-signed confirm; Stellar returns categorized unsupported outcomes; explorer helper remains usable on Stellar).
- `lib/spend-payment-confirm.test.ts`: Stellar session and experience reject at the rail gate with the same message as before.

## Verification

- `yarn eslint lib/spend/payment-rails lib/spend-payment-confirm.ts lib/spend-payment-confirm.test.ts`
- `yarn vitest lib/spend/payment-rails/payment-rails.test.ts lib/spend-payment-confirm.test.ts`
- `yarn build` (pre-commit) succeeded on the commit.

## Notes

Stellar rail methods that are not built yet return the shared `rail_operation_not_supported` error with non-leaky user copy. Base rail methods beyond user-signed confirm and explorer URLs are structural placeholders documented for follow-on work (IRL-14, IRL-19, IRL-20, IRL-21); production money movement remains in existing modules until those land.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-15](https://linear.app/irlenergy/issue/IRL-15/define-spend-payment-rail-interface-statuses-and-shared-errors)

<div><a href="https://cursor.com/agents/bc-567331d8-cd64-4daf-a820-2f0475af0f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-567331d8-cd64-4daf-a820-2f0475af0f7c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

