### PR TITLE
feat(spend): Base USDC rail orchestration (IRL-14)

### DIFF
--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -15,6 +15,7 @@ import {
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
 import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
+import { recipientUsdcAddressForSpendTransfer } from '@/lib/spend/recipient-usdc-for-treasury-transfer';
 import { resolvePrivyServerTransactionHash } from '@/lib/api/privy';
 import {
   findRecentTreasuryUsdcTransfer,
@@ -33,7 +34,6 @@ import type {
   SpendExperience,
   SpendSession,
 } from '@/lib/types';
-import { recipientUsdcAddressForSpendTransfer } from '@/lib/spend/recipient-usdc-for-treasury-transfer';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import {
   assertSpendRailAllowsMutatingSpendWork,

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -33,6 +33,7 @@ import type {
   SpendExperience,
   SpendSession,
 } from '@/lib/types';
+import { recipientUsdcAddressForSpendTransfer } from '@/lib/spend/recipient-usdc-for-treasury-transfer';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import {
   assertSpendRailAllowsMutatingSpendWork,
@@ -78,23 +79,6 @@ type ConfirmContext = {
   usdcAmount: number;
   pointsRequired: number;
 };
-
-/**
- * Server-wallet-funded USDC goes to the session embedded wallet. If session wallet equals the server wallet
- * (misconfiguration), fall back to the normalized embedded address from auth.
- */
-function recipientUsdcAddressForSpendTransfer(params: {
-  serverWalletAddress: string;
-  sessionWalletTrimmed: string;
-  normalizedWalletLower: string;
-}): `0x${string}` {
-  const serverWalletLower = params.serverWalletAddress.trim().toLowerCase();
-  const sessionLower = params.sessionWalletTrimmed.toLowerCase();
-  if (serverWalletLower === sessionLower) {
-    return params.normalizedWalletLower as `0x${string}`;
-  }
-  return params.sessionWalletTrimmed as `0x${string}`;
-}
 
 function restoreTierAfterRefund(params: {
   authUserId: string;

--- a/lib/spend/payment-rails/base-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.test.ts
@@ -1,0 +1,214 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
+  submitTreasuryUsdcTransfer: vi.fn(),
+  getTreasuryTxReceiptStatus: vi.fn(),
+}));
+
+import { createBaseUsdcSpendPaymentRail } from '@/lib/spend/payment-rails/base-usdc-rail';
+import { SPEND_RAIL_ANALYTICS_CODES } from '@/lib/spend/payment-rails/errors';
+import * as spendRailConfig from '@/lib/spend-rail-config';
+import {
+  submitTreasuryUsdcTransfer,
+  getTreasuryTxReceiptStatus,
+} from '@/lib/spend-treasury-usdc-transfer';
+import * as paymentVerify from '@/lib/spend-payment-verify';
+import * as posterUsdc from '@/lib/walletconnect-poster-direct-usdc';
+
+const EMBEDDED = '0x1111111111111111111111111111111111111111';
+const TREASURY = '0x3333333333333333333333333333333333333333';
+const RECEIVER = '0x2222222222222222222222222222222222222222';
+const VALID_PAYMENT_HASH =
+  '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+
+describe('createBaseUsdcSpendPaymentRail', () => {
+  const rail = createBaseUsdcSpendPaymentRail();
+
+  beforeEach(() => {
+    vi.mocked(submitTreasuryUsdcTransfer).mockReset();
+    vi.mocked(getTreasuryTxReceiptStatus).mockReset();
+    vi.spyOn(spendRailConfig, 'getSpendTreasuryWalletAddress').mockReturnValue(
+      TREASURY
+    );
+    vi.spyOn(spendRailConfig, 'getSpendRailBaseRpcUrl').mockReturnValue(
+      'https://mainnet.base.org'
+    );
+    vi.spyOn(
+      spendRailConfig,
+      'getSpendRailBaseUsdcContractAddress'
+    ).mockReturnValue('0x833589fcd6edb6e08f4c7c32d4f71b54bda02913');
+    vi.spyOn(spendRailConfig, 'getSpendReceivingWalletAddress').mockReturnValue(
+      RECEIVER
+    );
+    vi.spyOn(
+      spendRailConfig,
+      'getSpendBaseTreasuryPrivyTransferConfig'
+    ).mockReturnValue({
+      walletId: 'privy-wallet-1',
+      address: TREASURY as `0x${string}`,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('getTreasurySpendableBalance returns balance when RPC succeeds', async () => {
+    vi.spyOn(posterUsdc, 'fetchUsdcBalanceOnBase').mockResolvedValue(12.34);
+    const res = await rail.getTreasurySpendableBalance();
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value).toBe(12.34);
+  });
+
+  it('getTreasurySpendableBalance returns null when treasury address is not EVM', async () => {
+    vi.spyOn(spendRailConfig, 'getSpendTreasuryWalletAddress').mockReturnValue(
+      'not-an-address'
+    );
+    const res = await rail.getTreasurySpendableBalance();
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value).toBeNull();
+  });
+
+  it('runWalletReadinessOrchestration fails without a valid embedded wallet', async () => {
+    const res = await rail.runWalletReadinessOrchestration({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: '0xbad',
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('wallet_unavailable');
+  });
+
+  it('runWalletReadinessOrchestration fails when auth wallet does not match embedded', async () => {
+    const res = await rail.runWalletReadinessOrchestration({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower:
+        '0x9999999999999999999999999999999999999999',
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('wallet_unavailable');
+  });
+
+  it('runWalletReadinessOrchestration completes for a valid embedded EVM wallet', async () => {
+    const res = await rail.runWalletReadinessOrchestration({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value.status).toBe('completed');
+  });
+
+  it('initiateUserFunding returns pending when Privy submission is still resolving', async () => {
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: true,
+      submittedPending: true,
+      privyTransactionId: 'ptx-1',
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value.status).toBe('pending');
+  });
+
+  it('initiateUserFunding returns confirmed when receipt is already successful', async () => {
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: true,
+      txHash: VALID_PAYMENT_HASH,
+      privyTransactionId: 'ptx-2',
+    });
+    vi.mocked(getTreasuryTxReceiptStatus).mockResolvedValue('success');
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value.status).toBe('confirmed');
+  });
+
+  it('initiateUserFunding maps treasury insufficient errors to the treasury catalog', async () => {
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: false,
+      error: 'Insufficient USDC balance in treasury wallet.',
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('treasury_insufficient_funds');
+    expect(res.error.analyticsCode).toBe(
+      SPEND_RAIL_ANALYTICS_CODES.treasury_insufficient_funds
+    );
+  });
+
+  it('preparePayment is unsupported on Base until IRL-19', async () => {
+    const res = await rail.preparePayment({ spendSessionId: 's1' });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('rail_operation_not_supported');
+  });
+
+  it('confirmPayment rejects invalid global receiving wallet configuration', async () => {
+    vi.spyOn(spendRailConfig, 'getSpendReceivingWalletAddress').mockReturnValue(
+      ''
+    );
+    const res = await rail.confirmPayment({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      usdcAmount: 5,
+      paymentTxHash: VALID_PAYMENT_HASH,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('invalid_receiving_wallet');
+  });
+
+  it('confirmPayment returns confirmed when on-chain verification succeeds', async () => {
+    vi.spyOn(paymentVerify, 'verifySpendUsdcPaymentTx').mockResolvedValue({
+      ok: true,
+    });
+    const res = await rail.confirmPayment({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      usdcAmount: 5,
+      paymentTxHash: VALID_PAYMENT_HASH,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value.status).toBe('confirmed');
+    expect(paymentVerify.verifySpendUsdcPaymentTx).toHaveBeenCalledWith(
+      expect.objectContaining({
+        txHash: VALID_PAYMENT_HASH,
+        expectedFrom: EMBEDDED,
+        expectedTo: RECEIVER,
+        expectedUsdcAmount: 5,
+      })
+    );
+  });
+
+  it('explorerUrlForLedgerTx uses rail explorer template', () => {
+    vi.spyOn(
+      spendRailConfig,
+      'formatExplorerTxUrlForSpendLedger'
+    ).mockReturnValue('https://basescan.org/tx/0xabc');
+    const url = rail.explorerUrlForLedgerTx('0xabc');
+    expect(url).toBe('https://basescan.org/tx/0xabc');
+  });
+});

--- a/lib/spend/payment-rails/base-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.test.ts
@@ -104,6 +104,74 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     expect(res.value.status).toBe('completed');
   });
 
+  it('initiateUserFunding fails when treasury equals session without a distinct Privy auth wallet', async () => {
+    vi.spyOn(
+      spendRailConfig,
+      'getSpendBaseTreasuryPrivyTransferConfig'
+    ).mockReturnValue({
+      walletId: 'privy-wallet-1',
+      address: EMBEDDED as `0x${string}`,
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('wallet_unavailable');
+    expect(submitTreasuryUsdcTransfer).not.toHaveBeenCalled();
+  });
+
+  it('initiateUserFunding fails when treasury equals session and Privy wallet is the same address', async () => {
+    vi.spyOn(
+      spendRailConfig,
+      'getSpendBaseTreasuryPrivyTransferConfig'
+    ).mockReturnValue({
+      walletId: 'privy-wallet-1',
+      address: EMBEDDED as `0x${string}`,
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('unexpected');
+    expect(res.error.category).toBe('wallet_unavailable');
+    expect(submitTreasuryUsdcTransfer).not.toHaveBeenCalled();
+  });
+
+  it('initiateUserFunding targets Privy auth wallet when treasury is misconfigured to the session wallet', async () => {
+    const privyUser = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    vi.spyOn(
+      spendRailConfig,
+      'getSpendBaseTreasuryPrivyTransferConfig'
+    ).mockReturnValue({
+      walletId: 'privy-wallet-1',
+      address: EMBEDDED as `0x${string}`,
+    });
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: true,
+      submittedPending: true,
+      privyTransactionId: 'ptx-misconfig',
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: privyUser.toLowerCase(),
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(submitTreasuryUsdcTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientAddress: privyUser.toLowerCase(),
+      })
+    );
+  });
+
   it('initiateUserFunding returns pending when Privy submission is still resolving', async () => {
     vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
       ok: true,

--- a/lib/spend/payment-rails/base-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.test.ts
@@ -158,7 +158,7 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     );
   });
 
-  it('preparePayment is unsupported on Base until IRL-19', async () => {
+  it('preparePayment returns rail_operation_not_supported', async () => {
     const res = await rail.preparePayment({ spendSessionId: 's1' });
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('unexpected');

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -1,5 +1,30 @@
 import type { SpendRail, SpendWalletReadinessStatus } from '@/lib/types';
 import {
+  fetchUsdcBalanceOnBase,
+  isEvmAddress,
+} from '@/lib/walletconnect-poster-direct-usdc';
+import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
+import { isLedgerCanonicalEvmTxHash } from '@/lib/spend-ledger-explorer-url';
+import {
+  getSpendBaseTreasuryPrivyTransferConfig,
+  getSpendRailBaseRpcUrl,
+  getSpendRailBaseUsdcContractAddress,
+  getSpendReceivingWalletAddress,
+  getSpendTreasuryWalletAddress,
+} from '@/lib/spend-rail-config';
+import {
+  spendRailErrorFundingFailed,
+  spendRailErrorInvalidReceivingWallet,
+  spendRailErrorNetworkUnavailable,
+  spendRailErrorPaymentFailed,
+  spendRailErrorRailOperationNotSupported,
+  spendRailErrorTreasuryInsufficientFunds,
+  spendRailErrorWalletReadinessFailed,
+  spendRailErrorWalletUnavailable,
+  type SpendRailError,
+} from '@/lib/spend/payment-rails/errors';
+import {
+  errSpendRail,
   okSpendRail,
   spendPaymentRailExplorerUrl,
   type SpendPaymentRail,
@@ -13,8 +38,60 @@ import type {
 } from '@/lib/spend/payment-rails/types';
 
 /**
- * Base USDC rail: user-signed EVM flows today; additional orchestration moves behind this
- * object in IRL-14 / follow-on issues.
+ * Treasury-funded USDC targets the session embedded wallet. If the session wallet equals the
+ * treasury server wallet (misconfiguration), fall back to the authenticated user's normalized
+ * embedded address — same rule as `lib/spend-conversion-confirm.ts`.
+ */
+function recipientUsdcAddressForTreasuryFunding(params: {
+  serverWalletAddress: string;
+  sessionWalletTrimmed: string;
+  normalizedWalletLower: string;
+}): `0x${string}` {
+  const serverWalletLower = params.serverWalletAddress.trim().toLowerCase();
+  const sessionLower = params.sessionWalletTrimmed.toLowerCase();
+  if (serverWalletLower === sessionLower) {
+    return params.normalizedWalletLower as `0x${string}`;
+  }
+  return params.sessionWalletTrimmed as `0x${string}`;
+}
+
+function normalizedEmbeddedLower(ctx: SpendPaymentRailSessionContext): string {
+  const fromPrivy = ctx.privyNormalizedWalletAddressLower?.trim();
+  if (fromPrivy) return fromPrivy.toLowerCase();
+  const embedded = ctx.embeddedEvmWalletAddress?.trim();
+  return embedded ? embedded.toLowerCase() : '';
+}
+
+function classifyTreasurySubmitFailure(message: string): SpendRailError {
+  const m = message.toLowerCase();
+  if (
+    m.includes('insufficient') &&
+    (m.includes('balance') || m.includes('funds')) &&
+    !m.includes('gas') &&
+    !m.includes('native')
+  ) {
+    return spendRailErrorTreasuryInsufficientFunds();
+  }
+  if (m.includes('wallet address mismatch') || m.includes('privy wallet')) {
+    return spendRailErrorWalletReadinessFailed();
+  }
+  if (m.includes('rpc not configured') || m.includes('network unavailable')) {
+    return spendRailErrorNetworkUnavailable();
+  }
+  return spendRailErrorFundingFailed();
+}
+
+function classifyPaymentVerifyFailure(reason: string): SpendRailError {
+  const r = reason.toLowerCase();
+  if (r.includes('rpc not configured') || r.includes('receipt wait')) {
+    return spendRailErrorNetworkUnavailable();
+  }
+  return spendRailErrorPaymentFailed();
+}
+
+/**
+ * Base USDC rail: treasury balance, embedded-wallet readiness, Privy treasury funding,
+ * on-chain payment verification against the configured global receiving wallet, and explorer URLs.
  */
 export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
   const spendRail: SpendRail = 'base_usdc';
@@ -25,35 +102,150 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
     async getTreasurySpendableBalance(): Promise<
       SpendRailResult<number | null>
     > {
-      return okSpendRail(null);
+      const treasury = getSpendTreasuryWalletAddress(spendRail).trim();
+      if (!treasury || !isEvmAddress(treasury)) {
+        return okSpendRail(null);
+      }
+      try {
+        const bal = await fetchUsdcBalanceOnBase(treasury as `0x${string}`, {
+          rpcUrl: getSpendRailBaseRpcUrl(),
+          usdcContract: getSpendRailBaseUsdcContractAddress(),
+        });
+        return okSpendRail(bal);
+      } catch (e) {
+        console.error('base_usdc rail getTreasurySpendableBalance:', e);
+        return okSpendRail(null);
+      }
     },
 
     async runWalletReadinessOrchestration(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>> {
-      void ctx;
+      if (!ctx.spendSessionId?.trim()) {
+        return errSpendRail(spendRailErrorWalletReadinessFailed());
+      }
+      const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
+      if (!embedded || !isEvmAddress(embedded)) {
+        return errSpendRail(spendRailErrorWalletUnavailable());
+      }
+      const authLower = ctx.privyNormalizedWalletAddressLower?.trim();
+      if (authLower && embedded.toLowerCase() !== authLower.toLowerCase()) {
+        return errSpendRail(spendRailErrorWalletUnavailable());
+      }
       return okSpendRail({ status: 'completed' });
     },
 
     async initiateUserFunding(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
-      void ctx;
-      return okSpendRail({ status: 'pending' });
+      const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
+      if (!embedded || !isEvmAddress(embedded)) {
+        return errSpendRail(spendRailErrorWalletUnavailable());
+      }
+      const usdcAmount = ctx.usdcAmount;
+      if (
+        usdcAmount == null ||
+        !Number.isFinite(usdcAmount) ||
+        usdcAmount <= 0
+      ) {
+        return errSpendRail(spendRailErrorFundingFailed());
+      }
+
+      const transferCfg = getSpendBaseTreasuryPrivyTransferConfig();
+      if (!transferCfg) {
+        return errSpendRail(spendRailErrorFundingFailed());
+      }
+
+      const normalizedLower = normalizedEmbeddedLower(ctx);
+      if (!normalizedLower || !isEvmAddress(normalizedLower)) {
+        return errSpendRail(spendRailErrorWalletUnavailable());
+      }
+
+      const recipient = recipientUsdcAddressForTreasuryFunding({
+        serverWalletAddress: transferCfg.address,
+        sessionWalletTrimmed: embedded,
+        normalizedWalletLower: normalizedLower,
+      });
+
+      const { submitTreasuryUsdcTransfer, getTreasuryTxReceiptStatus } =
+        await import('@/lib/spend-treasury-usdc-transfer');
+
+      const sub = await submitTreasuryUsdcTransfer({
+        serverWalletId: transferCfg.walletId,
+        serverWalletAddress: transferCfg.address,
+        recipientAddress: recipient,
+        usdcAmount,
+      });
+
+      if (!sub.ok) {
+        return errSpendRail(classifyTreasurySubmitFailure(sub.error));
+      }
+
+      if ('submittedPending' in sub && sub.submittedPending) {
+        return okSpendRail({ status: 'pending' });
+      }
+
+      if (!('txHash' in sub)) {
+        return errSpendRail(spendRailErrorFundingFailed());
+      }
+
+      const receipt = await getTreasuryTxReceiptStatus(sub.txHash);
+      if (receipt === 'success') {
+        return okSpendRail({ status: 'confirmed' });
+      }
+      if (receipt === 'reverted') {
+        return errSpendRail(spendRailErrorFundingFailed());
+      }
+      return okSpendRail({ status: 'submitted' });
     },
 
     async preparePayment(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
       void ctx;
-      return okSpendRail({ status: 'prepared' });
+      return errSpendRail(spendRailErrorRailOperationNotSupported());
     },
 
     async confirmPayment(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
-      void ctx;
-      return okSpendRail({ status: 'submitted' });
+      const rawHash = ctx.paymentTxHash?.trim() ?? '';
+      if (!rawHash || !isLedgerCanonicalEvmTxHash(rawHash)) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+      const txHash = rawHash as `0x${string}`;
+
+      const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
+      if (!embedded || !isEvmAddress(embedded)) {
+        return errSpendRail(spendRailErrorWalletUnavailable());
+      }
+
+      const usdcAmount = ctx.usdcAmount;
+      if (
+        usdcAmount == null ||
+        !Number.isFinite(usdcAmount) ||
+        usdcAmount <= 0
+      ) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+
+      const receiving = getSpendReceivingWalletAddress(spendRail).trim();
+      if (!receiving || !isEvmAddress(receiving)) {
+        return errSpendRail(spendRailErrorInvalidReceivingWallet());
+      }
+
+      const verify = await verifySpendUsdcPaymentTx({
+        txHash,
+        expectedFrom: embedded as `0x${string}`,
+        expectedTo: receiving as `0x${string}`,
+        expectedUsdcAmount: usdcAmount,
+      });
+
+      if (!verify.ok) {
+        return errSpendRail(classifyPaymentVerifyFailure(verify.reason));
+      }
+
+      return okSpendRail({ status: 'confirmed' });
     },
 
     explorerUrlForLedgerTx(

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -38,13 +38,6 @@ import type {
   SpendRailPaymentOperationStatus,
 } from '@/lib/spend/payment-rails/types';
 
-function normalizedEmbeddedLower(ctx: SpendPaymentRailSessionContext): string {
-  const fromPrivy = ctx.privyNormalizedWalletAddressLower?.trim();
-  if (fromPrivy) return fromPrivy.toLowerCase();
-  const embedded = ctx.embeddedEvmWalletAddress?.trim();
-  return embedded ? embedded.toLowerCase() : '';
-}
-
 function classifyTreasurySubmitFailure(message: string): SpendRailError {
   const m = message.toLowerCase();
   if (
@@ -147,15 +140,28 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
         return errSpendRail(spendRailErrorFundingFailed());
       }
 
-      const normalizedLower = normalizedEmbeddedLower(ctx);
-      if (!normalizedLower || !isEvmAddress(normalizedLower)) {
-        return errSpendRail(spendRailErrorWalletUnavailable());
+      const serverLower = transferCfg.address.trim().toLowerCase();
+      const sessionLower = embedded.toLowerCase();
+      let normalizedWalletLower: string;
+      if (serverLower === sessionLower) {
+        const fromPrivy = ctx.privyNormalizedWalletAddressLower?.trim();
+        if (!fromPrivy || !isEvmAddress(fromPrivy)) {
+          return errSpendRail(spendRailErrorWalletUnavailable());
+        }
+        normalizedWalletLower = fromPrivy.toLowerCase();
+        if (normalizedWalletLower === sessionLower) {
+          return errSpendRail(spendRailErrorWalletUnavailable());
+        }
+      } else {
+        normalizedWalletLower =
+          ctx.privyNormalizedWalletAddressLower?.trim().toLowerCase() ??
+          sessionLower;
       }
 
       const recipient = recipientUsdcAddressForSpendTransfer({
         serverWalletAddress: transferCfg.address,
         sessionWalletTrimmed: embedded,
-        normalizedWalletLower: normalizedLower,
+        normalizedWalletLower,
       });
 
       const { submitTreasuryUsdcTransfer, getTreasuryTxReceiptStatus } =

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -1,4 +1,5 @@
 import type { SpendRail, SpendWalletReadinessStatus } from '@/lib/types';
+import { recipientUsdcAddressForSpendTransfer } from '@/lib/spend/recipient-usdc-for-treasury-transfer';
 import {
   fetchUsdcBalanceOnBase,
   isEvmAddress,
@@ -37,24 +38,6 @@ import type {
   SpendRailPaymentOperationStatus,
 } from '@/lib/spend/payment-rails/types';
 
-/**
- * Treasury-funded USDC targets the session embedded wallet. If the session wallet equals the
- * treasury server wallet (misconfiguration), fall back to the authenticated user's normalized
- * embedded address — same rule as `lib/spend-conversion-confirm.ts`.
- */
-function recipientUsdcAddressForTreasuryFunding(params: {
-  serverWalletAddress: string;
-  sessionWalletTrimmed: string;
-  normalizedWalletLower: string;
-}): `0x${string}` {
-  const serverWalletLower = params.serverWalletAddress.trim().toLowerCase();
-  const sessionLower = params.sessionWalletTrimmed.toLowerCase();
-  if (serverWalletLower === sessionLower) {
-    return params.normalizedWalletLower as `0x${string}`;
-  }
-  return params.sessionWalletTrimmed as `0x${string}`;
-}
-
 function normalizedEmbeddedLower(ctx: SpendPaymentRailSessionContext): string {
   const fromPrivy = ctx.privyNormalizedWalletAddressLower?.trim();
   if (fromPrivy) return fromPrivy.toLowerCase();
@@ -89,10 +72,20 @@ function classifyPaymentVerifyFailure(reason: string): SpendRailError {
   return spendRailErrorPaymentFailed();
 }
 
-/**
- * Base USDC rail: treasury balance, embedded-wallet readiness, Privy treasury funding,
- * on-chain payment verification against the configured global receiving wallet, and explorer URLs.
- */
+function isValidPositiveUsdcAmount(n: unknown): n is number {
+  return typeof n === 'number' && Number.isFinite(n) && n > 0;
+}
+
+function embeddedEvmFromContext(
+  ctx: SpendPaymentRailSessionContext
+): SpendRailResult<string> {
+  const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
+  if (!embedded || !isEvmAddress(embedded)) {
+    return errSpendRail(spendRailErrorWalletUnavailable());
+  }
+  return okSpendRail(embedded);
+}
+
 export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
   const spendRail: SpendRail = 'base_usdc';
 
@@ -124,10 +117,11 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
       if (!ctx.spendSessionId?.trim()) {
         return errSpendRail(spendRailErrorWalletReadinessFailed());
       }
-      const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
-      if (!embedded || !isEvmAddress(embedded)) {
-        return errSpendRail(spendRailErrorWalletUnavailable());
+      const embeddedRes = embeddedEvmFromContext(ctx);
+      if (!embeddedRes.ok) {
+        return embeddedRes;
       }
+      const embedded = embeddedRes.value;
       const authLower = ctx.privyNormalizedWalletAddressLower?.trim();
       if (authLower && embedded.toLowerCase() !== authLower.toLowerCase()) {
         return errSpendRail(spendRailErrorWalletUnavailable());
@@ -138,18 +132,15 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
     async initiateUserFunding(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
-      const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
-      if (!embedded || !isEvmAddress(embedded)) {
-        return errSpendRail(spendRailErrorWalletUnavailable());
+      const embeddedRes = embeddedEvmFromContext(ctx);
+      if (!embeddedRes.ok) {
+        return embeddedRes;
       }
-      const usdcAmount = ctx.usdcAmount;
-      if (
-        usdcAmount == null ||
-        !Number.isFinite(usdcAmount) ||
-        usdcAmount <= 0
-      ) {
+      const embedded = embeddedRes.value;
+      if (!isValidPositiveUsdcAmount(ctx.usdcAmount)) {
         return errSpendRail(spendRailErrorFundingFailed());
       }
+      const usdcAmount = ctx.usdcAmount;
 
       const transferCfg = getSpendBaseTreasuryPrivyTransferConfig();
       if (!transferCfg) {
@@ -161,7 +152,7 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
         return errSpendRail(spendRailErrorWalletUnavailable());
       }
 
-      const recipient = recipientUsdcAddressForTreasuryFunding({
+      const recipient = recipientUsdcAddressForSpendTransfer({
         serverWalletAddress: transferCfg.address,
         sessionWalletTrimmed: embedded,
         normalizedWalletLower: normalizedLower,
@@ -215,19 +206,16 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
       }
       const txHash = rawHash as `0x${string}`;
 
-      const embedded = ctx.embeddedEvmWalletAddress?.trim() ?? '';
-      if (!embedded || !isEvmAddress(embedded)) {
-        return errSpendRail(spendRailErrorWalletUnavailable());
+      const embeddedRes = embeddedEvmFromContext(ctx);
+      if (!embeddedRes.ok) {
+        return embeddedRes;
       }
+      const embedded = embeddedRes.value;
 
-      const usdcAmount = ctx.usdcAmount;
-      if (
-        usdcAmount == null ||
-        !Number.isFinite(usdcAmount) ||
-        usdcAmount <= 0
-      ) {
+      if (!isValidPositiveUsdcAmount(ctx.usdcAmount)) {
         return errSpendRail(spendRailErrorPaymentFailed());
       }
+      const usdcAmount = ctx.usdcAmount;
 
       const receiving = getSpendReceivingWalletAddress(spendRail).trim();
       if (!receiving || !isEvmAddress(receiving)) {

--- a/lib/spend/payment-rails/payment-rails.test.ts
+++ b/lib/spend/payment-rails/payment-rails.test.ts
@@ -90,10 +90,15 @@ describe('isTerminalSpendRailPaymentStatus', () => {
 });
 
 describe('getSpendPaymentRail', () => {
-  it('returns typed Base rail with user-signed payment confirm supported', () => {
+  it('returns typed Base rail with user-signed payment confirm supported', async () => {
     const rail = getSpendPaymentRail('base_usdc');
     expect(rail.spendRail).toBe('base_usdc');
     expect(rail.assertUserSignedOnchainPaymentConfirmSupported().ok).toBe(true);
+    await expect(
+      rail.preparePayment({ spendSessionId: 's1' })
+    ).resolves.toMatchObject({
+      ok: false,
+    });
   });
 
   it('returns typed Stellar rail that rejects user-signed confirm with catalog error', () => {

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -49,8 +49,8 @@ export interface SpendPaymentRail {
   ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>>;
 
   /**
-   * Prepare a payment action (idempotent descriptor). Unsupported on both rails at IRL-15
-   * except for typing; IRL-19 will implement descriptors.
+   * Prepare a payment action (idempotent descriptor). Unsupported on Base until IRL-19;
+   * Stellar returns **not supported** until backend submit metadata exists.
    */
   preparePayment(
     ctx: SpendPaymentRailSessionContext

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -57,8 +57,8 @@ export interface SpendPaymentRail {
   ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>>;
 
   /**
-   * Confirm payment after prepare/submit. Unsupported at IRL-15 except for typing;
-   * user-signed Base confirmation stays in `lib/spend-payment-confirm.ts` until extracted.
+   * Confirm on-chain payment evidence (user-submitted tx hash on Base USDC). Stellar remains
+   * unsupported at this boundary until server-controlled confirmation exists on the rail.
    */
   confirmPayment(
     ctx: SpendPaymentRailSessionContext

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -38,18 +38,15 @@ export type SpendPaymentRailSessionContext = {
   spendSessionId: string;
   spendExperienceId?: string;
   /**
-   * Base: Privy embedded EVM wallet tied to the spend session (same field semantics as
-   * `SpendSession.wallet_address` for Base pilot flows).
+   * Base pilot: optional session fields used by the Base USDC rail (`embeddedEvmWalletAddress`
+   * aligns with `SpendSession.wallet_address`; other rails ignore unset fields for now).
    */
   embeddedEvmWalletAddress?: string;
-  /**
-   * Base: lowercased EVM address from the authenticated user (Privy-linked). When set,
-   * readiness requires it to match `embeddedEvmWalletAddress`, mirroring spend payment confirm.
-   */
+  /** When set, Base readiness requires a case-insensitive match to `embeddedEvmWalletAddress`. */
   privyNormalizedWalletAddressLower?: string;
-  /** Base: human-readable USDC amount (6 decimals) for treasury funding and payment verify. */
+  /** Human-readable USDC amount for treasury funding and payment verification. */
   usdcAmount?: number;
-  /** Base: user-submitted on-chain payment hash for `confirmPayment` (canonical `0x` + 64 hex). */
+  /** User-submitted canonical `0x` + 64 hex payment hash for `confirmPayment`. */
   paymentTxHash?: string;
 };
 

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -37,6 +37,20 @@ export type SpendRailPaymentOperationStatus =
 export type SpendPaymentRailSessionContext = {
   spendSessionId: string;
   spendExperienceId?: string;
+  /**
+   * Base: Privy embedded EVM wallet tied to the spend session (same field semantics as
+   * `SpendSession.wallet_address` for Base pilot flows).
+   */
+  embeddedEvmWalletAddress?: string;
+  /**
+   * Base: lowercased EVM address from the authenticated user (Privy-linked). When set,
+   * readiness requires it to match `embeddedEvmWalletAddress`, mirroring spend payment confirm.
+   */
+  privyNormalizedWalletAddressLower?: string;
+  /** Base: human-readable USDC amount (6 decimals) for treasury funding and payment verify. */
+  usdcAmount?: number;
+  /** Base: user-submitted on-chain payment hash for `confirmPayment` (canonical `0x` + 64 hex). */
+  paymentTxHash?: string;
 };
 
 /**

--- a/lib/spend/recipient-usdc-for-treasury-transfer.ts
+++ b/lib/spend/recipient-usdc-for-treasury-transfer.ts
@@ -1,0 +1,17 @@
+/**
+ * Treasury- or server-wallet-funded USDC targets the session embedded wallet. If the session
+ * wallet equals the funding server wallet (misconfiguration), fall back to the authenticated
+ * user's normalized embedded address.
+ */
+export function recipientUsdcAddressForSpendTransfer(params: {
+  serverWalletAddress: string;
+  sessionWalletTrimmed: string;
+  normalizedWalletLower: string;
+}): `0x${string}` {
+  const serverWalletLower = params.serverWalletAddress.trim().toLowerCase();
+  const sessionLower = params.sessionWalletTrimmed.toLowerCase();
+  if (serverWalletLower === sessionLower) {
+    return params.normalizedWalletLower as `0x${string}`;
+  }
+  return params.sessionWalletTrimmed as `0x${string}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements real Base USDC behavior on `createBaseUsdcSpendPaymentRail()` for IRL-14: treasury spendable balance, embedded-wallet readiness (EVM validation plus optional Privy wallet match), treasury-to-user funding via existing Privy treasury transfer and on-chain receipt checks, on-chain payment verification against the globally configured receiving wallet, shared explorer URLs, and incremental `SpendRailError` mapping at the rail boundary.

`preparePayment` now returns `rail_operation_not_supported`, consistent with the Stellar rail and the IRL-19 scope for payment descriptors. `reconcilePendingOperations` stays a no-op in this change set.

## Session context

`SpendPaymentRailSessionContext` adds optional Base fields: `embeddedEvmWalletAddress`, `privyNormalizedWalletAddressLower`, `usdcAmount`, and `paymentTxHash`.

## Implementation notes

Treasury funding uses `getSpendBaseTreasuryPrivyTransferConfig()` and `submitTreasuryUsdcTransfer` with the same recipient resolution rule as `lib/spend-conversion-confirm.ts` when the session wallet equals the treasury server wallet.

The treasury transfer module is lazy-imported inside `initiateUserFunding` so importing the payment rail registry does not pull `@privy-io/server-auth` at module load time, which keeps Vitest happy-dom suites that import `getSpendPaymentRail` from failing.

## Tests

Added `lib/spend/payment-rails/base-usdc-rail.test.ts` and extended `lib/spend/payment-rails/payment-rails.test.ts` to assert Base `preparePayment` is unsupported.

Verification run: `yarn test lib/spend/payment-rails/ lib/spend-payment-confirm.test.ts`, `yarn lint`, and `yarn build` (pre-commit).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-14](https://linear.app/irlenergy/issue/IRL-14/extract-existing-base-usdc-behavior-behind-base-usdc-rail)

<div><a href="https://cursor.com/agents/bc-564b410e-4892-4be9-9b54-48b0739b6cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-564b410e-4892-4be9-9b54-48b0739b6cd2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

