### PR TITLE
feat(spend): backend Base USDC payment prepare and confirm binding (IRL-19)

### DIFF
--- a/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
@@ -59,14 +59,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   const { session, spendExperience, usdcAmount } = ctx;
 
-  if (session.user_id !== auth.userId) {
-    return apiError('Forbidden', 403);
-  }
-
-  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
-    return apiError('Wallet does not match this session', 400);
-  }
-
   const distinctId = resolveServerIdentity({
     privyUserId: auth.userId,
     walletAddress: normalizedWallet,

--- a/app/api/spend-sessions/[sessionId]/payment/prepare/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/prepare/__tests__/route.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyWallet = vi.fn();
+const mockGetPrivyUserId = vi.fn();
+const mockGetCtx = vi.fn();
+const mockRunPrepare = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
+  getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+}));
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: () => 'distinct-1',
+}));
+
+vi.mock('@/lib/spend-payment-prepare', () => ({
+  getSpendPaymentPrepareContextOr404: (...a: unknown[]) => mockGetCtx(...a),
+  runSpendPaymentPrepare: (...a: unknown[]) => mockRunPrepare(...a),
+}));
+
+import { POST } from '../route';
+
+describe('POST /api/spend-sessions/[sessionId]/payment/prepare', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockVerifyWallet.mockResolvedValue({ authorized: true, userId: 'privy-1' });
+    mockGetPrivyUserId.mockResolvedValue('privy-1');
+    mockGetCtx.mockResolvedValue({
+      session: {
+        id: 'sess-1',
+        user_id: 'privy-1',
+        wallet_address: '0xabcdef0123456789012345678901234567890abc',
+        spend_rail: 'base_usdc',
+      },
+      spendExperience: { id: 'exp-1' },
+      usdcAmount: 5,
+    });
+    mockRunPrepare.mockResolvedValue({
+      ok: true,
+      preparedAction: {
+        v: 1,
+        spend_rail: 'base_usdc',
+        evmTransactionRequest: {
+          chainId: 8453,
+          to: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+          data: '0xabcd',
+          gas: '100000',
+        },
+      },
+      session: {
+        id: 'sess-1',
+        status: 'conversion_complete',
+        expires_at: '2099-01-01T00:00:00.000Z',
+      },
+    });
+  });
+
+  it('returns 200 with preparedAction on success', async () => {
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/payment/prepare',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: '0xAbCdEf0123456789012345678901234567890aBc',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.data.preparedAction.evmTransactionRequest.gas).toBe('100000');
+    expect(j.data.spendRailSummary).toMatchObject({
+      rail: 'base_usdc',
+      displayName: 'Base USDC',
+    });
+  });
+
+  it('returns 400 for invalid walletAddress', async () => {
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/payment/prepare',
+      {
+        method: 'POST',
+        body: JSON.stringify({ walletAddress: 'not-an-address' }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/spend-sessions/[sessionId]/payment/prepare/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/prepare/route.ts
@@ -58,14 +58,6 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   const { session, spendExperience } = ctx;
 
-  if (session.user_id !== auth.userId) {
-    return apiError('Forbidden', 403);
-  }
-
-  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
-    return apiError('Wallet does not match this session', 400);
-  }
-
   const distinctId = resolveServerIdentity({
     privyUserId: auth.userId,
     walletAddress: normalizedWallet,

--- a/app/api/spend-sessions/[sessionId]/payment/prepare/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/prepare/route.ts
@@ -1,0 +1,97 @@
+import { NextRequest } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
+import { resolveServerIdentity } from '@/lib/analytics/server';
+import {
+  getSpendPaymentPrepareContextOr404,
+  runSpendPaymentPrepare,
+} from '@/lib/spend-payment-prepare';
+import { spendPaymentPrepareBodySchema } from '@/lib/schemas/spend-session';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { sessionId: string } };
+
+/**
+ * POST /api/spend-sessions/{sessionId}/payment/prepare
+ * Returns a JSON-serializable Privy-compatible EVM transaction request for Base USDC transfer.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const sessionId = params.sessionId;
+  if (!sessionId) {
+    return apiError('Missing session id', 400);
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  const parsed = spendPaymentPrepareBodySchema.safeParse(body);
+  if (!parsed.success) {
+    return apiValidationError(parsed.error);
+  }
+
+  const walletAddress = parsed.data.walletAddress.trim();
+  const normalizedWallet = walletAddress.toLowerCase();
+
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return apiError(auth.error ?? 'Unauthorized', 401);
+  }
+
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return apiError('Unauthorized', 401);
+  }
+
+  const ctx = await getSpendPaymentPrepareContextOr404(sessionId);
+  if ('error' in ctx) {
+    return apiError(ctx.error, ctx.httpStatus);
+  }
+
+  const { session, spendExperience } = ctx;
+
+  if (session.user_id !== auth.userId) {
+    return apiError('Forbidden', 403);
+  }
+
+  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
+    return apiError('Wallet does not match this session', 400);
+  }
+
+  const distinctId = resolveServerIdentity({
+    privyUserId: auth.userId,
+    walletAddress: normalizedWallet,
+  });
+
+  try {
+    const result = await runSpendPaymentPrepare({
+      session,
+      spendExperience,
+      normalizedWallet,
+      authUserId: auth.userId,
+      distinctId,
+    });
+
+    if (!result.ok) {
+      return apiError(result.error, result.httpStatus);
+    }
+
+    return apiSuccess({
+      preparedAction: result.preparedAction,
+      spendRailSummary: getSpendRailClientSummary(session.spend_rail),
+      session: result.session,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : 'Failed to prepare payment';
+    console.error('POST payment prepare:', e);
+    return apiError(msg, 500);
+  }
+}

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -25,12 +25,8 @@ import {
   formatSpendPaymentExplorerUrl,
   spendPaymentExplorerLinkLabel,
 } from '@/lib/spend-rail-explorer-url-client';
-import {
-  encodeUsdcTransferData,
-  isEvmAddress,
-  POSTER_CHECKOUT_CHAIN_ID,
-  POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-} from '@/lib/walletconnect-poster-direct-usdc';
+import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
+import { isSpendPaymentPrepareStoredActionV1 } from '@/lib/spend-payment-prepare-types';
 
 type SpendExperiencePageProps = {
   experienceId: string;
@@ -82,6 +78,12 @@ type PaymentConfirmResponse = {
   spendRailSummary: SpendRailClientSummary;
   session: Pick<SpendSession, 'id' | 'status' | 'expires_at' | 'completed_at'>;
   resumed: boolean;
+};
+
+type PaymentPrepareResponse = {
+  preparedAction: Record<string, unknown>;
+  spendRailSummary: SpendRailClientSummary;
+  session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
 };
 
 type ReceiptResponse = {
@@ -141,10 +143,6 @@ async function spendAuthedGet<T>(token: string, path: string): Promise<T> {
     method: 'GET',
     headers: { Authorization: `Bearer ${token}` },
   });
-}
-
-function toEvmHexAddress(value: string | undefined): `0x${string}` | null {
-  return value && isEvmAddress(value) ? (value as `0x${string}`) : null;
 }
 
 function eligibilityToneClass(status: SpendEligibilityStatus): string {
@@ -246,6 +244,48 @@ export function SpendExperiencePage({
     retry: false,
   });
 
+  const eligForPrepare = previewPayload?.eligibility;
+  const sessionStatusForPrepare = previewPayload?.session?.status;
+  const basePayPrepareEnabled = Boolean(
+    user &&
+    walletAddress &&
+    sessionId &&
+    !isFetching &&
+    !previewLoading &&
+    eligForPrepare?.preview &&
+    previewPayload?.spendRailSummary?.rail === 'base_usdc' &&
+    isEvmAddress(eligForPrepare.preview.receivingWalletAddress) &&
+    (eligForPrepare.status === 'ready_for_payment' ||
+      eligForPrepare.status === 'ready_for_payment_own_usdc' ||
+      eligForPrepare.status === 'payment_failed') &&
+    sessionStatusForPrepare !== 'payment_complete'
+  );
+
+  const { data: paymentPrepareData, isFetching: paymentPrepareLoading } =
+    useQuery({
+      queryKey: [
+        'spend-payment-prepare',
+        sessionId,
+        user?.id,
+        walletAddress,
+      ] as const,
+      queryFn: async () => {
+        const token = await getAccessToken();
+        if (!token || !walletAddress || !sessionId) {
+          throw new Error('Missing auth or session');
+        }
+        return spendAuthedPost<PaymentPrepareResponse>(
+          token,
+          `/api/spend-sessions/${sessionId}/payment/prepare`,
+          { walletAddress }
+        );
+      },
+      enabled: basePayPrepareEnabled,
+      staleTime: Infinity,
+      refetchOnWindowFocus: false,
+      retry: false,
+    });
+
   const sessionStatus = previewPayload?.session?.status;
 
   const { data: receiptPayload } = useQuery({
@@ -275,6 +315,9 @@ export function SpendExperiencePage({
     });
     await queryClient.invalidateQueries({
       queryKey: ['spend-receipt', sessionId],
+    });
+    await queryClient.invalidateQueries({
+      queryKey: ['spend-payment-prepare', sessionId],
     });
   }, [queryClient, sessionId, experienceId]);
 
@@ -327,26 +370,26 @@ export function SpendExperiencePage({
       toast.error('Wallet not ready');
       return;
     }
-    const preview = previewPayload.eligibility.preview;
-    const recipient = toEvmHexAddress(preview.receivingWalletAddress);
-    if (!recipient) {
-      toast.error('Invalid receiving wallet');
+    const prepared = paymentPrepareData?.preparedAction;
+    if (!isSpendPaymentPrepareStoredActionV1(prepared)) {
+      toast.error(
+        'Payment is not ready yet. Wait a moment or refresh the page.'
+      );
       return;
     }
+    const treq = prepared.evmTransactionRequest;
 
     try {
       await withTimeout(
-        evmWallet.switchChain(POSTER_CHECKOUT_CHAIN_ID),
+        evmWallet.switchChain(treq.chainId),
         WALLET_STEP_TIMEOUT_MS,
         'Switching to Base in your wallet'
       );
-      const data = encodeUsdcTransferData(recipient, preview.usdcAmount);
-      // Explicit gas avoids Privy/RPC preflight estimation errors in the sponsored ERC20 transfer modal.
       const transactionRequest = {
-        to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-        data,
-        chainId: POSTER_CHECKOUT_CHAIN_ID,
-        gas: 100000n,
+        to: treq.to as `0x${string}`,
+        data: treq.data as `0x${string}`,
+        chainId: treq.chainId,
+        gas: BigInt(treq.gas),
       };
       const spendPaymentDebug = process.env.NODE_ENV !== 'production';
       if (spendPaymentDebug) {
@@ -355,11 +398,11 @@ export function SpendExperiencePage({
           walletAddress,
           evmWalletAddress: evmWallet.address,
           evmWalletClientType: evmWallet.walletClientType,
-          chainId: POSTER_CHECKOUT_CHAIN_ID,
+          chainId: treq.chainId,
           sponsor: true,
-          to: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
-          hasData: Boolean(data),
-          dataLength: data.length,
+          to: treq.to,
+          hasData: Boolean(treq.data),
+          dataLength: treq.data.length,
           includesValueField: Object.prototype.hasOwnProperty.call(
             transactionRequest,
             'value'
@@ -415,6 +458,7 @@ export function SpendExperiencePage({
     walletAddress,
     evmWallet,
     previewPayload,
+    paymentPrepareData,
     paymentMutation,
     sendTransaction,
   ]);
@@ -661,7 +705,9 @@ export function SpendExperiencePage({
 
                     {showBaseWalletPay && (
                       <SpendPrimaryButton
-                        pending={paymentMutation.isPending}
+                        pending={
+                          paymentMutation.isPending || paymentPrepareLoading
+                        }
                         onClick={() => void sendUsdcPayment()}
                       >
                         {paymentMutation.isPending

--- a/database/spend-payment-prepare-operations.sql
+++ b/database/spend-payment-prepare-operations.sql
@@ -1,0 +1,62 @@
+-- IRL-19: Idempotent server-prepared Base USDC payment descriptor per spend session.
+-- Depends on: spend_sessions.
+
+CREATE TABLE IF NOT EXISTS spend_payment_prepare_operations (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    spend_session_id UUID NOT NULL REFERENCES spend_sessions(id) ON DELETE CASCADE,
+    user_id TEXT NOT NULL,
+    spend_rail TEXT NOT NULL
+        CHECK (spend_rail IN ('base_usdc', 'stellar_usdc')),
+    status VARCHAR(32) NOT NULL DEFAULT 'prepared'
+        CHECK (status IN ('prepared')),
+    prepared_action JSONB NOT NULL,
+    verification_snapshot JSONB NOT NULL,
+    idempotency_key TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT spend_payment_prepare_operations_idempotency_key_unique
+        UNIQUE (idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_spend_payment_prepare_operations_session
+    ON spend_payment_prepare_operations (spend_session_id);
+
+CREATE INDEX IF NOT EXISTS idx_spend_payment_prepare_operations_user
+    ON spend_payment_prepare_operations (user_id);
+
+COMMENT ON TABLE spend_payment_prepare_operations IS
+    'Per-session idempotent prepared payment action (Base: Privy EVM tx request + verification snapshot).';
+
+COMMENT ON COLUMN spend_payment_prepare_operations.prepared_action IS
+    'JSON-serializable client payload (e.g. Privy-compatible EVM transaction request for Base USDC transfer).';
+
+COMMENT ON COLUMN spend_payment_prepare_operations.verification_snapshot IS
+    'Immutable rail fields used to bind payment/confirm to the prepared descriptor (no client-supplied recipient trust).';
+
+COMMENT ON COLUMN spend_payment_prepare_operations.idempotency_key IS
+    'Deterministic v1 key: payment:{spend_session_id}. Distinct from spend_transactions idempotency (spend_payment:{sessionId}).';
+
+CREATE OR REPLACE FUNCTION set_spend_payment_prepare_operations_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS spend_payment_prepare_operations_updated_at
+    ON spend_payment_prepare_operations;
+CREATE TRIGGER spend_payment_prepare_operations_updated_at
+    BEFORE UPDATE ON spend_payment_prepare_operations
+    FOR EACH ROW
+    EXECUTE FUNCTION set_spend_payment_prepare_operations_updated_at();
+
+ALTER TABLE spend_payment_prepare_operations ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Service role full access spend_payment_prepare_operations"
+    ON spend_payment_prepare_operations
+    FOR ALL
+    USING (true)
+    WITH CHECK (true);

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -189,6 +189,8 @@ export interface SpendPilotRailMutationBlockedProperties {
     | 'conversion_confirm'
     | 'conversion_resume'
     | 'payment_confirm_new_tx'
+    | 'payment_confirm'
+    | 'payment_prepare'
     | 'admin_spend_experience_create'
     | 'admin_spend_experience_update'
     | 'admin_treasury_withdraw';

--- a/lib/db/spend-payment-prepare.ts
+++ b/lib/db/spend-payment-prepare.ts
@@ -50,17 +50,19 @@ export function spendPaymentPrepareIdempotencyKey(
   return `payment:${spendSessionId}`;
 }
 
-export async function getSpendPaymentPrepareBySessionId(
-  spendSessionId: string
+async function getSpendPaymentPrepareByColumn(
+  column: 'spend_session_id' | 'idempotency_key',
+  value: string,
+  label: string
 ): Promise<SpendPaymentPrepareOperation | null> {
   const { data, error } = await supabase
     .from('spend_payment_prepare_operations')
     .select(SPEND_PAYMENT_PREPARE_COLS)
-    .eq('spend_session_id', spendSessionId)
+    .eq(column, value)
     .maybeSingle();
 
   if (error) {
-    console.error('getSpendPaymentPrepareBySessionId error:', error);
+    console.error(`${label} error:`, error);
     throw new Error(
       error.message || 'Failed to load payment prepare operation'
     );
@@ -69,23 +71,24 @@ export async function getSpendPaymentPrepareBySessionId(
   return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
 }
 
+export async function getSpendPaymentPrepareBySessionId(
+  spendSessionId: string
+): Promise<SpendPaymentPrepareOperation | null> {
+  return getSpendPaymentPrepareByColumn(
+    'spend_session_id',
+    spendSessionId,
+    'getSpendPaymentPrepareBySessionId'
+  );
+}
+
 export async function getSpendPaymentPrepareByIdempotencyKey(
   idempotencyKey: string
 ): Promise<SpendPaymentPrepareOperation | null> {
-  const { data, error } = await supabase
-    .from('spend_payment_prepare_operations')
-    .select(SPEND_PAYMENT_PREPARE_COLS)
-    .eq('idempotency_key', idempotencyKey)
-    .maybeSingle();
-
-  if (error) {
-    console.error('getSpendPaymentPrepareByIdempotencyKey error:', error);
-    throw new Error(
-      error.message || 'Failed to load payment prepare operation'
-    );
-  }
-  if (!data) return null;
-  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+  return getSpendPaymentPrepareByColumn(
+    'idempotency_key',
+    idempotencyKey,
+    'getSpendPaymentPrepareByIdempotencyKey'
+  );
 }
 
 export type InsertSpendPaymentPrepareInput = {

--- a/lib/db/spend-payment-prepare.ts
+++ b/lib/db/spend-payment-prepare.ts
@@ -1,0 +1,173 @@
+import { supabase } from './client';
+import { normalizeSpendRail } from './spend-rail';
+import type {
+  SpendPaymentPrepareOperation,
+  SpendPaymentPrepareOperationStatus,
+  SpendRail,
+} from '@/lib/types';
+
+export const SPEND_PAYMENT_PREPARE_COLS = `
+  id,
+  spend_session_id,
+  user_id,
+  spend_rail,
+  status,
+  prepared_action,
+  verification_snapshot,
+  idempotency_key,
+  created_at,
+  updated_at
+`;
+
+function parseJsonObject(value: unknown): Record<string, unknown> {
+  if (value != null && typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+export function rowToSpendPaymentPrepareOperation(
+  row: Record<string, unknown>
+): SpendPaymentPrepareOperation {
+  return {
+    id: String(row.id),
+    spend_session_id: String(row.spend_session_id),
+    user_id: String(row.user_id),
+    spend_rail: normalizeSpendRail(row.spend_rail),
+    status: row.status as SpendPaymentPrepareOperationStatus,
+    prepared_action: parseJsonObject(row.prepared_action),
+    verification_snapshot: parseJsonObject(row.verification_snapshot),
+    idempotency_key: String(row.idempotency_key),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+/** v1 deterministic idempotency key: one prepared payment operation per spend session. */
+export function spendPaymentPrepareIdempotencyKey(
+  spendSessionId: string
+): string {
+  return `payment:${spendSessionId}`;
+}
+
+export async function getSpendPaymentPrepareBySessionId(
+  spendSessionId: string
+): Promise<SpendPaymentPrepareOperation | null> {
+  const { data, error } = await supabase
+    .from('spend_payment_prepare_operations')
+    .select(SPEND_PAYMENT_PREPARE_COLS)
+    .eq('spend_session_id', spendSessionId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendPaymentPrepareBySessionId error:', error);
+    throw new Error(
+      error.message || 'Failed to load payment prepare operation'
+    );
+  }
+  if (!data) return null;
+  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+}
+
+export async function getSpendPaymentPrepareByIdempotencyKey(
+  idempotencyKey: string
+): Promise<SpendPaymentPrepareOperation | null> {
+  const { data, error } = await supabase
+    .from('spend_payment_prepare_operations')
+    .select(SPEND_PAYMENT_PREPARE_COLS)
+    .eq('idempotency_key', idempotencyKey)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getSpendPaymentPrepareByIdempotencyKey error:', error);
+    throw new Error(
+      error.message || 'Failed to load payment prepare operation'
+    );
+  }
+  if (!data) return null;
+  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+}
+
+export type InsertSpendPaymentPrepareInput = {
+  spendSessionId: string;
+  userId: string;
+  spendRail: SpendRail;
+  preparedAction: Record<string, unknown>;
+  verificationSnapshot: Record<string, unknown>;
+};
+
+/**
+ * Inserts a prepared row or returns the existing row for the same idempotency key.
+ * On unique conflict, fetches the existing row (same pattern as wallet readiness).
+ */
+export async function insertSpendPaymentPrepareOrGet(
+  input: InsertSpendPaymentPrepareInput
+): Promise<{ row: SpendPaymentPrepareOperation; created: boolean }> {
+  const idempotency_key = spendPaymentPrepareIdempotencyKey(
+    input.spendSessionId
+  );
+  const insertRow = {
+    spend_session_id: input.spendSessionId,
+    user_id: input.userId,
+    spend_rail: input.spendRail,
+    status: 'prepared' as const,
+    prepared_action: input.preparedAction,
+    verification_snapshot: input.verificationSnapshot,
+    idempotency_key,
+  };
+
+  const { data: inserted, error: insertError } = await supabase
+    .from('spend_payment_prepare_operations')
+    .insert(insertRow)
+    .select(SPEND_PAYMENT_PREPARE_COLS)
+    .single();
+
+  if (!insertError && inserted) {
+    return {
+      row: rowToSpendPaymentPrepareOperation(
+        inserted as Record<string, unknown>
+      ),
+      created: true,
+    };
+  }
+
+  if (
+    insertError?.code === '23505' ||
+    insertError?.message?.includes('duplicate')
+  ) {
+    const existing =
+      await getSpendPaymentPrepareByIdempotencyKey(idempotency_key);
+    if (existing) {
+      return { row: existing, created: false };
+    }
+  }
+
+  console.error('insertSpendPaymentPrepareOrGet error:', insertError);
+  throw new Error(
+    insertError?.message || 'Failed to insert payment prepare operation'
+  );
+}
+
+export async function updateSpendPaymentPreparePayload(
+  id: string,
+  patch: {
+    preparedAction: Record<string, unknown>;
+    verificationSnapshot: Record<string, unknown>;
+  }
+): Promise<SpendPaymentPrepareOperation> {
+  const { data, error } = await supabase
+    .from('spend_payment_prepare_operations')
+    .update({
+      prepared_action: patch.preparedAction,
+      verification_snapshot: patch.verificationSnapshot,
+    })
+    .eq('id', id)
+    .select(SPEND_PAYMENT_PREPARE_COLS)
+    .single();
+
+  if (error || !data) {
+    console.error('updateSpendPaymentPreparePayload:', error);
+    throw new Error(error?.message || 'Failed to update payment prepare');
+  }
+  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+}

--- a/lib/schemas/spend-session.ts
+++ b/lib/schemas/spend-session.ts
@@ -34,6 +34,15 @@ export type SpendConversionConfirmBody = z.infer<
   typeof spendConversionConfirmBodySchema
 >;
 
+/** POST /api/spend-sessions/{sessionId}/payment/prepare */
+export const spendPaymentPrepareBodySchema = z.object({
+  walletAddress: evmAddressField,
+});
+
+export type SpendPaymentPrepareBody = z.infer<
+  typeof spendPaymentPrepareBodySchema
+>;
+
 /** POST /api/spend-sessions/{sessionId}/payment/confirm */
 export const spendPaymentConfirmBodySchema = z.object({
   walletAddress: evmAddressField,

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -3,7 +3,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockGetPointConversion = vi.fn();
 const mockFetchUserUsdc = vi.fn();
 const mockGetSpendTransaction = vi.fn();
-const mockRailGate = vi.fn(() => ({ ok: true as const }));
+const mockRailGate = vi.fn(
+  (
+    ...args: unknown[]
+  ):
+    | { ok: true }
+    | {
+        ok: false;
+        error: string;
+        analytics: {
+          spend_rail: string;
+          rail_operational: false;
+          unavailable_reason_codes: string[];
+        };
+      } => {
+    void args;
+    return { ok: true as const };
+  }
+);
 
 vi.mock('@/lib/db/spend-sessions', () => ({
   getPointConversionBySessionId: (...a: unknown[]) =>
@@ -15,6 +32,13 @@ vi.mock('@/lib/db/spend-sessions', () => ({
   updateSpendSessionStatus: vi.fn(),
   updateSpendTransactionFields: vi.fn(),
   confirmSpendTransactionIfSubmitted: vi.fn(),
+}));
+
+const mockGetPaymentPrepare = vi.fn();
+
+vi.mock('@/lib/db/spend-payment-prepare', () => ({
+  getSpendPaymentPrepareBySessionId: (...a: unknown[]) =>
+    mockGetPaymentPrepare(...a),
 }));
 
 vi.mock('@/lib/db/treasury-transactions', () => ({
@@ -37,6 +61,8 @@ vi.mock('@/lib/spend-payment-verify', () => ({
 vi.mock('@/lib/spend-rail-config', () => ({
   getSpendReceivingWalletAddress: () =>
     '0x2222222222222222222222222222222222222222',
+  getSpendRailBaseUsdcContractAddress: () =>
+    '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   assertSpendRailAllowsMutatingSpendWork: (...a: unknown[]) =>
     mockRailGate(...a),
 }));
@@ -130,6 +156,27 @@ describe('runSpendPaymentConfirm', () => {
     mockFetchUserUsdc.mockResolvedValue(10);
     mockRailGate.mockReturnValue({ ok: true as const });
     mockGetSpendTransaction.mockResolvedValue(null);
+    mockGetPaymentPrepare.mockResolvedValue({
+      id: 'prep-1',
+      spend_session_id: baseSession.id,
+      user_id: 'user-1',
+      spend_rail: 'base_usdc',
+      status: 'prepared',
+      prepared_action: {},
+      verification_snapshot: {
+        v: 1,
+        spend_rail: 'base_usdc',
+        chain_id: 8453,
+        usdc_contract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        receiving_wallet: '0x2222222222222222222222222222222222222222',
+        from_wallet: baseSession.wallet_address.toLowerCase(),
+        usdc_amount: 5,
+        transfer_calldata: '0x',
+      },
+      idempotency_key: 'payment:sess-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
   });
 
   it('rejects direct USDC payment while a points conversion is still in progress', async () => {
@@ -216,7 +263,7 @@ describe('runSpendPaymentConfirm', () => {
     expect(analytics.trackSpendPilotRailMutationBlocked).toHaveBeenCalledWith(
       'd1',
       expect.objectContaining({
-        mutation: 'payment_confirm_new_tx',
+        mutation: 'payment_confirm',
         spend_rail: 'base_usdc',
         rail_operational: false,
         spend_session_id: session.id,
@@ -225,5 +272,30 @@ describe('runSpendPaymentConfirm', () => {
     expect(
       spendSessions.insertSpendTransactionSubmitted
     ).not.toHaveBeenCalled();
+  });
+
+  it('rejects confirm when no server-prepared payment exists for Base', async () => {
+    mockGetPointConversion.mockResolvedValue(inProgressConversion('funded'));
+    mockGetPaymentPrepare.mockResolvedValue(null);
+
+    const session = {
+      ...baseSession,
+      status: 'conversion_complete' as const,
+    };
+
+    const result = await runSpendPaymentConfirm({
+      session,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      paymentTxHash: validHash,
+      usdcAmount: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.httpStatus).toBe(400);
+    expect(result.error).toMatch(/not ready to confirm/i);
   });
 });

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -329,10 +329,7 @@ export async function runSpendPaymentConfirm(input: {
     payment_tx_hash: txHash,
   };
 
-  const isConfirmedPaymentResume =
-    session.status === 'payment_complete' && spendTx?.status === 'confirmed';
-
-  if (!isConfirmedPaymentResume) {
+  if (!spendTx) {
     const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
     if (!railGate.ok) {
       trackSpendPilotRailMutationBlocked(distinctId, {

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -1,4 +1,3 @@
-import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import {
   getPointConversionBySessionId,
   getSpendSessionById,
@@ -14,10 +13,7 @@ import {
   explorerTxUrlForSpendLedger,
   isLedgerCanonicalEvmTxHash,
 } from '@/lib/spend-ledger-explorer-url';
-import {
-  computeConversionAmounts,
-  fetchUserUsdcBalanceSafe,
-} from '@/lib/spend-conversion-preview';
+import { fetchUserUsdcBalanceSafe } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
 import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
@@ -46,6 +42,10 @@ import {
   trackSpendPilotRailMutationBlocked,
 } from '@/lib/analytics/server';
 import type { SpendPilotPaymentEventProperties } from '@/lib/analytics/types';
+import type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
+
+export type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
+export { getSpendPaymentSessionContextOr404 as getSpendPaymentContextOr404 } from '@/lib/spend-payment-session-context';
 
 function normalizeTxHash(raw: string): `0x${string}` | null {
   const t = raw.trim();
@@ -61,31 +61,6 @@ function submittedPaymentHashConflicts(
   if (spendTx.status !== 'submitted') return false;
   const existing = (spendTx.payment_tx_hash ?? '').toLowerCase();
   return existing.length > 0 && existing !== requestedHashLower;
-}
-
-/** HTTP statuses allowed by `apiError` for spend pilot routes. */
-export type SpendPilotApiHttpStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
-
-export async function getSpendPaymentContextOr404(sessionId: string): Promise<
-  | {
-      session: SpendSession;
-      spendExperience: SpendExperience;
-      usdcAmount: number;
-    }
-  | { error: string; httpStatus: SpendPilotApiHttpStatus }
-> {
-  const session = await getSpendSessionById(sessionId);
-  if (!session) {
-    return { error: 'Spend session not found', httpStatus: 404 };
-  }
-  const spendExperience = await getSpendExperienceById(
-    session.spend_experience_id
-  );
-  if (!spendExperience) {
-    return { error: 'Spend experience not found', httpStatus: 404 };
-  }
-  const { usdcAmount } = computeConversionAmounts(spendExperience);
-  return { session, spendExperience, usdcAmount };
 }
 
 export type SpendPaymentConfirmResult =
@@ -121,7 +96,6 @@ async function finalizeSuccess(params: {
   trackSpendPaymentCompleted(params.distinctId, {
     ...params.analytics,
     status: 'confirmed',
-    payment_tx_hash: params.analytics.payment_tx_hash,
   });
   return true;
 }
@@ -144,7 +118,6 @@ async function finalizeFailure(params: {
     ...params.analytics,
     status: 'failed',
     error_reason: params.reason,
-    payment_tx_hash: params.analytics.payment_tx_hash,
   });
 }
 
@@ -279,8 +252,14 @@ export async function runSpendPaymentConfirm(input: {
   let toAddr: `0x${string}`;
   let usdcAmount: number;
 
+  let spendTx: SpendTransaction | null = null;
+
   if (session.spend_rail === 'base_usdc') {
-    const preparedOp = await getSpendPaymentPrepareBySessionId(session.id);
+    const [preparedOp, tx] = await Promise.all([
+      getSpendPaymentPrepareBySessionId(session.id),
+      getSpendTransactionBySessionId(session.id),
+    ]);
+    spendTx = tx;
     if (!preparedOp) {
       return {
         ok: false,
@@ -330,6 +309,7 @@ export async function runSpendPaymentConfirm(input: {
     toAddr = snap.receiving_wallet as `0x${string}`;
     usdcAmount = snap.usdc_amount;
   } else {
+    spendTx = await getSpendTransactionBySessionId(session.id);
     fromAddr = normalizedWallet as `0x${string}`;
     toAddr = receivingLive as `0x${string}`;
     usdcAmount = input.usdcAmount;
@@ -348,8 +328,6 @@ export async function runSpendPaymentConfirm(input: {
     point_conversion_id: fundedConversion?.id,
     payment_tx_hash: txHash,
   };
-
-  let spendTx = await getSpendTransactionBySessionId(session.id);
 
   const isConfirmedPaymentResume =
     session.status === 'payment_complete' && spendTx?.status === 'confirmed';

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -8,6 +8,7 @@ import {
   updateSpendTransactionFields,
   confirmSpendTransactionIfSubmitted,
 } from '@/lib/db/spend-sessions';
+import { getSpendPaymentPrepareBySessionId } from '@/lib/db/spend-payment-prepare';
 import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import {
   explorerTxUrlForSpendLedger,
@@ -22,9 +23,17 @@ import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
 import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
 import {
   assertSpendRailAllowsMutatingSpendWork,
+  getSpendRailBaseUsdcContractAddress,
   getSpendReceivingWalletAddress,
 } from '@/lib/spend-rail-config';
-import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
+import {
+  isEvmAddress,
+  POSTER_CHECKOUT_CHAIN_ID,
+} from '@/lib/walletconnect-poster-direct-usdc';
+import {
+  isSpendBaseUsdcVerificationSnapshotV1,
+  spendBaseUsdcSnapshotMatchesLiveRail,
+} from '@/lib/spend-payment-prepare-types';
 import type {
   SpendExperience,
   SpendSession,
@@ -229,35 +238,6 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  const receiving = getSpendReceivingWalletAddress(
-    spendExperience.spend_rail
-  ).trim();
-  if (!isEvmAddress(receiving)) {
-    return {
-      ok: false,
-      error: 'Invalid receiving wallet configuration',
-      httpStatus: 500,
-    };
-  }
-
-  const fromAddr = normalizedWallet as `0x${string}`;
-  const toAddr = receiving as `0x${string}`;
-  const usdcAmount = input.usdcAmount;
-  const requestedHashLower = txHash.toLowerCase();
-
-  const baseAnalytics: SpendPilotPaymentEventProperties = {
-    spend_experience_id: spendExperience.id,
-    event_id: spendExperience.event_id,
-    user_id: authUserId,
-    wallet_address: normalizedWallet,
-    points_amount: fundedConversion ? fundedConversion.points_deducted : 0,
-    usdc_amount: usdcAmount,
-    status: 'submitted',
-    spend_session_id: session.id,
-    point_conversion_id: fundedConversion?.id,
-    payment_tx_hash: txHash,
-  };
-
   const sessionReadyForFundedConversion =
     session.status === 'conversion_complete' ||
     session.status === 'payment_pending';
@@ -284,13 +264,101 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
+  const receivingLive = getSpendReceivingWalletAddress(
+    spendExperience.spend_rail
+  ).trim();
+  if (!isEvmAddress(receivingLive)) {
+    return {
+      ok: false,
+      error: 'Invalid receiving wallet configuration',
+      httpStatus: 500,
+    };
+  }
+
+  let fromAddr: `0x${string}`;
+  let toAddr: `0x${string}`;
+  let usdcAmount: number;
+
+  if (session.spend_rail === 'base_usdc') {
+    const preparedOp = await getSpendPaymentPrepareBySessionId(session.id);
+    if (!preparedOp) {
+      return {
+        ok: false,
+        error:
+          'Payment is not ready to confirm. Refresh this page to prepare your payment, then complete it in your wallet.',
+        httpStatus: 400,
+      };
+    }
+    const snap = preparedOp.verification_snapshot;
+    if (!isSpendBaseUsdcVerificationSnapshotV1(snap)) {
+      return {
+        ok: false,
+        error:
+          'Payment is not ready to confirm. Refresh this page to prepare your payment, then complete it in your wallet.',
+        httpStatus: 400,
+      };
+    }
+    if (
+      !spendBaseUsdcSnapshotMatchesLiveRail({
+        snapshot: snap,
+        liveSpendRail: session.spend_rail,
+        liveReceivingLower: receivingLive.toLowerCase(),
+        liveUsdcContractLower:
+          getSpendRailBaseUsdcContractAddress().toLowerCase(),
+        liveChainId: POSTER_CHECKOUT_CHAIN_ID,
+      })
+    ) {
+      return {
+        ok: false,
+        error:
+          'Payment no longer matches the configured receiving wallet. Refresh this page and try again.',
+        httpStatus: 400,
+      };
+    }
+    if (
+      snap.usdc_amount !== input.usdcAmount ||
+      snap.from_wallet !== normalizedWallet.toLowerCase()
+    ) {
+      return {
+        ok: false,
+        error:
+          'Payment details do not match this session. Refresh this page and try again.',
+        httpStatus: 400,
+      };
+    }
+    fromAddr = snap.from_wallet as `0x${string}`;
+    toAddr = snap.receiving_wallet as `0x${string}`;
+    usdcAmount = snap.usdc_amount;
+  } else {
+    fromAddr = normalizedWallet as `0x${string}`;
+    toAddr = receivingLive as `0x${string}`;
+    usdcAmount = input.usdcAmount;
+  }
+  const requestedHashLower = txHash.toLowerCase();
+
+  const baseAnalytics: SpendPilotPaymentEventProperties = {
+    spend_experience_id: spendExperience.id,
+    event_id: spendExperience.event_id,
+    user_id: authUserId,
+    wallet_address: normalizedWallet,
+    points_amount: fundedConversion ? fundedConversion.points_deducted : 0,
+    usdc_amount: usdcAmount,
+    status: 'submitted',
+    spend_session_id: session.id,
+    point_conversion_id: fundedConversion?.id,
+    payment_tx_hash: txHash,
+  };
+
   let spendTx = await getSpendTransactionBySessionId(session.id);
 
-  if (!spendTx) {
+  const isConfirmedPaymentResume =
+    session.status === 'payment_complete' && spendTx?.status === 'confirmed';
+
+  if (!isConfirmedPaymentResume) {
     const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
     if (!railGate.ok) {
       trackSpendPilotRailMutationBlocked(distinctId, {
-        mutation: 'payment_confirm_new_tx',
+        mutation: 'payment_confirm',
         ...railGate.analytics,
         spend_experience_id: spendExperience.id,
         event_id: spendExperience.event_id,
@@ -340,7 +408,7 @@ export async function runSpendPaymentConfirm(input: {
       userId: authUserId,
       usdcAmount,
       fromWalletAddress: normalizedWallet,
-      toWalletAddress: receiving.toLowerCase(),
+      toWalletAddress: toAddr.toLowerCase(),
       paymentTxHash: txHash,
       spendRail: session.spend_rail,
     });

--- a/lib/spend-payment-prepare-types.ts
+++ b/lib/spend-payment-prepare-types.ts
@@ -1,0 +1,81 @@
+import type { SpendRail } from '@/lib/types';
+
+/** JSON-serializable Privy / viem-compatible USDC transfer on Base (bigint `gas` as string). */
+export type SpendPreparedBaseUsdcEvmTransactionRequestJson = {
+  chainId: number;
+  to: string;
+  data: string;
+  gas: string;
+};
+
+/**
+ * Immutable verification binding for Base USDC user-signed payment (IRL-19).
+ * Confirm uses this snapshot (plus live rail alignment checks) — not client-supplied recipient.
+ */
+export type SpendBaseUsdcPaymentVerificationSnapshotV1 = {
+  v: 1;
+  spend_rail: 'base_usdc';
+  chain_id: number;
+  usdc_contract: string;
+  receiving_wallet: string;
+  from_wallet: string;
+  usdc_amount: number;
+  transfer_calldata: string;
+};
+
+export type SpendPaymentPrepareStoredActionV1 = {
+  v: 1;
+  spend_rail: 'base_usdc';
+  evmTransactionRequest: SpendPreparedBaseUsdcEvmTransactionRequestJson;
+};
+
+export function isSpendBaseUsdcVerificationSnapshotV1(
+  value: unknown
+): value is SpendBaseUsdcPaymentVerificationSnapshotV1 {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  return (
+    o.v === 1 &&
+    o.spend_rail === 'base_usdc' &&
+    typeof o.chain_id === 'number' &&
+    typeof o.usdc_contract === 'string' &&
+    typeof o.receiving_wallet === 'string' &&
+    typeof o.from_wallet === 'string' &&
+    typeof o.usdc_amount === 'number' &&
+    typeof o.transfer_calldata === 'string'
+  );
+}
+
+export function isSpendPaymentPrepareStoredActionV1(
+  value: unknown
+): value is SpendPaymentPrepareStoredActionV1 {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  if (o.v !== 1 || o.spend_rail !== 'base_usdc') return false;
+  const evm = o.evmTransactionRequest;
+  if (!evm || typeof evm !== 'object') return false;
+  const e = evm as Record<string, unknown>;
+  return (
+    typeof e.chainId === 'number' &&
+    typeof e.to === 'string' &&
+    typeof e.data === 'string' &&
+    typeof e.gas === 'string'
+  );
+}
+
+/** True when live rail config still matches the prepared snapshot (receiver, USDC contract, chain). */
+export function spendBaseUsdcSnapshotMatchesLiveRail(params: {
+  snapshot: SpendBaseUsdcPaymentVerificationSnapshotV1;
+  liveSpendRail: SpendRail;
+  liveReceivingLower: string;
+  liveUsdcContractLower: string;
+  liveChainId: number;
+}): boolean {
+  const s = params.snapshot;
+  if (s.spend_rail !== params.liveSpendRail) return false;
+  return (
+    s.receiving_wallet === params.liveReceivingLower &&
+    s.usdc_contract === params.liveUsdcContractLower &&
+    s.chain_id === params.liveChainId
+  );
+}

--- a/lib/spend-payment-prepare.ts
+++ b/lib/spend-payment-prepare.ts
@@ -1,0 +1,296 @@
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import {
+  getPointConversionBySessionId,
+  getSpendSessionById,
+} from '@/lib/db/spend-sessions';
+import {
+  insertSpendPaymentPrepareOrGet,
+  updateSpendPaymentPreparePayload,
+} from '@/lib/db/spend-payment-prepare';
+import {
+  computeConversionAmounts,
+  fetchUserUsdcBalanceSafe,
+} from '@/lib/spend-conversion-preview';
+import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
+import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
+import {
+  assertSpendRailAllowsMutatingSpendWork,
+  getSpendRailBaseUsdcContractAddress,
+  getSpendReceivingWalletAddress,
+} from '@/lib/spend-rail-config';
+import { spendBaseUsdcSnapshotMatchesLiveRail } from '@/lib/spend-payment-prepare-types';
+import {
+  isEvmAddress,
+  POSTER_CHECKOUT_CHAIN_ID,
+} from '@/lib/walletconnect-poster-direct-usdc';
+import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
+import type { SpendExperience, SpendSession } from '@/lib/types';
+
+export type SpendPilotApiHttpStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
+
+export async function getSpendPaymentPrepareContextOr404(
+  sessionId: string
+): Promise<
+  | {
+      session: SpendSession;
+      spendExperience: SpendExperience;
+      usdcAmount: number;
+    }
+  | { error: string; httpStatus: SpendPilotApiHttpStatus }
+> {
+  const session = await getSpendSessionById(sessionId);
+  if (!session) {
+    return { error: 'Spend session not found', httpStatus: 404 };
+  }
+  const spendExperience = await getSpendExperienceById(
+    session.spend_experience_id
+  );
+  if (!spendExperience) {
+    return { error: 'Spend experience not found', httpStatus: 404 };
+  }
+  const { usdcAmount } = computeConversionAmounts(spendExperience);
+  return { session, spendExperience, usdcAmount };
+}
+
+export type SpendPaymentPrepareResult =
+  | {
+      ok: true;
+      preparedAction: Record<string, unknown>;
+      session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
+    }
+  | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
+
+function snapshotsContentEqual(
+  a: Record<string, unknown>,
+  b: Record<string, unknown>
+): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+/**
+ * Validates session + wallet gates, persists idempotent prepare (Base USDC), and returns
+ * the JSON-serializable prepared action for the client.
+ */
+export async function runSpendPaymentPrepare(input: {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  normalizedWallet: string;
+  authUserId: string;
+  distinctId: string;
+}): Promise<SpendPaymentPrepareResult> {
+  const { session, spendExperience, normalizedWallet, authUserId, distinctId } =
+    input;
+
+  if (session.user_id !== authUserId) {
+    return { ok: false, error: 'Forbidden', httpStatus: 403 };
+  }
+
+  if (session.wallet_address.toLowerCase() !== normalizedWallet) {
+    return {
+      ok: false,
+      error: 'Wallet does not match this session',
+      httpStatus: 400,
+    };
+  }
+
+  const now = new Date();
+  if (now > new Date(session.expires_at)) {
+    return { ok: false, error: 'Spend session expired', httpStatus: 400 };
+  }
+
+  const openGate = assertSpendExperienceOpenForSessions(spendExperience, now);
+  if (!openGate.ok) {
+    return {
+      ok: false,
+      error: 'Spend experience is not active',
+      httpStatus: 400,
+    };
+  }
+
+  const spendPaymentRail = getSpendPaymentRail(spendExperience.spend_rail);
+  const userSignedGate =
+    spendPaymentRail.assertUserSignedOnchainPaymentConfirmSupported();
+  if (!userSignedGate.ok) {
+    return {
+      ok: false,
+      error: userSignedGate.error.userMessage,
+      httpStatus: 400,
+    };
+  }
+
+  const { usdcAmount } = computeConversionAmounts(spendExperience);
+
+  const pointConversion = await getPointConversionBySessionId(session.id);
+  const fundedConversion =
+    pointConversion?.status === 'funded' ? pointConversion : null;
+
+  let payingWithOwnUsdc = false;
+  if (!fundedConversion) {
+    const userUsdc = await fetchUserUsdcBalanceSafe(normalizedWallet);
+    if (userUsdc !== null && userUsdc >= usdcAmount) {
+      payingWithOwnUsdc = true;
+    } else {
+      return {
+        ok: false,
+        error: 'Conversion must be completed before payment',
+        httpStatus: 400,
+      };
+    }
+  }
+
+  if (
+    payingWithOwnUsdc &&
+    pointConversion &&
+    pointConversion.status !== 'failed'
+  ) {
+    return {
+      ok: false,
+      error:
+        'Points conversion is still in progress. Complete or wait for conversion before paying with your wallet.',
+      httpStatus: 400,
+    };
+  }
+
+  const sessionReadyForFundedConversion =
+    session.status === 'conversion_complete' ||
+    session.status === 'payment_pending';
+  const sessionReadyForOwnUsdc =
+    payingWithOwnUsdc &&
+    (session.status === 'created' || session.status === 'payment_pending');
+
+  if (!sessionReadyForFundedConversion && !sessionReadyForOwnUsdc) {
+    return {
+      ok: false,
+      error: 'Session is not ready for payment',
+      httpStatus: 400,
+    };
+  }
+
+  const receiving = getSpendReceivingWalletAddress(session.spend_rail).trim();
+  if (!isEvmAddress(receiving)) {
+    return {
+      ok: false,
+      error: 'Invalid receiving wallet configuration',
+      httpStatus: 500,
+    };
+  }
+
+  const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+  if (!railGate.ok) {
+    trackSpendPilotRailMutationBlocked(distinctId, {
+      mutation: 'payment_prepare',
+      ...railGate.analytics,
+      spend_experience_id: spendExperience.id,
+      event_id: spendExperience.event_id,
+      user_id: authUserId,
+      wallet_address: normalizedWallet,
+      spend_session_id: session.id,
+      point_conversion_id: fundedConversion?.id,
+    });
+    return {
+      ok: false,
+      error: railGate.error,
+      httpStatus: 400,
+    };
+  }
+
+  const railPrepare = await spendPaymentRail.preparePayment({
+    spendSessionId: session.id,
+    spendExperienceId: spendExperience.id,
+    embeddedEvmWalletAddress: session.wallet_address,
+    privyNormalizedWalletAddressLower: normalizedWallet,
+    usdcAmount,
+  });
+
+  if (!railPrepare.ok) {
+    return {
+      ok: false,
+      error: railPrepare.error.userMessage,
+      httpStatus: 400,
+    };
+  }
+
+  if (railPrepare.value.status !== 'prepared' || !railPrepare.value.baseUsdc) {
+    return {
+      ok: false,
+      error: 'Payment preparation is not available for this session',
+      httpStatus: 400,
+    };
+  }
+
+  const { preparedAction, verificationSnapshot } = railPrepare.value.baseUsdc;
+
+  const liveReceiving = getSpendReceivingWalletAddress(
+    session.spend_rail
+  ).toLowerCase();
+  const liveUsdc = getSpendRailBaseUsdcContractAddress().toLowerCase();
+
+  if (
+    !spendBaseUsdcSnapshotMatchesLiveRail({
+      snapshot: verificationSnapshot,
+      liveSpendRail: session.spend_rail,
+      liveReceivingLower: liveReceiving,
+      liveUsdcContractLower: liveUsdc,
+      liveChainId: POSTER_CHECKOUT_CHAIN_ID,
+    })
+  ) {
+    return {
+      ok: false,
+      error: 'Invalid payment rail configuration',
+      httpStatus: 500,
+    };
+  }
+
+  const { row, created } = await insertSpendPaymentPrepareOrGet({
+    spendSessionId: session.id,
+    userId: authUserId,
+    spendRail: session.spend_rail,
+    preparedAction: { ...preparedAction },
+    verificationSnapshot: { ...verificationSnapshot },
+  });
+
+  const newAction = { ...preparedAction } as Record<string, unknown>;
+  const newSnap = { ...verificationSnapshot } as Record<string, unknown>;
+
+  if (
+    !created &&
+    snapshotsContentEqual(row.prepared_action, newAction) &&
+    snapshotsContentEqual(row.verification_snapshot, newSnap)
+  ) {
+    return {
+      ok: true,
+      preparedAction: row.prepared_action,
+      session: {
+        id: session.id,
+        status: session.status,
+        expires_at: session.expires_at,
+      },
+    };
+  }
+
+  if (!created) {
+    const updated = await updateSpendPaymentPreparePayload(row.id, {
+      preparedAction: newAction,
+      verificationSnapshot: newSnap,
+    });
+    return {
+      ok: true,
+      preparedAction: updated.prepared_action,
+      session: {
+        id: session.id,
+        status: session.status,
+        expires_at: session.expires_at,
+      },
+    };
+  }
+
+  return {
+    ok: true,
+    preparedAction: row.prepared_action,
+    session: {
+      id: session.id,
+      status: session.status,
+      expires_at: session.expires_at,
+    },
+  };
+}

--- a/lib/spend-payment-prepare.ts
+++ b/lib/spend-payment-prepare.ts
@@ -34,6 +34,23 @@ export type SpendPaymentPrepareResult =
     }
   | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
 
+/** Canonical JSON for compare — PostgreSQL jsonb does not preserve object key order. */
+function stableJsonStringify(value: unknown): string {
+  if (value === null) return 'null';
+  const t = typeof value;
+  if (t === 'number' || t === 'boolean') return JSON.stringify(value);
+  if (t === 'string') return JSON.stringify(value);
+  if (t !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => stableJsonStringify(item)).join(',')}]`;
+  }
+  const o = value as Record<string, unknown>;
+  const keys = Object.keys(o).sort();
+  return `{${keys
+    .map((k) => `${JSON.stringify(k)}:${stableJsonStringify(o[k])}`)
+    .join(',')}}`;
+}
+
 function snapshotPairUnchanged(
   rowAction: Record<string, unknown>,
   rowSnap: Record<string, unknown>,
@@ -41,8 +58,8 @@ function snapshotPairUnchanged(
   nextSnap: Record<string, unknown>
 ): boolean {
   return (
-    JSON.stringify([rowAction, rowSnap]) ===
-    JSON.stringify([nextAction, nextSnap])
+    stableJsonStringify([rowAction, rowSnap]) ===
+    stableJsonStringify([nextAction, nextSnap])
   );
 }
 

--- a/lib/spend-payment-prepare.ts
+++ b/lib/spend-payment-prepare.ts
@@ -1,8 +1,4 @@
-import { getSpendExperienceById } from '@/lib/db/spend-experiences';
-import {
-  getPointConversionBySessionId,
-  getSpendSessionById,
-} from '@/lib/db/spend-sessions';
+import { getPointConversionBySessionId } from '@/lib/db/spend-sessions';
 import {
   insertSpendPaymentPrepareOrGet,
   updateSpendPaymentPreparePayload,
@@ -24,33 +20,11 @@ import {
   POSTER_CHECKOUT_CHAIN_ID,
 } from '@/lib/walletconnect-poster-direct-usdc';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
+import type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
 import type { SpendExperience, SpendSession } from '@/lib/types';
 
-export type SpendPilotApiHttpStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;
-
-export async function getSpendPaymentPrepareContextOr404(
-  sessionId: string
-): Promise<
-  | {
-      session: SpendSession;
-      spendExperience: SpendExperience;
-      usdcAmount: number;
-    }
-  | { error: string; httpStatus: SpendPilotApiHttpStatus }
-> {
-  const session = await getSpendSessionById(sessionId);
-  if (!session) {
-    return { error: 'Spend session not found', httpStatus: 404 };
-  }
-  const spendExperience = await getSpendExperienceById(
-    session.spend_experience_id
-  );
-  if (!spendExperience) {
-    return { error: 'Spend experience not found', httpStatus: 404 };
-  }
-  const { usdcAmount } = computeConversionAmounts(spendExperience);
-  return { session, spendExperience, usdcAmount };
-}
+export type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
+export { getSpendPaymentSessionContextOr404 as getSpendPaymentPrepareContextOr404 } from '@/lib/spend-payment-session-context';
 
 export type SpendPaymentPrepareResult =
   | {
@@ -60,11 +34,26 @@ export type SpendPaymentPrepareResult =
     }
   | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
 
-function snapshotsContentEqual(
-  a: Record<string, unknown>,
-  b: Record<string, unknown>
+function snapshotPairUnchanged(
+  rowAction: Record<string, unknown>,
+  rowSnap: Record<string, unknown>,
+  nextAction: Record<string, unknown>,
+  nextSnap: Record<string, unknown>
 ): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return (
+    JSON.stringify([rowAction, rowSnap]) ===
+    JSON.stringify([nextAction, nextSnap])
+  );
+}
+
+function paymentPrepareResponseSession(
+  session: SpendSession
+): Pick<SpendSession, 'id' | 'status' | 'expires_at'> {
+  return {
+    id: session.id,
+    status: session.status,
+    expires_at: session.expires_at,
+  };
 }
 
 /**
@@ -166,7 +155,9 @@ export async function runSpendPaymentPrepare(input: {
     };
   }
 
-  const receiving = getSpendReceivingWalletAddress(session.spend_rail).trim();
+  const receiving = getSpendReceivingWalletAddress(
+    spendExperience.spend_rail
+  ).trim();
   if (!isEvmAddress(receiving)) {
     return {
       ok: false,
@@ -220,9 +211,7 @@ export async function runSpendPaymentPrepare(input: {
 
   const { preparedAction, verificationSnapshot } = railPrepare.value.baseUsdc;
 
-  const liveReceiving = getSpendReceivingWalletAddress(
-    session.spend_rail
-  ).toLowerCase();
+  const liveReceiving = receiving.toLowerCase();
   const liveUsdc = getSpendRailBaseUsdcContractAddress().toLowerCase();
 
   if (
@@ -241,30 +230,30 @@ export async function runSpendPaymentPrepare(input: {
     };
   }
 
+  const newAction = { ...preparedAction } as Record<string, unknown>;
+  const newSnap = { ...verificationSnapshot } as Record<string, unknown>;
+
   const { row, created } = await insertSpendPaymentPrepareOrGet({
     spendSessionId: session.id,
     userId: authUserId,
     spendRail: session.spend_rail,
-    preparedAction: { ...preparedAction },
-    verificationSnapshot: { ...verificationSnapshot },
+    preparedAction: newAction,
+    verificationSnapshot: newSnap,
   });
-
-  const newAction = { ...preparedAction } as Record<string, unknown>;
-  const newSnap = { ...verificationSnapshot } as Record<string, unknown>;
 
   if (
     !created &&
-    snapshotsContentEqual(row.prepared_action, newAction) &&
-    snapshotsContentEqual(row.verification_snapshot, newSnap)
+    snapshotPairUnchanged(
+      row.prepared_action,
+      row.verification_snapshot,
+      newAction,
+      newSnap
+    )
   ) {
     return {
       ok: true,
       preparedAction: row.prepared_action,
-      session: {
-        id: session.id,
-        status: session.status,
-        expires_at: session.expires_at,
-      },
+      session: paymentPrepareResponseSession(session),
     };
   }
 
@@ -276,21 +265,13 @@ export async function runSpendPaymentPrepare(input: {
     return {
       ok: true,
       preparedAction: updated.prepared_action,
-      session: {
-        id: session.id,
-        status: session.status,
-        expires_at: session.expires_at,
-      },
+      session: paymentPrepareResponseSession(session),
     };
   }
 
   return {
     ok: true,
     preparedAction: row.prepared_action,
-    session: {
-      id: session.id,
-      status: session.status,
-      expires_at: session.expires_at,
-    },
+    session: paymentPrepareResponseSession(session),
   };
 }

--- a/lib/spend-payment-session-context.ts
+++ b/lib/spend-payment-session-context.ts
@@ -1,0 +1,29 @@
+import { getSpendExperienceById } from '@/lib/db/spend-experiences';
+import { getSpendSessionById } from '@/lib/db/spend-sessions';
+import { computeConversionAmounts } from '@/lib/spend-conversion-preview';
+import type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
+import type { SpendExperience, SpendSession } from '@/lib/types';
+
+export async function getSpendPaymentSessionContextOr404(
+  sessionId: string
+): Promise<
+  | {
+      session: SpendSession;
+      spendExperience: SpendExperience;
+      usdcAmount: number;
+    }
+  | { error: string; httpStatus: SpendPilotApiHttpStatus }
+> {
+  const session = await getSpendSessionById(sessionId);
+  if (!session) {
+    return { error: 'Spend session not found', httpStatus: 404 };
+  }
+  const spendExperience = await getSpendExperienceById(
+    session.spend_experience_id
+  );
+  if (!spendExperience) {
+    return { error: 'Spend experience not found', httpStatus: 404 };
+  }
+  const { usdcAmount } = computeConversionAmounts(spendExperience);
+  return { session, spendExperience, usdcAmount };
+}

--- a/lib/spend-pilot-http-status.ts
+++ b/lib/spend-pilot-http-status.ts
@@ -1,0 +1,2 @@
+/** HTTP statuses used by spend pilot payment APIs with `apiError`. */
+export type SpendPilotApiHttpStatus = 400 | 401 | 403 | 404 | 409 | 429 | 500;

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -3,6 +3,8 @@ import { recipientUsdcAddressForSpendTransfer } from '@/lib/spend/recipient-usdc
 import {
   fetchUsdcBalanceOnBase,
   isEvmAddress,
+  encodeUsdcTransferData,
+  POSTER_CHECKOUT_CHAIN_ID,
 } from '@/lib/walletconnect-poster-direct-usdc';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
 import { isLedgerCanonicalEvmTxHash } from '@/lib/spend-ledger-explorer-url';
@@ -18,7 +20,6 @@ import {
   spendRailErrorInvalidReceivingWallet,
   spendRailErrorNetworkUnavailable,
   spendRailErrorPaymentFailed,
-  spendRailErrorRailOperationNotSupported,
   spendRailErrorTreasuryInsufficientFunds,
   spendRailErrorWalletReadinessFailed,
   spendRailErrorWalletUnavailable,
@@ -28,6 +29,7 @@ import {
   errSpendRail,
   okSpendRail,
   spendPaymentRailExplorerUrl,
+  type SpendPaymentPrepareRailValue,
   type SpendPaymentRail,
   type SpendRailResult,
 } from '@/lib/spend/payment-rails/spend-payment-rail';
@@ -198,9 +200,51 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
 
     async preparePayment(
       ctx: SpendPaymentRailSessionContext
-    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
-      void ctx;
-      return errSpendRail(spendRailErrorRailOperationNotSupported());
+    ): Promise<SpendRailResult<SpendPaymentPrepareRailValue>> {
+      const embeddedRes = embeddedEvmFromContext(ctx);
+      if (!embeddedRes.ok) {
+        return embeddedRes;
+      }
+      const embedded = embeddedRes.value;
+      if (!isValidPositiveUsdcAmount(ctx.usdcAmount)) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+      const usdcAmount = ctx.usdcAmount;
+
+      const receiving = getSpendReceivingWalletAddress(spendRail).trim();
+      if (!receiving || !isEvmAddress(receiving)) {
+        return errSpendRail(spendRailErrorInvalidReceivingWallet());
+      }
+
+      const usdcContract = getSpendRailBaseUsdcContractAddress();
+      const recipient = receiving as `0x${string}`;
+      const data = encodeUsdcTransferData(recipient, usdcAmount);
+      const gas = 100000n;
+      const evmTransactionRequest = {
+        chainId: POSTER_CHECKOUT_CHAIN_ID,
+        to: usdcContract.toLowerCase(),
+        data,
+        gas: gas.toString(),
+      };
+      const preparedAction = {
+        v: 1 as const,
+        spend_rail: 'base_usdc' as const,
+        evmTransactionRequest,
+      };
+      const verificationSnapshot = {
+        v: 1 as const,
+        spend_rail: 'base_usdc' as const,
+        chain_id: POSTER_CHECKOUT_CHAIN_ID,
+        usdc_contract: usdcContract.toLowerCase(),
+        receiving_wallet: receiving.toLowerCase(),
+        from_wallet: embedded.toLowerCase(),
+        usdc_amount: usdcAmount,
+        transfer_calldata: data,
+      };
+      return okSpendRail({
+        status: 'prepared',
+        baseUsdc: { preparedAction, verificationSnapshot },
+      });
     },
 
     async confirmPayment(

--- a/lib/spend/payment-rails/payment-rails.test.ts
+++ b/lib/spend/payment-rails/payment-rails.test.ts
@@ -90,15 +90,22 @@ describe('isTerminalSpendRailPaymentStatus', () => {
 });
 
 describe('getSpendPaymentRail', () => {
-  it('returns typed Base rail with user-signed payment confirm supported', async () => {
+  it('returns typed Base rail with preparePayment supported for Base USDC', async () => {
     const rail = getSpendPaymentRail('base_usdc');
     expect(rail.spendRail).toBe('base_usdc');
     expect(rail.assertUserSignedOnchainPaymentConfirmSupported().ok).toBe(true);
-    await expect(
-      rail.preparePayment({ spendSessionId: 's1' })
-    ).resolves.toMatchObject({
-      ok: false,
+    const res = await rail.preparePayment({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: '0x1111111111111111111111111111111111111111',
+      usdcAmount: 1.5,
     });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('expected prepare ok');
+    expect(res.value.status).toBe('prepared');
+    expect(res.value.baseUsdc?.preparedAction.v).toBe(1);
+    expect(res.value.baseUsdc?.preparedAction.evmTransactionRequest.gas).toBe(
+      '100000'
+    );
   });
 
   it('returns typed Stellar rail that rejects user-signed confirm with catalog error', () => {

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -8,6 +8,19 @@ import type {
   SpendRailPaymentOperationStatus,
   SpendWalletReadinessStatus,
 } from '@/lib/spend/payment-rails/types';
+import type {
+  SpendBaseUsdcPaymentVerificationSnapshotV1,
+  SpendPaymentPrepareStoredActionV1,
+} from '@/lib/spend-payment-prepare-types';
+
+/** Successful `preparePayment` payload (Base USDC fills `baseUsdc`; other rails omit). */
+export type SpendPaymentPrepareRailValue = {
+  status: SpendRailPaymentOperationStatus;
+  baseUsdc?: {
+    preparedAction: SpendPaymentPrepareStoredActionV1;
+    verificationSnapshot: SpendBaseUsdcPaymentVerificationSnapshotV1;
+  };
+};
 
 export type SpendRailResult<T> =
   | { ok: true; value: T }
@@ -54,7 +67,7 @@ export interface SpendPaymentRail {
    */
   preparePayment(
     ctx: SpendPaymentRailSessionContext
-  ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>>;
+  ): Promise<SpendRailResult<SpendPaymentPrepareRailValue>>;
 
   /**
    * Confirm on-chain payment evidence (user-submitted tx hash on Base USDC). Stellar remains

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -2,6 +2,7 @@ import type { SpendRail } from '@/lib/types';
 import {
   errSpendRail,
   spendPaymentRailExplorerUrl,
+  type SpendPaymentPrepareRailValue,
   type SpendPaymentRail,
   type SpendRailResult,
 } from '@/lib/spend/payment-rails/spend-payment-rail';
@@ -50,7 +51,7 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
 
     async preparePayment(
       ctx: SpendPaymentRailSessionContext
-    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
+    ): Promise<SpendRailResult<SpendPaymentPrepareRailValue>> {
       void ctx;
       return notSupported();
     },

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -453,3 +453,24 @@ export type SpendWalletReadinessOperation = {
   created_at: string;
   updated_at: string;
 };
+
+/** v1 idempotency key `payment:{spend_session_id}` (distinct from `spend_payment:{sessionId}` on spend_transactions). */
+export type SpendPaymentPrepareOperationStatus = 'prepared';
+
+/**
+ * Server-prepared payment action row (IRL-19). `prepared_action` / `verification_snapshot` are
+ * rail-specific JSON; Base USDC uses `SpendPaymentPrepareStoredActionV1` + snapshot types in
+ * `lib/spend-payment-prepare-types.ts`.
+ */
+export type SpendPaymentPrepareOperation = {
+  id: string;
+  spend_session_id: string;
+  user_id: string;
+  spend_rail: SpendRail;
+  status: SpendPaymentPrepareOperationStatus;
+  prepared_action: Record<string, unknown>;
+  verification_snapshot: Record<string, unknown>;
+  idempotency_key: string;
+  created_at: string;
+  updated_at: string;
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Server-generated Base USDC payment transaction descriptors, idempotent prepare persistence, and confirm verification bound to the prepared snapshot plus live global receiving wallet, USDC contract, and chain from rail configuration.

## Changes

- **POST** `/api/spend-sessions/{sessionId}/payment/prepare` uses the same Privy plus `walletAddress` JSON body auth model as payment confirm. The response includes a JSON-serializable `preparedAction` (v1 Base shape: `evmTransactionRequest` with `chainId`, `to`, `data`, and `gas` as a decimal string for stable JSON).
- **Database** — new migration `database/spend-payment-prepare-operations.sql` adding `spend_payment_prepare_operations` with unique idempotency key `payment:{spend_session_id}` (separate from `spend_payment:{sessionId}` on `spend_transactions`). Rows do not expire; when a new descriptor is computed and JSON differs from the stored row, the payload is updated in place so users are not stuck after rare config drift.
- **Base `preparePayment`** replaces the unsupported stub: builds calldata via `encodeUsdcTransferData`, uses rail config for recipient and USDC contract, keeps explicit gas **100000** (string in API) to match the previous sponsored client path.
- **`runSpendPaymentConfirm`** loads the prepared operation for `base_usdc`, rejects missing or malformed snapshots, requires the snapshot to still align with the current global receiver and Base USDC contract and chain id, then calls `verifySpendUsdcPaymentTx` with snapshot-bound `from`, `to`, and amount.
- **`assertSpendRailAllowsMutatingSpendWork`** gates both prepare and confirm (except idempotent resume when the session payment is already confirmed). Analytics mutation labels `payment_prepare` and `payment_confirm` were added to the shared analytics type union.
- **`components/spend/spend-experience-page.tsx`** fetches prepare when the Base wallet pay UI is shown and passes only backend `evmTransactionRequest` fields into Privy `sendTransaction` (including `BigInt` for `gas` on the client).

## Ops note

Apply the new SQL migration to the database before relying on prepare or confirm in deployed environments.

## Tests

Targeted Vitest files for payment prepare route, payment confirm behavior, and rail unit tests; `yarn build` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-19](https://linear.app/irlenergy/issue/IRL-19/implement-backend-generated-base-payment-action-descriptors)

<div><a href="https://cursor.com/agents/bc-5fc82839-41f4-47b9-944c-4eeaaa18bcd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fc82839-41f4-47b9-944c-4eeaaa18bcd0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

