### PR TITLE
feat(spend): IRL-20 conversion rail readiness, funding, needs_review

### DIFF
--- a/database/fix-spend-conversion-player-case-duplicates.sql
+++ b/database/fix-spend-conversion-player-case-duplicates.sql
@@ -191,8 +191,8 @@ BEGIN
     RAISE EXCEPTION 'Conversion mismatch';
   END IF;
 
-  IF v_status IS DISTINCT FROM 'points_deducted' THEN
-    RAISE EXCEPTION 'Conversion is not in points_deducted state';
+  IF v_status NOT IN ('points_deducted', 'funding_pending', 'needs_review') THEN
+    RAISE EXCEPTION 'Conversion is not refundable from this state';
   END IF;
 
   IF v_points::INTEGER IS DISTINCT FROM p_points_to_refund THEN

--- a/database/point-conversions-needs-review-funding-idempotency.sql
+++ b/database/point-conversions-needs-review-funding-idempotency.sql
@@ -1,0 +1,168 @@
+-- IRL-20: `needs_review` conversion status, funding idempotency key mutability, refund RPC for
+-- definitive failures after `funding_pending` / `needs_review`.
+--
+-- Idempotency: app sets `point_conversions.idempotency_key` to `fund_user:<conversion_id>` once
+-- after `confirm_spend_conversion_atomic`, before treasury funding. Uniqueness is enforced by
+-- `idx_point_conversions_idempotency` plus one row per `spend_session_id`.
+
+-- ---------------------------------------------------------------------------
+-- Status CHECK: add `needs_review`
+-- ---------------------------------------------------------------------------
+ALTER TABLE point_conversions DROP CONSTRAINT IF EXISTS point_conversions_status_check;
+
+ALTER TABLE point_conversions
+  ADD CONSTRAINT point_conversions_status_check
+  CHECK (status IN (
+    'pending',
+    'points_deducted',
+    'funding_pending',
+    'needs_review',
+    'funded',
+    'failed'
+  ));
+
+COMMENT ON CONSTRAINT point_conversions_status_check ON point_conversions IS
+  'Conversion lifecycle including IRL-20 needs_review for ambiguous funding outcomes.';
+
+-- ---------------------------------------------------------------------------
+-- Ledger mutability: allow first-time set of idempotency_key (NULL → non-NULL only)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION enforce_point_conversions_ledger_mutability()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  funding_changed BOOLEAN := OLD.funding_tx_hash IS DISTINCT FROM NEW.funding_tx_hash;
+  explorer_changed BOOLEAN := OLD.explorer_tx_url IS DISTINCT FROM NEW.explorer_tx_url;
+BEGIN
+  NEW.updated_at := NOW();
+
+  IF OLD.id IS DISTINCT FROM NEW.id
+     OR OLD.spend_experience_id IS DISTINCT FROM NEW.spend_experience_id
+     OR OLD.spend_session_id IS DISTINCT FROM NEW.spend_session_id
+     OR OLD.user_id IS DISTINCT FROM NEW.user_id
+     OR OLD.points_deducted IS DISTINCT FROM NEW.points_deducted
+     OR OLD.usdc_amount IS DISTINCT FROM NEW.usdc_amount
+     OR OLD.treasury_wallet_address IS DISTINCT FROM NEW.treasury_wallet_address
+     OR OLD.user_wallet_address IS DISTINCT FROM NEW.user_wallet_address
+     OR OLD.spend_rail IS DISTINCT FROM NEW.spend_rail
+     OR OLD.network IS DISTINCT FROM NEW.network
+     OR OLD.asset_symbol IS DISTINCT FROM NEW.asset_symbol
+     OR OLD.created_at IS DISTINCT FROM NEW.created_at
+  THEN
+    RAISE EXCEPTION 'point_conversions: snapshot columns cannot be changed after insert';
+  END IF;
+
+  IF OLD.idempotency_key IS DISTINCT FROM NEW.idempotency_key THEN
+    IF NOT (
+      OLD.idempotency_key IS NULL
+      AND NEW.idempotency_key IS NOT NULL
+      AND trim(NEW.idempotency_key) <> ''
+    ) THEN
+      RAISE EXCEPTION 'point_conversions: idempotency_key can only be set once from NULL';
+    END IF;
+  END IF;
+
+  IF funding_changed THEN
+    IF OLD.funding_tx_hash IS NULL THEN
+      NULL;
+    ELSIF OLD.funding_tx_hash LIKE 'pending:%' AND COALESCE(NEW.funding_tx_hash, '') NOT LIKE 'pending:%' THEN
+      NULL;
+    ELSIF OLD.funding_tx_hash LIKE 'pending:%' AND NEW.funding_tx_hash LIKE 'pending:%'
+          AND OLD.funding_tx_hash IS DISTINCT FROM NEW.funding_tx_hash THEN
+      RAISE EXCEPTION 'point_conversions: funding pending reference cannot change';
+    ELSIF OLD.funding_tx_hash LIKE 'pending:%' AND NEW.funding_tx_hash IS NULL THEN
+      RAISE EXCEPTION 'point_conversions: funding_tx_hash cannot be cleared';
+    ELSIF NEW.funding_tx_hash IS DISTINCT FROM OLD.funding_tx_hash THEN
+      RAISE EXCEPTION 'point_conversions: funding_tx_hash cannot be overwritten';
+    END IF;
+  END IF;
+
+  IF explorer_changed THEN
+    IF OLD.explorer_tx_url IS NULL THEN
+      NULL;
+    ELSIF OLD.explorer_tx_url IS DISTINCT FROM NEW.explorer_tx_url THEN
+      RAISE EXCEPTION 'point_conversions: explorer_tx_url cannot be changed after it is set';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Refund: allow definitive unwind from funding_pending / needs_review (caller must ensure
+-- no successful funding can still land — e.g. receipt `reverted` or pre-submit failure).
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION refund_spend_conversion_on_funding_failure(
+  p_conversion_id UUID,
+  p_user_id TEXT,
+  p_spend_session_id UUID,
+  p_points_to_refund INTEGER,
+  p_failed_reason TEXT
+) RETURNS VOID AS $$
+DECLARE
+  v_status VARCHAR(32);
+  v_session TEXT;
+  v_user TEXT;
+  v_points NUMERIC(24, 8);
+  v_player_id BIGINT;
+BEGIN
+  IF p_points_to_refund IS NULL OR p_points_to_refund <= 0 THEN
+    RAISE EXCEPTION 'Invalid refund amount';
+  END IF;
+
+  SELECT status, user_id, spend_session_id, points_deducted
+  INTO v_status, v_user, v_session, v_points
+  FROM point_conversions
+  WHERE id = p_conversion_id
+  FOR UPDATE;
+
+  IF v_status IS NULL THEN
+    RAISE EXCEPTION 'Conversion not found';
+  END IF;
+
+  IF v_user IS DISTINCT FROM p_user_id OR v_session::TEXT IS DISTINCT FROM p_spend_session_id::TEXT THEN
+    RAISE EXCEPTION 'Conversion mismatch';
+  END IF;
+
+  IF v_status NOT IN ('points_deducted', 'funding_pending', 'needs_review') THEN
+    RAISE EXCEPTION 'Conversion is not refundable from this state';
+  END IF;
+
+  IF v_points::INTEGER IS DISTINCT FROM p_points_to_refund THEN
+    RAISE EXCEPTION 'Points amount mismatch';
+  END IF;
+
+  SELECT id
+  INTO v_player_id
+  FROM players
+  WHERE lower(trim(wallet_address)) = (
+    SELECT lower(trim(wallet_address)) FROM spend_sessions WHERE id = p_spend_session_id
+  )
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found for session';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) + p_points_to_refund,
+      updated_at = NOW()
+  WHERE id = v_player_id;
+
+  UPDATE point_conversions
+  SET
+    status = 'failed',
+    failed_reason = left(
+      COALESCE(p_failed_reason, 'funding_transaction_failed'),
+      256
+    ),
+    completed_at = NOW()
+  WHERE id = p_conversion_id;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION refund_spend_conversion_on_funding_failure IS
+  'Reverses spend conversion funding: restores points and marks conversion failed when funding '
+  'definitively cannot succeed (IRL-20: from points_deducted, funding_pending, or needs_review).';

--- a/database/spend-conversion-confirm-atomic.sql
+++ b/database/spend-conversion-confirm-atomic.sql
@@ -180,8 +180,8 @@ BEGIN
     RAISE EXCEPTION 'Conversion mismatch';
   END IF;
 
-  IF v_status IS DISTINCT FROM 'points_deducted' THEN
-    RAISE EXCEPTION 'Conversion is not in points_deducted state';
+  IF v_status NOT IN ('points_deducted', 'funding_pending', 'needs_review') THEN
+    RAISE EXCEPTION 'Conversion is not refundable from this state';
   END IF;
 
   IF v_points::INTEGER IS DISTINCT FROM p_points_to_refund THEN

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -385,6 +385,13 @@ export async function confirmSpendTransactionIfSubmitted(
   return rowToSpendTransaction(data as Record<string, unknown>);
 }
 
+/** Deterministic idempotency key for treasury→user conversion funding (IRL-20). */
+export function spendConversionFundingIdempotencyKey(
+  pointConversionId: string
+): string {
+  return `fund_user:${pointConversionId}`;
+}
+
 /**
  * If USDC transfer fails after points were deducted, refund points and mark conversion `failed`.
  */

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -240,6 +240,7 @@ export async function updatePointConversionFields(
       | 'completed_at'
       | 'failed_reason'
       | 'explorer_tx_url'
+      | 'idempotency_key'
     >
   >
 ): Promise<PointConversion> {

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -5,6 +5,7 @@ import {
   getPointConversionBySessionId,
   getSpendSessionById,
   refundSpendConversionOnFundingFailure,
+  spendConversionFundingIdempotencyKey,
   updatePointConversionFields,
   updateSpendSessionStatus,
 } from '@/lib/db/spend-sessions';
@@ -34,7 +35,10 @@ import type {
 } from '@/lib/types';
 import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
 import type { SpendPaymentRailSessionContext } from '@/lib/spend/payment-rails/types';
-import { type SpendRailError } from '@/lib/spend/payment-rails/errors';
+import {
+  spendRailErrorCategoryToHttpStatus,
+  type SpendRailErrorCategory,
+} from '@/lib/spend/payment-rails/errors';
 import {
   assertSpendRailAllowsMutatingSpendWork,
   isSpendRailOperational,
@@ -59,6 +63,20 @@ const MISCONFIGURED_CONVERSION_ERROR =
 const FUNDING_ACKNOWLEDGED_MESSAGE =
   'USDC transfer submitted. We are confirming it on Base.';
 
+export type SpendConversionConfirmResult =
+  | {
+      ok: true;
+      pointConversion: PointConversion;
+      session: SpendSession;
+      resumed: boolean;
+    }
+  | {
+      ok: false;
+      httpStatus: 400 | 401 | 403 | 404 | 409 | 500;
+      error: string;
+      capture?: boolean;
+    };
+
 function embeddedSpendWalletForSession(session: SpendSession): string {
   if (session.spend_rail === 'stellar_usdc') {
     return session.rail_user_wallet_address.trim();
@@ -66,13 +84,8 @@ function embeddedSpendWalletForSession(session: SpendSession): string {
   return session.wallet_address.trim();
 }
 
-function httpStatusForSpendRailError(
-  category: SpendRailError['category']
-): 400 | 500 {
-  return category === 'network_unavailable' ? 500 : 400;
-}
-
-async function tryRefundSpendConversionPoints(input: {
+/** Logs on failure; refund RPC errors do not block returning the user-facing rail error. */
+async function refundSpendConversionPointsBestEffort(input: {
   conversion: PointConversion;
   session: SpendSession;
   failedReason: string;
@@ -88,6 +101,43 @@ async function tryRefundSpendConversionPoints(input: {
   } catch (e) {
     console.error('refundSpendConversionOnFundingFailure:', e);
   }
+}
+
+async function conversionRailFailureOutcome(input: {
+  phase: 'readiness' | 'funding';
+  conv: PointConversion;
+  session: SpendSession;
+  distinctId: string;
+  baseAnalytics: SpendPilotConversionEventProperties;
+  category: SpendRailErrorCategory;
+  userMessage: string;
+}): Promise<{
+  kind: 'error';
+  value: SpendConversionConfirmResult;
+  pointsRefunded: number;
+}> {
+  const prefix = input.phase === 'readiness' ? 'readiness' : 'funding';
+  await refundSpendConversionPointsBestEffort({
+    conversion: input.conv,
+    session: input.session,
+    failedReason: `${prefix}:${input.category}:${input.userMessage}`,
+  });
+  trackSpendConversionFailed(input.distinctId, {
+    ...input.baseAnalytics,
+    point_conversion_id: input.conv.id,
+    spend_session_id: input.session.id,
+    status: 'failed',
+    error_reason: `${prefix}_failed:${input.category}`,
+  });
+  return {
+    kind: 'error',
+    value: {
+      ok: false,
+      httpStatus: spendRailErrorCategoryToHttpStatus(input.category),
+      error: input.userMessage,
+    },
+    pointsRefunded: Math.ceil(Number(input.conv.points_deducted)),
+  };
 }
 
 /**
@@ -160,7 +210,7 @@ async function runWalletReadinessAndUserFunding(input: {
     };
   }
 
-  const fundingKey = `fund_user:${pointConversion.id}`;
+  const fundingKey = spendConversionFundingIdempotencyKey(pointConversion.id);
   let conv = pointConversion;
   if (!conv.idempotency_key) {
     conv = await updatePointConversionFields(conv.id, {
@@ -181,54 +231,28 @@ async function runWalletReadinessAndUserFunding(input: {
 
   const readiness = await rail.runWalletReadinessOrchestration(ctx);
   if (!readiness.ok) {
-    const reason = readiness.error.userMessage;
-    await tryRefundSpendConversionPoints({
-      conversion: conv,
+    return conversionRailFailureOutcome({
+      phase: 'readiness',
+      conv,
       session,
-      failedReason: `readiness:${readiness.error.category}:${reason}`,
+      distinctId,
+      baseAnalytics,
+      category: readiness.error.category,
+      userMessage: readiness.error.userMessage,
     });
-    trackSpendConversionFailed(distinctId, {
-      ...baseAnalytics,
-      point_conversion_id: conv.id,
-      spend_session_id: session.id,
-      status: 'failed',
-      error_reason: `readiness_failed:${readiness.error.category}`,
-    });
-    return {
-      kind: 'error',
-      value: {
-        ok: false,
-        httpStatus: httpStatusForSpendRailError(readiness.error.category),
-        error: reason,
-      },
-      pointsRefunded: Math.ceil(Number(conv.points_deducted)),
-    };
   }
 
   const funding = await rail.initiateUserFunding(ctx);
   if (!funding.ok) {
-    const reason = funding.error.userMessage;
-    await tryRefundSpendConversionPoints({
-      conversion: conv,
+    return conversionRailFailureOutcome({
+      phase: 'funding',
+      conv,
       session,
-      failedReason: `funding:${funding.error.category}:${reason}`,
+      distinctId,
+      baseAnalytics,
+      category: funding.error.category,
+      userMessage: funding.error.userMessage,
     });
-    trackSpendConversionFailed(distinctId, {
-      ...baseAnalytics,
-      point_conversion_id: conv.id,
-      spend_session_id: session.id,
-      status: 'failed',
-      error_reason: `funding_failed:${funding.error.category}`,
-    });
-    return {
-      kind: 'error',
-      value: {
-        ok: false,
-        httpStatus: httpStatusForSpendRailError(funding.error.category),
-        error: funding.error.userMessage,
-      },
-      pointsRefunded: Math.ceil(Number(conv.points_deducted)),
-    };
   }
 
   const { status, txReference } = funding.value;
@@ -251,7 +275,7 @@ async function runWalletReadinessAndUserFunding(input: {
       session,
       spendExperience,
       serverWalletAddress: serverWallet.address,
-      txHash: ref as `0x${string}`,
+      txHash: ref,
       distinctId,
       baseAnalytics,
     });
@@ -343,20 +367,6 @@ function restoreTierAfterRefundResumeOnlyWallet(params: {
 async function markSessionAfterFunding(sessionId: string): Promise<void> {
   await updateSpendSessionStatus(sessionId, 'conversion_complete');
 }
-
-export type SpendConversionConfirmResult =
-  | {
-      ok: true;
-      pointConversion: PointConversion;
-      session: SpendSession;
-      resumed: boolean;
-    }
-  | {
-      ok: false;
-      httpStatus: 400 | 401 | 403 | 404 | 409 | 500;
-      error: string;
-      capture?: boolean;
-    };
 
 export async function finalizeSpendConversionFunding(input: {
   pointConversion: PointConversion;
@@ -658,7 +668,15 @@ export async function runSpendConversionConfirm(
     throw e;
   }
 
-  const conv = (await getPointConversionBySessionId(session.id))!;
+  const conv = await getPointConversionBySessionId(session.id);
+  if (!conv) {
+    return {
+      ok: false,
+      httpStatus: 500,
+      error:
+        'Points conversion could not be loaded. Please try again or contact support.',
+    };
+  }
   const previousPoints = preRpcPoints;
   const newPoints = rpc.playerTotalPoints;
 
@@ -815,7 +833,7 @@ async function fundOrResumeUsdc(input: {
         );
         const normalized = polled?.trim();
         if (normalized && isEvmTxHash(normalized)) {
-          hash = normalized as `0x${string}`;
+          hash = normalized;
           conv = await updatePointConversionFields(
             conv.id,
             pointConversionFundingHashPatch(session, hash)
@@ -855,17 +873,11 @@ async function fundOrResumeUsdc(input: {
 
   const receiptStatus = await getTreasuryTxReceiptStatus(hash);
   if (receiptStatus === 'reverted') {
-    try {
-      await refundSpendConversionOnFundingFailure({
-        conversionId: conv.id,
-        userId: conv.user_id,
-        spendSessionId: session.id,
-        pointsToRefund: Math.ceil(Number(conv.points_deducted)),
-        failedReason: 'funding transaction reverted',
-      });
-    } catch (r) {
-      console.error('resume wait refund:', r);
-    }
+    await refundSpendConversionPointsBestEffort({
+      conversion: conv,
+      session,
+      failedReason: 'funding transaction reverted',
+    });
     return {
       error: {
         ok: false,

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -15,13 +15,11 @@ import {
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
 import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
-import { recipientUsdcAddressForSpendTransfer } from '@/lib/spend/recipient-usdc-for-treasury-transfer';
 import { resolvePrivyServerTransactionHash } from '@/lib/api/privy';
 import {
   findRecentTreasuryUsdcTransfer,
   getTreasuryTxReceiptStatus,
   isEvmTxHash,
-  submitTreasuryUsdcTransfer,
 } from '@/lib/spend-treasury-usdc-transfer';
 import {
   fetchServerWalletUsdcBalanceSafe,
@@ -34,7 +32,9 @@ import type {
   SpendExperience,
   SpendSession,
 } from '@/lib/types';
-import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
+import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
+import type { SpendPaymentRailSessionContext } from '@/lib/spend/payment-rails/types';
+import { type SpendRailError } from '@/lib/spend/payment-rails/errors';
 import {
   assertSpendRailAllowsMutatingSpendWork,
   isSpendRailOperational,
@@ -52,11 +52,240 @@ import type { SpendPilotConversionEventProperties } from '@/lib/analytics/types'
 const RESUMABLE: PointConversion['status'][] = [
   'points_deducted',
   'funding_pending',
+  'needs_review',
 ];
 const MISCONFIGURED_CONVERSION_ERROR =
   'Conversion is not configured correctly. Please contact support.';
 const FUNDING_ACKNOWLEDGED_MESSAGE =
   'USDC transfer submitted. We are confirming it on Base.';
+
+function embeddedSpendWalletForSession(session: SpendSession): string {
+  if (session.spend_rail === 'stellar_usdc') {
+    return session.rail_user_wallet_address.trim();
+  }
+  return session.wallet_address.trim();
+}
+
+function httpStatusForSpendRailError(
+  category: SpendRailError['category']
+): 400 | 500 {
+  return category === 'network_unavailable' ? 500 : 400;
+}
+
+async function tryRefundSpendConversionPoints(input: {
+  conversion: PointConversion;
+  session: SpendSession;
+  failedReason: string;
+}): Promise<void> {
+  try {
+    await refundSpendConversionOnFundingFailure({
+      conversionId: input.conversion.id,
+      userId: input.conversion.user_id,
+      spendSessionId: input.session.id,
+      pointsToRefund: Math.ceil(Number(input.conversion.points_deducted)),
+      failedReason: input.failedReason.slice(0, 256),
+    });
+  } catch (e) {
+    console.error('refundSpendConversionOnFundingFailure:', e);
+  }
+}
+
+/**
+ * IRL-20: after `points_deducted`, run rail readiness then `initiateUserFunding`.
+ * Persists `fund_user:<point_conversion_id>` on `point_conversions.idempotency_key` before funding
+ * (session uniqueness is enforced by `idx_point_conversions_session_unique`).
+ */
+async function runWalletReadinessAndUserFunding(input: {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  normalizedWallet: string;
+  pointConversion: PointConversion;
+  usdcAmount: number;
+  distinctId: string;
+  baseAnalytics: SpendPilotConversionEventProperties;
+  skipSpendRailMutationGate?: boolean;
+}): Promise<
+  | { kind: 'funded'; conversion: PointConversion }
+  | { kind: 'ambiguous_review'; conversion: PointConversion }
+  | {
+      kind: 'error';
+      value: SpendConversionConfirmResult;
+      pointsRefunded?: number;
+    }
+> {
+  const {
+    session,
+    spendExperience,
+    normalizedWallet,
+    pointConversion,
+    usdcAmount,
+    distinctId,
+    baseAnalytics,
+    skipSpendRailMutationGate,
+  } = input;
+
+  if (!skipSpendRailMutationGate) {
+    const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+    if (!railGate.ok) {
+      trackSpendPilotRailMutationBlocked(distinctId, {
+        mutation: 'conversion_confirm',
+        ...railGate.analytics,
+        spend_experience_id: spendExperience.id,
+        event_id: spendExperience.event_id,
+        user_id: session.user_id,
+        wallet_address: normalizedWallet,
+        spend_session_id: session.id,
+        point_conversion_id: pointConversion.id,
+      });
+      return {
+        kind: 'error',
+        value: {
+          ok: false,
+          httpStatus: 400,
+          error: railGate.error,
+        },
+      };
+    }
+  }
+
+  const serverWallet = getSpendServerWalletTransferConfig(spendExperience);
+  if (!serverWallet) {
+    return {
+      kind: 'error',
+      value: {
+        ok: false,
+        httpStatus: 500,
+        error: MISCONFIGURED_CONVERSION_ERROR,
+      },
+    };
+  }
+
+  const fundingKey = `fund_user:${pointConversion.id}`;
+  let conv = pointConversion;
+  if (!conv.idempotency_key) {
+    conv = await updatePointConversionFields(conv.id, {
+      idempotency_key: fundingKey,
+    });
+  }
+
+  const rail = getSpendPaymentRail(session.spend_rail);
+  const ctx: SpendPaymentRailSessionContext = {
+    spendSessionId: session.id,
+    spendExperienceId: spendExperience.id,
+    pointConversionId: conv.id,
+    fundingReferenceId: fundingKey,
+    embeddedEvmWalletAddress: embeddedSpendWalletForSession(session),
+    privyNormalizedWalletAddressLower: normalizedWallet,
+    usdcAmount,
+  };
+
+  const readiness = await rail.runWalletReadinessOrchestration(ctx);
+  if (!readiness.ok) {
+    const reason = readiness.error.userMessage;
+    await tryRefundSpendConversionPoints({
+      conversion: conv,
+      session,
+      failedReason: `readiness:${readiness.error.category}:${reason}`,
+    });
+    trackSpendConversionFailed(distinctId, {
+      ...baseAnalytics,
+      point_conversion_id: conv.id,
+      spend_session_id: session.id,
+      status: 'failed',
+      error_reason: `readiness_failed:${readiness.error.category}`,
+    });
+    return {
+      kind: 'error',
+      value: {
+        ok: false,
+        httpStatus: httpStatusForSpendRailError(readiness.error.category),
+        error: reason,
+      },
+      pointsRefunded: Math.ceil(Number(conv.points_deducted)),
+    };
+  }
+
+  const funding = await rail.initiateUserFunding(ctx);
+  if (!funding.ok) {
+    const reason = funding.error.userMessage;
+    await tryRefundSpendConversionPoints({
+      conversion: conv,
+      session,
+      failedReason: `funding:${funding.error.category}:${reason}`,
+    });
+    trackSpendConversionFailed(distinctId, {
+      ...baseAnalytics,
+      point_conversion_id: conv.id,
+      spend_session_id: session.id,
+      status: 'failed',
+      error_reason: `funding_failed:${funding.error.category}`,
+    });
+    return {
+      kind: 'error',
+      value: {
+        ok: false,
+        httpStatus: httpStatusForSpendRailError(funding.error.category),
+        error: funding.error.userMessage,
+      },
+      pointsRefunded: Math.ceil(Number(conv.points_deducted)),
+    };
+  }
+
+  const { status, txReference } = funding.value;
+  const ref = (txReference ?? '').trim();
+
+  if (status === 'confirmed') {
+    if (!isEvmTxHash(ref)) {
+      return {
+        kind: 'error',
+        value: {
+          ok: false,
+          httpStatus: 500,
+          error:
+            'Unexpected funding confirmation without a valid transaction hash.',
+        },
+      };
+    }
+    const done = await finalizeSpendConversionFunding({
+      pointConversion: { ...conv, funding_tx_hash: ref },
+      session,
+      spendExperience,
+      serverWalletAddress: serverWallet.address,
+      txHash: ref as `0x${string}`,
+      distinctId,
+      baseAnalytics,
+    });
+    return { kind: 'funded', conversion: done };
+  }
+
+  if (status === 'pending' || status === 'submitted') {
+    if (!ref) {
+      return {
+        kind: 'error',
+        value: {
+          ok: false,
+          httpStatus: 500,
+          error: 'Unexpected funding response without a transaction reference.',
+        },
+      };
+    }
+    const updated = await updatePointConversionFields(conv.id, {
+      status: 'needs_review',
+      ...pointConversionFundingHashPatch(session, ref),
+    });
+    await updateSpendSessionStatus(session.id, 'conversion_pending');
+    return { kind: 'ambiguous_review', conversion: updated };
+  }
+
+  return {
+    kind: 'error',
+    value: {
+      ok: false,
+      httpStatus: 500,
+      error: 'Unexpected funding orchestration outcome.',
+    },
+  };
+}
 
 function pointConversionFundingHashPatch(
   session: SpendSession,
@@ -388,20 +617,6 @@ export async function runSpendConversionConfirm(
     };
   }
 
-  if (!isEvmAddress(session.wallet_address.trim())) {
-    return {
-      ok: false,
-      httpStatus: 400,
-      error: 'Invalid wallet for this session.',
-    };
-  }
-
-  const userRecipient = recipientUsdcAddressForSpendTransfer({
-    serverWalletAddress: serverWallet.address,
-    sessionWalletTrimmed: session.wallet_address.trim(),
-    normalizedWalletLower: normalizedWallet,
-  });
-
   let rpc: Awaited<ReturnType<typeof confirmSpendConversionAtomic>>;
   try {
     rpc = await confirmSpendConversionAtomic({
@@ -443,7 +658,7 @@ export async function runSpendConversionConfirm(
     throw e;
   }
 
-  let conv = (await getPointConversionBySessionId(session.id))!;
+  const conv = (await getPointConversionBySessionId(session.id))!;
   const previousPoints = preRpcPoints;
   const newPoints = rpc.playerTotalPoints;
 
@@ -467,86 +682,31 @@ export async function runSpendConversionConfirm(
     await updateSpendSessionStatus(session.id, 'conversion_pending');
   }
 
-  const sub = await submitTreasuryUsdcTransfer({
-    serverWalletId: serverWallet.walletId,
-    serverWalletAddress: serverWallet.address,
-    recipientAddress: userRecipient,
+  const fundOutcome = await runWalletReadinessAndUserFunding({
+    session,
+    spendExperience,
+    normalizedWallet,
+    pointConversion: conv,
     usdcAmount,
+    distinctId,
+    baseAnalytics,
   });
 
-  if (!sub.ok) {
-    const failReason = sub.error.slice(0, 256);
-    try {
-      await refundSpendConversionOnFundingFailure({
-        conversionId: conv.id,
-        userId: authUserId,
-        spendSessionId: session.id,
-        pointsToRefund: pointsRequired,
-        failedReason: failReason,
-      });
-    } catch (refundErr) {
-      console.error('refund after funding failure:', refundErr);
-    }
-    const failedConv =
-      (await getPointConversionBySessionId(session.id)) ?? conv;
-    trackSpendConversionFailed(distinctId, {
-      ...baseAnalytics,
-      point_conversion_id: failedConv.id,
-      spend_session_id: session.id,
-      status: 'failed',
-      error_reason: `funding_submission_failed: ${failReason}`,
-    });
-
-    if (failedConv.user_id === authUserId) {
+  if (fundOutcome.kind === 'error') {
+    if (fundOutcome.pointsRefunded && conv.user_id === authUserId) {
       restoreTierAfterRefund({
         authUserId,
         normalizedWallet,
         balanceAfterDeduction: newPoints,
-        pointsRestored: pointsRequired,
+        pointsRestored: fundOutcome.pointsRefunded,
       });
     }
-
-    return {
-      ok: false,
-      httpStatus: 400,
-      error: 'USDC transfer could not be sent. Your points have been restored.',
-    };
+    return fundOutcome.value;
   }
-
-  if ('submittedPending' in sub && sub.submittedPending) {
-    const fundingPlaceholder = `pending:${sub.privyTransactionId}`;
-    conv = await updatePointConversionFields(conv.id, {
-      status: 'funding_pending',
-      ...pointConversionFundingHashPatch(session, fundingPlaceholder),
-    });
-    await updateSpendSessionStatus(session.id, 'conversion_pending');
-
-    return {
-      ok: true,
-      pointConversion: conv,
-      session: (await getSpendSessionById(session.id)) ?? session,
-      resumed: rpc.outcome === 'already_exists',
-    };
-  }
-
-  if (!('txHash' in sub)) {
-    return {
-      ok: false,
-      httpStatus: 500,
-      error: 'Unexpected treasury submit response.',
-    };
-  }
-
-  const txHash = sub.txHash;
-  conv = await updatePointConversionFields(conv.id, {
-    status: 'funding_pending',
-    ...pointConversionFundingHashPatch(session, txHash),
-  });
-  await updateSpendSessionStatus(session.id, 'conversion_pending');
 
   return {
     ok: true,
-    pointConversion: conv,
+    pointConversion: fundOutcome.conversion,
     session: (await getSpendSessionById(session.id)) ?? session,
     resumed: rpc.outcome === 'already_exists',
   };
@@ -608,84 +768,34 @@ async function fundOrResumeUsdc(input: {
 
   let conv = pointConversion;
   if (conv.status === 'points_deducted' && !conv.funding_tx_hash) {
-    const userRecipient = recipientUsdcAddressForSpendTransfer({
-      serverWalletAddress: serverWallet.address,
-      sessionWalletTrimmed: session.wallet_address.trim(),
-      normalizedWalletLower: normalizedWallet,
-    });
-
-    const sub = await submitTreasuryUsdcTransfer({
-      serverWalletId: serverWallet.walletId,
-      serverWalletAddress: serverWallet.address,
-      recipientAddress: userRecipient,
+    const onward = await runWalletReadinessAndUserFunding({
+      session,
+      spendExperience,
+      normalizedWallet,
+      pointConversion: conv,
       usdcAmount,
+      distinctId,
+      baseAnalytics,
+      skipSpendRailMutationGate: true,
     });
-    if (!sub.ok) {
-      const fail = sub.error.slice(0, 256);
-      try {
-        await refundSpendConversionOnFundingFailure({
-          conversionId: conv.id,
-          userId: conv.user_id,
-          spendSessionId: session.id,
-          pointsToRefund: Math.ceil(Number(conv.points_deducted)),
-          failedReason: fail,
-        });
-      } catch (e) {
-        console.error('resume refund failed:', e);
+    if (onward.kind === 'error') {
+      if (onward.pointsRefunded) {
+        const p = await getPlayerByWallet(session.wallet_address);
+        if (p) {
+          const cur = Number(p.total_points ?? 0);
+          restoreTierAfterRefundResumeOnlyWallet({
+            normalizedWallet,
+            balanceNow: cur,
+            pointsRestored: onward.pointsRefunded,
+          });
+        }
       }
-      trackSpendConversionFailed(distinctId, {
-        ...baseAnalytics,
-        point_conversion_id: conv.id,
-        spend_session_id: session.id,
-        status: 'failed',
-        error_reason: 'funding_submission_failed',
-      });
-
-      const p = await getPlayerByWallet(session.wallet_address);
-      if (p) {
-        const cur = Number(p.total_points ?? 0);
-        const refunded = Math.ceil(Number(conv.points_deducted));
-        restoreTierAfterRefundResumeOnlyWallet({
-          normalizedWallet,
-          balanceNow: cur,
-          pointsRestored: refunded,
-        });
-      }
-      return {
-        error: {
-          ok: false,
-          httpStatus: 400,
-          error:
-            'USDC transfer could not be sent. Your points have been restored.',
-        },
-      };
+      return { error: onward.value };
     }
-    if ('submittedPending' in sub && sub.submittedPending) {
-      conv = await updatePointConversionFields(conv.id, {
-        status: 'funding_pending',
-        ...pointConversionFundingHashPatch(
-          session,
-          `pending:${sub.privyTransactionId}`
-        ),
-      });
-      await updateSpendSessionStatus(session.id, 'conversion_pending');
-    } else {
-      if (!('txHash' in sub)) {
-        return {
-          error: {
-            ok: false,
-            httpStatus: 500,
-            error: 'Unexpected treasury submit response.',
-          },
-        };
-      }
-      const txHash = sub.txHash;
-      conv = await updatePointConversionFields(conv.id, {
-        status: 'funding_pending',
-        ...pointConversionFundingHashPatch(session, txHash),
-      });
-      await updateSpendSessionStatus(session.id, 'conversion_pending');
+    if (onward.kind === 'funded') {
+      return { conversion: onward.conversion, error: null };
     }
+    conv = onward.conversion;
   }
 
   let hash = conv.funding_tx_hash?.trim() as `0x${string}` | undefined;
@@ -694,7 +804,7 @@ async function fundOrResumeUsdc(input: {
   if (
     !hash &&
     trimmedFunding.startsWith(pendingPrefix) &&
-    conv.status === 'funding_pending'
+    (conv.status === 'funding_pending' || conv.status === 'needs_review')
   ) {
     const privyId = trimmedFunding.slice(pendingPrefix.length).trim();
     if (privyId) {
@@ -716,7 +826,10 @@ async function fundOrResumeUsdc(input: {
       }
     }
   }
-  if (!hash && conv.status === 'funding_pending') {
+  if (
+    !hash &&
+    (conv.status === 'funding_pending' || conv.status === 'needs_review')
+  ) {
     const recovered = await findRecentTreasuryUsdcTransfer({
       serverWalletAddress: serverWallet.address,
       recipientAddress: session.wallet_address as `0x${string}`,

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -89,7 +89,7 @@ async function refundSpendConversionPointsBestEffort(input: {
   conversion: PointConversion;
   session: SpendSession;
   failedReason: string;
-}): Promise<void> {
+}): Promise<boolean> {
   try {
     await refundSpendConversionOnFundingFailure({
       conversionId: input.conversion.id,
@@ -98,8 +98,10 @@ async function refundSpendConversionPointsBestEffort(input: {
       pointsToRefund: Math.ceil(Number(input.conversion.points_deducted)),
       failedReason: input.failedReason.slice(0, 256),
     });
+    return true;
   } catch (e) {
     console.error('refundSpendConversionOnFundingFailure:', e);
+    return false;
   }
 }
 
@@ -114,10 +116,10 @@ async function conversionRailFailureOutcome(input: {
 }): Promise<{
   kind: 'error';
   value: SpendConversionConfirmResult;
-  pointsRefunded: number;
+  pointsRefunded?: number;
 }> {
   const prefix = input.phase === 'readiness' ? 'readiness' : 'funding';
-  await refundSpendConversionPointsBestEffort({
+  const refundOk = await refundSpendConversionPointsBestEffort({
     conversion: input.conv,
     session: input.session,
     failedReason: `${prefix}:${input.category}:${input.userMessage}`,
@@ -136,7 +138,9 @@ async function conversionRailFailureOutcome(input: {
       httpStatus: spendRailErrorCategoryToHttpStatus(input.category),
       error: input.userMessage,
     },
-    pointsRefunded: Math.ceil(Number(input.conv.points_deducted)),
+    ...(refundOk
+      ? { pointsRefunded: Math.ceil(Number(input.conv.points_deducted)) }
+      : {}),
   };
 }
 

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -37,6 +37,7 @@ const IN_PROGRESS: PointConversion['status'][] = [
   'pending',
   'points_deducted',
   'funding_pending',
+  'needs_review',
 ];
 
 export type SpendConversionPreview = {

--- a/lib/spend/payment-rails/base-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.test.ts
@@ -187,6 +187,47 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error('unexpected');
     expect(res.value.status).toBe('pending');
+    expect(res.value.txReference).toBe('pending:ptx-1');
+  });
+
+  it('initiateUserFunding passes deterministic referenceId when fundingReferenceId is set', async () => {
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: true,
+      submittedPending: true,
+      privyTransactionId: 'ptx-ref',
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      usdcAmount: 5,
+      fundingReferenceId: 'fund_user:00000000-0000-0000-0000-000000000001',
+    });
+    expect(res.ok).toBe(true);
+    expect(submitTreasuryUsdcTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        referenceId: 'fund_user:00000000-0000-0000-0000-000000000001',
+      })
+    );
+  });
+
+  it('initiateUserFunding returns submitted with tx hash when receipt is not yet final', async () => {
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: true,
+      txHash: VALID_PAYMENT_HASH,
+      privyTransactionId: 'ptx-2',
+    });
+    vi.mocked(getTreasuryTxReceiptStatus).mockResolvedValue(null);
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value.status).toBe('submitted');
+    expect(res.value.txReference).toBe(VALID_PAYMENT_HASH);
   });
 
   it('initiateUserFunding returns confirmed when receipt is already successful', async () => {
@@ -205,6 +246,7 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error('unexpected');
     expect(res.value.status).toBe('confirmed');
+    expect(res.value.txReference).toBe(VALID_PAYMENT_HASH);
   });
 
   it('initiateUserFunding maps treasury insufficient errors to the treasury catalog', async () => {
@@ -226,11 +268,16 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     );
   });
 
-  it('preparePayment returns rail_operation_not_supported', async () => {
-    const res = await rail.preparePayment({ spendSessionId: 's1' });
-    expect(res.ok).toBe(false);
-    if (res.ok) throw new Error('unexpected');
-    expect(res.error.category).toBe('rail_operation_not_supported');
+  it('preparePayment returns prepared when wallet and amount are valid', async () => {
+    const res = await rail.preparePayment({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value.status).toBe('prepared');
+    expect(res.value.baseUsdc?.preparedAction.v).toBe(1);
   });
 
   it('confirmPayment rejects invalid global receiving wallet configuration', async () => {

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -124,9 +124,12 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
       return okSpendRail({ status: 'completed' });
     },
 
-    async initiateUserFunding(
-      ctx: SpendPaymentRailSessionContext
-    ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
+    async initiateUserFunding(ctx: SpendPaymentRailSessionContext): Promise<
+      SpendRailResult<{
+        status: SpendRailFundingOperationStatus;
+        txReference?: string | null;
+      }>
+    > {
       const embeddedRes = embeddedEvmFromContext(ctx);
       if (!embeddedRes.ok) {
         return embeddedRes;
@@ -174,6 +177,7 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
         serverWalletAddress: transferCfg.address,
         recipientAddress: recipient,
         usdcAmount,
+        referenceId: ctx.fundingReferenceId?.trim() || undefined,
       });
 
       if (!sub.ok) {
@@ -181,7 +185,10 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
       }
 
       if ('submittedPending' in sub && sub.submittedPending) {
-        return okSpendRail({ status: 'pending' });
+        return okSpendRail({
+          status: 'pending',
+          txReference: `pending:${sub.privyTransactionId}`,
+        });
       }
 
       if (!('txHash' in sub)) {
@@ -190,12 +197,18 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
 
       const receipt = await getTreasuryTxReceiptStatus(sub.txHash);
       if (receipt === 'success') {
-        return okSpendRail({ status: 'confirmed' });
+        return okSpendRail({
+          status: 'confirmed',
+          txReference: sub.txHash,
+        });
       }
       if (receipt === 'reverted') {
         return errSpendRail(spendRailErrorFundingFailed());
       }
-      return okSpendRail({ status: 'submitted' });
+      return okSpendRail({
+        status: 'submitted',
+        txReference: sub.txHash,
+      });
     },
 
     async preparePayment(

--- a/lib/spend/payment-rails/errors.ts
+++ b/lib/spend/payment-rails/errors.ts
@@ -117,6 +117,14 @@ export const spendRailErrorRailOperationNotSupported = (): SpendRailError =>
     SPEND_RAIL_ANALYTICS_CODES.rail_operation_not_supported
   );
 
+/** Treasury→user points conversion funding is not implemented for this rail (IRL-20). */
+export const spendRailErrorConversionFundingNotSupported = (): SpendRailError =>
+  err(
+    'rail_operation_not_supported',
+    'Points-to-USDC conversion is not available on this payment network yet. Please ask an event host.',
+    SPEND_RAIL_ANALYTICS_CODES.rail_operation_not_supported
+  );
+
 export function isSpendRailError(value: unknown): value is SpendRailError {
   if (!value || typeof value !== 'object') return false;
   const v = value as Record<string, unknown>;

--- a/lib/spend/payment-rails/errors.ts
+++ b/lib/spend/payment-rails/errors.ts
@@ -134,3 +134,10 @@ export function isSpendRailError(value: unknown): value is SpendRailError {
     typeof v.analyticsCode === 'string'
   );
 }
+
+/** HTTP status for surfacing a rail error to clients (conversion / payment routes). */
+export function spendRailErrorCategoryToHttpStatus(
+  category: SpendRailErrorCategory
+): 400 | 500 {
+  return category === 'network_unavailable' ? 500 : 400;
+}

--- a/lib/spend/payment-rails/payment-rails.test.ts
+++ b/lib/spend/payment-rails/payment-rails.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import {
   SPEND_RAIL_ANALYTICS_CODES,
+  spendRailErrorConversionFundingNotSupported,
   spendRailErrorDuplicateRequest,
   spendRailErrorFundingFailed,
   spendRailErrorInvalidReceivingWallet,
@@ -50,6 +51,11 @@ describe('spend rail error catalog', () => {
     [
       'unsupported',
       spendRailErrorRailOperationNotSupported,
+      'rail_operation_not_supported',
+    ],
+    [
+      'conversion funding unsupported',
+      spendRailErrorConversionFundingNotSupported,
       'rail_operation_not_supported',
     ],
   ] as const;
@@ -146,5 +152,15 @@ describe('getSpendPaymentRail', () => {
     ).resolves.toMatchObject({ ok: false });
 
     expect(rail.explorerUrlForLedgerTx(null)).toBeNull();
+  });
+
+  it('Stellar conversion readiness uses conversion-specific unsupported copy', async () => {
+    const rail = getSpendPaymentRail('stellar_usdc');
+    const res = await rail.runWalletReadinessOrchestration({
+      spendSessionId: 's1',
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected failure');
+    expect(res.error.userMessage).toContain('Points-to-USDC');
   });
 });

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -57,9 +57,13 @@ export interface SpendPaymentRail {
    * Treasury → user funding at the rail operation layer. Real orchestration moves in IRL-14 /
    * conversion refactors; Base returns a neutral pending placeholder, Stellar is unsupported.
    */
-  initiateUserFunding(
-    ctx: SpendPaymentRailSessionContext
-  ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>>;
+  initiateUserFunding(ctx: SpendPaymentRailSessionContext): Promise<
+    SpendRailResult<{
+      status: SpendRailFundingOperationStatus;
+      /** Ledger reference when known (`0x…` hash or `pending:<privyTransactionId>`). */
+      txReference?: string | null;
+    }>
+  >;
 
   /**
    * Prepare a payment action (idempotent descriptor). Unsupported on Base until IRL-19;

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -6,7 +6,10 @@ import {
   type SpendPaymentRail,
   type SpendRailResult,
 } from '@/lib/spend/payment-rails/spend-payment-rail';
-import { spendRailErrorRailOperationNotSupported } from '@/lib/spend/payment-rails/errors';
+import {
+  spendRailErrorRailOperationNotSupported,
+  spendRailErrorConversionFundingNotSupported,
+} from '@/lib/spend/payment-rails/errors';
 import type {
   SpendPaymentRailReconcileContext,
   SpendPaymentRailSessionContext,
@@ -17,6 +20,9 @@ import type {
 
 const unsupported = (): SpendRailResult<never> =>
   errSpendRail(spendRailErrorRailOperationNotSupported());
+
+const conversionFundingUnsupported = (): SpendRailResult<never> =>
+  errSpendRail(spendRailErrorConversionFundingNotSupported());
 
 /**
  * Stellar USDC rail: registered for typing and shared errors; orchestration methods return
@@ -39,14 +45,14 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>> {
       void ctx;
-      return notSupported();
+      return conversionFundingUnsupported();
     },
 
     async initiateUserFunding(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
       void ctx;
-      return notSupported();
+      return conversionFundingUnsupported();
     },
 
     async preparePayment(

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -48,9 +48,12 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
       return conversionFundingUnsupported();
     },
 
-    async initiateUserFunding(
-      ctx: SpendPaymentRailSessionContext
-    ): Promise<SpendRailResult<{ status: SpendRailFundingOperationStatus }>> {
+    async initiateUserFunding(ctx: SpendPaymentRailSessionContext): Promise<
+      SpendRailResult<{
+        status: SpendRailFundingOperationStatus;
+        txReference?: string | null;
+      }>
+    > {
       void ctx;
       return conversionFundingUnsupported();
     },

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -38,6 +38,16 @@ export type SpendPaymentRailSessionContext = {
   spendSessionId: string;
   spendExperienceId?: string;
   /**
+   * Spend pilot conversion row used for funding idempotency (`fund_user:<id>`) and analytics.
+   * Optional for payment-only rail calls.
+   */
+  pointConversionId?: string;
+  /**
+   * Deterministic Privy REST `reference_id` for treasury→user funding (conversion-scoped).
+   * When set, Base USDC rail passes this to `submitTreasuryUsdcTransfer`.
+   */
+  fundingReferenceId?: string;
+  /**
    * Base pilot: optional session fields used by the Base USDC rail (`embeddedEvmWalletAddress`
    * aligns with `SpendSession.wallet_address`; other rails ignore unset fields for now).
    */

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -339,6 +339,8 @@ export type PointConversionStatus =
   | 'pending'
   | 'points_deducted'
   | 'funding_pending'
+  /** Ambiguous funding outcome (submitted / pending confirmation); no automatic refund (IRL-20). */
+  | 'needs_review'
   | 'funded'
   | 'failed';
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-20: after `confirm_spend_conversion_atomic`, conversion confirm runs `getSpendPaymentRail(session.spend_rail).runWalletReadinessOrchestration` then `initiateUserFunding` with a populated `SpendPaymentRailSessionContext`.

## Details

- **Ordering:** First committed step remains `confirm_spend_conversion_atomic`; readiness and funding run only after that commit (and after session and analytics updates for newly created rows, matching prior ordering relative to funding).
- **Idempotency:** Persists `point_conversions.idempotency_key` to `fund_user:<point_conversion_id>` before funding and passes the same value as Privy `reference_id` on Base (`submitTreasuryUsdcTransfer`). Session uniqueness continues to rely on `idx_point_conversions_session_unique` plus the partial unique index on `idempotency_key` (documented in migration comments).
- **`needs_review`:** New persisted `point_conversions.status` for ambiguous funding (`pending:` Privy handle or on-chain hash without immediate success). No automatic refund on that path. Resume and finalize paths treat `needs_review` like `funding_pending` for polling and eventual finalize or reverted refund.
- **Refunds:** `refund_spend_conversion_on_funding_failure` now allows refund from `funding_pending` and `needs_review` when the caller has a definitive failure (for example a reverted receipt), aligning the resume path with the database. Canonical SQL under `database/` updated to match.
- **Ledger trigger:** `enforce_point_conversions_ledger_mutability` allows a one-time `idempotency_key` set from NULL (required under IRL-6 immutability rules).
- **Stellar:** Readiness and funding entrypoints return conversion-specific unsupported copy; after atomic deduction, failure refunds points when still in `points_deducted`.
- **Types and preview:** `PointConversionStatus` includes `needs_review`; spend eligibility treats it as conversion in progress.

## Verification

- Vitest: spend-sessions API routes and `lib/spend/payment-rails/*` (repository still has unrelated failing tests on main).
- Production build and typecheck passed via pre-commit `next build`.

## Migration

Apply `database/point-conversions-needs-review-funding-idempotency.sql` to the database before deploying application changes.

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-20](https://linear.app/irlenergy/issue/IRL-20/update-conversion-flow-to-call-rail-readiness-and-funding-methods)

<div><a href="https://cursor.com/agents/bc-ab7fbedc-bf86-4028-8bef-0daaf464512e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ab7fbedc-bf86-4028-8bef-0daaf464512e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

