### PR TITLE
IRL-18: Stellar sponsor activation + Privy trustline wallet readiness

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -89,6 +89,11 @@ REWARDS_TOKEN_OWNER_SECRET_KEY=
 # NEXT_PUBLIC_STELLAR_NETWORK=PUBLIC
 # NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE=https://stellar.expert/explorer/public/tx/{txHash}
 # Optional Horizon override (validated only when set): NEXT_PUBLIC_STELLAR_HORIZON_URL=
+# IRL-18: sponsor wallet secret (S…56) pays account creation + fee-bump trustline; USDC issuer override for non-public:
+# SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY=S...
+# SPEND_RAIL_STELLAR_USDC_USDC_ISSUER=G...
+# SPEND_RAIL_STELLAR_USDC_ASSET_CODE=USDC
+# Optional starting XLM for new Stellar accounts (default 3): SPEND_RAIL_STELLAR_USDC_CREATE_ACCOUNT_XLM=3
 
 # Claim NFT (WalletCon NFT on Base — see lib/walletcon-nft.ts): mock "mint open" for local UI testing.
 # When set to "true", GET /api/claim-nft returns canMint: true, hasClaimed: false so the claim button appears.

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -6,6 +6,7 @@ import {
 import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
 import { captureHandledException } from '@/lib/monitoring/capture-handled-exception';
 import { resolveServerIdentity } from '@/lib/analytics/server';
+import { getSpendWalletReadinessBySessionId } from '@/lib/db/spend-wallet-readiness';
 import {
   getSpendContextOr404,
   runSpendConversionConfirm,
@@ -102,6 +103,11 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError(result.error, result.httpStatus);
     }
 
+    const walletReadiness =
+      spendExperience.spend_rail === 'stellar_usdc'
+        ? await getSpendWalletReadinessBySessionId(session.id)
+        : null;
+
     return apiSuccess({
       pointConversion: result.pointConversion,
       session: {
@@ -118,6 +124,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       },
       spendRailSummary: getSpendRailClientSummary(spendExperience.spend_rail),
       resumed: result.resumed,
+      ...(walletReadiness ? { walletReadiness } : {}),
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Failed to confirm conversion';

--- a/database/irl-18-treasury-stellar-setup-types.sql
+++ b/database/irl-18-treasury-stellar-setup-types.sql
@@ -1,0 +1,17 @@
+-- IRL-18: Treasury ledger types for Stellar account activation and USDC trustline setup.
+
+ALTER TABLE treasury_transactions
+  DROP CONSTRAINT IF EXISTS treasury_transactions_transaction_type_check;
+
+ALTER TABLE treasury_transactions
+  ADD CONSTRAINT treasury_transactions_transaction_type_check
+  CHECK (transaction_type IN (
+      'fund_user',
+      'receive_payment',
+      'admin_recovery',
+      'stellar_account_activation',
+      'stellar_usdc_trustline_setup'
+  ));
+
+COMMENT ON CONSTRAINT treasury_transactions_transaction_type_check ON treasury_transactions IS
+  'Includes Stellar readiness audit types (IRL-18): stellar_account_activation, stellar_usdc_trustline_setup.';

--- a/lib/db/treasury-transactions.ts
+++ b/lib/db/treasury-transactions.ts
@@ -51,7 +51,11 @@ function rowToTreasury(row: Record<string, unknown>): TreasuryTransaction {
 
 type TreasuryLedgerInsertType = Extract<
   TreasuryTransaction['transaction_type'],
-  'fund_user' | 'receive_payment' | 'admin_recovery'
+  | 'fund_user'
+  | 'receive_payment'
+  | 'admin_recovery'
+  | 'stellar_account_activation'
+  | 'stellar_usdc_trustline_setup'
 >;
 
 async function insertTreasuryLedgerRowIfAbsent(params: {
@@ -157,6 +161,73 @@ export function insertTreasuryAdminRecoveryLedgerIfAbsent(input: {
     toWalletAddress: input.toWalletAddress,
     txHash: input.txHash,
   });
+}
+
+type StellarSetupTreasuryType = Extract<
+  TreasuryTransaction['transaction_type'],
+  'stellar_account_activation' | 'stellar_usdc_trustline_setup'
+>;
+
+/**
+ * Inserts a `treasury_transactions` audit row for Stellar readiness (activation or trustline)
+ * using a `pending:{uuid}` tx_hash placeholder until the on-ledger hash is known (IRL-18).
+ */
+export async function insertTreasuryStellarSetupRow(input: {
+  spendExperienceId: string;
+  transactionType: StellarSetupTreasuryType;
+  fromWalletAddress: string;
+  toWalletAddress: string;
+  pendingTxCorrelation: string;
+}): Promise<string> {
+  const spend_rail = 'stellar_usdc' as const;
+  const tx_hash = `pending:${input.pendingTxCorrelation.trim()}`;
+  const { data, error } = await supabase
+    .from('treasury_transactions')
+    .insert({
+      spend_experience_id: input.spendExperienceId,
+      transaction_type: input.transactionType,
+      amount: 0,
+      spend_rail,
+      network: spendLedgerNetworkLabel(spend_rail),
+      asset_symbol: 'USDC',
+      from_wallet_address: input.fromWalletAddress.trim(),
+      to_wallet_address: input.toWalletAddress.trim(),
+      tx_hash,
+      explorer_tx_url: null,
+      status: 'submitted',
+    })
+    .select('id')
+    .single();
+
+  if (error || !data) {
+    console.error(
+      `insertTreasuryStellarSetupRow (${input.transactionType}):`,
+      error
+    );
+    throw new Error(error?.message || 'Failed to insert treasury row');
+  }
+  return String((data as Record<string, unknown>).id);
+}
+
+export async function finalizeTreasuryStellarSetupRow(input: {
+  id: string;
+  txHashNormalized: string;
+  explorerTxUrl: string | null;
+  status: 'confirmed' | 'failed';
+}): Promise<void> {
+  const { error } = await supabase
+    .from('treasury_transactions')
+    .update({
+      tx_hash: input.txHashNormalized.trim().toLowerCase(),
+      explorer_tx_url: input.explorerTxUrl,
+      status: input.status,
+    })
+    .eq('id', input.id);
+
+  if (error) {
+    console.error('finalizeTreasuryStellarSetupRow:', error);
+    throw new Error(error.message || 'Failed to finalize treasury row');
+  }
 }
 
 export async function listTreasuryTransactionsForExperience(

--- a/lib/privy-server-rest.ts
+++ b/lib/privy-server-rest.ts
@@ -112,6 +112,52 @@ function privyRestFetch(
 }
 
 /**
+ * POST /v1/wallets/{walletId}/raw_sign — sign a 32-byte hash (Tier-2 chains, e.g. Stellar).
+ * @see https://docs.privy.io/wallets/using-wallets/other-chains
+ */
+export async function privyWalletRawSignTransactionHash(input: {
+  walletId: string;
+  /** 32-byte transaction signing hash (e.g. Stellar `Transaction.prototype.hash()`). */
+  hash32: Buffer;
+}): Promise<Buffer> {
+  if (input.hash32.length !== 32) {
+    throw new Error('privyWalletRawSignTransactionHash: expected 32-byte hash');
+  }
+  const hashHex0x = `0x${input.hash32.toString('hex')}` as const;
+  const res = await privyRestFetch(
+    `/wallets/${encodeURIComponent(input.walletId)}/raw_sign`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        params: { hash: hashHex0x },
+      }),
+    }
+  );
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new PrivyRestApiError(res.status, text);
+  }
+  const json = (await res.json()) as {
+    data?: { signature?: string };
+  };
+  const sig = json.data?.signature?.trim();
+  if (!sig || !sig.startsWith('0x')) {
+    throw new PrivyRestApiError(
+      500,
+      `Malformed Privy raw_sign response: ${JSON.stringify(json)}`
+    );
+  }
+  const raw = Buffer.from(sig.slice(2), 'hex');
+  if (raw.length !== 64) {
+    throw new PrivyRestApiError(
+      500,
+      `Unexpected raw_sign signature length ${raw.length}`
+    );
+  }
+  return raw;
+}
+
+/**
  * POST /v1/wallets/{walletId}/rpc — `method: eth_sendTransaction`.
  */
 export async function signAndSendTransaction(

--- a/lib/privy/__tests__/stellar-rail-wallet.test.ts
+++ b/lib/privy/__tests__/stellar-rail-wallet.test.ts
@@ -20,7 +20,10 @@ vi.mock('@/lib/db/players', () => ({
     mockCreateOrUpdatePlayerForStellar(...a),
 }));
 
-import { ensureStellarRailUserWallet } from '../stellar-rail-wallet';
+import {
+  ensureStellarRailUserWallet,
+  resolveStellarPrivyWalletIdForUser,
+} from '../stellar-rail-wallet';
 
 describe('ensureStellarRailUserWallet', () => {
   beforeEach(() => {
@@ -97,5 +100,49 @@ describe('ensureStellarRailUserWallet', () => {
       'u@test.com',
       'new-id'
     );
+  });
+});
+
+describe('resolveStellarPrivyWalletIdForUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns the linked Stellar wallet id matching the address', async () => {
+    mockGetUser.mockResolvedValue({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          id: 'wid-99',
+        },
+      ],
+    });
+    await expect(
+      resolveStellarPrivyWalletIdForUser(
+        'privy-u1',
+        'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+      )
+    ).resolves.toBe('wid-99');
+  });
+
+  it('throws when no matching Stellar wallet is linked', async () => {
+    mockGetUser.mockResolvedValue({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: 'GOTHERBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          id: 'wid-x',
+        },
+      ],
+    });
+    await expect(
+      resolveStellarPrivyWalletIdForUser(
+        'privy-u1',
+        'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+      )
+    ).rejects.toThrow('stellar_privy_wallet_id_unresolved');
   });
 });

--- a/lib/privy/stellar-rail-wallet.ts
+++ b/lib/privy/stellar-rail-wallet.ts
@@ -69,3 +69,25 @@ export async function ensureStellarRailUserWallet(
     provisioned: true,
   };
 }
+
+/**
+ * Resolves the Privy Stellar embedded wallet id for a known G-address (server-side).
+ */
+export async function resolveStellarPrivyWalletIdForUser(
+  privyUserId: string,
+  canonicalAddress: string
+): Promise<string> {
+  const privy = getPrivyClient();
+  const user = await privy.getUser(privyUserId);
+  const wanted = canonicalAddress.trim();
+  const linked = user.linkedAccounts?.find((a) => {
+    if (a.type !== 'wallet' || !('chainType' in a)) return false;
+    if (a.chainType !== 'stellar') return false;
+    if (!('address' in a) || typeof a.address !== 'string') return false;
+    return a.address.trim() === wanted;
+  });
+  if (linked && 'id' in linked && linked.id != null && linked.id !== '') {
+    return String(linked.id);
+  }
+  throw new Error('stellar_privy_wallet_id_unresolved');
+}

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -164,6 +164,8 @@ async function runWalletReadinessAndUserFunding(input: {
 }): Promise<
   | { kind: 'funded'; conversion: PointConversion }
   | { kind: 'ambiguous_review'; conversion: PointConversion }
+  | { kind: 'readiness_pending'; conversion: PointConversion }
+  | { kind: 'readiness_needs_review'; conversion: PointConversion }
   | {
       kind: 'error';
       value: SpendConversionConfirmResult;
@@ -248,6 +250,29 @@ async function runWalletReadinessAndUserFunding(input: {
       category: readiness.error.category,
       userMessage: readiness.error.userMessage,
     });
+  }
+
+  if (readiness.value.status === 'needs_review') {
+    const updated = await updatePointConversionFields(conv.id, {
+      status: 'needs_review',
+    });
+    await updateSpendSessionStatus(session.id, 'conversion_pending');
+    return { kind: 'readiness_needs_review', conversion: updated };
+  }
+
+  if (readiness.value.status === 'pending') {
+    return { kind: 'readiness_pending', conversion: conv };
+  }
+
+  if (readiness.value.status !== 'completed') {
+    return {
+      kind: 'error',
+      value: {
+        ok: false,
+        httpStatus: 500,
+        error: 'Unexpected wallet readiness status.',
+      },
+    };
   }
 
   const funding = await rail.initiateUserFunding(ctx);
@@ -794,9 +819,12 @@ async function fundOrResumeUsdc(input: {
 
   let conv = pointConversion;
   if (
-    conv.status === 'points_deducted' &&
     !conv.funding_tx_hash &&
-    spendConversionResumeInvokesWalletReadinessOrchestration(session.spend_rail)
+    spendConversionResumeInvokesWalletReadinessOrchestration(
+      session.spend_rail
+    ) &&
+    (conv.status === 'points_deducted' ||
+      (session.spend_rail === 'stellar_usdc' && conv.status === 'needs_review'))
   ) {
     const onward = await runWalletReadinessAndUserFunding({
       session,
@@ -823,6 +851,12 @@ async function fundOrResumeUsdc(input: {
       return { error: onward.value };
     }
     if (onward.kind === 'funded') {
+      return { conversion: onward.conversion, error: null };
+    }
+    if (
+      onward.kind === 'readiness_pending' ||
+      onward.kind === 'readiness_needs_review'
+    ) {
       return { conversion: onward.conversion, error: null };
     }
     conv = onward.conversion;

--- a/lib/spend-rail-config/index.test.ts
+++ b/lib/spend-rail-config/index.test.ts
@@ -146,6 +146,7 @@ describe('getSpendRailOperationalDiagnostics — stellar_usdc', () => {
       'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
       'NEXT_PUBLIC_STELLAR_NETWORK',
       'NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE',
+      'SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY',
     ]) {
       prev[k] = process.env[k];
     }
@@ -158,10 +159,13 @@ describe('getSpendRailOperationalDiagnostics — stellar_usdc', () => {
     }
   });
 
-  it('happy path when enabled with valid receiving and network', () => {
+  it('happy path when enabled with valid receiving and network', async () => {
+    const { Keypair } = await import('@stellar/stellar-sdk');
     process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
     process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
     process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    process.env.SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY =
+      Keypair.random().secret();
     delete process.env
       .NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE;
     const d = getSpendRailOperationalDiagnostics('stellar_usdc');
@@ -169,18 +173,24 @@ describe('getSpendRailOperationalDiagnostics — stellar_usdc', () => {
     expect(getSpendReceivingWalletAddress('stellar_usdc')).toBe(VALID_STELLAR);
   });
 
-  it('unavailable when receiving invalid', () => {
+  it('unavailable when receiving invalid', async () => {
+    const { Keypair } = await import('@stellar/stellar-sdk');
     process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
     process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = 'bad';
     process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    process.env.SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY =
+      Keypair.random().secret();
     const d = getSpendRailOperationalDiagnostics('stellar_usdc');
     expect(d.operational).toBe(false);
   });
 
-  it('unavailable when network env missing', () => {
+  it('unavailable when network env missing', async () => {
+    const { Keypair } = await import('@stellar/stellar-sdk');
     process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
     process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
     process.env.NEXT_PUBLIC_STELLAR_NETWORK = '';
+    process.env.SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY =
+      Keypair.random().secret();
     const d = getSpendRailOperationalDiagnostics('stellar_usdc');
     expect(d.operational).toBe(false);
   });

--- a/lib/spend-rail-config/index.ts
+++ b/lib/spend-rail-config/index.ts
@@ -5,6 +5,7 @@ import {
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import type { SpendRail } from '@/lib/types';
 import { mapSpendRailOperationalReasonToAdminCurated } from '@/lib/spend-rail-config/admin-curated-unavailable-reasons';
+import { collectStellarSpendReadinessConfigReasons } from '@/lib/spend/stellar-wallet-readiness-config';
 import type {
   SpendRailCatalogEntry,
   SpendRailClientSummary,
@@ -206,6 +207,7 @@ function collectStellarOperationalReasons(parsed: ParsedStellar): string[] {
   reasons.push(
     ...validateExplorerTemplate(parsed.explorerTxUrlTemplate, 'Stellar')
   );
+  reasons.push(...collectStellarSpendReadinessConfigReasons());
   return reasons;
 }
 

--- a/lib/spend/payment-rails/payment-rails.test.ts
+++ b/lib/spend/payment-rails/payment-rails.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, vi } from 'vitest';
 
-// Registry imports Stellar rail → stellar-rail-wallet → Privy server client (not loadable in happy-dom).
-vi.mock('@/lib/privy/stellar-rail-wallet', () => ({
-  ensureStellarRailUserWallet: vi.fn(),
+// Registry imports Stellar rail → readiness orchestration (Stellar SDK + Horizon).
+vi.mock('@/lib/spend/stellar-wallet-readiness-orchestration', () => ({
+  runStellarUsdcWalletReadinessOrchestration: vi.fn().mockResolvedValue({
+    ok: true,
+    status: 'completed',
+    address: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+  }),
 }));
 
 import {

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -47,8 +47,7 @@ export interface SpendPaymentRail {
   /**
    * Coarse wallet readiness orchestration (e.g. sponsored account + trustline). Base USDC
    * treats readiness as **completed** at this boundary because session wallets are verified EVM
-   * up front. Stellar USDC provisions the Privy-managed Stellar account on conversion confirm
-   * (IRL-21) via this hook; session create leaves `rail_user_wallet_address` null until then.
+   * up front. Stellar USDC runs hybrid sponsor + Privy-signed setup until ledger-confirmed (IRL-18).
    */
   runWalletReadinessOrchestration(
     ctx: SpendPaymentRailSessionContext

--- a/lib/spend/payment-rails/stellar-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.test.ts
@@ -8,7 +8,7 @@ const hoisted = vi.hoisted(() => ({
   mockInsertOrGet: vi.fn(),
   mockUpdateReadiness: vi.fn(),
   mockUpdateSessionRail: vi.fn(),
-  mockEnsureStellar: vi.fn(),
+  mockOrchestrator: vi.fn(),
 }));
 
 vi.mock('@/lib/db/spend-wallet-readiness', () => ({
@@ -23,9 +23,9 @@ vi.mock('@/lib/db/spend-sessions', () => ({
     hoisted.mockUpdateSessionRail(...a),
 }));
 
-vi.mock('@/lib/privy/stellar-rail-wallet', () => ({
-  ensureStellarRailUserWallet: (...a: unknown[]) =>
-    hoisted.mockEnsureStellar(...a),
+vi.mock('@/lib/spend/stellar-wallet-readiness-orchestration', () => ({
+  runStellarUsdcWalletReadinessOrchestration: (...a: unknown[]) =>
+    hoisted.mockOrchestrator(...a),
 }));
 
 import { createStellarUsdcSpendPaymentRail } from './stellar-usdc-rail';
@@ -33,7 +33,7 @@ import { createStellarUsdcSpendPaymentRail } from './stellar-usdc-rail';
 const sessionId = '770e8400-e29b-41d4-a716-446655440000';
 const STELLAR_G = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
-function pendingRow(opts?: { status?: 'pending' | 'completed' }) {
+function pendingRow(opts?: { status?: 'pending' | 'completed' | 'failed' }) {
   const status = opts?.status ?? 'pending';
   return {
     id: '880e8400-e29b-41d4-a716-446655440001',
@@ -54,26 +54,27 @@ function pendingRow(opts?: { status?: 'pending' | 'completed' }) {
   };
 }
 
-describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-21)', () => {
+describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-18)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     hoisted.mockUpdateReadiness.mockResolvedValue(
       pendingRow({ status: 'completed' })
     );
     hoisted.mockUpdateSessionRail.mockResolvedValue({});
-    hoisted.mockEnsureStellar.mockResolvedValue({
+    hoisted.mockOrchestrator.mockResolvedValue({
+      ok: true,
+      status: 'completed',
       address: STELLAR_G,
-      walletId: 'w1',
-      provisioned: true,
     });
   });
 
   const ctx = {
     spendSessionId: sessionId,
+    spendExperienceId: '990e8400-e29b-41d4-a716-446655440002',
     sessionOwnerPrivyUserId: 'privy-1',
   };
 
-  it('happy path: ensures Stellar wallet, updates readiness + session', async () => {
+  it('happy path: orchestration completed syncs session rail address', async () => {
     hoisted.mockInsertOrGet.mockResolvedValue({
       row: pendingRow(),
       created: true,
@@ -85,22 +86,22 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-21)', () =
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error('expected ok');
     expect(res.value.status).toBe('completed');
-    expect(hoisted.mockEnsureStellar).toHaveBeenCalledTimes(1);
-    expect(hoisted.mockEnsureStellar).toHaveBeenCalledWith('privy-1');
+    expect(hoisted.mockOrchestrator).toHaveBeenCalledTimes(1);
+    expect(hoisted.mockOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        spendSessionId: sessionId,
+        spendExperienceId: ctx.spendExperienceId,
+        sessionOwnerPrivyUserId: 'privy-1',
+      })
+    );
     expect(hoisted.mockUpdateSessionRail).toHaveBeenCalledWith(
       sessionId,
       STELLAR_G
     );
-    expect(hoisted.mockUpdateReadiness).toHaveBeenCalledWith(
-      pendingRow().id,
-      expect.objectContaining({
-        status: 'completed',
-        rail_user_wallet_address: STELLAR_G,
-      })
-    );
+    expect(hoisted.mockUpdateReadiness).not.toHaveBeenCalled();
   });
 
-  it('idempotent second call: completed row skips Privy but syncs session rail address', async () => {
+  it('idempotent second call: completed row skips orchestration but syncs session rail address', async () => {
     hoisted.mockInsertOrGet.mockResolvedValue({
       row: {
         ...pendingRow({ status: 'completed' }),
@@ -113,7 +114,7 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-21)', () =
     const res = await rail.runWalletReadinessOrchestration(ctx);
 
     expect(res.ok).toBe(true);
-    expect(hoisted.mockEnsureStellar).not.toHaveBeenCalled();
+    expect(hoisted.mockOrchestrator).not.toHaveBeenCalled();
     expect(hoisted.mockUpdateReadiness).not.toHaveBeenCalled();
     expect(hoisted.mockUpdateSessionRail).toHaveBeenCalledTimes(1);
     expect(hoisted.mockUpdateSessionRail).toHaveBeenCalledWith(
@@ -122,12 +123,15 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-21)', () =
     );
   });
 
-  it('Privy failure: categorized SpendRailError + persisted diagnostics', async () => {
+  it('orchestration failure: categorized SpendRailError + persisted diagnostics', async () => {
     hoisted.mockInsertOrGet.mockResolvedValue({
       row: pendingRow(),
       created: true,
     });
-    hoisted.mockEnsureStellar.mockRejectedValue(new Error('privy outage'));
+    hoisted.mockOrchestrator.mockResolvedValue({
+      ok: false,
+      error: spendRailErrorWalletReadinessFailed(),
+    });
 
     const rail = createStellarUsdcSpendPaymentRail();
     const res = await rail.runWalletReadinessOrchestration(ctx);
@@ -145,9 +149,6 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-21)', () =
         sanitized_error_category: 'wallet_readiness_failed',
         sanitized_error_code:
           SPEND_RAIL_ANALYTICS_CODES.wallet_readiness_failed,
-        internal_diagnostics: expect.objectContaining({
-          error_message: 'privy outage',
-        }),
       })
     );
   });
@@ -163,38 +164,44 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-21)', () =
     expect(hoisted.mockInsertOrGet).not.toHaveBeenCalled();
   });
 
-  it('network-style Privy errors map to network_unavailable', async () => {
+  it('returns pending when orchestration is still confirming on ledger', async () => {
     hoisted.mockInsertOrGet.mockResolvedValue({
       row: pendingRow(),
       created: true,
     });
-    hoisted.mockEnsureStellar.mockRejectedValue(
-      new Error('fetch failed upstream')
-    );
+    hoisted.mockOrchestrator.mockResolvedValue({
+      ok: true,
+      status: 'pending',
+      address: STELLAR_G,
+    });
 
     const rail = createStellarUsdcSpendPaymentRail();
     const res = await rail.runWalletReadinessOrchestration(ctx);
-
-    expect(res.ok).toBe(false);
-    if (res.ok) throw new Error('expected failure');
-    expect(res.error.category).toBe('network_unavailable');
-    expect(hoisted.mockUpdateReadiness).toHaveBeenCalledWith(
-      pendingRow().id,
-      expect.objectContaining({
-        status: 'failed',
-        sanitized_error_category: 'network_unavailable',
-      })
-    );
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('expected ok');
+    expect(res.value.status).toBe('pending');
+    expect(hoisted.mockUpdateSessionRail).not.toHaveBeenCalled();
   });
 
-  it('at most one ensureStellar call per invocation (no retry loop)', async () => {
+  it('at most one orchestration call per invocation (no retry loop)', async () => {
     hoisted.mockInsertOrGet.mockResolvedValue({
       row: pendingRow(),
       created: true,
     });
-    hoisted.mockEnsureStellar.mockRejectedValueOnce(new Error('first'));
+    hoisted.mockOrchestrator.mockRejectedValueOnce(new Error('first'));
     const rail = createStellarUsdcSpendPaymentRail();
     await rail.runWalletReadinessOrchestration(ctx);
-    expect(hoisted.mockEnsureStellar).toHaveBeenCalledTimes(1);
+    expect(hoisted.mockOrchestrator).toHaveBeenCalledTimes(1);
+  });
+
+  it('failed row short-circuits without calling orchestration', async () => {
+    hoisted.mockInsertOrGet.mockResolvedValue({
+      row: pendingRow({ status: 'failed' }),
+      created: false,
+    });
+    const rail = createStellarUsdcSpendPaymentRail();
+    const res = await rail.runWalletReadinessOrchestration(ctx);
+    expect(res.ok).toBe(false);
+    expect(hoisted.mockOrchestrator).not.toHaveBeenCalled();
   });
 });

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -1,5 +1,4 @@
 import type { SpendRail, SpendWalletReadinessStatus } from '@/lib/types';
-import { ensureStellarRailUserWallet } from '@/lib/privy/stellar-rail-wallet';
 import {
   insertPendingSpendWalletReadinessOrGet,
   updateSpendWalletReadinessFields,
@@ -26,6 +25,7 @@ import type {
   SpendRailFundingOperationStatus,
   SpendRailPaymentOperationStatus,
 } from '@/lib/spend/payment-rails/types';
+import { runStellarUsdcWalletReadinessOrchestration } from '@/lib/spend/stellar-wallet-readiness-orchestration';
 
 const unsupported = (): SpendRailResult<never> =>
   errSpendRail(spendRailErrorRailOperationNotSupported());
@@ -61,8 +61,8 @@ function internalDiagnosticsFromError(e: unknown): Record<string, unknown> {
 }
 
 /**
- * Stellar USDC rail: wallet readiness provisions a Privy-managed Stellar account on
- * conversion confirm (IRL-21). Funding/payment remain stubbed until follow-up issues.
+ * Stellar USDC rail: hybrid readiness (IRL-18) — sponsor-funded account creation,
+ * Privy-signed sponsored USDC trustline, ledger-confirmed completion, treasury audit rows.
  */
 export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
   const spendRail: SpendRail = 'stellar_usdc';
@@ -112,23 +112,48 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
         return okSpendRail({ status: 'completed' });
       }
 
+      if (row.status === 'failed') {
+        return errSpendRail(spendRailErrorWalletReadinessFailed());
+      }
+
       try {
-        const stellar = await ensureStellarRailUserWallet(privyUserId);
-        await updateSpendWalletReadinessFields(row.id, {
-          status: 'completed',
-          rail_user_wallet_address: stellar.address,
-          step_metadata: {
-            stellar_wallet_provisioned: stellar.provisioned,
-          },
-          sanitized_error_category: null,
-          sanitized_error_code: null,
-          internal_diagnostics: null,
+        const outcome = await runStellarUsdcWalletReadinessOrchestration({
+          readinessRow: row,
+          spendSessionId: sessionId,
+          spendExperienceId: ctx.spendExperienceId,
+          sessionOwnerPrivyUserId: privyUserId,
         });
-        await updateSpendSessionRailUserWalletAddress(
-          sessionId,
-          stellar.address
-        );
-        return okSpendRail({ status: 'completed' });
+
+        if (!outcome.ok) {
+          try {
+            await updateSpendWalletReadinessFields(row.id, {
+              status: 'failed',
+              sanitized_error_category: outcome.error.category,
+              sanitized_error_code: outcome.error.analyticsCode,
+              internal_diagnostics: { phase: 'orchestration_pre_ledger' },
+            });
+          } catch (persistErr) {
+            console.error(
+              'stellar_usdc readiness failure metadata persist:',
+              persistErr
+            );
+          }
+          return errSpendRail(outcome.error);
+        }
+
+        if (outcome.status === 'completed' && outcome.address) {
+          try {
+            await updateSpendSessionRailUserWalletAddress(
+              sessionId,
+              outcome.address
+            );
+          } catch (e) {
+            console.error('stellar_usdc readiness session address sync:', e);
+            return errSpendRail(classifyStellarReadinessException(e));
+          }
+        }
+
+        return okSpendRail({ status: outcome.status });
       } catch (e) {
         console.error('stellar_usdc runWalletReadinessOrchestration:', e);
         const railErr = classifyStellarReadinessException(e);

--- a/lib/spend/stellar-wallet-readiness-config.ts
+++ b/lib/spend/stellar-wallet-readiness-config.ts
@@ -1,0 +1,116 @@
+import { Keypair, Networks } from '@stellar/stellar-sdk';
+import { getStellarNetworkConfig } from '@/lib/stellar/utils/network';
+
+/** Circle-issued USDC on Stellar public network (canonical issuer). */
+export const STELLAR_PUBLIC_USDC_ISSUER =
+  'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN';
+
+const STELLAR_SECRET_PREFIX = 'S';
+const STELLAR_SECRET_LEN = 56;
+
+function trimEnv(key: string): string {
+  return (process.env[key] ?? '').trim();
+}
+
+export function getStellarSpendHorizonUrl(): string {
+  const fromEnv = trimEnv('NEXT_PUBLIC_STELLAR_HORIZON_URL');
+  if (fromEnv) {
+    try {
+      // eslint-disable-next-line no-new -- URL validates shape
+      new URL(fromEnv);
+      return fromEnv;
+    } catch {
+      return getStellarNetworkConfig().horizonUrl;
+    }
+  }
+  return getStellarNetworkConfig().horizonUrl;
+}
+
+/**
+ * Network passphrase for Stellar classic txs (spend readiness). Prefer explicit
+ * `NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE` when set; otherwise map from network name.
+ */
+export function getStellarSpendNetworkPassphrase(): string {
+  const explicit = trimEnv('NEXT_PUBLIC_STELLAR_NETWORK_PASSPHRASE');
+  if (explicit) return explicit;
+  const upper = trimEnv('NEXT_PUBLIC_STELLAR_NETWORK').toUpperCase();
+  if (upper === 'PUBLIC' || upper === 'MAINNET') {
+    return Networks.PUBLIC;
+  }
+  return Networks.TESTNET;
+}
+
+export function getStellarSpendUsdcAssetCode(): string {
+  return trimEnv('SPEND_RAIL_STELLAR_USDC_ASSET_CODE') || 'USDC';
+}
+
+export function getStellarSpendUsdcIssuer(): string {
+  const fromEnv = trimEnv('SPEND_RAIL_STELLAR_USDC_USDC_ISSUER');
+  if (fromEnv) return fromEnv;
+  const upper = trimEnv('NEXT_PUBLIC_STELLAR_NETWORK').toUpperCase();
+  if (upper === 'PUBLIC' || upper === 'MAINNET') {
+    return STELLAR_PUBLIC_USDC_ISSUER;
+  }
+  return '';
+}
+
+export function parseStellarSpendSponsorKeypair(): Keypair {
+  const secret = trimEnv('SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY');
+  if (!secret) {
+    throw new Error(
+      'SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY is not configured'
+    );
+  }
+  if (
+    !secret.startsWith(STELLAR_SECRET_PREFIX) ||
+    secret.length !== STELLAR_SECRET_LEN
+  ) {
+    throw new Error(
+      'SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY is not a valid Stellar secret seed'
+    );
+  }
+  try {
+    return Keypair.fromSecret(secret);
+  } catch {
+    throw new Error(
+      'SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY could not be parsed'
+    );
+  }
+}
+
+/** XLM funded on new accounts so reserves + trustline + fees are covered on public network. */
+export function getStellarSpendCreateAccountStartingBalance(): string {
+  return trimEnv('SPEND_RAIL_STELLAR_USDC_CREATE_ACCOUNT_XLM') || '3';
+}
+
+export function isStellarSpendPublicNetworkRequired(): boolean {
+  const upper = trimEnv('NEXT_PUBLIC_STELLAR_NETWORK').toUpperCase();
+  return upper === 'PUBLIC' || upper === 'MAINNET';
+}
+
+export function collectStellarSpendReadinessConfigReasons(): string[] {
+  const reasons: string[] = [];
+  if (!isStellarSpendPublicNetworkRequired()) {
+    reasons.push(
+      'Stellar spend readiness requires NEXT_PUBLIC_STELLAR_NETWORK=PUBLIC (mainnet)'
+    );
+  }
+  const sponsor = trimEnv('SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY');
+  if (!sponsor) {
+    reasons.push('SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY is missing');
+  } else if (
+    !sponsor.startsWith(STELLAR_SECRET_PREFIX) ||
+    sponsor.length !== STELLAR_SECRET_LEN
+  ) {
+    reasons.push(
+      'SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY is not a valid Stellar secret seed'
+    );
+  }
+  const issuer = getStellarSpendUsdcIssuer();
+  if (!issuer) {
+    reasons.push(
+      'SPEND_RAIL_STELLAR_USDC_USDC_ISSUER is missing (required when not on Stellar public mainnet defaults)'
+    );
+  }
+  return reasons;
+}

--- a/lib/spend/stellar-wallet-readiness-orchestration.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.ts
@@ -1,0 +1,646 @@
+import {
+  Asset,
+  Horizon,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { privyWalletRawSignTransactionHash } from '@/lib/privy-server-rest';
+import {
+  ensureStellarRailUserWallet,
+  resolveStellarPrivyWalletIdForUser,
+} from '@/lib/privy/stellar-rail-wallet';
+import {
+  finalizeTreasuryStellarSetupRow,
+  insertTreasuryStellarSetupRow,
+} from '@/lib/db/treasury-transactions';
+import { updateSpendWalletReadinessFields } from '@/lib/db/spend-wallet-readiness';
+import { updateSpendSessionRailUserWalletAddress } from '@/lib/db/spend-sessions';
+import { explorerTxUrlForSpendLedger } from '@/lib/spend-ledger-explorer-url';
+import {
+  spendRailErrorNetworkUnavailable,
+  spendRailErrorTreasuryInsufficientFunds,
+  spendRailErrorWalletReadinessFailed,
+  spendRailErrorWalletUnavailable,
+  type SpendRailError,
+} from '@/lib/spend/payment-rails/errors';
+import type { SpendWalletReadinessOperation } from '@/lib/types';
+import {
+  getStellarSpendCreateAccountStartingBalance,
+  getStellarSpendHorizonUrl,
+  getStellarSpendNetworkPassphrase,
+  getStellarSpendUsdcAssetCode,
+  getStellarSpendUsdcIssuer,
+  parseStellarSpendSponsorKeypair,
+} from '@/lib/spend/stellar-wallet-readiness-config';
+import { isStellarReadinessSubmittedMetadataStale } from '@/lib/spend/stellar-wallet-readiness-stale';
+
+export { STELLAR_WALLET_READINESS_STALE_SUBMITTED_MS } from '@/lib/spend/stellar-wallet-readiness-stale';
+
+/** Stable `step_metadata.current_step` values for clients (IRL-18). */
+export const STELLAR_WALLET_READINESS_CURRENT_STEP = {
+  wallet_provisioning: 'wallet_provisioning',
+  account_activation_submitting: 'account_activation_submitting',
+  account_activation_confirming: 'account_activation_confirming',
+  trustline_submitting: 'trustline_submitting',
+  trustline_confirming: 'trustline_confirming',
+} as const;
+
+export type StellarWalletReadinessCurrentStep =
+  (typeof STELLAR_WALLET_READINESS_CURRENT_STEP)[keyof typeof STELLAR_WALLET_READINESS_CURRENT_STEP];
+
+const HORIZON_TX_POLL_ATTEMPTS = 8;
+const HORIZON_TX_POLL_INTERVAL_MS = 1500;
+
+export type StellarWalletReadinessOrchestrationOutput =
+  | { ok: true; status: 'completed'; address: string }
+  | { ok: true; status: 'pending'; address: string | null }
+  | { ok: true; status: 'needs_review'; address: string | null }
+  | { ok: false; error: SpendRailError };
+
+function mergeMeta(
+  base: Record<string, unknown>,
+  patch: Record<string, unknown>
+): Record<string, unknown> {
+  return { ...base, ...patch };
+}
+
+function classifyHorizonSubmit(e: unknown): SpendRailError {
+  const raw = e instanceof Error ? e.message : String(e);
+  const s = raw.toLowerCase();
+  if (
+    s.includes('fetch') ||
+    s.includes('econn') ||
+    s.includes('timeout') ||
+    s.includes('socket') ||
+    s.includes('502') ||
+    s.includes('503') ||
+    s.includes('504')
+  ) {
+    return spendRailErrorNetworkUnavailable();
+  }
+  if (
+    s.includes('underfunded') ||
+    s.includes('op_underfunded') ||
+    s.includes('insufficient balance')
+  ) {
+    return spendRailErrorTreasuryInsufficientFunds();
+  }
+  return spendRailErrorWalletReadinessFailed();
+}
+
+async function loadAccountOrNull(
+  server: Horizon.Server,
+  publicKey: string
+): Promise<Horizon.AccountResponse | null> {
+  try {
+    return await server.loadAccount(publicKey);
+  } catch (e: unknown) {
+    const status = (e as { response?: { status?: number } })?.response?.status;
+    if (status === 404) return null;
+    throw e;
+  }
+}
+
+function hasUsdcTrustline(
+  account: Horizon.AccountResponse,
+  code: string,
+  issuer: string
+): boolean {
+  for (const b of account.balances) {
+    if (
+      b.asset_type !== 'credit_alphanum4' &&
+      b.asset_type !== 'credit_alphanum12'
+    ) {
+      continue;
+    }
+    if (b.asset_code === code && b.asset_issuer === issuer) return true;
+  }
+  return false;
+}
+
+async function waitForHorizonTxSuccess(
+  server: Horizon.Server,
+  txHash: string
+): Promise<'success' | 'failed' | 'pending'> {
+  const h = txHash.trim().toLowerCase();
+  for (let i = 0; i < HORIZON_TX_POLL_ATTEMPTS; i += 1) {
+    try {
+      const tx = await server.transactions().transaction(h).call();
+      if (tx.successful) return 'success';
+      return 'failed';
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 404) {
+        await new Promise((r) => setTimeout(r, HORIZON_TX_POLL_INTERVAL_MS));
+        continue;
+      }
+      throw e;
+    }
+  }
+  return 'pending';
+}
+
+export async function runStellarUsdcWalletReadinessOrchestration(input: {
+  readinessRow: SpendWalletReadinessOperation;
+  spendSessionId: string;
+  spendExperienceId: string | undefined;
+  sessionOwnerPrivyUserId: string;
+}): Promise<StellarWalletReadinessOrchestrationOutput> {
+  const {
+    readinessRow,
+    spendSessionId,
+    spendExperienceId,
+    sessionOwnerPrivyUserId,
+  } = input;
+  const rowId = readinessRow.id;
+  let stepMeta: Record<string, unknown> = {
+    ...readinessRow.step_metadata,
+  };
+
+  const horizonUrl = getStellarSpendHorizonUrl();
+  const passphrase = getStellarSpendNetworkPassphrase();
+  const usdcCode = getStellarSpendUsdcAssetCode();
+  const usdcIssuer = getStellarSpendUsdcIssuer();
+  if (!usdcIssuer) {
+    return {
+      ok: false,
+      error: spendRailErrorWalletReadinessFailed(),
+    };
+  }
+
+  const server = new Horizon.Server(horizonUrl, {
+    allowHttp: horizonUrl.startsWith('http://'),
+  });
+
+  let sponsor: Keypair;
+  try {
+    sponsor = parseStellarSpendSponsorKeypair();
+  } catch {
+    return {
+      ok: false,
+      error: spendRailErrorWalletReadinessFailed(),
+    };
+  }
+
+  if (readinessRow.status === 'needs_review') {
+    const addr = readinessRow.rail_user_wallet_address?.trim() ?? null;
+    if (!addr) {
+      return { ok: true, status: 'needs_review', address: null };
+    }
+    try {
+      const acct = await loadAccountOrNull(server, addr);
+      if (acct && hasUsdcTrustline(acct, usdcCode, usdcIssuer)) {
+        stepMeta = mergeMeta(stepMeta, {
+          current_step:
+            STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+          trustline_confirmed: true,
+        });
+        await updateSpendWalletReadinessFields(rowId, {
+          status: 'completed',
+          rail_user_wallet_address: addr,
+          step_metadata: stepMeta,
+          sanitized_error_category: null,
+          sanitized_error_code: null,
+          internal_diagnostics: null,
+        });
+        await updateSpendSessionRailUserWalletAddress(spendSessionId, addr);
+        return { ok: true, status: 'completed', address: addr };
+      }
+    } catch {
+      return { ok: true, status: 'needs_review', address: addr };
+    }
+    return { ok: true, status: 'needs_review', address: addr };
+  }
+
+  if (
+    readinessRow.status === 'pending' &&
+    isStellarReadinessSubmittedMetadataStale(stepMeta) &&
+    (typeof stepMeta.activation_tx_hash === 'string' ||
+      typeof stepMeta.trustline_tx_hash === 'string')
+  ) {
+    stepMeta = mergeMeta(stepMeta, {
+      current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+      stale_submitted: true,
+    });
+    await updateSpendWalletReadinessFields(rowId, {
+      status: 'needs_review',
+      step_metadata: stepMeta,
+      sanitized_error_category: 'wallet_readiness_failed',
+      sanitized_error_code: 'spend_rail_wallet_readiness_needs_review',
+      internal_diagnostics: { reason: 'stale_submitted_setup' },
+    });
+    return {
+      ok: true,
+      status: 'needs_review',
+      address: readinessRow.rail_user_wallet_address?.trim() ?? null,
+    };
+  }
+
+  let stellar: Awaited<ReturnType<typeof ensureStellarRailUserWallet>>;
+  try {
+    stellar = await ensureStellarRailUserWallet(sessionOwnerPrivyUserId);
+  } catch {
+    return { ok: false, error: spendRailErrorWalletUnavailable() };
+  }
+
+  const userPub = stellar.address.trim();
+  let walletId = stellar.walletId?.trim();
+  if (!walletId) {
+    try {
+      walletId = await resolveStellarPrivyWalletIdForUser(
+        sessionOwnerPrivyUserId,
+        userPub
+      );
+    } catch {
+      return { ok: false, error: spendRailErrorWalletUnavailable() };
+    }
+  }
+
+  stepMeta = mergeMeta(stepMeta, {
+    current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.wallet_provisioning,
+    stellar_wallet_provisioned: stellar.provisioned,
+  });
+  await updateSpendWalletReadinessFields(rowId, {
+    rail_user_wallet_address: userPub,
+    step_metadata: stepMeta,
+  });
+
+  let userAccount = await loadAccountOrNull(server, userPub);
+
+  const existingActivationHash =
+    typeof stepMeta.activation_tx_hash === 'string'
+      ? stepMeta.activation_tx_hash.trim()
+      : '';
+  if (!userAccount && existingActivationHash) {
+    const actPoll = await waitForHorizonTxSuccess(
+      server,
+      existingActivationHash
+    );
+    if (actPoll === 'pending') {
+      stepMeta = mergeMeta(stepMeta, {
+        current_step:
+          STELLAR_WALLET_READINESS_CURRENT_STEP.account_activation_confirming,
+      });
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'pending',
+        step_metadata: stepMeta,
+      });
+      return { ok: true, status: 'pending', address: userPub };
+    }
+    if (actPoll === 'failed') {
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'failed',
+        sanitized_error_category: 'wallet_readiness_failed',
+        sanitized_error_code: 'spend_rail_wallet_readiness_failed',
+        internal_diagnostics: { activation_tx_hash: existingActivationHash },
+      });
+      return { ok: false, error: spendRailErrorWalletReadinessFailed() };
+    }
+    userAccount = await loadAccountOrNull(server, userPub);
+  }
+
+  if (!userAccount) {
+    stepMeta = mergeMeta(stepMeta, {
+      current_step:
+        STELLAR_WALLET_READINESS_CURRENT_STEP.account_activation_submitting,
+    });
+    await updateSpendWalletReadinessFields(rowId, { step_metadata: stepMeta });
+
+    let sponsorAccount: Horizon.AccountResponse;
+    try {
+      sponsorAccount = await server.loadAccount(sponsor.publicKey());
+    } catch (e) {
+      return { ok: false, error: classifyHorizonSubmit(e) };
+    }
+
+    const startBal = getStellarSpendCreateAccountStartingBalance();
+    const activationTx = new TransactionBuilder(sponsorAccount, {
+      fee: (await server.fetchBaseFee()).toString(),
+      networkPassphrase: passphrase,
+    })
+      .addOperation(
+        Operation.createAccount({
+          destination: userPub,
+          startingBalance: startBal,
+        })
+      )
+      .setTimeout(180)
+      .build();
+    activationTx.sign(sponsor);
+
+    let sponsorTreasuryId: string | null =
+      readinessRow.sponsor_treasury_transaction_id;
+    if (spendExperienceId && !sponsorTreasuryId) {
+      const corr = crypto.randomUUID();
+      try {
+        sponsorTreasuryId = await insertTreasuryStellarSetupRow({
+          spendExperienceId,
+          transactionType: 'stellar_account_activation',
+          fromWalletAddress: sponsor.publicKey(),
+          toWalletAddress: userPub,
+          pendingTxCorrelation: corr,
+        });
+      } catch (e) {
+        console.error('insertTreasuryStellarSetupRow activation:', e);
+      }
+    }
+
+    if (sponsorTreasuryId) {
+      await updateSpendWalletReadinessFields(rowId, {
+        sponsor_treasury_transaction_id: sponsorTreasuryId,
+      });
+    }
+
+    let activationHash: string;
+    try {
+      const res = await server.submitTransaction(activationTx);
+      activationHash = res.hash;
+    } catch (e) {
+      return { ok: false, error: classifyHorizonSubmit(e) };
+    }
+
+    stepMeta = mergeMeta(stepMeta, {
+      current_step:
+        STELLAR_WALLET_READINESS_CURRENT_STEP.account_activation_confirming,
+      activation_tx_hash: activationHash,
+      activation_tx_submitted_at: new Date().toISOString(),
+    });
+    await updateSpendWalletReadinessFields(rowId, { step_metadata: stepMeta });
+
+    const actOutcome = await waitForHorizonTxSuccess(server, activationHash);
+    if (actOutcome === 'pending') {
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'pending',
+        step_metadata: stepMeta,
+      });
+      return { ok: true, status: 'pending', address: userPub };
+    }
+    if (actOutcome === 'failed') {
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'failed',
+        sanitized_error_category: 'wallet_readiness_failed',
+        sanitized_error_code: 'spend_rail_wallet_readiness_failed',
+        internal_diagnostics: { activation_tx_hash: activationHash },
+      });
+      return { ok: false, error: spendRailErrorWalletReadinessFailed() };
+    }
+
+    if (sponsorTreasuryId && spendExperienceId) {
+      const explorerUrl = explorerTxUrlForSpendLedger(
+        'stellar_usdc',
+        activationHash
+      );
+      try {
+        await finalizeTreasuryStellarSetupRow({
+          id: sponsorTreasuryId,
+          txHashNormalized: activationHash.toLowerCase(),
+          explorerTxUrl: explorerUrl,
+          status: 'confirmed',
+        });
+      } catch (e) {
+        console.error('finalizeTreasuryStellarSetupRow activation:', e);
+      }
+    }
+
+    userAccount = await loadAccountOrNull(server, userPub);
+    if (!userAccount) {
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'needs_review',
+        internal_diagnostics: { activation_tx_hash: activationHash },
+      });
+      return { ok: true, status: 'needs_review', address: userPub };
+    }
+  }
+
+  if (hasUsdcTrustline(userAccount, usdcCode, usdcIssuer)) {
+    stepMeta = mergeMeta(stepMeta, {
+      current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+      trustline_confirmed: true,
+    });
+    await updateSpendWalletReadinessFields(rowId, {
+      status: 'completed',
+      rail_user_wallet_address: userPub,
+      step_metadata: stepMeta,
+      sanitized_error_category: null,
+      sanitized_error_code: null,
+      internal_diagnostics: null,
+    });
+    await updateSpendSessionRailUserWalletAddress(spendSessionId, userPub);
+    return { ok: true, status: 'completed', address: userPub };
+  }
+
+  const existingTrustHash =
+    typeof stepMeta.trustline_tx_hash === 'string'
+      ? stepMeta.trustline_tx_hash.trim()
+      : '';
+  if (existingTrustHash) {
+    const trustPoll = await waitForHorizonTxSuccess(server, existingTrustHash);
+    if (trustPoll === 'pending') {
+      stepMeta = mergeMeta(stepMeta, {
+        current_step:
+          STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+      });
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'pending',
+        rail_user_wallet_address: userPub,
+        step_metadata: stepMeta,
+      });
+      return { ok: true, status: 'pending', address: userPub };
+    }
+    if (trustPoll === 'failed') {
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'failed',
+        sanitized_error_category: 'wallet_readiness_failed',
+        sanitized_error_code: 'spend_rail_wallet_readiness_failed',
+        internal_diagnostics: { trustline_tx_hash: existingTrustHash },
+      });
+      return { ok: false, error: spendRailErrorWalletReadinessFailed() };
+    }
+    const recheck = await loadAccountOrNull(server, userPub);
+    if (recheck && hasUsdcTrustline(recheck, usdcCode, usdcIssuer)) {
+      stepMeta = mergeMeta(stepMeta, {
+        current_step:
+          STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+        trustline_confirmed: true,
+      });
+      await updateSpendWalletReadinessFields(rowId, {
+        status: 'completed',
+        rail_user_wallet_address: userPub,
+        step_metadata: stepMeta,
+        sanitized_error_category: null,
+        sanitized_error_code: null,
+        internal_diagnostics: null,
+      });
+      await updateSpendSessionRailUserWalletAddress(spendSessionId, userPub);
+      return { ok: true, status: 'completed', address: userPub };
+    }
+    await updateSpendWalletReadinessFields(rowId, {
+      status: 'needs_review',
+      rail_user_wallet_address: userPub,
+      internal_diagnostics: { trustline_tx_hash: existingTrustHash },
+    });
+    return { ok: true, status: 'needs_review', address: userPub };
+  }
+
+  const usdcAsset = new Asset(usdcCode, usdcIssuer);
+
+  stepMeta = mergeMeta(stepMeta, {
+    current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_submitting,
+  });
+  await updateSpendWalletReadinessFields(rowId, { step_metadata: stepMeta });
+
+  const inner = new TransactionBuilder(userAccount, {
+    fee: '0',
+    networkPassphrase: passphrase,
+  })
+    .addOperation(
+      Operation.beginSponsoringFutureReserves({
+        sponsoredId: userPub,
+        source: sponsor.publicKey(),
+      })
+    )
+    .addOperation(
+      Operation.changeTrust({
+        asset: usdcAsset,
+        limit: '9223372036854775807',
+      })
+    )
+    .addOperation(
+      Operation.endSponsoringFutureReserves({
+        source: sponsor.publicKey(),
+      })
+    )
+    .setTimeout(180)
+    .build();
+
+  inner.sign(sponsor);
+
+  const hash32 = inner.hash();
+  let userSig: Buffer;
+  try {
+    userSig = await privyWalletRawSignTransactionHash({
+      walletId,
+      hash32,
+    });
+  } catch (e) {
+    return { ok: false, error: classifyHorizonSubmit(e) };
+  }
+
+  const userKp = Keypair.fromPublicKey(userPub);
+  inner.addDecoratedSignature(
+    new xdr.DecoratedSignature({
+      hint: userKp.signatureHint(),
+      signature: userSig,
+    })
+  );
+
+  const baseFee = (await server.fetchBaseFee()).toString();
+  const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+    sponsor,
+    (Number(baseFee) * 10).toString(),
+    inner,
+    passphrase
+  );
+  feeBump.sign(sponsor);
+
+  let trustlineTreasuryId: string | null =
+    readinessRow.trustline_treasury_transaction_id;
+  if (spendExperienceId && !trustlineTreasuryId) {
+    const corr = crypto.randomUUID();
+    try {
+      trustlineTreasuryId = await insertTreasuryStellarSetupRow({
+        spendExperienceId,
+        transactionType: 'stellar_usdc_trustline_setup',
+        fromWalletAddress: sponsor.publicKey(),
+        toWalletAddress: userPub,
+        pendingTxCorrelation: corr,
+      });
+    } catch (e) {
+      console.error('insertTreasuryStellarSetupRow trustline:', e);
+    }
+  }
+  if (trustlineTreasuryId) {
+    await updateSpendWalletReadinessFields(rowId, {
+      trustline_treasury_transaction_id: trustlineTreasuryId,
+    });
+  }
+
+  let trustHash: string;
+  try {
+    const res = await server.submitTransaction(feeBump);
+    trustHash = res.hash;
+  } catch (e) {
+    return { ok: false, error: classifyHorizonSubmit(e) };
+  }
+
+  stepMeta = mergeMeta(stepMeta, {
+    current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+    trustline_tx_hash: trustHash,
+    trustline_tx_submitted_at: new Date().toISOString(),
+  });
+  await updateSpendWalletReadinessFields(rowId, { step_metadata: stepMeta });
+
+  const trustOutcome = await waitForHorizonTxSuccess(server, trustHash);
+  if (trustOutcome === 'pending') {
+    await updateSpendWalletReadinessFields(rowId, {
+      status: 'pending',
+      rail_user_wallet_address: userPub,
+      step_metadata: stepMeta,
+    });
+    return { ok: true, status: 'pending', address: userPub };
+  }
+  if (trustOutcome === 'failed') {
+    await updateSpendWalletReadinessFields(rowId, {
+      status: 'failed',
+      sanitized_error_category: 'wallet_readiness_failed',
+      sanitized_error_code: 'spend_rail_wallet_readiness_failed',
+      internal_diagnostics: { trustline_tx_hash: trustHash },
+    });
+    return { ok: false, error: spendRailErrorWalletReadinessFailed() };
+  }
+
+  if (trustlineTreasuryId && spendExperienceId) {
+    const trustExplorer = explorerTxUrlForSpendLedger(
+      'stellar_usdc',
+      trustHash
+    );
+    try {
+      await finalizeTreasuryStellarSetupRow({
+        id: trustlineTreasuryId,
+        txHashNormalized: trustHash.toLowerCase(),
+        explorerTxUrl: trustExplorer,
+        status: 'confirmed',
+      });
+    } catch (e) {
+      console.error('finalizeTreasuryStellarSetupRow trustline:', e);
+    }
+  }
+
+  const refreshed = await loadAccountOrNull(server, userPub);
+  if (!refreshed || !hasUsdcTrustline(refreshed, usdcCode, usdcIssuer)) {
+    await updateSpendWalletReadinessFields(rowId, {
+      status: 'needs_review',
+      rail_user_wallet_address: userPub,
+      internal_diagnostics: { trustline_tx_hash: trustHash },
+    });
+    return { ok: true, status: 'needs_review', address: userPub };
+  }
+
+  stepMeta = mergeMeta(stepMeta, {
+    current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_confirming,
+    trustline_confirmed: true,
+  });
+  await updateSpendWalletReadinessFields(rowId, {
+    status: 'completed',
+    rail_user_wallet_address: userPub,
+    step_metadata: stepMeta,
+    sanitized_error_category: null,
+    sanitized_error_code: null,
+    internal_diagnostics: null,
+  });
+  await updateSpendSessionRailUserWalletAddress(spendSessionId, userPub);
+  return { ok: true, status: 'completed', address: userPub };
+}

--- a/lib/spend/stellar-wallet-readiness-stale.test.ts
+++ b/lib/spend/stellar-wallet-readiness-stale.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isStellarReadinessSubmittedMetadataStale,
+  STELLAR_WALLET_READINESS_STALE_SUBMITTED_MS,
+} from '@/lib/spend/stellar-wallet-readiness-stale';
+
+describe('isStellarReadinessSubmittedMetadataStale', () => {
+  it('returns false when no submitted timestamps exist', () => {
+    expect(isStellarReadinessSubmittedMetadataStale({}, 1_000_000_000)).toBe(
+      false
+    );
+  });
+
+  it('returns true when oldest submitted timestamp exceeds stale window', () => {
+    const t0 = new Date('2026-01-01T00:00:00.000Z').getTime();
+    expect(
+      isStellarReadinessSubmittedMetadataStale(
+        {
+          activation_tx_submitted_at: new Date(
+            t0 - STELLAR_WALLET_READINESS_STALE_SUBMITTED_MS - 60_000
+          ).toISOString(),
+        },
+        t0
+      )
+    ).toBe(true);
+  });
+
+  it('returns false just inside the stale window', () => {
+    const t0 = new Date('2026-01-01T12:00:00.000Z').getTime();
+    expect(
+      isStellarReadinessSubmittedMetadataStale(
+        {
+          trustline_tx_submitted_at: new Date(
+            t0 - STELLAR_WALLET_READINESS_STALE_SUBMITTED_MS + 5_000
+          ).toISOString(),
+        },
+        t0
+      )
+    ).toBe(false);
+  });
+});

--- a/lib/spend/stellar-wallet-readiness-stale.ts
+++ b/lib/spend/stellar-wallet-readiness-stale.ts
@@ -1,0 +1,27 @@
+const STALE_SUBMITTED_MS = 15 * 60 * 1000;
+
+export const STELLAR_WALLET_READINESS_STALE_SUBMITTED_MS = STALE_SUBMITTED_MS;
+
+function parseIsoMs(iso: unknown): number | null {
+  if (typeof iso !== 'string') return null;
+  const t = Date.parse(iso);
+  return Number.isFinite(t) ? t : null;
+}
+
+/**
+ * Whether submitted activation/trustline setup is older than the product stale window.
+ * Used to move ambiguous on-ledger setup into `needs_review` (IRL-18).
+ */
+export function isStellarReadinessSubmittedMetadataStale(
+  meta: Record<string, unknown>,
+  nowMs: number = Date.now()
+): boolean {
+  const candidates: number[] = [];
+  const a = parseIsoMs(meta.activation_tx_submitted_at);
+  const b = parseIsoMs(meta.trustline_tx_submitted_at);
+  if (a) candidates.push(a);
+  if (b) candidates.push(b);
+  if (candidates.length === 0) return false;
+  const oldest = Math.min(...candidates);
+  return nowMs - oldest > STALE_SUBMITTED_MS;
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -402,7 +402,9 @@ export type SpendTransaction = {
 export type TreasuryTransactionType =
   | 'fund_user'
   | 'receive_payment'
-  | 'admin_recovery';
+  | 'admin_recovery'
+  | 'stellar_account_activation'
+  | 'stellar_usdc_trustline_setup';
 
 export type TreasuryTransactionRowStatus =
   | 'pending'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Hybrid Stellar wallet readiness after Privy resolves the user Stellar address: sponsor key submits `CreateAccount`, fee-bump plus sponsored `changeTrust` for USDC uses Privy `raw_sign`, completion requires Horizon-confirmed account and trustline, and treasury ledger rows use new audit types linked from `spend_wallet_readiness_operations`.

## Key changes

- Orchestration module for activation, trustline, resume or poll of pending txs, stale submitted setup moving the readiness row to `needs_review`, and stable `step_metadata.current_step` strings for clients.
- Server-only Stellar spend config (Horizon URL, network passphrase, USDC issuer with mainnet default, sponsor secret parsing) wired into rail operational diagnostics when Stellar spend is enabled (public network plus valid sponsor seed required).
- Privy REST `raw_sign` helper for signing the Stellar transaction hash.
- `resolveStellarPrivyWalletIdForUser` when the player row lacks a Privy wallet id.
- Stellar USDC rail delegates readiness to orchestration and maps coarse statuses.
- Conversion confirm skips funding until readiness is `completed`; exposes `readiness_pending` and `readiness_needs_review` outcomes; Stellar resume can re-run readiness when conversion is `needs_review` without a funding hash.
- Conversion confirm API includes optional `walletReadiness` for `stellar_usdc` responses.
- Treasury types `stellar_account_activation` and `stellar_usdc_trustline_setup` with insert and finalize helpers; SQL migration extends the check constraint.

## Tests

Unit coverage for stale metadata, Stellar rail with mocked orchestration, spend rail config with sponsor env, Privy wallet id resolution, and conversion confirm route.

## Database and configuration

Apply `database/irl-18-treasury-stellar-setup-types.sql`. Set `SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY` and related variables per `.env.local.example`.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-18](https://linear.app/irlenergy/issue/IRL-18/sponsor-stellar-account-activation-and-usdc-trustline-setup)

<div><a href="https://cursor.com/agents/bc-c6677a67-ebd8-4f11-a657-05068317feef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c6677a67-ebd8-4f11-a657-05068317feef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

