### PR TITLE
feat(spend): explicit conversion retry after safe refund (IRL-17)

### DIFF
--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -107,6 +107,8 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
         funding_tx_hash: '0xabc',
         explorer_tx_url: null,
         idempotency_key: null,
+        conversion_attempt_count: 1,
+        conversion_last_failure: null,
         created_at: '2026-01-01T00:00:00.000Z',
         completed_at: '2026-01-01T00:00:01.000Z',
         failed_reason: null,
@@ -114,6 +116,7 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
       },
       session: { ...session, status: 'conversion_complete' as const },
       resumed: false,
+      clientHint: 'funded',
     });
 
     const req = new NextRequest(
@@ -133,6 +136,14 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
     };
     expect(json.success).toBe(true);
     expect(json.data.pointConversion.status).toBe('funded');
+    expect((json as { data: { clientHint?: string } }).data.clientHint).toBe(
+      'funded'
+    );
+    expect(mockRunConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'confirm',
+      })
+    );
     expect(
       (json as { data: { spendExperience: { spend_rail: string } } }).data
         .spendExperience.spend_rail
@@ -181,6 +192,68 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
         route: '/api/spend-sessions/[sessionId]/conversion/confirm',
         operation: 'spend_conversion_confirm',
         statusCode: 400,
+      })
+    );
+  });
+
+  it('forwards retry_conversion intent to domain logic', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: true,
+      userId: 'privy-1',
+    });
+    mockGetPrivyUserId.mockResolvedValue('privy-1');
+    mockGetSpendContext.mockResolvedValue({
+      session,
+      spendExperience,
+      usdcAmount: 5,
+      pointsRequired: 5000,
+    });
+    mockResolve.mockReturnValue('distinct-1');
+    mockRunConfirm.mockResolvedValue({
+      ok: true,
+      pointConversion: {
+        id: 'conv-1',
+        spend_experience_id: spendExperience.id,
+        spend_session_id: session.id,
+        user_id: 'privy-1',
+        points_deducted: 5000,
+        usdc_amount: 5,
+        status: 'points_deducted',
+        spend_rail: 'base_usdc',
+        network: 'Base',
+        asset_symbol: 'USDC',
+        treasury_wallet_address: spendExperience.treasury_wallet_address,
+        user_wallet_address: session.wallet_address,
+        funding_tx_hash: null,
+        explorer_tx_url: null,
+        idempotency_key: 'fund_user:conv-1',
+        conversion_attempt_count: 2,
+        conversion_last_failure: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        completed_at: null,
+        failed_reason: null,
+        updated_at: '2026-01-01T00:00:01.000Z',
+      },
+      session: { ...session, status: 'conversion_pending' as const },
+      resumed: true,
+      clientHint: 'processing',
+    });
+
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/conversion/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: session.wallet_address,
+          intent: 'retry_conversion',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(200);
+    expect(mockRunConfirm).toHaveBeenCalledWith(
+      expect.objectContaining({
+        intent: 'retry_conversion',
       })
     );
   });

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -22,6 +22,7 @@ type RouteParams = { params: { sessionId: string } };
 /**
  * POST /api/spend-sessions/{sessionId}/conversion/confirm
  * Atomically deducts points, creates point conversion, sends treasury USDC to the user wallet (PRD §11).
+ * Optional body `intent`: `confirm` (default) or `retry_conversion` after a safe refunded failure (IRL-17).
  */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const sessionId = params.sessionId;
@@ -83,6 +84,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       distinctId,
       usdcAmount,
       pointsRequired,
+      intent: parsed.data.intent,
     });
 
     if (!result.ok) {
@@ -124,6 +126,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       },
       spendRailSummary: getSpendRailClientSummary(spendExperience.spend_rail),
       resumed: result.resumed,
+      clientHint: result.clientHint,
       ...(walletReadiness ? { walletReadiness } : {}),
     });
   } catch (e) {

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -530,15 +530,16 @@ export function SpendExperiencePage({
     Boolean(elig?.status && isPostPointsConversionFlow(elig.status)) &&
     !showPayDirectUsdc;
 
-  const showConvert =
-    elig?.status === 'eligible' &&
-    preview &&
+  const sessionAllowsConversionActions =
+    Boolean(preview) &&
     (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
+
+  const showConvert =
+    elig?.status === 'eligible' && sessionAllowsConversionActions;
 
   const showRetryConversion =
     elig?.status === 'conversion_failed_retryable' &&
-    preview &&
-    (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
+    sessionAllowsConversionActions;
 
   const showBaseWalletPay =
     !isPaymentComplete &&

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -152,8 +152,7 @@ function eligibilityToneClass(status: SpendEligibilityStatus): string {
     status === 'eligible' ||
     status === 'ready_for_payment' ||
     status === 'ready_for_payment_own_usdc' ||
-    status === 'payment_complete' ||
-    status === 'conversion_failed_retryable'
+    status === 'payment_complete'
   ) {
     return 'body-small font-grotesk text-emerald-800';
   }
@@ -169,9 +168,7 @@ function isPostPointsConversionFlow(status: SpendEligibilityStatus): boolean {
     status === 'ready_for_payment' ||
     status === 'conversion_in_progress' ||
     status === 'payment_failed' ||
-    status === 'payment_complete' ||
-    status === 'conversion_failed_retryable' ||
-    status === 'conversion_failed_retry_exhausted'
+    status === 'payment_complete'
   );
 }
 

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -7,6 +7,7 @@ import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { SpendPageShell } from '@/components/spend/spend-page-shell';
 import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
+import { Button } from '@/components/ui/button';
 import type {
   PointConversion,
   SpendExperience,
@@ -71,6 +72,7 @@ type ConversionConfirmResponse = {
   };
   spendRailSummary: SpendRailClientSummary;
   resumed: boolean;
+  clientHint: 'funded' | 'processing';
 };
 
 type PaymentConfirmResponse = {
@@ -150,9 +152,13 @@ function eligibilityToneClass(status: SpendEligibilityStatus): string {
     status === 'eligible' ||
     status === 'ready_for_payment' ||
     status === 'ready_for_payment_own_usdc' ||
-    status === 'payment_complete'
+    status === 'payment_complete' ||
+    status === 'conversion_failed_retryable'
   ) {
     return 'body-small font-grotesk text-emerald-800';
+  }
+  if (status === 'conversion_failed_retry_exhausted') {
+    return 'body-small font-grotesk text-red-800';
   }
   return 'body-small font-grotesk text-amber-900';
 }
@@ -163,7 +169,9 @@ function isPostPointsConversionFlow(status: SpendEligibilityStatus): boolean {
     status === 'ready_for_payment' ||
     status === 'conversion_in_progress' ||
     status === 'payment_failed' ||
-    status === 'payment_complete'
+    status === 'payment_complete' ||
+    status === 'conversion_failed_retryable' ||
+    status === 'conversion_failed_retry_exhausted'
   );
 }
 
@@ -322,7 +330,7 @@ export function SpendExperiencePage({
   }, [queryClient, sessionId, experienceId]);
 
   const conversionMutation = useMutation({
-    mutationFn: async () => {
+    mutationFn: async (intent: 'confirm' | 'retry_conversion') => {
       const token = await getAccessToken();
       if (!token || !walletAddress || !sessionId) {
         throw new Error('Missing auth or session');
@@ -330,11 +338,15 @@ export function SpendExperiencePage({
       return spendAuthedPost<ConversionConfirmResponse>(
         token,
         `/api/spend-sessions/${sessionId}/conversion/confirm`,
-        { walletAddress }
+        { walletAddress, intent }
       );
     },
-    onSuccess: async () => {
-      toast.success('USDC is on the way to your wallet.');
+    onSuccess: async (data) => {
+      if (data.clientHint === 'funded') {
+        toast.success('USDC is on the way to your wallet.');
+      } else {
+        toast.success('We are processing your conversion.');
+      }
       await invalidateSpendQueries();
     },
     onError: (e) => {
@@ -523,6 +535,11 @@ export function SpendExperiencePage({
     preview &&
     (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
 
+  const showRetryConversion =
+    elig?.status === 'conversion_failed_retryable' &&
+    preview &&
+    (sessionStatus === 'created' || sessionStatus === 'conversion_pending');
+
   const showBaseWalletPay =
     !isPaymentComplete &&
     (elig?.status === 'ready_for_payment' ||
@@ -695,12 +712,30 @@ export function SpendExperiencePage({
                     {showConvert && (
                       <SpendPrimaryButton
                         pending={conversionMutation.isPending}
-                        onClick={() => conversionMutation.mutate()}
+                        onClick={() => conversionMutation.mutate('confirm')}
                       >
                         {conversionMutation.isPending
                           ? 'Converting…'
                           : `Convert points to ${assetSymbol}`}
                       </SpendPrimaryButton>
+                    )}
+
+                    {showRetryConversion && (
+                      <div className="flex flex-col gap-2">
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="h-[44px] w-full border-[#171717] font-grotesk text-[#171717]"
+                          disabled={conversionMutation.isPending}
+                          onClick={() =>
+                            conversionMutation.mutate('retry_conversion')
+                          }
+                        >
+                          {conversionMutation.isPending
+                            ? 'Retrying…'
+                            : 'Retry conversion'}
+                        </Button>
+                      </div>
                     )}
 
                     {showBaseWalletPay && (

--- a/database/point-conversions-retry-metadata.sql
+++ b/database/point-conversions-retry-metadata.sql
@@ -1,0 +1,281 @@
+-- IRL-17: audit metadata for explicit conversion retries after safe refund.
+
+ALTER TABLE point_conversions
+  ADD COLUMN IF NOT EXISTS conversion_attempt_count INTEGER NOT NULL DEFAULT 1,
+  ADD COLUMN IF NOT EXISTS conversion_last_failure JSONB;
+
+COMMENT ON COLUMN point_conversions.conversion_attempt_count IS
+  'Number of point-deduction attempts for this session conversion (1 on first confirm; incremented on each explicit retry). Max 4 attempts total.';
+
+COMMENT ON COLUMN point_conversions.conversion_last_failure IS
+  'Last terminal failure metadata after a safe points refund (timestamps, phase, category, snippet) for support.';
+
+UPDATE point_conversions
+SET conversion_attempt_count = 1
+WHERE conversion_attempt_count IS NULL;
+
+-- After a refunded failure, deduct points again and reset the row for a new funding attempt (same conversion id / idempotency key).
+CREATE OR REPLACE FUNCTION retry_spend_conversion_after_refund_atomic(
+  p_spend_session_id UUID,
+  p_user_id TEXT,
+  p_wallet_address TEXT,
+  p_spend_experience_id UUID,
+  p_points_to_deduct INTEGER,
+  p_usdc_amount NUMERIC(24, 8)
+) RETURNS TABLE (
+  outcome TEXT,
+  conversion_id UUID,
+  player_total_points INTEGER
+) AS $$
+DECLARE
+  v_session spend_sessions%ROWTYPE;
+  v_conv point_conversions%ROWTYPE;
+  v_player_id BIGINT;
+  v_player_total INTEGER;
+BEGIN
+  IF p_points_to_deduct IS NULL OR p_points_to_deduct <= 0 THEN
+    RAISE EXCEPTION 'Invalid points amount';
+  END IF;
+
+  IF p_usdc_amount IS NULL OR p_usdc_amount <= 0 THEN
+    RAISE EXCEPTION 'Invalid USDC amount';
+  END IF;
+
+  SELECT *
+  INTO v_session
+  FROM spend_sessions
+  WHERE id = p_spend_session_id
+  FOR UPDATE;
+
+  IF v_session.id IS NULL THEN
+    RAISE EXCEPTION 'Spend session not found';
+  END IF;
+
+  IF v_session.user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Session does not belong to this user';
+  END IF;
+
+  IF lower(trim(v_session.wallet_address)) IS DISTINCT FROM lower(trim(p_wallet_address)) THEN
+    RAISE EXCEPTION 'Wallet does not match this session';
+  END IF;
+
+  IF v_session.spend_experience_id IS DISTINCT FROM p_spend_experience_id THEN
+    RAISE EXCEPTION 'Spend experience mismatch';
+  END IF;
+
+  SELECT *
+  INTO v_conv
+  FROM point_conversions
+  WHERE spend_session_id = p_spend_session_id
+  FOR UPDATE;
+
+  IF v_conv.id IS NULL THEN
+    RAISE EXCEPTION 'No conversion for session';
+  END IF;
+
+  IF v_conv.status IS DISTINCT FROM 'failed' THEN
+    RAISE EXCEPTION 'Conversion is not in a retryable failed state';
+  END IF;
+
+  IF v_conv.conversion_attempt_count >= 4 THEN
+    RAISE EXCEPTION 'Conversion retry limit reached';
+  END IF;
+
+  IF v_conv.user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Conversion does not belong to this user';
+  END IF;
+
+  IF v_conv.points_deducted::INTEGER IS DISTINCT FROM p_points_to_deduct THEN
+    RAISE EXCEPTION 'Points amount mismatch';
+  END IF;
+
+  IF v_conv.usdc_amount IS DISTINCT FROM p_usdc_amount THEN
+    RAISE EXCEPTION 'USDC amount mismatch';
+  END IF;
+
+  SELECT id, COALESCE(total_points, 0)::INTEGER
+  INTO v_player_id, v_player_total
+  FROM players
+  WHERE lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found';
+  END IF;
+
+  IF v_player_total < p_points_to_deduct THEN
+    RAISE EXCEPTION 'Insufficient points';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) - p_points_to_deduct,
+      updated_at = NOW()
+  WHERE id = v_player_id
+  RETURNING total_points::INTEGER INTO v_player_total;
+
+  UPDATE point_conversions
+  SET
+    conversion_attempt_count = conversion_attempt_count + 1,
+    status = 'points_deducted',
+    failed_reason = NULL,
+    completed_at = NULL,
+    funding_tx_hash = NULL,
+    explorer_tx_url = NULL,
+    updated_at = NOW()
+  WHERE id = v_conv.id;
+
+  RETURN QUERY SELECT 'retried'::TEXT, v_conv.id, v_player_total;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION retry_spend_conversion_after_refund_atomic IS
+  'Spend pilot: after a safe refund to status failed, deduct points again and reset the same conversion row for an explicit user retry (IRL-17).';
+
+-- Ensure new inserts set attempt count explicitly (default covers, but keep function self-documenting).
+CREATE OR REPLACE FUNCTION confirm_spend_conversion_atomic(
+  p_spend_session_id UUID,
+  p_user_id TEXT,
+  p_wallet_address TEXT,
+  p_spend_experience_id UUID,
+  p_points_to_deduct INTEGER,
+  p_usdc_amount NUMERIC(24, 8),
+  p_treasury_wallet_address TEXT,
+  p_user_wallet_address TEXT
+) RETURNS TABLE (
+  outcome TEXT,
+  conversion_id UUID,
+  player_total_points INTEGER
+) AS $$
+DECLARE
+  v_session spend_sessions%ROWTYPE;
+  v_existing_id UUID;
+  v_player_id BIGINT;
+  v_player_total INTEGER;
+  v_funded_exists BOOLEAN;
+BEGIN
+  IF p_points_to_deduct IS NULL OR p_points_to_deduct <= 0 THEN
+    RAISE EXCEPTION 'Invalid points amount';
+  END IF;
+
+  IF p_usdc_amount IS NULL OR p_usdc_amount <= 0 THEN
+    RAISE EXCEPTION 'Invalid USDC amount';
+  END IF;
+
+  SELECT *
+  INTO v_session
+  FROM spend_sessions
+  WHERE id = p_spend_session_id
+  FOR UPDATE;
+
+  IF v_session.id IS NULL THEN
+    RAISE EXCEPTION 'Spend session not found';
+  END IF;
+
+  IF v_session.user_id IS DISTINCT FROM p_user_id THEN
+    RAISE EXCEPTION 'Session does not belong to this user';
+  END IF;
+
+  IF lower(trim(v_session.wallet_address)) IS DISTINCT FROM lower(trim(p_wallet_address)) THEN
+    RAISE EXCEPTION 'Wallet does not match this session';
+  END IF;
+
+  IF v_session.spend_experience_id IS DISTINCT FROM p_spend_experience_id THEN
+    RAISE EXCEPTION 'Spend experience mismatch';
+  END IF;
+
+  SELECT pc.id
+  INTO v_existing_id
+  FROM point_conversions pc
+  WHERE pc.spend_session_id = p_spend_session_id
+  LIMIT 1;
+
+  IF v_existing_id IS NOT NULL THEN
+    SELECT COALESCE(total_points, 0)::INTEGER
+    INTO v_player_total
+    FROM players
+    WHERE lower(trim(wallet_address)) = lower(trim(p_wallet_address));
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'Player not found';
+    END IF;
+
+    RETURN QUERY SELECT 'already_exists'::TEXT, v_existing_id, v_player_total;
+    RETURN;
+  END IF;
+
+  SELECT EXISTS (
+    SELECT 1
+    FROM point_conversions pc
+    WHERE pc.spend_experience_id = p_spend_experience_id
+      AND pc.user_id = p_user_id
+      AND pc.status = 'funded'
+  )
+  INTO v_funded_exists;
+
+  IF v_funded_exists THEN
+    RAISE EXCEPTION 'Already converted for this spend experience';
+  END IF;
+
+  SELECT id, COALESCE(total_points, 0)::INTEGER
+  INTO v_player_id, v_player_total
+  FROM players
+  WHERE lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF v_player_id IS NULL THEN
+    RAISE EXCEPTION 'Player not found';
+  END IF;
+
+  IF v_player_total < p_points_to_deduct THEN
+    RAISE EXCEPTION 'Insufficient points';
+  END IF;
+
+  UPDATE players
+  SET total_points = COALESCE(total_points, 0) - p_points_to_deduct,
+      updated_at = NOW()
+  WHERE id = v_player_id
+  RETURNING total_points::INTEGER INTO v_player_total;
+
+  INSERT INTO point_conversions (
+    spend_experience_id,
+    spend_session_id,
+    user_id,
+    points_deducted,
+    usdc_amount,
+    status,
+    treasury_wallet_address,
+    user_wallet_address,
+    spend_rail,
+    network,
+    asset_symbol,
+    conversion_attempt_count
+  )
+  VALUES (
+    p_spend_experience_id,
+    p_spend_session_id,
+    p_user_id,
+    p_points_to_deduct,
+    p_usdc_amount,
+    'points_deducted',
+    p_treasury_wallet_address,
+    p_user_wallet_address,
+    COALESCE(v_session.spend_rail, 'base_usdc'),
+    CASE COALESCE(v_session.spend_rail, 'base_usdc')
+      WHEN 'stellar_usdc' THEN 'Stellar'
+      ELSE 'Base'
+    END,
+    'USDC',
+    1
+  )
+  RETURNING id INTO v_existing_id;
+
+  RETURN QUERY SELECT 'created'::TEXT, v_existing_id, v_player_total;
+
+EXCEPTION
+  WHEN unique_violation THEN
+    RAISE EXCEPTION 'Conversion already in progress';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION confirm_spend_conversion_atomic IS
+  'Spend pilot: atomically deduct points and create point_conversions row (pending). Idempotent per session if row exists.';

--- a/database/point-conversions-retry-metadata.sql
+++ b/database/point-conversions-retry-metadata.sql
@@ -5,14 +5,12 @@ ALTER TABLE point_conversions
   ADD COLUMN IF NOT EXISTS conversion_last_failure JSONB;
 
 COMMENT ON COLUMN point_conversions.conversion_attempt_count IS
-  'Number of point-deduction attempts for this session conversion (1 on first confirm; incremented on each explicit retry). Max 4 attempts total.';
+  'Number of point-deduction attempts for this session conversion (1 on first confirm; incremented on each explicit retry). Capped at MAX_SPEND_CONVERSION_POINT_DEDUCTION_ATTEMPTS in lib/spend-eligibility-messages.ts (must match retry RPC).';
 
 COMMENT ON COLUMN point_conversions.conversion_last_failure IS
   'Last terminal failure metadata after a safe points refund (timestamps, phase, category, snippet) for support.';
 
-UPDATE point_conversions
-SET conversion_attempt_count = 1
-WHERE conversion_attempt_count IS NULL;
+-- Existing rows receive DEFAULT 1 from ADD COLUMN NOT NULL DEFAULT 1; no separate backfill needed.
 
 -- After a refunded failure, deduct points again and reset the row for a new funding attempt (same conversion id / idempotency key).
 CREATE OR REPLACE FUNCTION retry_spend_conversion_after_refund_atomic(
@@ -77,6 +75,7 @@ BEGIN
     RAISE EXCEPTION 'Conversion is not in a retryable failed state';
   END IF;
 
+  -- Cap must match MAX_SPEND_CONVERSION_POINT_DEDUCTION_ATTEMPTS in lib/spend-eligibility-messages.ts
   IF v_conv.conversion_attempt_count >= 4 THEN
     RAISE EXCEPTION 'Conversion retry limit reached';
   END IF;

--- a/lib/db/spend-ledger-rows.ts
+++ b/lib/db/spend-ledger-rows.ts
@@ -1,6 +1,7 @@
 import { normalizeSpendRail } from './spend-rail';
 import type {
   PointConversion,
+  PointConversionLastFailure,
   SpendSession,
   SpendTransaction,
 } from '@/lib/types';
@@ -36,6 +37,8 @@ export const CONVERSION_COLS = `
   funding_tx_hash,
   explorer_tx_url,
   idempotency_key,
+  conversion_attempt_count,
+  conversion_last_failure,
   created_at,
   completed_at,
   failed_reason,
@@ -120,7 +123,40 @@ export function rowToSpendTransaction(
   };
 }
 
+function rowToConversionLastFailure(
+  raw: unknown
+): PointConversionLastFailure | null {
+  if (raw == null || typeof raw !== 'object') return null;
+  const o = raw as Record<string, unknown>;
+  const recordedAt = o.recorded_at;
+  const phase = o.phase;
+  const category = o.category;
+  const reasonSnippet = o.reason_snippet;
+  if (
+    typeof recordedAt !== 'string' ||
+    (phase !== 'readiness' && phase !== 'funding' && phase !== 'resume') ||
+    typeof category !== 'string' ||
+    typeof reasonSnippet !== 'string'
+  ) {
+    return null;
+  }
+  return {
+    recorded_at: recordedAt,
+    phase,
+    category,
+    reason_snippet: reasonSnippet,
+  };
+}
+
 export function rowToConversion(row: Record<string, unknown>): PointConversion {
+  const attemptRaw = row.conversion_attempt_count;
+  const attemptCount =
+    typeof attemptRaw === 'number' && Number.isFinite(attemptRaw)
+      ? attemptRaw
+      : typeof attemptRaw === 'string'
+        ? Number(attemptRaw)
+        : 1;
+
   return {
     id: String(row.id),
     spend_experience_id: String(row.spend_experience_id),
@@ -140,6 +176,11 @@ export function rowToConversion(row: Record<string, unknown>): PointConversion {
       row.explorer_tx_url == null ? null : String(row.explorer_tx_url),
     idempotency_key:
       row.idempotency_key == null ? null : String(row.idempotency_key),
+    conversion_attempt_count:
+      Number.isFinite(attemptCount) && attemptCount >= 1 ? attemptCount : 1,
+    conversion_last_failure: rowToConversionLastFailure(
+      row.conversion_last_failure
+    ),
     created_at: String(row.created_at),
     completed_at: row.completed_at == null ? null : String(row.completed_at),
     failed_reason: row.failed_reason == null ? null : String(row.failed_reason),

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -183,6 +183,27 @@ export type RetrySpendConversionAfterRefundRpcResult = {
   playerTotalPoints: number;
 };
 
+function readSpendConversionRpcRow(data: unknown): {
+  outcome: string | undefined;
+  conversionId: string | undefined;
+  playerTotalPoints: unknown;
+} {
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || typeof row !== 'object') {
+    return {
+      outcome: undefined,
+      conversionId: undefined,
+      playerTotalPoints: undefined,
+    };
+  }
+  const r = row as Record<string, unknown>;
+  return {
+    outcome: r.outcome as string | undefined,
+    conversionId: r.conversion_id as string | undefined,
+    playerTotalPoints: r.player_total_points,
+  };
+}
+
 /**
  * Atomically deduct points and create `point_conversions` (status `points_deducted`), or return existing
  * conversion for the session. Requires `confirm_spend_conversion_atomic` in the database.
@@ -215,10 +236,8 @@ export async function confirmSpendConversionAtomic(input: {
     throw new Error(error.message || 'confirm_spend_conversion_atomic failed');
   }
 
-  const row = Array.isArray(data) ? data[0] : data;
-  const outcome = row?.outcome as string | undefined;
-  const conversionId = row?.conversion_id as string | undefined;
-  const playerTotalPoints = row?.player_total_points;
+  const { outcome, conversionId, playerTotalPoints } =
+    readSpendConversionRpcRow(data);
 
   if (
     (outcome !== 'created' && outcome !== 'already_exists') ||
@@ -266,10 +285,8 @@ export async function retrySpendConversionAfterRefundAtomic(input: {
     );
   }
 
-  const row = Array.isArray(data) ? data[0] : data;
-  const outcome = row?.outcome as string | undefined;
-  const conversionId = row?.conversion_id as string | undefined;
-  const playerTotalPoints = row?.player_total_points;
+  const { outcome, conversionId, playerTotalPoints } =
+    readSpendConversionRpcRow(data);
 
   if (
     outcome !== 'retried' ||

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -177,6 +177,12 @@ export type ConfirmSpendConversionRpcResult = {
   playerTotalPoints: number;
 };
 
+export type RetrySpendConversionAfterRefundRpcResult = {
+  outcome: 'retried';
+  conversionId: string;
+  playerTotalPoints: number;
+};
+
 /**
  * Atomically deduct points and create `point_conversions` (status `points_deducted`), or return existing
  * conversion for the session. Requires `confirm_spend_conversion_atomic` in the database.
@@ -231,6 +237,57 @@ export async function confirmSpendConversionAtomic(input: {
   };
 }
 
+/**
+ * IRL-17: deduct points again and reset the same `point_conversions` row after a safe refund (`failed`).
+ */
+export async function retrySpendConversionAfterRefundAtomic(input: {
+  spendSessionId: string;
+  userId: string;
+  walletAddress: string;
+  spendExperienceId: string;
+  pointsToDeduct: number;
+  usdcAmount: number;
+}): Promise<RetrySpendConversionAfterRefundRpcResult> {
+  const { data, error } = await supabase.rpc(
+    'retry_spend_conversion_after_refund_atomic',
+    {
+      p_spend_session_id: input.spendSessionId,
+      p_user_id: input.userId,
+      p_wallet_address: input.walletAddress,
+      p_spend_experience_id: input.spendExperienceId,
+      p_points_to_deduct: input.pointsToDeduct,
+      p_usdc_amount: input.usdcAmount,
+    }
+  );
+
+  if (error) {
+    throw new Error(
+      error.message || 'retry_spend_conversion_after_refund_atomic failed'
+    );
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  const outcome = row?.outcome as string | undefined;
+  const conversionId = row?.conversion_id as string | undefined;
+  const playerTotalPoints = row?.player_total_points;
+
+  if (
+    outcome !== 'retried' ||
+    !conversionId ||
+    typeof playerTotalPoints !== 'number'
+  ) {
+    throw new Error(
+      'Unexpected RPC response from retry_spend_conversion_after_refund_atomic'
+    );
+  }
+
+  return {
+    outcome: 'retried',
+    conversionId,
+    playerTotalPoints,
+  };
+}
+
 export async function updatePointConversionFields(
   conversionId: string,
   patch: Partial<
@@ -242,6 +299,8 @@ export async function updatePointConversionFields(
       | 'failed_reason'
       | 'explorer_tx_url'
       | 'idempotency_key'
+      | 'conversion_attempt_count'
+      | 'conversion_last_failure'
     >
   >
 ): Promise<PointConversion> {

--- a/lib/schemas/spend-session.ts
+++ b/lib/schemas/spend-session.ts
@@ -28,6 +28,7 @@ export type SpendConversionPreviewBody = z.infer<
 /** POST /api/spend-sessions/{sessionId}/conversion/confirm */
 export const spendConversionConfirmBodySchema = z.object({
   walletAddress: evmAddressField,
+  intent: z.enum(['confirm', 'retry_conversion']).optional().default('confirm'),
 });
 
 export type SpendConversionConfirmBody = z.infer<

--- a/lib/spend-conversion-confirm.test.ts
+++ b/lib/spend-conversion-confirm.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import {
+  SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION,
+  SPEND_ELIGIBILITY_MESSAGES,
+} from '@/lib/spend-eligibility-messages';
+import type {
+  SpendExperience,
+  SpendSession,
+  PointConversion,
+} from '@/lib/types';
+
+const mockGetPointConversion = vi.fn();
+const mockGetSpendSessionById = vi.fn();
+const mockConfirmAtomic = vi.fn();
+const mockRetryAtomic = vi.fn();
+const mockLoadEligibility = vi.fn();
+const mockGetPlayerByWallet = vi.fn();
+const mockAssertSpendExperienceOpen = vi.fn();
+const mockAssertSpendRailAllows = vi.fn();
+const mockGetSpendPaymentRail = vi.fn();
+const mockGetTreasuryFundingMeta = vi.fn();
+
+vi.mock('@/lib/db/spend-sessions', () => ({
+  getPointConversionBySessionId: (...a: unknown[]) =>
+    mockGetPointConversion(...a),
+  getSpendSessionById: (...a: unknown[]) => mockGetSpendSessionById(...a),
+  confirmSpendConversionAtomic: (...a: unknown[]) => mockConfirmAtomic(...a),
+  retrySpendConversionAfterRefundAtomic: (...a: unknown[]) =>
+    mockRetryAtomic(...a),
+  refundSpendConversionOnFundingFailure: vi.fn(),
+  spendConversionFundingIdempotencyKey: (id: string) => `fund_user:${id}`,
+  updatePointConversionFields: vi.fn(),
+  updateSpendSessionStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerByWallet: (...a: unknown[]) => mockGetPlayerByWallet(...a),
+}));
+
+vi.mock('@/lib/spend-conversion-preview', () => ({
+  computeConversionAmounts: () => ({ usdcAmount: 5, pointsRequired: 5000 }),
+  loadSpendEligibilityForSession: (...a: unknown[]) =>
+    mockLoadEligibility(...a),
+}));
+
+vi.mock('@/lib/spend-experience-guard', () => ({
+  assertSpendExperienceOpenForSessions: (...a: unknown[]) =>
+    mockAssertSpendExperienceOpen(...a),
+}));
+
+vi.mock('@/lib/spend-rail-config', () => ({
+  assertSpendRailAllowsMutatingSpendWork: (...a: unknown[]) =>
+    mockAssertSpendRailAllows(...a),
+  isSpendRailOperational: () => true,
+}));
+
+vi.mock('@/lib/spend-server-wallet', () => ({
+  getSpendTreasuryFundingWalletMeta: (...a: unknown[]) =>
+    mockGetTreasuryFundingMeta(...a),
+}));
+
+vi.mock('@/lib/spend/payment-rails', () => ({
+  getSpendPaymentRail: () => mockGetSpendPaymentRail(),
+}));
+
+vi.mock('@/lib/tier-progression', () => ({
+  checkAndTrackTierProgression: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: () => 'distinct',
+  trackSpendConversionCompleted: vi.fn(),
+  trackSpendConversionConfirmed: vi.fn(),
+  trackSpendConversionFailed: vi.fn(),
+  trackSpendPilotRailMutationBlocked: vi.fn(),
+  trackSpendTreasuryInsufficientFunds: vi.fn(),
+}));
+
+vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
+  findRecentTreasuryUsdcTransfer: vi.fn(),
+  getTreasuryTxReceiptStatus: vi.fn(),
+  isEvmTxHash: vi.fn(),
+}));
+
+vi.mock('@/lib/api/privy', () => ({
+  resolvePrivyServerTransactionHash: vi.fn(),
+}));
+
+vi.mock('@/lib/db/treasury-transactions', () => ({
+  insertTreasuryFundUserLedgerIfAbsent: vi.fn(),
+}));
+
+vi.mock('@/lib/spend-ledger-explorer-url', () => ({
+  explorerTxUrlForSpendLedger: vi.fn(),
+  isStellarTransactionHash: vi.fn(),
+  isValidSpendConversionFundingTxReference: vi.fn(),
+}));
+
+vi.mock('@/lib/spend/spend-conversion-resume-policy', () => ({
+  spendConversionResumeInvokesWalletReadinessOrchestration: () => false,
+}));
+
+vi.mock('@/lib/spend/stellar-treasury-funding', () => ({
+  getStellarTreasuryFundingTxOutcome: vi.fn(),
+}));
+
+import { runSpendConversionConfirm } from '@/lib/spend-conversion-confirm';
+
+const baseSession: SpendSession = {
+  id: 'sess-1',
+  spend_experience_id: 'exp-1',
+  user_id: 'privy-1',
+  wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  spend_rail: 'base_usdc',
+  rail_user_wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  status: 'created',
+  qr_token_hash: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  expires_at: '2026-12-31T00:00:00.000Z',
+  completed_at: null,
+};
+
+const baseExperience: SpendExperience = {
+  id: 'exp-1',
+  title: 'E',
+  description: null,
+  event_id: null,
+  status: 'active',
+  spend_rail: 'base_usdc',
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  privy_server_wallet_id: 'w',
+  server_wallet_address: '0x4444444444444444444444444444444444444444',
+  server_wallet_chain: 'base',
+  server_wallet_created_at: '2026-01-01T00:00:00.000Z',
+  spend_create_idempotency_key: 'k',
+  start_time: '2026-01-01T00:00:00.000Z',
+  end_time: '2030-01-01T00:00:00.000Z',
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+function failedConversion(
+  attemptCount: number,
+  over: Partial<PointConversion> = {}
+): PointConversion {
+  return {
+    id: 'conv-1',
+    spend_experience_id: 'exp-1',
+    spend_session_id: baseSession.id,
+    user_id: 'privy-1',
+    points_deducted: 5000,
+    usdc_amount: 5,
+    status: 'failed',
+    spend_rail: 'base_usdc',
+    network: 'Base',
+    asset_symbol: 'USDC',
+    treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+    user_wallet_address: baseSession.wallet_address,
+    funding_tx_hash: null,
+    explorer_tx_url: null,
+    idempotency_key: 'fund_user:conv-1',
+    conversion_attempt_count: attemptCount,
+    conversion_last_failure: {
+      recorded_at: '2026-01-01T00:00:00.000Z',
+      phase: 'readiness',
+      category: 'test',
+      reason_snippet: 'x',
+    },
+    created_at: '2026-01-01T00:00:00.000Z',
+    completed_at: '2026-01-01T00:00:01.000Z',
+    failed_reason: 'readiness:test',
+    updated_at: '2026-01-01T00:00:01.000Z',
+    ...over,
+  };
+}
+
+describe('runSpendConversionConfirm (IRL-17 retry)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSpendSessionById.mockImplementation(async (id: string) => ({
+      ...baseSession,
+      id,
+    }));
+    mockAssertSpendExperienceOpen.mockReturnValue({ ok: true as const });
+    mockAssertSpendRailAllows.mockReturnValue({ ok: true as const });
+    mockGetTreasuryFundingMeta.mockReturnValue({
+      treasuryAddress: '0x1111111111111111111111111111111111111111',
+    });
+    mockGetSpendPaymentRail.mockReturnValue({
+      getTreasurySpendableBalance: async () => ({
+        ok: true as const,
+        value: 100,
+      }),
+      runWalletReadinessOrchestration: vi.fn(),
+      initiateUserFunding: vi.fn(),
+    });
+  });
+
+  it('rejects confirm intent when conversion is failed (explicit retry required)', async () => {
+    mockGetPointConversion.mockResolvedValue(failedConversion(1));
+    const r = await runSpendConversionConfirm({
+      session: baseSession,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'privy-1',
+      distinctId: 'd',
+      usdcAmount: 5,
+      pointsRequired: 5000,
+      intent: 'confirm',
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.httpStatus).toBe(400);
+    expect(r.error).toBe(SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION);
+    expect(mockRetryAtomic).not.toHaveBeenCalled();
+    expect(mockConfirmAtomic).not.toHaveBeenCalled();
+  });
+
+  it('rejects retry_conversion when there is no failed conversion', async () => {
+    mockGetPointConversion.mockResolvedValue(null);
+    const r = await runSpendConversionConfirm({
+      session: baseSession,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'privy-1',
+      distinctId: 'd',
+      usdcAmount: 5,
+      pointsRequired: 5000,
+      intent: 'retry_conversion',
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.httpStatus).toBe(400);
+    expect(mockRetryAtomic).not.toHaveBeenCalled();
+  });
+
+  it('blocks retry when preview eligibility is not conversion_failed_retryable', async () => {
+    mockGetPointConversion.mockResolvedValue(failedConversion(4));
+    mockLoadEligibility.mockResolvedValue({
+      status: 'conversion_failed_retry_exhausted',
+      message: SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted,
+      preview: null,
+    });
+    const r = await runSpendConversionConfirm({
+      session: baseSession,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'privy-1',
+      distinctId: 'd',
+      usdcAmount: 5,
+      pointsRequired: 5000,
+      intent: 'retry_conversion',
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.error).toBe(
+      SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted
+    );
+    expect(mockRetryAtomic).not.toHaveBeenCalled();
+  });
+
+  it('maps retry RPC retry limit errors to user-facing copy', async () => {
+    mockGetPointConversion.mockResolvedValue(failedConversion(3));
+    mockLoadEligibility.mockResolvedValue({
+      status: 'conversion_failed_retryable',
+      message: SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retryable,
+      preview: {},
+    });
+    mockGetPlayerByWallet.mockResolvedValue({ total_points: 6000 });
+    mockRetryAtomic.mockRejectedValue(
+      new Error('Conversion retry limit reached')
+    );
+    const r = await runSpendConversionConfirm({
+      session: baseSession,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'privy-1',
+      distinctId: 'd',
+      usdcAmount: 5,
+      pointsRequired: 5000,
+      intent: 'retry_conversion',
+    });
+    expect(r.ok).toBe(false);
+    if (r.ok) throw new Error('expected failure');
+    expect(r.httpStatus).toBe(400);
+    expect(r.error).toBe(
+      SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted
+    );
+  });
+});

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -5,7 +5,9 @@ import {
   getPointConversionBySessionId,
   getSpendSessionById,
   refundSpendConversionOnFundingFailure,
+  retrySpendConversionAfterRefundAtomic,
   spendConversionFundingIdempotencyKey,
+  type RetrySpendConversionAfterRefundRpcResult,
   updatePointConversionFields,
   updateSpendSessionStatus,
 } from '@/lib/db/spend-sessions';
@@ -15,7 +17,10 @@ import {
   computeConversionAmounts,
   loadSpendEligibilityForSession,
 } from '@/lib/spend-conversion-preview';
-import { SPEND_ELIGIBILITY_MESSAGES } from '@/lib/spend-eligibility-messages';
+import {
+  SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION,
+  SPEND_ELIGIBILITY_MESSAGES,
+} from '@/lib/spend-eligibility-messages';
 import { resolvePrivyServerTransactionHash } from '@/lib/api/privy';
 import {
   findRecentTreasuryUsdcTransfer,
@@ -52,6 +57,7 @@ import {
 import type { SpendPilotConversionEventProperties } from '@/lib/analytics/types';
 import type {
   PointConversion,
+  PointConversionLastFailure,
   SpendExperience,
   SpendSession,
 } from '@/lib/types';
@@ -77,12 +83,16 @@ function fundingAcknowledgedMessage(
     : FUNDING_ACKNOWLEDGED_MESSAGE;
 }
 
+export type SpendConversionConfirmIntent = 'confirm' | 'retry_conversion';
+
 export type SpendConversionConfirmResult =
   | {
       ok: true;
       pointConversion: PointConversion;
       session: SpendSession;
       resumed: boolean;
+      /** Drives client toasts: do not show “USDC on the way” when `processing`. */
+      clientHint: 'funded' | 'processing';
     }
   | {
       ok: false;
@@ -90,6 +100,32 @@ export type SpendConversionConfirmResult =
       error: string;
       capture?: boolean;
     };
+
+function conversionClientHint(
+  pointConversion: PointConversion
+): 'funded' | 'processing' {
+  return pointConversion.status === 'funded' ? 'funded' : 'processing';
+}
+
+async function persistConversionLastFailure(input: {
+  conversionId: string;
+  phase: PointConversionLastFailure['phase'];
+  category: string;
+  reasonSnippet: string;
+}): Promise<void> {
+  try {
+    await updatePointConversionFields(input.conversionId, {
+      conversion_last_failure: {
+        recorded_at: new Date().toISOString(),
+        phase: input.phase,
+        category: input.category,
+        reason_snippet: input.reasonSnippet.slice(0, 500),
+      },
+    });
+  } catch (e) {
+    console.error('persistConversionLastFailure:', e);
+  }
+}
 
 function embeddedSpendWalletForSession(session: SpendSession): string {
   if (session.spend_rail === 'stellar_usdc') {
@@ -139,6 +175,12 @@ async function conversionRailFailureOutcome(input: {
     conversion: input.conv,
     session: input.session,
     failedReason: `${prefix}:${input.category}:${input.userMessage}`,
+  });
+  void persistConversionLastFailure({
+    conversionId: input.conv.id,
+    phase: input.phase,
+    category: input.category,
+    reasonSnippet: input.userMessage,
   });
   trackSpendConversionFailed(input.distinctId, {
     ...input.baseAnalytics,
@@ -377,6 +419,8 @@ type ConfirmContext = {
   distinctId: string;
   usdcAmount: number;
   pointsRequired: number;
+  /** Default `confirm`. Use `retry_conversion` only after a safe refunded `failed` row (IRL-17). */
+  intent?: SpendConversionConfirmIntent;
 };
 
 function restoreTierAfterRefund(params: {
@@ -568,6 +612,7 @@ export async function runSpendConversionConfirm(
   const { session, spendExperience, normalizedWallet, authUserId, distinctId } =
     input;
   const { usdcAmount, pointsRequired } = input;
+  const intent = input.intent ?? 'confirm';
   const now = new Date();
 
   const baseAnalytics: SpendPilotConversionEventProperties = {
@@ -582,19 +627,241 @@ export async function runSpendConversionConfirm(
 
   let pointConversion = await getPointConversionBySessionId(session.id);
 
-  if (
-    pointConversion?.status === 'funded' ||
-    pointConversion?.status === 'failed'
-  ) {
-    if (pointConversion.status === 'funded') {
-      await markSessionAfterFunding(session.id);
+  if (intent === 'retry_conversion') {
+    if (!pointConversion || pointConversion.status !== 'failed') {
+      return {
+        ok: false,
+        httpStatus: 400,
+        error:
+          'There is no refunded failed conversion to retry for this session.',
+      };
     }
+  }
+
+  if (pointConversion?.status === 'funded') {
+    await markSessionAfterFunding(session.id);
     const freshSession = await getSpendSessionById(session.id);
     return {
       ok: true,
       pointConversion,
       session: freshSession ?? session,
       resumed: true,
+      clientHint: conversionClientHint(pointConversion),
+    };
+  }
+
+  if (pointConversion?.status === 'failed') {
+    if (intent !== 'retry_conversion') {
+      return {
+        ok: false,
+        httpStatus: 400,
+        error: SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION,
+      };
+    }
+
+    if (now > new Date(session.expires_at)) {
+      return { ok: false, httpStatus: 400, error: 'This session has expired.' };
+    }
+
+    const openGate = assertSpendExperienceOpenForSessions(spendExperience, now);
+    if (!openGate.ok) {
+      return { ok: false, httpStatus: 400, error: openGate.error };
+    }
+
+    const retryEligibility = await loadSpendEligibilityForSession({
+      session,
+      spendExperience,
+      now,
+    });
+
+    if (retryEligibility.status === 'treasury_insufficient') {
+      trackSpendTreasuryInsufficientFunds(distinctId, {
+        ...baseAnalytics,
+        status: 'treasury_insufficient',
+        error_reason: 'treasury_insufficient',
+      });
+    }
+
+    if (retryEligibility.status !== 'conversion_failed_retryable') {
+      if (retryEligibility.status === 'rail_unavailable') {
+        const rg = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+        if (!rg.ok) {
+          trackSpendPilotRailMutationBlocked(distinctId, {
+            mutation: 'conversion_confirm',
+            ...rg.analytics,
+            spend_experience_id: spendExperience.id,
+            event_id: spendExperience.event_id,
+            user_id: authUserId,
+            wallet_address: normalizedWallet,
+            spend_session_id: session.id,
+          });
+        }
+      }
+      return {
+        ok: false,
+        httpStatus: 400,
+        error: retryEligibility.message,
+      };
+    }
+
+    const retryRailGate = assertSpendRailAllowsMutatingSpendWork(
+      session.spend_rail
+    );
+    if (!retryRailGate.ok) {
+      trackSpendPilotRailMutationBlocked(distinctId, {
+        mutation: 'conversion_confirm',
+        ...retryRailGate.analytics,
+        spend_experience_id: spendExperience.id,
+        event_id: spendExperience.event_id,
+        user_id: authUserId,
+        wallet_address: normalizedWallet,
+        spend_session_id: session.id,
+      });
+      return {
+        ok: false,
+        httpStatus: 400,
+        error: retryRailGate.error,
+      };
+    }
+
+    const retryTreasury = await getSpendPaymentRail(
+      session.spend_rail
+    ).getTreasurySpendableBalance();
+    if (!retryTreasury.ok) {
+      return {
+        ok: false,
+        httpStatus: spendRailErrorCategoryToHttpStatus(
+          retryTreasury.error.category
+        ),
+        error: retryTreasury.error.userMessage,
+      };
+    }
+    const retryBal = retryTreasury.value;
+    if (retryBal === null || retryBal < usdcAmount) {
+      trackSpendTreasuryInsufficientFunds(distinctId, {
+        ...baseAnalytics,
+        status: 'treasury_insufficient',
+        error_reason: 'treasury_insufficient_at_confirm_retry',
+      });
+      return {
+        ok: false,
+        httpStatus: 400,
+        error:
+          session.spend_rail === 'stellar_usdc'
+            ? STELLAR_TREASURY_INSUFFICIENT_AT_CONFIRM
+            : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient,
+      };
+    }
+
+    const retryPlayer = await getPlayerByWallet(session.wallet_address);
+    const preRetryPoints =
+      retryPlayer != null ? Number(retryPlayer.total_points ?? 0) : 0;
+
+    let retryRpc: RetrySpendConversionAfterRefundRpcResult;
+    try {
+      retryRpc = await retrySpendConversionAfterRefundAtomic({
+        spendSessionId: session.id,
+        userId: authUserId,
+        walletAddress: session.wallet_address,
+        spendExperienceId: spendExperience.id,
+        pointsToDeduct: pointsRequired,
+        usdcAmount,
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      if (msg.includes('Conversion retry limit reached')) {
+        return {
+          ok: false,
+          httpStatus: 400,
+          error: SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted,
+        };
+      }
+      if (
+        msg.includes('Insufficient points') ||
+        msg.includes('Player not found')
+      ) {
+        return { ok: false, httpStatus: 400, error: msg, capture: true };
+      }
+      if (msg.includes('not in a retryable failed state')) {
+        return {
+          ok: false,
+          httpStatus: 409,
+          error:
+            'This conversion cannot be retried from its current state. Please contact support if this persists.',
+        };
+      }
+      if (
+        msg.includes('PGRST202') ||
+        msg.includes('retry_spend_conversion_after_refund_atomic')
+      ) {
+        return {
+          ok: false,
+          httpStatus: 500,
+          error:
+            'Points conversion is not available yet. Please try again later.',
+        };
+      }
+      throw e;
+    }
+
+    const convAfterRetry = await getPointConversionBySessionId(session.id);
+    if (!convAfterRetry) {
+      return {
+        ok: false,
+        httpStatus: 500,
+        error:
+          'Points conversion could not be loaded. Please try again or contact support.',
+      };
+    }
+
+    void checkAndTrackTierProgression(
+      resolveServerIdentity({
+        privyUserId: authUserId,
+        walletAddress: normalizedWallet,
+      }),
+      preRetryPoints,
+      retryRpc.playerTotalPoints
+    );
+
+    trackSpendConversionConfirmed(distinctId, {
+      ...baseAnalytics,
+      point_conversion_id: convAfterRetry.id,
+      spend_session_id: session.id,
+      status: 'points_deducted',
+    });
+    await updateSpendSessionStatus(session.id, 'conversion_pending');
+
+    const retryFundOutcome = await runWalletReadinessAndUserFunding({
+      session,
+      spendExperience,
+      normalizedWallet,
+      pointConversion: convAfterRetry,
+      usdcAmount,
+      distinctId,
+      baseAnalytics,
+    });
+
+    if (retryFundOutcome.kind === 'error') {
+      if (
+        retryFundOutcome.pointsRefunded &&
+        convAfterRetry.user_id === authUserId
+      ) {
+        restoreTierAfterRefund({
+          authUserId,
+          normalizedWallet,
+          balanceAfterDeduction: retryRpc.playerTotalPoints,
+          pointsRestored: retryFundOutcome.pointsRefunded,
+        });
+      }
+      return retryFundOutcome.value;
+    }
+
+    return {
+      ok: true,
+      pointConversion: retryFundOutcome.conversion,
+      session: (await getSpendSessionById(session.id)) ?? session,
+      resumed: true,
+      clientHint: conversionClientHint(retryFundOutcome.conversion),
     };
   }
 
@@ -617,6 +884,16 @@ export async function runSpendConversionConfirm(
       pointConversion,
       session: (await getSpendSessionById(session.id)) ?? session,
       resumed: true,
+      clientHint: conversionClientHint(pointConversion),
+    };
+  }
+
+  if (intent === 'retry_conversion') {
+    return {
+      ok: false,
+      httpStatus: 400,
+      error:
+        'Retry is only available after a refunded failed conversion for this session.',
     };
   }
 
@@ -806,6 +1083,7 @@ export async function runSpendConversionConfirm(
     pointConversion: fundOutcome.conversion,
     session: (await getSpendSessionById(session.id)) ?? session,
     resumed: rpc.outcome === 'already_exists',
+    clientHint: conversionClientHint(fundOutcome.conversion),
   };
 }
 
@@ -995,6 +1273,13 @@ async function fundOrResumeUsdc(input: {
       conversion: conv,
       session,
       failedReason: 'funding transaction reverted',
+    });
+    void persistConversionLastFailure({
+      conversionId: conv.id,
+      phase: 'funding',
+      category: 'tx_reverted',
+      reasonSnippet:
+        'The funding transaction could not be confirmed. Your points have been restored.',
     });
     return {
       error: {

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -20,6 +20,7 @@ import {
 import {
   SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION,
   SPEND_ELIGIBILITY_MESSAGES,
+  SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE,
 } from '@/lib/spend-eligibility-messages';
 import { resolvePrivyServerTransactionHash } from '@/lib/api/privy';
 import {
@@ -72,9 +73,6 @@ const MISCONFIGURED_CONVERSION_ERROR =
 const FUNDING_ACKNOWLEDGED_MESSAGE =
   'USDC transfer submitted. We are confirming it on Base.';
 
-const STELLAR_TREASURY_INSUFFICIENT_AT_CONFIRM =
-  "We're unable to fund this spend right now. Please try again shortly.";
-
 function fundingAcknowledgedMessage(
   spendRail: SpendSession['spend_rail']
 ): string {
@@ -123,6 +121,7 @@ async function persistConversionLastFailure(input: {
       },
     });
   } catch (e) {
+    // Best-effort audit metadata; do not block refund or confirm responses.
     console.error('persistConversionLastFailure:', e);
   }
 }
@@ -748,7 +747,7 @@ export async function runSpendConversionConfirm(
         httpStatus: 400,
         error:
           session.spend_rail === 'stellar_usdc'
-            ? STELLAR_TREASURY_INSUFFICIENT_AT_CONFIRM
+            ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
             : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient,
       };
     }
@@ -969,7 +968,7 @@ export async function runSpendConversionConfirm(
       httpStatus: 400,
       error:
         session.spend_rail === 'stellar_usdc'
-          ? STELLAR_TREASURY_INSUFFICIENT_AT_CONFIRM
+          ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
           : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient,
     };
   }

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -130,6 +130,8 @@ describe('buildSpendEligibilityPreview', () => {
       funding_tx_hash: '0x',
       explorer_tx_url: null,
       idempotency_key: null,
+      conversion_attempt_count: 1,
+      conversion_last_failure: null,
       created_at: '',
       completed_at: '',
       failed_reason: null,
@@ -166,6 +168,8 @@ describe('buildSpendEligibilityPreview', () => {
       funding_tx_hash: '0xabc',
       explorer_tx_url: null,
       idempotency_key: null,
+      conversion_attempt_count: 1,
+      conversion_last_failure: null,
       created_at: '',
       completed_at: '',
       failed_reason: null,
@@ -202,6 +206,8 @@ describe('buildSpendEligibilityPreview', () => {
       funding_tx_hash: '0xabc',
       explorer_tx_url: null,
       idempotency_key: null,
+      conversion_attempt_count: 1,
+      conversion_last_failure: null,
       created_at: '',
       completed_at: '',
       failed_reason: null,
@@ -260,6 +266,8 @@ describe('buildSpendEligibilityPreview', () => {
         funding_tx_hash: '0xabc',
         explorer_tx_url: null,
         idempotency_key: null,
+        conversion_attempt_count: 1,
+        conversion_last_failure: null,
         created_at: '',
         completed_at: '',
         failed_reason: null,
@@ -300,6 +308,125 @@ describe('buildSpendEligibilityPreview', () => {
       if (prev === undefined) delete process.env.SPEND_RAIL_BASE_USDC_ENABLED;
       else process.env.SPEND_RAIL_BASE_USDC_ENABLED = prev;
     }
+  });
+
+  it('returns conversion_failed_retryable when conversion failed under retry cap', () => {
+    const failedConv: PointConversion = {
+      id: 'c1',
+      spend_experience_id: 'e1',
+      spend_session_id: 's1',
+      user_id: 'u1',
+      points_deducted: 5000,
+      usdc_amount: 5,
+      status: 'failed',
+      spend_rail: 'base_usdc',
+      network: 'Base',
+      asset_symbol: 'USDC',
+      treasury_wallet_address: '0x1',
+      user_wallet_address: '0x3',
+      funding_tx_hash: null,
+      explorer_tx_url: null,
+      idempotency_key: null,
+      conversion_attempt_count: 1,
+      conversion_last_failure: {
+        recorded_at: '2026-01-01T00:00:00.000Z',
+        phase: 'readiness',
+        category: 'x',
+        reason_snippet: 'y',
+      },
+      created_at: '',
+      completed_at: '',
+      failed_reason: 'readiness:x',
+      updated_at: '',
+    };
+    const r = buildSpendEligibilityPreview({
+      session: sess(),
+      spendExperience: exp(),
+      player: player(6000),
+      pointConversion: failedConv,
+      spendTransaction: null,
+      fundedConversionForOtherSession: null,
+      treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
+      now,
+    });
+    expect(r.status).toBe('conversion_failed_retryable');
+  });
+
+  it('returns conversion_failed_retry_exhausted when failed after max attempts', () => {
+    const failedConv: PointConversion = {
+      id: 'c1',
+      spend_experience_id: 'e1',
+      spend_session_id: 's1',
+      user_id: 'u1',
+      points_deducted: 5000,
+      usdc_amount: 5,
+      status: 'failed',
+      spend_rail: 'base_usdc',
+      network: 'Base',
+      asset_symbol: 'USDC',
+      treasury_wallet_address: '0x1',
+      user_wallet_address: '0x3',
+      funding_tx_hash: null,
+      explorer_tx_url: null,
+      idempotency_key: null,
+      conversion_attempt_count: 4,
+      conversion_last_failure: null,
+      created_at: '',
+      completed_at: '',
+      failed_reason: 'x',
+      updated_at: '',
+    };
+    const r = buildSpendEligibilityPreview({
+      session: sess(),
+      spendExperience: exp(),
+      player: player(6000),
+      pointConversion: failedConv,
+      spendTransaction: null,
+      fundedConversionForOtherSession: null,
+      treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
+      now,
+    });
+    expect(r.status).toBe('conversion_failed_retry_exhausted');
+  });
+
+  it('returns conversion_in_progress for needs_review (not retryable via failed path)', () => {
+    const conv: PointConversion = {
+      id: 'c1',
+      spend_experience_id: 'e1',
+      spend_session_id: 's1',
+      user_id: 'u1',
+      points_deducted: 5000,
+      usdc_amount: 5,
+      status: 'needs_review',
+      spend_rail: 'base_usdc',
+      network: 'Base',
+      asset_symbol: 'USDC',
+      treasury_wallet_address: '0x1',
+      user_wallet_address: '0x3',
+      funding_tx_hash: '0xabc',
+      explorer_tx_url: null,
+      idempotency_key: null,
+      conversion_attempt_count: 1,
+      conversion_last_failure: null,
+      created_at: '',
+      completed_at: null,
+      failed_reason: null,
+      updated_at: '',
+    };
+    const r = buildSpendEligibilityPreview({
+      session: sess({ status: 'conversion_pending' }),
+      spendExperience: exp(),
+      player: player(1000),
+      pointConversion: conv,
+      spendTransaction: null,
+      fundedConversionForOtherSession: null,
+      treasuryUsdcBalance: 100,
+      userUsdcBalance: null,
+      now,
+    });
+    expect(r.status).toBe('conversion_in_progress');
   });
 
   it('returns ready_for_payment_own_usdc when wallet has enough USDC (no conversion)', () => {

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -206,6 +206,49 @@ export function buildSpendEligibilityPreview(
     };
   }
 
+  if (pointConversion?.status === 'failed') {
+    const attempts = pointConversion.conversion_attempt_count;
+    if (attempts >= 4) {
+      return {
+        status: 'conversion_failed_retry_exhausted',
+        message: SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted,
+        preview: basePreview(),
+      };
+    }
+    const balance =
+      player?.total_points != null ? Number(player.total_points) : 0;
+    if (balance < pointsRequired) {
+      return {
+        status: 'insufficient_points',
+        message: SPEND_ELIGIBILITY_MESSAGES.insufficient_points,
+        preview: basePreview(),
+      };
+    }
+    if (!spendRailSupportsPointsToUsdcConversion(spendExperience.spend_rail)) {
+      return {
+        status: 'conversion_unsupported',
+        message: SPEND_ELIGIBILITY_MESSAGES.conversion_unsupported,
+        preview: basePreview(),
+      };
+    }
+    if (treasuryUsdcBalance === null || treasuryUsdcBalance < usdcAmount) {
+      const insufficientMsg =
+        spendExperience.spend_rail === 'stellar_usdc'
+          ? "We're unable to fund this spend right now. Please try again shortly."
+          : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
+      return {
+        status: 'treasury_insufficient',
+        message: insufficientMsg,
+        preview: basePreview(),
+      };
+    }
+    return {
+      status: 'conversion_failed_retryable',
+      message: SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retryable,
+      preview: basePreview(),
+    };
+  }
+
   if (pointConversion && IN_PROGRESS.includes(pointConversion.status)) {
     return {
       status: 'conversion_in_progress',

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -1,5 +1,7 @@
 import {
+  MAX_SPEND_CONVERSION_POINT_DEDUCTION_ATTEMPTS,
   SPEND_ELIGIBILITY_MESSAGES,
+  SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
 import {
@@ -208,7 +210,7 @@ export function buildSpendEligibilityPreview(
 
   if (pointConversion?.status === 'failed') {
     const attempts = pointConversion.conversion_attempt_count;
-    if (attempts >= 4) {
+    if (attempts >= MAX_SPEND_CONVERSION_POINT_DEDUCTION_ATTEMPTS) {
       return {
         status: 'conversion_failed_retry_exhausted',
         message: SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted,
@@ -234,7 +236,7 @@ export function buildSpendEligibilityPreview(
     if (treasuryUsdcBalance === null || treasuryUsdcBalance < usdcAmount) {
       const insufficientMsg =
         spendExperience.spend_rail === 'stellar_usdc'
-          ? "We're unable to fund this spend right now. Please try again shortly."
+          ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
           : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
       return {
         status: 'treasury_insufficient',
@@ -293,7 +295,7 @@ export function buildSpendEligibilityPreview(
   if (treasuryUsdcBalance === null || treasuryUsdcBalance < usdcAmount) {
     const insufficientMsg =
       spendExperience.spend_rail === 'stellar_usdc'
-        ? "We're unable to fund this spend right now. Please try again shortly."
+        ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
         : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
     return {
       status: 'treasury_insufficient',

--- a/lib/spend-eligibility-messages.ts
+++ b/lib/spend-eligibility-messages.ts
@@ -55,6 +55,19 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
     'Your USDC payment was received. You are all set for this event.',
 };
 
+/**
+ * Stellar treasury shortfall at preview/confirm — softer wording than the generic
+ * `treasury_insufficient` eligibility message.
+ */
+export const SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE =
+  "We're unable to fund this spend right now. Please try again shortly.";
+
+/**
+ * IRL-17: max point-deduction attempts per conversion row. Keep in sync with
+ * `retry_spend_conversion_after_refund_atomic` in the database migration.
+ */
+export const MAX_SPEND_CONVERSION_POINT_DEDUCTION_ATTEMPTS = 4;
+
 /** Returned when POST conversion/confirm is called without `retry_conversion` while the row is `failed`. */
 export const SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION =
   'Your points were returned after the last attempt. Use “Retry conversion” to try again.';

--- a/lib/spend-eligibility-messages.ts
+++ b/lib/spend-eligibility-messages.ts
@@ -6,6 +6,10 @@ export type SpendEligibilityStatus =
   | 'insufficient_points'
   | 'already_converted'
   | 'conversion_in_progress'
+  /** Refunded failure: user may explicitly retry conversion (IRL-17). */
+  | 'conversion_failed_retryable'
+  /** Max explicit retries exhausted; contact support (IRL-17). */
+  | 'conversion_failed_retry_exhausted'
   | 'experience_inactive'
   | 'session_expired'
   | 'rail_unavailable'
@@ -27,6 +31,10 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
   already_converted: 'You have already converted for this spend experience.',
   conversion_in_progress:
     'Your conversion is already in progress. Please wait.',
+  conversion_failed_retryable:
+    'Your points were returned after the last attempt. You can try converting again.',
+  conversion_failed_retry_exhausted:
+    'This conversion has reached the maximum number of retries. Please contact support for help.',
   experience_inactive:
     'This spend experience is inactive or outside its active window.',
   session_expired: 'This spend session has expired. Scan the event QR again.',
@@ -46,3 +54,7 @@ export const SPEND_ELIGIBILITY_MESSAGES: Record<
   payment_complete:
     'Your USDC payment was received. You are all set for this event.',
 };
+
+/** Returned when POST conversion/confirm is called without `retry_conversion` while the row is `failed`. */
+export const SPEND_CONVERSION_FAILED_REQUIRES_RETRY_ACTION =
+  'Your points were returned after the last attempt. Use “Retry conversion” to try again.';

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -143,6 +143,8 @@ function inProgressConversion(
     funding_tx_hash: null,
     explorer_tx_url: null,
     idempotency_key: null,
+    conversion_attempt_count: 1,
+    conversion_last_failure: null,
     created_at: '2026-01-01T00:00:00.000Z',
     completed_at: null,
     failed_reason: null,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -344,6 +344,14 @@ export type PointConversionStatus =
   | 'funded'
   | 'failed';
 
+/** Persisted on `point_conversions.conversion_last_failure` after a safe refund (IRL-17). */
+export type PointConversionLastFailure = {
+  recorded_at: string;
+  phase: 'readiness' | 'funding' | 'resume';
+  category: string;
+  reason_snippet: string;
+};
+
 export type PointConversion = {
   id: string;
   spend_experience_id: string;
@@ -364,6 +372,10 @@ export type PointConversion = {
   /** Canonical explorer URL when known; set-once in DB. */
   explorer_tx_url: string | null;
   idempotency_key: string | null;
+  /** Point-deduction attempts for this row (1 on first confirm; incremented on each explicit retry). */
+  conversion_attempt_count: number;
+  /** Last refunded failure metadata for support (IRL-17). */
+  conversion_last_failure: PointConversionLastFailure | null;
   created_at: string;
   completed_at: string | null;
   failed_reason: string | null;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements IRL-17: after a safe points refund (`point_conversions.status === 'failed'`), users can explicitly retry conversion on the same row with server-side attempt limits and audit metadata.

**What changed**

- **Database** (`database/point-conversions-retry-metadata.sql`): adds `conversion_attempt_count` (default 1) and `conversion_last_failure` (JSONB); new RPC `retry_spend_conversion_after_refund_atomic` to re-deduct points and reset the row for another funding attempt while preserving `fund_user:<id>` idempotency; `confirm_spend_conversion_atomic` insert sets attempt count to 1.
- **Confirm flow** (`lib/spend-conversion-confirm.ts`): `failed` is no longer treated like `funded`; optional `intent: 'retry_conversion'` runs the retry RPC plus readiness/funding; successful responses include `clientHint` (`funded` vs `processing`) for correct client toasts; persists `conversion_last_failure` after refunds / reverts.
- **Preview / copy** (`lib/spend-conversion-preview.ts`, `lib/spend-eligibility-messages.ts`): new eligibility statuses `conversion_failed_retryable` and `conversion_failed_retry_exhausted` (max 4 point-deduction attempts); message for blocked confirm without retry intent.
- **API** (`lib/schemas/spend-session.ts`, confirm route): optional body field `intent` (`confirm` default | `retry_conversion`); response includes `clientHint`.
- **UI** (`components/spend/spend-experience-page.tsx`): outline **Retry conversion** button; conversion mutation passes `intent`; toasts depend on `clientHint` (no “USDC is on the way” while only processing).
- **Tests**: `lib/spend-conversion-confirm.test.ts`, preview and confirm route tests updated.

**Deploy note:** apply the new SQL migration to Supabase (or your migration runner) before relying on retry in production.

**Verification:** `yarn test` on touched tests; `yarn build` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-17](https://linear.app/irlenergy/issue/IRL-17/support-explicit-conversion-retry-after-safe-refund)

<div><a href="https://cursor.com/agents/bc-763df450-deaa-4591-b850-9601439856ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-763df450-deaa-4591-b850-9601439856ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

