### PR TITLE
feat(IRL-28): payment prepare/confirm operation lifecycle

### DIFF
--- a/app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/__tests__/route.test.ts
@@ -63,6 +63,13 @@ describe('POST /api/spend-sessions/[sessionId]/payment/confirm', () => {
         completed_at: '2026-01-01T00:00:01.000Z',
       },
       resumed: false,
+      paymentOperation: {
+        id: 'prep-1',
+        status: 'confirmed',
+        attempt_count: 0,
+        last_failure_reason: null,
+        last_failure_at: null,
+      },
     });
   });
 
@@ -81,6 +88,7 @@ describe('POST /api/spend-sessions/[sessionId]/payment/confirm', () => {
     const j = await res.json();
     expect(res.status).toBe(200);
     expect(j.data.spendTransaction.id).toBe('tx-1');
+    expect(j.data.paymentOperation?.status).toBe('confirmed');
     expect(j.data.session.status).toBe('payment_complete');
     expect(j.data.spendRailSummary).toMatchObject({
       rail: 'base_usdc',

--- a/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
@@ -76,7 +76,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
 
     if (!result.ok) {
-      return apiError(result.error, result.httpStatus);
+      return apiError(result.error, result.httpStatus, result.details);
     }
 
     return apiSuccess({
@@ -89,6 +89,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         completed_at: result.session.completed_at,
       },
       resumed: result.resumed,
+      paymentOperation: result.paymentOperation,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Failed to confirm payment';

--- a/app/api/spend-sessions/[sessionId]/payment/prepare/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/prepare/__tests__/route.test.ts
@@ -54,6 +54,13 @@ describe('POST /api/spend-sessions/[sessionId]/payment/prepare', () => {
         status: 'conversion_complete',
         expires_at: '2099-01-01T00:00:00.000Z',
       },
+      paymentOperation: {
+        id: 'prep-1',
+        status: 'prepared',
+        attempt_count: 0,
+        last_failure_reason: null,
+        last_failure_at: null,
+      },
     });
   });
 
@@ -71,6 +78,8 @@ describe('POST /api/spend-sessions/[sessionId]/payment/prepare', () => {
     const j = await res.json();
     expect(res.status).toBe(200);
     expect(j.data.preparedAction.evmTransactionRequest.gas).toBe('100000');
+    expect(j.data.paymentOperation.status).toBe('prepared');
+    expect(j.data.paymentOperation.attempt_count).toBe(0);
     expect(j.data.spendRailSummary).toMatchObject({
       rail: 'base_usdc',
       displayName: 'Base USDC',

--- a/app/api/spend-sessions/[sessionId]/payment/prepare/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/prepare/route.ts
@@ -73,13 +73,14 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
 
     if (!result.ok) {
-      return apiError(result.error, result.httpStatus);
+      return apiError(result.error, result.httpStatus, result.details);
     }
 
     return apiSuccess({
       preparedAction: result.preparedAction,
       spendRailSummary: getSpendRailClientSummary(session.spend_rail),
       session: result.session,
+      paymentOperation: result.paymentOperation,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Failed to prepare payment';

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -10,6 +10,7 @@ import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
 import type {
   PointConversion,
   SpendExperience,
+  SpendPaymentOperationClientSummary,
   SpendSession,
   SpendTransaction,
 } from '@/lib/types';
@@ -78,12 +79,14 @@ type PaymentConfirmResponse = {
   spendRailSummary: SpendRailClientSummary;
   session: Pick<SpendSession, 'id' | 'status' | 'expires_at' | 'completed_at'>;
   resumed: boolean;
+  paymentOperation?: SpendPaymentOperationClientSummary;
 };
 
 type PaymentPrepareResponse = {
   preparedAction: Record<string, unknown>;
   spendRailSummary: SpendRailClientSummary;
   session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
+  paymentOperation: SpendPaymentOperationClientSummary;
 };
 
 type ReceiptResponse = {
@@ -96,6 +99,14 @@ type ReceiptResponse = {
 };
 
 const WALLET_STEP_TIMEOUT_MS = 180_000;
+
+function isPaymentNeedsReviewFromApiError(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  const d = error.details as
+    | { paymentOperation?: { status?: string } }
+    | undefined;
+  return d?.paymentOperation?.status === 'needs_review';
+}
 
 function withTimeout<T>(
   promise: Promise<T>,
@@ -261,30 +272,38 @@ export function SpendExperiencePage({
     sessionStatusForPrepare !== 'payment_complete'
   );
 
-  const { data: paymentPrepareData, isFetching: paymentPrepareLoading } =
-    useQuery({
-      queryKey: [
-        'spend-payment-prepare',
-        sessionId,
-        user?.id,
-        walletAddress,
-      ] as const,
-      queryFn: async () => {
-        const token = await getAccessToken();
-        if (!token || !walletAddress || !sessionId) {
-          throw new Error('Missing auth or session');
-        }
-        return spendAuthedPost<PaymentPrepareResponse>(
-          token,
-          `/api/spend-sessions/${sessionId}/payment/prepare`,
-          { walletAddress }
-        );
-      },
-      enabled: basePayPrepareEnabled,
-      staleTime: Infinity,
-      refetchOnWindowFocus: false,
-      retry: false,
-    });
+  const {
+    data: paymentPrepareData,
+    isFetching: paymentPrepareLoading,
+    error: paymentPrepareError,
+  } = useQuery({
+    queryKey: [
+      'spend-payment-prepare',
+      sessionId,
+      user?.id,
+      walletAddress,
+    ] as const,
+    queryFn: async () => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress || !sessionId) {
+        throw new Error('Missing auth or session');
+      }
+      return spendAuthedPost<PaymentPrepareResponse>(
+        token,
+        `/api/spend-sessions/${sessionId}/payment/prepare`,
+        { walletAddress }
+      );
+    },
+    enabled: basePayPrepareEnabled,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: false,
+  });
+
+  const paymentPrepareNeedsReview = useMemo(
+    () => isPaymentNeedsReviewFromApiError(paymentPrepareError),
+    [paymentPrepareError]
+  );
 
   const sessionStatus = previewPayload?.session?.status;
 
@@ -525,6 +544,7 @@ export function SpendExperiencePage({
 
   const showBaseWalletPay =
     !isPaymentComplete &&
+    !paymentPrepareNeedsReview &&
     (elig?.status === 'ready_for_payment' ||
       elig?.status === 'ready_for_payment_own_usdc' ||
       elig?.status === 'payment_failed') &&
@@ -715,6 +735,18 @@ export function SpendExperiencePage({
                           : `Spend $${preview.usdcAmount.toFixed(2)} ${assetSymbol}`}
                       </SpendPrimaryButton>
                     )}
+
+                    {postPointsConversion &&
+                      paymentPrepareNeedsReview &&
+                      !isPaymentComplete &&
+                      resolvedSpendRail === 'base_usdc' && (
+                        <p className="body-small font-grotesk text-amber-900">
+                          We could not automatically confirm your last payment
+                          transaction. Please contact support with your
+                          transaction hash and do not pay again until support
+                          clears this session.
+                        </p>
+                      )}
 
                     {displayReceipt && (
                       <div className="space-y-3 rounded-sm border border-emerald-200/90 bg-emerald-50/90 p-4 text-[#171717]">

--- a/database/irl-28-spend-payment-prepare-operation-lifecycle.sql
+++ b/database/irl-28-spend-payment-prepare-operation-lifecycle.sql
@@ -1,0 +1,52 @@
+-- IRL-28: Full payment prepare-operation lifecycle (prepared → submitted → terminal) with
+-- retry metadata and needs_review for unresolved on-chain verification.
+
+-- ---------------------------------------------------------------------------
+-- Status CHECK: align with SpendRailPaymentOperationStatus vocabulary
+-- ---------------------------------------------------------------------------
+ALTER TABLE spend_payment_prepare_operations
+  DROP CONSTRAINT IF EXISTS spend_payment_prepare_operations_status_check;
+
+ALTER TABLE spend_payment_prepare_operations
+  ADD CONSTRAINT spend_payment_prepare_operations_status_check
+  CHECK (status IN (
+    'prepared',
+    'submitted',
+    'confirmed',
+    'failed',
+    'needs_review'
+  ));
+
+COMMENT ON CONSTRAINT spend_payment_prepare_operations_status_check
+  ON spend_payment_prepare_operations IS
+  'Payment operation lifecycle (IRL-28); canonical with spend_transactions for tx hash / verification.';
+
+-- ---------------------------------------------------------------------------
+-- Retry / failure / ambiguity metadata
+-- ---------------------------------------------------------------------------
+ALTER TABLE spend_payment_prepare_operations
+  ADD COLUMN IF NOT EXISTS attempt_count INTEGER NOT NULL DEFAULT 0;
+
+ALTER TABLE spend_payment_prepare_operations
+  ADD COLUMN IF NOT EXISTS last_failure_reason TEXT;
+
+ALTER TABLE spend_payment_prepare_operations
+  ADD COLUMN IF NOT EXISTS last_failure_at TIMESTAMPTZ;
+
+ALTER TABLE spend_payment_prepare_operations
+  ADD COLUMN IF NOT EXISTS last_ambiguity_metadata JSONB;
+
+COMMENT ON COLUMN spend_payment_prepare_operations.attempt_count IS
+  'Increments when a failed-without-blocked-retry prepare is reset to prepared for an explicit user retry (IRL-28).';
+
+COMMENT ON COLUMN spend_payment_prepare_operations.last_failure_reason IS
+  'Sanitized last definitive verification failure reason from confirm, when status is failed.';
+
+COMMENT ON COLUMN spend_payment_prepare_operations.last_failure_at IS
+  'Timestamp of the last recorded failure metadata update.';
+
+COMMENT ON COLUMN spend_payment_prepare_operations.last_ambiguity_metadata IS
+  'Structured context when status is needs_review (e.g. unresolved RPC / receipt wait).';
+
+COMMENT ON TABLE spend_payment_prepare_operations IS
+  'Per-session idempotent payment operation (prepare descriptor + lifecycle). IRL-28: status drives retry and needs_review gating.';

--- a/lib/api/client.ts
+++ b/lib/api/client.ts
@@ -4,7 +4,11 @@ import type { ApiResponse } from './response';
  * Custom error class for API errors with status code
  */
 export class ApiError extends Error {
-  constructor(public status: number, message: string) {
+  constructor(
+    public status: number,
+    message: string,
+    public details?: unknown
+  ) {
     super(message);
     this.name = 'ApiError';
   }
@@ -23,11 +27,14 @@ export async function apiClient<T>(
 ): Promise<T> {
   const response = await fetch(endpoint, options);
   const json: ApiResponse<T> = await response.json();
-  
+
   if (!response.ok || !json.success) {
-    throw new ApiError(response.status, json.error || 'Request failed');
+    throw new ApiError(
+      response.status,
+      json.error || 'Request failed',
+      json.details
+    );
   }
-  
+
   return json.data as T;
 }
-

--- a/lib/api/response.ts
+++ b/lib/api/response.ts
@@ -1,5 +1,5 @@
-import { NextResponse } from "next/server";
-import { ZodError } from "zod";
+import { NextResponse } from 'next/server';
+import { ZodError } from 'zod';
 
 /**
  * Standardized API response type
@@ -9,6 +9,8 @@ export type ApiResponse<T = unknown> = {
   data?: T;
   error?: string;
   message?: string;
+  /** Optional machine-readable context on errors (e.g. IRL-28 payment operation summary). */
+  details?: unknown;
 };
 
 /**
@@ -20,7 +22,7 @@ export type ApiResponse<T = unknown> = {
 export function apiSuccess<T>(
   data: T,
   message?: string,
-  status = 200,
+  status = 200
 ): NextResponse<ApiResponse<T>> {
   const response: ApiResponse<T> = {
     success: true,
@@ -42,13 +44,15 @@ export function apiSuccess<T>(
 export function apiError(
   error: string,
   status: 400 | 401 | 403 | 404 | 409 | 429 | 500 = 500,
+  details?: unknown
 ): NextResponse<ApiResponse> {
   return NextResponse.json(
     {
       success: false,
       error,
+      ...(details !== undefined ? { details } : {}),
     },
-    { status },
+    { status }
   );
 }
 
@@ -59,25 +63,24 @@ export function apiError(
  */
 export function apiValidationError(
   zodError: ZodError,
-  status = 400,
+  status = 400
 ): NextResponse<ApiResponse> {
   // Format Zod errors into a readable message
   const errorMessages = zodError.issues.map((issue) => {
-    const path = issue.path.join(".");
+    const path = issue.path.join('.');
     return path ? `${path}: ${issue.message}` : issue.message;
   });
 
   const errorMessage =
     errorMessages.length === 1
       ? errorMessages[0]
-      : `Validation failed: ${errorMessages.join("; ")}`;
+      : `Validation failed: ${errorMessages.join('; ')}`;
 
   return NextResponse.json(
     {
       success: false,
       error: errorMessage,
     },
-    { status },
+    { status }
   );
 }
-

--- a/lib/db/spend-payment-prepare.ts
+++ b/lib/db/spend-payment-prepare.ts
@@ -1,6 +1,7 @@
 import { supabase } from './client';
 import { normalizeSpendRail } from './spend-rail';
 import type {
+  SpendPaymentOperationClientSummary,
   SpendPaymentPrepareOperation,
   SpendPaymentPrepareOperationStatus,
   SpendRail,
@@ -15,6 +16,10 @@ export const SPEND_PAYMENT_PREPARE_COLS = `
   prepared_action,
   verification_snapshot,
   idempotency_key,
+  attempt_count,
+  last_failure_reason,
+  last_failure_at,
+  last_ambiguity_metadata,
   created_at,
   updated_at
 `;
@@ -26,9 +31,25 @@ function parseJsonObject(value: unknown): Record<string, unknown> {
   return {};
 }
 
+function parseNullableJsonObject(
+  value: unknown
+): Record<string, unknown> | null {
+  if (value == null) return null;
+  if (typeof value === 'object' && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return null;
+}
+
 export function rowToSpendPaymentPrepareOperation(
   row: Record<string, unknown>
 ): SpendPaymentPrepareOperation {
+  const attemptRaw = row.attempt_count;
+  const attemptCount =
+    typeof attemptRaw === 'number' && Number.isFinite(attemptRaw)
+      ? attemptRaw
+      : 0;
+
   return {
     id: String(row.id),
     spend_session_id: String(row.spend_session_id),
@@ -38,6 +59,14 @@ export function rowToSpendPaymentPrepareOperation(
     prepared_action: parseJsonObject(row.prepared_action),
     verification_snapshot: parseJsonObject(row.verification_snapshot),
     idempotency_key: String(row.idempotency_key),
+    attempt_count: attemptCount,
+    last_failure_reason:
+      row.last_failure_reason == null ? null : String(row.last_failure_reason),
+    last_failure_at:
+      row.last_failure_at == null ? null : String(row.last_failure_at),
+    last_ambiguity_metadata: parseNullableJsonObject(
+      row.last_ambiguity_metadata
+    ),
     created_at: String(row.created_at),
     updated_at: String(row.updated_at),
   };
@@ -151,6 +180,69 @@ export async function insertSpendPaymentPrepareOrGet(
   );
 }
 
+export type PatchSpendPaymentPrepareInput = {
+  status?: SpendPaymentPrepareOperationStatus;
+  preparedAction?: Record<string, unknown>;
+  verificationSnapshot?: Record<string, unknown>;
+  attemptCount?: number;
+  lastFailureReason?: string | null;
+  lastFailureAt?: string | null;
+  lastAmbiguityMetadata?: Record<string, unknown> | null;
+};
+
+export async function patchSpendPaymentPrepare(
+  id: string,
+  patch: PatchSpendPaymentPrepareInput
+): Promise<SpendPaymentPrepareOperation> {
+  const update: Record<string, unknown> = {};
+  if (patch.status !== undefined) update.status = patch.status;
+  if (patch.preparedAction !== undefined) {
+    update.prepared_action = patch.preparedAction;
+  }
+  if (patch.verificationSnapshot !== undefined) {
+    update.verification_snapshot = patch.verificationSnapshot;
+  }
+  if (patch.attemptCount !== undefined) {
+    update.attempt_count = patch.attemptCount;
+  }
+  if (patch.lastFailureReason !== undefined) {
+    update.last_failure_reason = patch.lastFailureReason;
+  }
+  if (patch.lastFailureAt !== undefined) {
+    update.last_failure_at = patch.lastFailureAt;
+  }
+  if (patch.lastAmbiguityMetadata !== undefined) {
+    update.last_ambiguity_metadata = patch.lastAmbiguityMetadata;
+  }
+
+  if (Object.keys(update).length === 0) {
+    const { data: existing, error: loadErr } = await supabase
+      .from('spend_payment_prepare_operations')
+      .select(SPEND_PAYMENT_PREPARE_COLS)
+      .eq('id', id)
+      .single();
+    if (loadErr || !existing) {
+      throw new Error(loadErr?.message || 'Failed to load payment prepare');
+    }
+    return rowToSpendPaymentPrepareOperation(
+      existing as Record<string, unknown>
+    );
+  }
+
+  const { data, error } = await supabase
+    .from('spend_payment_prepare_operations')
+    .update(update)
+    .eq('id', id)
+    .select(SPEND_PAYMENT_PREPARE_COLS)
+    .single();
+
+  if (error || !data) {
+    console.error('patchSpendPaymentPrepare:', error);
+    throw new Error(error?.message || 'Failed to patch payment prepare');
+  }
+  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+}
+
 export async function updateSpendPaymentPreparePayload(
   id: string,
   patch: {
@@ -158,19 +250,20 @@ export async function updateSpendPaymentPreparePayload(
     verificationSnapshot: Record<string, unknown>;
   }
 ): Promise<SpendPaymentPrepareOperation> {
-  const { data, error } = await supabase
-    .from('spend_payment_prepare_operations')
-    .update({
-      prepared_action: patch.preparedAction,
-      verification_snapshot: patch.verificationSnapshot,
-    })
-    .eq('id', id)
-    .select(SPEND_PAYMENT_PREPARE_COLS)
-    .single();
+  return patchSpendPaymentPrepare(id, {
+    preparedAction: patch.preparedAction,
+    verificationSnapshot: patch.verificationSnapshot,
+  });
+}
 
-  if (error || !data) {
-    console.error('updateSpendPaymentPreparePayload:', error);
-    throw new Error(error?.message || 'Failed to update payment prepare');
-  }
-  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+export function spendPaymentOperationClientSummary(
+  row: SpendPaymentPrepareOperation
+): SpendPaymentOperationClientSummary {
+  return {
+    id: row.id,
+    status: row.status,
+    attempt_count: row.attempt_count,
+    last_failure_reason: row.last_failure_reason,
+    last_failure_at: row.last_failure_at,
+  };
 }

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -35,11 +35,18 @@ vi.mock('@/lib/db/spend-sessions', () => ({
 }));
 
 const mockGetPaymentPrepare = vi.fn();
+const mockPatchPrepare = vi.fn();
 
-vi.mock('@/lib/db/spend-payment-prepare', () => ({
-  getSpendPaymentPrepareBySessionId: (...a: unknown[]) =>
-    mockGetPaymentPrepare(...a),
-}));
+vi.mock('@/lib/db/spend-payment-prepare', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/db/spend-payment-prepare')>();
+  return {
+    ...actual,
+    getSpendPaymentPrepareBySessionId: (...a: unknown[]) =>
+      mockGetPaymentPrepare(...a),
+    patchSpendPaymentPrepare: (...a: unknown[]) => mockPatchPrepare(...a),
+  };
+});
 
 vi.mock('@/lib/db/treasury-transactions', () => ({
   insertTreasuryReceivePaymentLedgerIfAbsent: vi.fn(),
@@ -77,10 +84,12 @@ vi.mock('@/lib/analytics/server', () => ({
 import { runSpendPaymentConfirm } from '@/lib/spend-payment-confirm';
 import * as analytics from '@/lib/analytics/server';
 import * as spendSessions from '@/lib/db/spend-sessions';
+import * as spendPaymentVerify from '@/lib/spend-payment-verify';
 import type {
   PointConversion,
   SpendExperience,
   SpendSession,
+  SpendTransaction,
 } from '@/lib/types';
 
 const validHash =
@@ -153,6 +162,7 @@ function inProgressConversion(
 describe('runSpendPaymentConfirm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockPatchPrepare.mockReset();
     mockFetchUserUsdc.mockResolvedValue(10);
     mockRailGate.mockReturnValue({ ok: true as const });
     mockGetSpendTransaction.mockResolvedValue(null);
@@ -174,6 +184,10 @@ describe('runSpendPaymentConfirm', () => {
         transfer_calldata: '0x',
       },
       idempotency_key: 'payment:sess-1',
+      attempt_count: 0,
+      last_failure_reason: null,
+      last_failure_at: null,
+      last_ambiguity_metadata: null,
       created_at: '2026-01-01T00:00:00.000Z',
       updated_at: '2026-01-01T00:00:00.000Z',
     });
@@ -297,5 +311,144 @@ describe('runSpendPaymentConfirm', () => {
     if (result.ok) throw new Error('expected failure');
     expect(result.httpStatus).toBe(400);
     expect(result.error).toMatch(/not ready to confirm/i);
+  });
+
+  it('rejects confirm while payment operation needs_review', async () => {
+    mockGetPointConversion.mockResolvedValue(inProgressConversion('funded'));
+    mockGetPaymentPrepare.mockResolvedValue({
+      id: 'prep-1',
+      spend_session_id: baseSession.id,
+      user_id: 'user-1',
+      spend_rail: 'base_usdc',
+      status: 'needs_review',
+      prepared_action: {},
+      verification_snapshot: {
+        v: 1,
+        spend_rail: 'base_usdc',
+        chain_id: 8453,
+        usdc_contract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        receiving_wallet: '0x2222222222222222222222222222222222222222',
+        from_wallet: baseSession.wallet_address.toLowerCase(),
+        usdc_amount: 5,
+        transfer_calldata: '0x',
+      },
+      idempotency_key: 'payment:sess-1',
+      attempt_count: 0,
+      last_failure_reason: 'timeout',
+      last_failure_at: '2026-01-01T00:00:01.000Z',
+      last_ambiguity_metadata: {},
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const session = {
+      ...baseSession,
+      status: 'conversion_complete' as const,
+    };
+
+    const result = await runSpendPaymentConfirm({
+      session,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      paymentTxHash: validHash,
+      usdcAmount: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.httpStatus).toBe(400);
+    expect(result.details?.paymentOperation?.status).toBe('needs_review');
+    expect(
+      spendSessions.insertSpendTransactionSubmitted
+    ).not.toHaveBeenCalled();
+  });
+
+  it('marks payment operation needs_review and does not mark spend transaction failed when verification is ambiguous', async () => {
+    mockGetPointConversion.mockResolvedValue(inProgressConversion('funded'));
+    mockGetSpendTransaction.mockResolvedValue(null);
+
+    const submittedTx: SpendTransaction = {
+      id: 'tx-1',
+      spend_experience_id: 'exp-1',
+      spend_session_id: 'sess-1',
+      user_id: 'user-1',
+      usdc_amount: 5,
+      spend_rail: 'base_usdc',
+      network: 'Base',
+      asset_symbol: 'USDC',
+      from_wallet_address: baseSession.wallet_address.toLowerCase(),
+      to_wallet_address: '0x2222222222222222222222222222222222222222',
+      status: 'submitted',
+      payment_tx_hash: validHash,
+      explorer_tx_url: null,
+      idempotency_key: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: null,
+      failed_reason: null,
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+
+    vi.mocked(spendSessions.insertSpendTransactionSubmitted).mockResolvedValue(
+      submittedTx
+    );
+
+    vi.mocked(spendPaymentVerify.verifySpendUsdcPaymentTx).mockResolvedValue({
+      ok: false,
+      reason: 'waitForTransactionReceipt timeout',
+    });
+
+    mockPatchPrepare.mockResolvedValue({
+      id: 'prep-1',
+      spend_session_id: baseSession.id,
+      user_id: 'user-1',
+      spend_rail: 'base_usdc',
+      status: 'needs_review',
+      prepared_action: {},
+      verification_snapshot: {
+        v: 1,
+        spend_rail: 'base_usdc',
+        chain_id: 8453,
+        usdc_contract: '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+        receiving_wallet: '0x2222222222222222222222222222222222222222',
+        from_wallet: baseSession.wallet_address.toLowerCase(),
+        usdc_amount: 5,
+        transfer_calldata: '0x',
+      },
+      idempotency_key: 'payment:sess-1',
+      attempt_count: 0,
+      last_failure_reason: 'waitForTransactionReceipt timeout',
+      last_failure_at: '2026-01-01T00:00:02.000Z',
+      last_ambiguity_metadata: { spend_transaction_id: 'tx-1' },
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:02.000Z',
+    });
+
+    const session = {
+      ...baseSession,
+      status: 'conversion_complete' as const,
+    };
+
+    const result = await runSpendPaymentConfirm({
+      session,
+      spendExperience: baseExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      paymentTxHash: validHash,
+      usdcAmount: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.httpStatus).toBe(400);
+    expect(
+      mockPatchPrepare.mock.calls.some(
+        (args) => (args[1] as { status?: string })?.status === 'needs_review'
+      )
+    ).toBe(true);
+    expect(spendSessions.updateSpendTransactionFields).not.toHaveBeenCalled();
+    expect(analytics.trackSpendPaymentFailed).not.toHaveBeenCalled();
   });
 });

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -7,7 +7,11 @@ import {
   updateSpendTransactionFields,
   confirmSpendTransactionIfSubmitted,
 } from '@/lib/db/spend-sessions';
-import { getSpendPaymentPrepareBySessionId } from '@/lib/db/spend-payment-prepare';
+import {
+  getSpendPaymentPrepareBySessionId,
+  patchSpendPaymentPrepare,
+  spendPaymentOperationClientSummary,
+} from '@/lib/db/spend-payment-prepare';
 import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import {
   explorerTxUrlForSpendLedger,
@@ -16,6 +20,7 @@ import {
 import { fetchUserUsdcBalanceSafe } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
+import { isAmbiguousSpendPaymentVerifyFailure } from '@/lib/spend-payment-verify-ambiguous';
 import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
 import {
   assertSpendRailAllowsMutatingSpendWork,
@@ -23,15 +28,17 @@ import {
   getSpendReceivingWalletAddress,
 } from '@/lib/spend-rail-config';
 import {
-  isEvmAddress,
-  POSTER_CHECKOUT_CHAIN_ID,
-} from '@/lib/walletconnect-poster-direct-usdc';
-import {
   isSpendBaseUsdcVerificationSnapshotV1,
   spendBaseUsdcSnapshotMatchesLiveRail,
 } from '@/lib/spend-payment-prepare-types';
+import {
+  isEvmAddress,
+  POSTER_CHECKOUT_CHAIN_ID,
+} from '@/lib/walletconnect-poster-direct-usdc';
 import type {
   SpendExperience,
+  SpendPaymentOperationClientSummary,
+  SpendPaymentPrepareOperation,
   SpendSession,
   SpendTransaction,
 } from '@/lib/types';
@@ -69,14 +76,14 @@ export type SpendPaymentConfirmResult =
       spendTransaction: SpendTransaction;
       session: SpendSession;
       resumed: boolean;
+      paymentOperation?: SpendPaymentOperationClientSummary;
     }
-  | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
-
-const PAYMENT_HASH_CONFLICT: SpendPaymentConfirmResult = {
-  ok: false,
-  error: 'A different payment is already in progress for this session',
-  httpStatus: 409,
-};
+  | {
+      ok: false;
+      error: string;
+      httpStatus: SpendPilotApiHttpStatus;
+      details?: { paymentOperation?: SpendPaymentOperationClientSummary };
+    };
 
 async function finalizeSuccess(params: {
   spendTransactionId: string;
@@ -222,11 +229,15 @@ export async function runSpendPaymentConfirm(input: {
     if (session.status === 'payment_complete') {
       const existing = await getSpendTransactionBySessionId(session.id);
       if (existing?.status === 'confirmed') {
+        const prepOp = await getSpendPaymentPrepareBySessionId(session.id);
         return {
           ok: true,
           spendTransaction: existing,
           session: { ...session, status: 'payment_complete' },
           resumed: true,
+          paymentOperation: prepOp
+            ? spendPaymentOperationClientSummary(prepOp)
+            : undefined,
         };
       }
     }
@@ -253,6 +264,7 @@ export async function runSpendPaymentConfirm(input: {
   let usdcAmount: number;
 
   let spendTx: SpendTransaction | null = null;
+  let basePaymentPrepare: SpendPaymentPrepareOperation | null = null;
 
   if (session.spend_rail === 'base_usdc') {
     const [preparedOp, tx] = await Promise.all([
@@ -268,6 +280,43 @@ export async function runSpendPaymentConfirm(input: {
         httpStatus: 400,
       };
     }
+    basePaymentPrepare = preparedOp;
+
+    if (preparedOp.status === 'needs_review') {
+      return {
+        ok: false,
+        error:
+          'This payment is under review. Please contact support with your transaction hash if you already sent funds. Do not send another payment.',
+        httpStatus: 400,
+        details: {
+          paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+        },
+      };
+    }
+
+    if (preparedOp.status === 'failed') {
+      return {
+        ok: false,
+        error:
+          'Prepare your payment again in this app after a failed attempt, then submit a new transaction from your wallet.',
+        httpStatus: 400,
+        details: {
+          paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+        },
+      };
+    }
+
+    if (preparedOp.status === 'confirmed' && spendTx?.status === 'confirmed') {
+      const fresh = await getSpendSessionById(session.id);
+      return {
+        ok: true,
+        spendTransaction: spendTx,
+        session: fresh ?? { ...session, status: 'payment_complete' },
+        resumed: true,
+        paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+      };
+    }
+
     const snap = preparedOp.verification_snapshot;
     if (!isSpendBaseUsdcVerificationSnapshotV1(snap)) {
       return {
@@ -316,6 +365,18 @@ export async function runSpendPaymentConfirm(input: {
   }
   const requestedHashLower = txHash.toLowerCase();
 
+  const paymentHashConflict = async (): Promise<SpendPaymentConfirmResult> => {
+    const op = await getSpendPaymentPrepareBySessionId(session.id);
+    return {
+      ok: false,
+      error: 'A different payment is already in progress for this session',
+      httpStatus: 409,
+      details: op
+        ? { paymentOperation: spendPaymentOperationClientSummary(op) }
+        : undefined,
+    };
+  };
+
   const baseAnalytics: SpendPilotPaymentEventProperties = {
     spend_experience_id: spendExperience.id,
     event_id: spendExperience.event_id,
@@ -352,16 +413,20 @@ export async function runSpendPaymentConfirm(input: {
 
   if (spendTx?.status === 'confirmed') {
     const fresh = await getSpendSessionById(session.id);
+    const prepOp = await getSpendPaymentPrepareBySessionId(session.id);
     return {
       ok: true,
       spendTransaction: spendTx,
       session: fresh ?? { ...session, status: 'payment_complete' },
       resumed: true,
+      paymentOperation: prepOp
+        ? spendPaymentOperationClientSummary(prepOp)
+        : undefined,
     };
   }
 
   if (spendTx && submittedPaymentHashConflicts(spendTx, requestedHashLower)) {
-    return PAYMENT_HASH_CONFLICT;
+    return await paymentHashConflict();
   }
 
   if (spendTx?.status === 'failed') {
@@ -405,7 +470,7 @@ export async function runSpendPaymentConfirm(input: {
   }
 
   if (submittedPaymentHashConflicts(spendTx, requestedHashLower)) {
-    return PAYMENT_HASH_CONFLICT;
+    return await paymentHashConflict();
   }
 
   if (spendTx.status === 'pending') {
@@ -421,6 +486,17 @@ export async function runSpendPaymentConfirm(input: {
         error: 'Failed to load payment record',
         httpStatus: 500,
       };
+    }
+  }
+
+  if (session.spend_rail === 'base_usdc' && basePaymentPrepare) {
+    const aligned =
+      spendTx.status === 'submitted' &&
+      (spendTx.payment_tx_hash ?? '').toLowerCase() === requestedHashLower;
+    if (aligned) {
+      await patchSpendPaymentPrepare(basePaymentPrepare.id, {
+        status: 'submitted',
+      });
     }
   }
 
@@ -445,6 +521,36 @@ export async function runSpendPaymentConfirm(input: {
   });
 
   if (!verify.ok) {
+    if (session.spend_rail === 'base_usdc' && basePaymentPrepare) {
+      const nowIso = new Date().toISOString();
+      if (isAmbiguousSpendPaymentVerifyFailure(verify.reason)) {
+        const opRow = await patchSpendPaymentPrepare(basePaymentPrepare.id, {
+          status: 'needs_review',
+          lastFailureReason: verify.reason,
+          lastFailureAt: nowIso,
+          lastAmbiguityMetadata: {
+            spend_transaction_id: spendTx.id,
+            verify_reason: verify.reason,
+          },
+        });
+        return {
+          ok: false,
+          error:
+            'We could not fully verify this payment yet. Please contact support with your transaction hash and do not send another payment.',
+          httpStatus: 400,
+          details: {
+            paymentOperation: spendPaymentOperationClientSummary(opRow),
+          },
+        };
+      }
+      await patchSpendPaymentPrepare(basePaymentPrepare.id, {
+        status: 'failed',
+        lastFailureReason: verify.reason,
+        lastFailureAt: nowIso,
+        lastAmbiguityMetadata: null,
+      });
+    }
+
     await finalizeFailure({
       spendTransactionId: spendTx.id,
       sessionId: session.id,
@@ -452,11 +558,20 @@ export async function runSpendPaymentConfirm(input: {
       analytics: { ...baseAnalytics, spend_transaction_id: spendTx.id },
       reason: verify.reason,
     });
+
+    const opAfter =
+      session.spend_rail === 'base_usdc'
+        ? await getSpendPaymentPrepareBySessionId(session.id)
+        : null;
+
     return {
       ok: false,
       error:
         'Payment could not be verified on-chain. If funds left your wallet, contact support with your transaction hash.',
       httpStatus: 400,
+      details: opAfter
+        ? { paymentOperation: spendPaymentOperationClientSummary(opAfter) }
+        : undefined,
     };
   }
 
@@ -471,6 +586,21 @@ export async function runSpendPaymentConfirm(input: {
     getSpendTransactionBySessionId(session.id),
     getSpendSessionById(session.id),
   ]);
+
+  if (updatedTx?.status === 'confirmed' && basePaymentPrepare) {
+    await patchSpendPaymentPrepare(basePaymentPrepare.id, {
+      status: 'confirmed',
+      lastFailureReason: null,
+      lastFailureAt: null,
+      lastAmbiguityMetadata: null,
+    });
+  }
+
+  let paymentOpSummary: SpendPaymentOperationClientSummary | undefined;
+  if (session.spend_rail === 'base_usdc') {
+    const po = await getSpendPaymentPrepareBySessionId(session.id);
+    paymentOpSummary = po ? spendPaymentOperationClientSummary(po) : undefined;
+  }
 
   if (updatedTx?.status === 'confirmed' && updatedTx.payment_tx_hash) {
     void insertTreasuryReceivePaymentLedgerIfAbsent({
@@ -489,6 +619,7 @@ export async function runSpendPaymentConfirm(input: {
       spendTransaction: updatedTx,
       session: freshSession ?? { ...session, status: 'payment_complete' },
       resumed: true,
+      paymentOperation: paymentOpSummary,
     };
   }
 
@@ -501,5 +632,6 @@ export async function runSpendPaymentConfirm(input: {
       completed_at: new Date().toISOString(),
     },
     resumed: resumed || isSameSubmittedHash,
+    paymentOperation: paymentOpSummary,
   };
 }

--- a/lib/spend-payment-prepare.ts
+++ b/lib/spend-payment-prepare.ts
@@ -1,6 +1,11 @@
-import { getPointConversionBySessionId } from '@/lib/db/spend-sessions';
+import {
+  getPointConversionBySessionId,
+  getSpendTransactionBySessionId,
+} from '@/lib/db/spend-sessions';
 import {
   insertSpendPaymentPrepareOrGet,
+  patchSpendPaymentPrepare,
+  spendPaymentOperationClientSummary,
   updateSpendPaymentPreparePayload,
 } from '@/lib/db/spend-payment-prepare';
 import {
@@ -21,18 +26,32 @@ import {
 } from '@/lib/walletconnect-poster-direct-usdc';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
 import type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
-import type { SpendExperience, SpendSession } from '@/lib/types';
+import type {
+  SpendExperience,
+  SpendPaymentOperationClientSummary,
+  SpendSession,
+} from '@/lib/types';
 
 export type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
 export { getSpendPaymentSessionContextOr404 as getSpendPaymentPrepareContextOr404 } from '@/lib/spend-payment-session-context';
+export { spendPaymentOperationClientSummary } from '@/lib/db/spend-payment-prepare';
+
+const NEEDS_REVIEW_PREPARE_MESSAGE =
+  'This payment is under review. Please contact support with your transaction hash if you already sent funds. Do not send another payment.';
 
 export type SpendPaymentPrepareResult =
   | {
       ok: true;
       preparedAction: Record<string, unknown>;
       session: Pick<SpendSession, 'id' | 'status' | 'expires_at'>;
+      paymentOperation: SpendPaymentOperationClientSummary;
     }
-  | { ok: false; error: string; httpStatus: SpendPilotApiHttpStatus };
+  | {
+      ok: false;
+      error: string;
+      httpStatus: SpendPilotApiHttpStatus;
+      details?: { paymentOperation?: SpendPaymentOperationClientSummary };
+    };
 
 /** Canonical JSON for compare — PostgreSQL jsonb does not preserve object key order. */
 function stableJsonStringify(value: unknown): string {
@@ -102,6 +121,14 @@ export async function runSpendPaymentPrepare(input: {
   const now = new Date();
   if (now > new Date(session.expires_at)) {
     return { ok: false, error: 'Spend session expired', httpStatus: 400 };
+  }
+
+  if (session.status === 'payment_complete') {
+    return {
+      ok: false,
+      error: 'Payment already completed for this session.',
+      httpStatus: 409,
+    };
   }
 
   const openGate = assertSpendExperienceOpenForSessions(spendExperience, now);
@@ -250,13 +277,77 @@ export async function runSpendPaymentPrepare(input: {
   const newAction = { ...preparedAction } as Record<string, unknown>;
   const newSnap = { ...verificationSnapshot } as Record<string, unknown>;
 
-  const { row, created } = await insertSpendPaymentPrepareOrGet({
+  const { row: initialRow, created } = await insertSpendPaymentPrepareOrGet({
     spendSessionId: session.id,
     userId: authUserId,
     spendRail: session.spend_rail,
     preparedAction: newAction,
     verificationSnapshot: newSnap,
   });
+  let row = initialRow;
+
+  const spendTx = await getSpendTransactionBySessionId(session.id);
+
+  if (spendTx?.status === 'confirmed' && row.status !== 'confirmed') {
+    row = await patchSpendPaymentPrepare(row.id, { status: 'confirmed' });
+  }
+
+  if (
+    spendTx?.status === 'failed' &&
+    (spendTx.payment_tx_hash ?? '').trim().length > 0 &&
+    row.status === 'submitted'
+  ) {
+    row = await patchSpendPaymentPrepare(row.id, {
+      status: 'failed',
+      lastFailureReason: spendTx.failed_reason ?? 'verification_failed',
+      lastFailureAt: spendTx.completed_at ?? new Date().toISOString(),
+      lastAmbiguityMetadata: null,
+    });
+  }
+
+  const opSummary = () => spendPaymentOperationClientSummary(row);
+
+  if (spendTx?.status === 'confirmed') {
+    return {
+      ok: false,
+      error: 'Payment already completed for this session.',
+      httpStatus: 409,
+      details: { paymentOperation: opSummary() },
+    };
+  }
+
+  if (row.status === 'needs_review') {
+    return {
+      ok: false,
+      error: NEEDS_REVIEW_PREPARE_MESSAGE,
+      httpStatus: 400,
+      details: { paymentOperation: opSummary() },
+    };
+  }
+
+  if (row.status === 'confirmed') {
+    return {
+      ok: false,
+      error: 'Payment already completed for this session.',
+      httpStatus: 409,
+      details: { paymentOperation: opSummary() },
+    };
+  }
+
+  if (row.status === 'failed') {
+    row = await patchSpendPaymentPrepare(row.id, {
+      status: 'prepared',
+      preparedAction: newAction,
+      verificationSnapshot: newSnap,
+      attemptCount: row.attempt_count + 1,
+    });
+    return {
+      ok: true,
+      preparedAction: row.prepared_action,
+      session: paymentPrepareResponseSession(session),
+      paymentOperation: spendPaymentOperationClientSummary(row),
+    };
+  }
 
   if (
     !created &&
@@ -271,6 +362,7 @@ export async function runSpendPaymentPrepare(input: {
       ok: true,
       preparedAction: row.prepared_action,
       session: paymentPrepareResponseSession(session),
+      paymentOperation: spendPaymentOperationClientSummary(row),
     };
   }
 
@@ -279,10 +371,12 @@ export async function runSpendPaymentPrepare(input: {
       preparedAction: newAction,
       verificationSnapshot: newSnap,
     });
+    row = updated;
     return {
       ok: true,
       preparedAction: updated.prepared_action,
       session: paymentPrepareResponseSession(session),
+      paymentOperation: spendPaymentOperationClientSummary(row),
     };
   }
 
@@ -290,5 +384,6 @@ export async function runSpendPaymentPrepare(input: {
     ok: true,
     preparedAction: row.prepared_action,
     session: paymentPrepareResponseSession(session),
+    paymentOperation: spendPaymentOperationClientSummary(row),
   };
 }

--- a/lib/spend-payment-verify-ambiguous.ts
+++ b/lib/spend-payment-verify-ambiguous.ts
@@ -1,0 +1,13 @@
+/**
+ * Classifies Base USDC payment verification error strings (IRL-28). Kept dependency-free so
+ * callers and tests do not load RPC / rail config or Privy server modules.
+ */
+export function isAmbiguousSpendPaymentVerifyFailure(reason: string): boolean {
+  const r = reason.toLowerCase();
+  return (
+    r.includes('timeout') ||
+    r.includes('rpc not configured') ||
+    r.includes('receipt wait') ||
+    r.includes('wait failed')
+  );
+}

--- a/lib/spend-payment-verify-classify.test.ts
+++ b/lib/spend-payment-verify-classify.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from 'vitest';
+import { isAmbiguousSpendPaymentVerifyFailure } from '@/lib/spend-payment-verify-ambiguous';
+
+describe('isAmbiguousSpendPaymentVerifyFailure', () => {
+  it('returns true for timeout / RPC / receipt-wait style reasons', () => {
+    expect(
+      isAmbiguousSpendPaymentVerifyFailure('waitForTransactionReceipt timeout')
+    ).toBe(true);
+    expect(isAmbiguousSpendPaymentVerifyFailure('RPC not configured')).toBe(
+      true
+    );
+    expect(
+      isAmbiguousSpendPaymentVerifyFailure('receipt wait failed: network')
+    ).toBe(true);
+  });
+
+  it('returns false for definitive on-chain outcomes', () => {
+    expect(isAmbiguousSpendPaymentVerifyFailure('transaction_reverted')).toBe(
+      false
+    );
+    expect(
+      isAmbiguousSpendPaymentVerifyFailure('no_matching_usdc_transfer')
+    ).toBe(false);
+  });
+});

--- a/lib/spend-payment-verify.ts
+++ b/lib/spend-payment-verify.ts
@@ -15,9 +15,6 @@ export type SpendPaymentTxVerifyResult =
   | { ok: true }
   | { ok: false; reason: string };
 
-/**
- * Confirms a Base USDC transfer receipt: success, token, from, to, and amount (6 decimals).
- */
 export async function verifySpendUsdcPaymentTx(params: {
   txHash: `0x${string}`;
   expectedFrom: `0x${string}`;

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -21,8 +21,8 @@ export type SpendRailFundingOperationStatus =
   | 'needs_review';
 
 /**
- * Payment operation lifecycle at the **rail orchestration layer** (not `spend_transactions.status`;
- * DB alignment is deferred).
+ * Payment operation lifecycle at the **rail orchestration layer** and on
+ * `spend_payment_prepare_operations.status` (IRL-28).
  *
  * **confirmed** means on-chain (or network-appropriate) evidence consistent with spend payment
  * ledger confirmation semantics; verification lives in rail implementations.

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -459,12 +459,20 @@ export type SpendWalletReadinessOperation = {
   updated_at: string;
 };
 
-/** v1 idempotency key `payment:{spend_session_id}` (distinct from `spend_payment:{sessionId}` on spend_transactions). */
-export type SpendPaymentPrepareOperationStatus = 'prepared';
+/**
+ * `spend_payment_prepare_operations.status` — aligned with `SpendRailPaymentOperationStatus`
+ * (IRL-28).
+ */
+export type SpendPaymentPrepareOperationStatus =
+  | 'prepared'
+  | 'submitted'
+  | 'confirmed'
+  | 'failed'
+  | 'needs_review';
 
 /**
- * Server-prepared payment action row (IRL-19). `prepared_action` / `verification_snapshot` are
- * rail-specific JSON; Base USDC uses `SpendPaymentPrepareStoredActionV1` + snapshot types in
+ * Server-prepared payment action row (IRL-19 / IRL-28). `prepared_action` / `verification_snapshot`
+ * are rail-specific JSON; Base USDC uses `SpendPaymentPrepareStoredActionV1` + snapshot types in
  * `lib/spend-payment-prepare-types.ts`.
  */
 export type SpendPaymentPrepareOperation = {
@@ -476,6 +484,19 @@ export type SpendPaymentPrepareOperation = {
   prepared_action: Record<string, unknown>;
   verification_snapshot: Record<string, unknown>;
   idempotency_key: string;
+  attempt_count: number;
+  last_failure_reason: string | null;
+  last_failure_at: string | null;
+  last_ambiguity_metadata: Record<string, unknown> | null;
   created_at: string;
   updated_at: string;
+};
+
+/** Client-safe subset for Pay / retry / needs_review gating (IRL-28). */
+export type SpendPaymentOperationClientSummary = {
+  id: string;
+  status: SpendPaymentPrepareOperationStatus;
+  attempt_count: number;
+  last_failure_reason: string | null;
+  last_failure_at: string | null;
 };

--- a/src/__tests__/setup.ts
+++ b/src/__tests__/setup.ts
@@ -122,6 +122,15 @@ vi.mock('@privy-io/react-auth', () => ({
   PrivyProvider: ({ children }: { children: React.ReactNode }) => children,
 }));
 
+/** happy-dom is a browser-like environment; server-auth throws on import without this mock. */
+vi.mock('@privy-io/server-auth', () => ({
+  PrivyClient: class MockPrivyServerClient {
+    constructor(..._args: unknown[]) {
+      void _args;
+    }
+  },
+}));
+
 // Mock Mapbox GL
 vi.mock('mapbox-gl', () => ({
   Map: vi.fn(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements IRL-28: one durable payment operation per spend session (`payment:{spend_session_id}`) with explicit lifecycle states, idempotent prepare on refresh, user-driven retry after definitive failure without treating ambiguous on-chain verification as a user-retriable failure.

**Database:** `database/irl-28-spend-payment-prepare-operation-lifecycle.sql` extends `spend_payment_prepare_operations.status` to `prepared`, `submitted`, `confirmed`, `failed`, `needs_review` and adds `attempt_count`, `last_failure_reason`, `last_failure_at`, `last_ambiguity_metadata`.

**Server:** `runSpendPaymentPrepare` reconciles with `spend_transactions`, blocks `needs_review` and duplicate success, and resets `failed` to `prepared` with incremented `attempt_count` on explicit prepare. `runSpendPaymentConfirm` updates the prepare row in lockstep (`submitted` / `confirmed` / `failed` / `needs_review`), skips `finalizeFailure` when verification is ambiguous (timeout / receipt wait style), and returns `paymentOperation` plus optional `details` on errors.

**API:** `apiSuccess` responses for payment prepare/confirm include `paymentOperation`. `apiError` accepts optional `details`; `ApiError` exposes `details` and `apiClient` passes it through.

**Client:** Spend experience page reads prepare-query errors for `needs_review`, hides the Base Pay button, and shows a short support message.

**Tests:** Extended `lib/spend-payment-confirm.test.ts`, payment route tests, `lib/spend-payment-verify-classify.test.ts` for ambiguity classification. Vitest setup mocks `@privy-io/server-auth` so happy-dom can load the Stellar rail dependency chain.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-28](https://linear.app/irlenergy/issue/IRL-28/implement-payment-prepareconfirm-operation-lifecycle)

<div><a href="https://cursor.com/agents/bc-fb1d2c1c-482b-41e0-9cd2-804779191204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-fb1d2c1c-482b-41e0-9cd2-804779191204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

