### PR TITLE
feat(spend): backend-controlled Stellar USDC final payment (IRL-24)

### DIFF
--- a/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/payment/confirm/route.ts
@@ -40,7 +40,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   const walletAddress = parsed.data.walletAddress.trim();
   const normalizedWallet = walletAddress.toLowerCase();
-  const paymentTxHash = parsed.data.paymentTxHash.trim();
+  const paymentTxHash = parsed.data.paymentTxHash?.trim() ?? '';
+  const stellarBackendConfirm = parsed.data.stellarBackendConfirm === true;
 
   const auth = await verifyWalletOwnership(request, walletAddress);
   if (!auth.authorized || !auth.userId) {
@@ -59,6 +60,16 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
 
   const { session, spendExperience, usdcAmount } = ctx;
 
+  if (session.spend_rail === 'stellar_usdc' && !stellarBackendConfirm) {
+    return apiError(
+      'Stellar payments require `"stellarBackendConfirm": true` in the JSON body (no paymentTxHash).',
+      400
+    );
+  }
+  if (session.spend_rail === 'base_usdc' && stellarBackendConfirm) {
+    return apiError('Invalid confirmation body for this payment network.', 400);
+  }
+
   const distinctId = resolveServerIdentity({
     privyUserId: auth.userId,
     walletAddress: normalizedWallet,
@@ -71,7 +82,8 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       normalizedWallet,
       authUserId: auth.userId,
       distinctId,
-      paymentTxHash,
+      paymentTxHash: paymentTxHash || undefined,
+      stellarBackendConfirm,
       usdcAmount,
     });
 

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -28,7 +28,11 @@ import {
   spendPaymentExplorerLinkLabel,
 } from '@/lib/spend-rail-explorer-url-client';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
-import { isSpendPaymentPrepareStoredActionV1 } from '@/lib/spend-payment-prepare-types';
+import { stellarWalletAddressSchema } from '@/lib/schemas/player';
+import {
+  isSpendPaymentPrepareStoredActionV1,
+  isSpendStellarUsdcBackendSubmitPreparedActionV1,
+} from '@/lib/spend-payment-prepare-types';
 
 type SpendExperiencePageProps = {
   experienceId: string;
@@ -277,6 +281,25 @@ export function SpendExperiencePage({
     sessionStatusForPrepare !== 'payment_complete'
   );
 
+  const stellarPayPrepareEnabled = Boolean(
+    user &&
+    walletAddress &&
+    sessionId &&
+    !isFetching &&
+    !previewLoading &&
+    eligForPrepare?.preview &&
+    previewPayload?.spendRailSummary?.rail === 'stellar_usdc' &&
+    stellarWalletAddressSchema.safeParse(
+      eligForPrepare.preview.receivingWalletAddress.trim()
+    ).success &&
+    (eligForPrepare.status === 'ready_for_payment' ||
+      eligForPrepare.status === 'ready_for_payment_own_usdc' ||
+      eligForPrepare.status === 'payment_failed') &&
+    sessionStatusForPrepare !== 'payment_complete'
+  );
+
+  const payPrepareEnabled = basePayPrepareEnabled || stellarPayPrepareEnabled;
+
   const {
     data: paymentPrepareData,
     isFetching: paymentPrepareLoading,
@@ -299,7 +322,7 @@ export function SpendExperiencePage({
         { walletAddress }
       );
     },
-    enabled: basePayPrepareEnabled,
+    enabled: payPrepareEnabled,
     staleTime: Infinity,
     refetchOnWindowFocus: false,
     retry: false,
@@ -372,15 +395,24 @@ export function SpendExperiencePage({
   });
 
   const paymentMutation = useMutation({
-    mutationFn: async (paymentTxHash: string) => {
+    mutationFn: async (input: {
+      paymentTxHash?: string;
+      stellarBackendConfirm?: boolean;
+    }) => {
       const token = await getAccessToken();
       if (!token || !walletAddress || !sessionId) {
         throw new Error('Missing auth or session');
       }
+      const body: Record<string, unknown> = { walletAddress };
+      if (input.stellarBackendConfirm) {
+        body.stellarBackendConfirm = true;
+      } else if (input.paymentTxHash) {
+        body.paymentTxHash = input.paymentTxHash;
+      }
       return spendAuthedPost<PaymentConfirmResponse>(
         token,
         `/api/spend-sessions/${sessionId}/payment/confirm`,
-        { walletAddress, paymentTxHash }
+        body
       );
     },
     onSuccess: async () => {
@@ -394,12 +426,21 @@ export function SpendExperiencePage({
   });
 
   const sendUsdcPayment = useCallback(async () => {
-    if (!walletAddress || !evmWallet || !previewPayload?.eligibility.preview) {
+    if (!walletAddress || !previewPayload?.eligibility.preview) {
       toast.error('Wallet not ready');
       return;
     }
     const prepared = paymentPrepareData?.preparedAction;
-    if (!isSpendPaymentPrepareStoredActionV1(prepared)) {
+    if (isSpendStellarUsdcBackendSubmitPreparedActionV1(prepared)) {
+      try {
+        await paymentMutation.mutateAsync({ stellarBackendConfirm: true });
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        toast.error(msg);
+      }
+      return;
+    }
+    if (!evmWallet || !isSpendPaymentPrepareStoredActionV1(prepared)) {
       toast.error(
         'Payment is not ready yet. Wait a moment or refresh the page.'
       );
@@ -477,7 +518,7 @@ export function SpendExperiencePage({
           sponsor: true,
         });
       }
-      await paymentMutation.mutateAsync(hash);
+      await paymentMutation.mutateAsync({ paymentTxHash: hash });
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       toast.error(msg);
@@ -557,15 +598,19 @@ export function SpendExperiencePage({
     elig?.status === 'conversion_failed_retryable' &&
     sessionAllowsConversionActions;
 
-  const showBaseWalletPay =
+  const showWalletPay =
     !isPaymentComplete &&
     !paymentPrepareNeedsReview &&
     (elig?.status === 'ready_for_payment' ||
       elig?.status === 'ready_for_payment_own_usdc' ||
       elig?.status === 'payment_failed') &&
     preview &&
-    resolvedSpendRail === 'base_usdc' &&
-    isEvmAddress(preview.receivingWalletAddress);
+    ((resolvedSpendRail === 'base_usdc' &&
+      isEvmAddress(preview.receivingWalletAddress)) ||
+      (resolvedSpendRail === 'stellar_usdc' &&
+        stellarWalletAddressSchema.safeParse(
+          preview.receivingWalletAddress.trim()
+        ).success));
 
   const displayReceipt = isPaymentComplete;
 
@@ -756,7 +801,7 @@ export function SpendExperiencePage({
                       </div>
                     )}
 
-                    {showBaseWalletPay && (
+                    {showWalletPay && (
                       <SpendPrimaryButton
                         pending={
                           paymentMutation.isPending || paymentPrepareLoading
@@ -764,15 +809,27 @@ export function SpendExperiencePage({
                         onClick={() => void sendUsdcPayment()}
                       >
                         {paymentMutation.isPending
-                          ? `Pay with ${assetSymbol}…`
-                          : `Spend $${preview.usdcAmount.toFixed(2)} ${assetSymbol}`}
+                          ? resolvedSpendRail === 'stellar_usdc' &&
+                            isSpendStellarUsdcBackendSubmitPreparedActionV1(
+                              paymentPrepareData?.preparedAction
+                            )
+                            ? paymentPrepareData.preparedAction.display
+                                .submitting_label
+                            : `Pay with ${assetSymbol}…`
+                          : isSpendStellarUsdcBackendSubmitPreparedActionV1(
+                                paymentPrepareData?.preparedAction
+                              )
+                            ? paymentPrepareData.preparedAction.display
+                                .pay_label
+                            : `Spend $${preview.usdcAmount.toFixed(2)} ${assetSymbol}`}
                       </SpendPrimaryButton>
                     )}
 
                     {postPointsConversion &&
                       paymentPrepareNeedsReview &&
                       !isPaymentComplete &&
-                      resolvedSpendRail === 'base_usdc' && (
+                      (resolvedSpendRail === 'base_usdc' ||
+                        resolvedSpendRail === 'stellar_usdc') && (
                         <p className="body-small font-grotesk text-amber-900">
                           We could not automatically confirm your last payment
                           transaction. Please contact support with your

--- a/lib/schemas/spend-session.ts
+++ b/lib/schemas/spend-session.ts
@@ -45,15 +45,33 @@ export type SpendPaymentPrepareBody = z.infer<
 >;
 
 /** POST /api/spend-sessions/{sessionId}/payment/confirm */
-export const spendPaymentConfirmBodySchema = z.object({
-  walletAddress: evmAddressField,
-  paymentTxHash: z
-    .string()
-    .min(1, 'paymentTxHash is required')
-    .refine((s) => /^0x[a-fA-F0-9]{64}$/.test(s.trim()), {
-      message: 'paymentTxHash must be a 32-byte hex hash with 0x prefix',
-    }),
-});
+export const spendPaymentConfirmBodySchema = z
+  .object({
+    walletAddress: evmAddressField,
+    paymentTxHash: z.string().trim().optional(),
+    stellarBackendConfirm: z.literal(true).optional(),
+  })
+  .superRefine((val, ctx) => {
+    const hash = val.paymentTxHash?.trim() ?? '';
+    if (val.stellarBackendConfirm === true) {
+      if (hash.length > 0) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'paymentTxHash must not be sent for Stellar backend confirmations',
+          path: ['paymentTxHash'],
+        });
+      }
+      return;
+    }
+    if (!/^0x[a-fA-F0-9]{64}$/.test(hash)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'paymentTxHash must be a 32-byte hex hash with 0x prefix',
+        path: ['paymentTxHash'],
+      });
+    }
+  });
 
 export type SpendPaymentConfirmBody = z.infer<
   typeof spendPaymentConfirmBodySchema

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -66,12 +66,20 @@ vi.mock('@/lib/spend-payment-verify', () => ({
 }));
 
 vi.mock('@/lib/spend-rail-config', () => ({
-  getSpendReceivingWalletAddress: () =>
-    '0x2222222222222222222222222222222222222222',
+  getSpendReceivingWalletAddress: (spendRail: string) =>
+    spendRail === 'stellar_usdc'
+      ? 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H'
+      : '0x2222222222222222222222222222222222222222',
   getSpendRailBaseUsdcContractAddress: () =>
     '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
   assertSpendRailAllowsMutatingSpendWork: (...a: unknown[]) =>
     mockRailGate(...a),
+}));
+
+vi.mock('@/lib/spend/stellar-wallet-readiness-config', () => ({
+  getStellarSpendUsdcIssuer: () =>
+    'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+  getStellarSpendUsdcAssetCode: () => 'USDC',
 }));
 
 vi.mock('@/lib/analytics/server', () => ({
@@ -216,7 +224,8 @@ describe('runSpendPaymentConfirm', () => {
     expect(result.error).toMatch(/conversion is still in progress/i);
   });
 
-  it('rejects user-signed payment confirm for stellar_usdc via spend payment rail', async () => {
+  it('rejects Stellar payment confirm without stellarBackendConfirm', async () => {
+    mockGetPointConversion.mockResolvedValue(inProgressConversion('funded'));
     const stellarExperience = {
       ...baseExperience,
       spend_rail: 'stellar_usdc' as const,
@@ -224,6 +233,39 @@ describe('runSpendPaymentConfirm', () => {
     const stellarSession = {
       ...baseSession,
       spend_rail: 'stellar_usdc' as const,
+      status: 'conversion_complete' as const,
+      rail_user_wallet_address:
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    };
+
+    const result = await runSpendPaymentConfirm({
+      session: stellarSession,
+      spendExperience: stellarExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      paymentTxHash: undefined,
+      usdcAmount: 5,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(result.httpStatus).toBe(400);
+    expect(result.error).toMatch(/in-app Stellar payment confirmation/i);
+  });
+
+  it('rejects Stellar payment confirm when paymentTxHash is sent', async () => {
+    mockGetPointConversion.mockResolvedValue(inProgressConversion('funded'));
+    const stellarExperience = {
+      ...baseExperience,
+      spend_rail: 'stellar_usdc' as const,
+    };
+    const stellarSession = {
+      ...baseSession,
+      spend_rail: 'stellar_usdc' as const,
+      status: 'conversion_complete' as const,
+      rail_user_wallet_address:
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
     };
 
     const result = await runSpendPaymentConfirm({
@@ -233,15 +275,14 @@ describe('runSpendPaymentConfirm', () => {
       authUserId: 'user-1',
       distinctId: 'd1',
       paymentTxHash: validHash,
+      stellarBackendConfirm: true,
       usdcAmount: 5,
     });
 
     expect(result.ok).toBe(false);
     if (result.ok) throw new Error('expected failure');
     expect(result.httpStatus).toBe(400);
-    expect(result.error).toBe(
-      'USDC payment verification on this network is not available in this release.'
-    );
+    expect(result.error).toMatch(/Do not send paymentTxHash/i);
   });
 
   it('returns 400 and does not insert when rail blocks new payment tx (HTTP 400 per spend API convention)', async () => {

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -16,10 +16,12 @@ import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-tr
 import {
   explorerTxUrlForSpendLedger,
   isLedgerCanonicalEvmTxHash,
+  isStellarTransactionHash,
 } from '@/lib/spend-ledger-explorer-url';
 import { fetchUserUsdcBalanceSafe } from '@/lib/spend-conversion-preview';
 import { assertSpendExperienceOpenForSessions } from '@/lib/spend-experience-guard';
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
+import { verifySpendStellarUsdcPaymentTx } from '@/lib/spend-payment-verify-stellar';
 import { isAmbiguousSpendPaymentVerifyFailure } from '@/lib/spend-payment-verify-ambiguous';
 import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
 import {
@@ -28,14 +30,22 @@ import {
   getSpendReceivingWalletAddress,
 } from '@/lib/spend-rail-config';
 import {
+  getStellarSpendUsdcAssetCode,
+  getStellarSpendUsdcIssuer,
+} from '@/lib/spend/stellar-wallet-readiness-config';
+import { stellarWalletAddressSchema } from '@/lib/schemas/player';
+import {
   isSpendBaseUsdcVerificationSnapshotV1,
+  isSpendStellarUsdcVerificationSnapshotV1,
   spendBaseUsdcSnapshotMatchesLiveRail,
+  spendStellarUsdcSnapshotMatchesLiveRail,
 } from '@/lib/spend-payment-prepare-types';
 import {
   isEvmAddress,
   POSTER_CHECKOUT_CHAIN_ID,
 } from '@/lib/walletconnect-poster-direct-usdc';
 import type {
+  PointConversion,
   SpendExperience,
   SpendPaymentOperationClientSummary,
   SpendPaymentPrepareOperation,
@@ -128,6 +138,441 @@ async function finalizeFailure(params: {
   });
 }
 
+type StellarConfirmDeps = {
+  fundedConversion: PointConversion | null;
+  receivingLive: string;
+};
+
+async function runSpendPaymentConfirmStellarUsdc(input: {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  normalizedWallet: string;
+  authUserId: string;
+  distinctId: string;
+  usdcAmount: number;
+  paymentTxHash?: string;
+  stellarBackendConfirm?: boolean;
+  deps: StellarConfirmDeps;
+}): Promise<SpendPaymentConfirmResult> {
+  const {
+    session,
+    spendExperience,
+    normalizedWallet,
+    authUserId,
+    distinctId,
+    deps,
+  } = input;
+  const { fundedConversion, receivingLive } = deps;
+
+  if (!input.stellarBackendConfirm) {
+    return {
+      ok: false,
+      error:
+        'Use the in-app Stellar payment confirmation (do not send a transaction hash).',
+      httpStatus: 400,
+    };
+  }
+  if (input.paymentTxHash?.trim()) {
+    return {
+      ok: false,
+      error: 'Do not send paymentTxHash for Stellar backend payments.',
+      httpStatus: 400,
+    };
+  }
+
+  const spendPaymentRail = getSpendPaymentRail('stellar_usdc');
+
+  const [preparedOp, spendTxInitial] = await Promise.all([
+    getSpendPaymentPrepareBySessionId(session.id),
+    getSpendTransactionBySessionId(session.id),
+  ]);
+
+  if (!preparedOp) {
+    return {
+      ok: false,
+      error:
+        'Payment is not ready to confirm. Refresh this page to prepare your payment.',
+      httpStatus: 400,
+    };
+  }
+
+  if (preparedOp.status === 'needs_review') {
+    return {
+      ok: false,
+      error:
+        'This payment is under review. Please contact support and do not send another payment.',
+      httpStatus: 400,
+      details: {
+        paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+      },
+    };
+  }
+
+  if (preparedOp.status === 'failed') {
+    return {
+      ok: false,
+      error:
+        'Prepare your payment again in this app after a failed attempt, then try paying again.',
+      httpStatus: 400,
+      details: {
+        paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+      },
+    };
+  }
+
+  if (
+    preparedOp.status === 'confirmed' &&
+    spendTxInitial?.status === 'confirmed'
+  ) {
+    const fresh = await getSpendSessionById(session.id);
+    return {
+      ok: true,
+      spendTransaction: spendTxInitial,
+      session: fresh ?? { ...session, status: 'payment_complete' },
+      resumed: true,
+      paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+    };
+  }
+
+  const snap = preparedOp.verification_snapshot;
+  if (!isSpendStellarUsdcVerificationSnapshotV1(snap)) {
+    return {
+      ok: false,
+      error:
+        'Payment is not ready to confirm. Refresh this page to prepare your payment.',
+      httpStatus: 400,
+    };
+  }
+
+  const issuerLive = getStellarSpendUsdcIssuer();
+  const codeLive = getStellarSpendUsdcAssetCode();
+  if (
+    !issuerLive ||
+    !spendStellarUsdcSnapshotMatchesLiveRail({
+      snapshot: snap,
+      liveSpendRail: session.spend_rail,
+      liveReceiving: receivingLive,
+      liveUsdcIssuer: issuerLive,
+      liveUsdcCode: codeLive,
+    })
+  ) {
+    return {
+      ok: false,
+      error:
+        'Payment no longer matches the configured receiving wallet. Refresh this page and try again.',
+      httpStatus: 400,
+    };
+  }
+
+  const railAddr = session.rail_user_wallet_address?.trim() ?? '';
+  if (!railAddr || snap.from_wallet !== railAddr) {
+    return {
+      ok: false,
+      error:
+        'Payment details do not match this session. Refresh this page and try again.',
+      httpStatus: 400,
+    };
+  }
+
+  if (snap.usdc_amount !== input.usdcAmount) {
+    return {
+      ok: false,
+      error:
+        'Payment details do not match this session. Refresh this page and try again.',
+      httpStatus: 400,
+    };
+  }
+
+  let spendTx: SpendTransaction | null = spendTxInitial;
+
+  const stellarAnalyticsBase: SpendPilotPaymentEventProperties = {
+    spend_experience_id: spendExperience.id,
+    event_id: spendExperience.event_id,
+    user_id: authUserId,
+    wallet_address: normalizedWallet,
+    points_amount: fundedConversion ? fundedConversion.points_deducted : 0,
+    usdc_amount: snap.usdc_amount,
+    status: 'submitted',
+    spend_session_id: session.id,
+    point_conversion_id: fundedConversion?.id,
+    payment_tx_hash: spendTx?.payment_tx_hash ?? '',
+  };
+
+  const applyStellarPrepareTerminal = async (
+    status: 'confirmed' | 'failed' | 'needs_review',
+    patch: {
+      lastFailureReason?: string | null;
+      lastFailureAt?: string | null;
+      lastAmbiguityMetadata?: Record<string, unknown> | null;
+    }
+  ) => {
+    await patchSpendPaymentPrepare(preparedOp.id, {
+      status,
+      lastFailureReason: patch.lastFailureReason ?? null,
+      lastFailureAt: patch.lastFailureAt ?? null,
+      lastAmbiguityMetadata: patch.lastAmbiguityMetadata ?? null,
+    });
+  };
+
+  const handleVerifyOutcome = async (
+    ledgerHash: string,
+    verify: Awaited<ReturnType<typeof verifySpendStellarUsdcPaymentTx>>
+  ): Promise<SpendPaymentConfirmResult> => {
+    if (verify.ok) {
+      if (!spendTx) {
+        return {
+          ok: false,
+          error: 'Failed to load payment record',
+          httpStatus: 500,
+        };
+      }
+      const didWin = await finalizeSuccess({
+        spendTransactionId: spendTx.id,
+        sessionId: session.id,
+        distinctId,
+        analytics: {
+          ...stellarAnalyticsBase,
+          spend_transaction_id: spendTx.id,
+          payment_tx_hash: ledgerHash,
+        },
+      });
+      await applyStellarPrepareTerminal('confirmed', {
+        lastFailureReason: null,
+        lastFailureAt: null,
+        lastAmbiguityMetadata: null,
+      });
+      const [updatedTx, freshSession, prepFresh] = await Promise.all([
+        getSpendTransactionBySessionId(session.id),
+        getSpendSessionById(session.id),
+        getSpendPaymentPrepareBySessionId(session.id),
+      ]);
+      if (updatedTx?.status === 'confirmed' && updatedTx.payment_tx_hash) {
+        void insertTreasuryReceivePaymentLedgerIfAbsent({
+          spendExperienceId: spendExperience.id,
+          spendRail: spendExperience.spend_rail,
+          amount: updatedTx.usdc_amount,
+          fromWalletAddress: updatedTx.from_wallet_address,
+          toWalletAddress: updatedTx.to_wallet_address,
+          txHash: updatedTx.payment_tx_hash,
+        });
+      }
+      return {
+        ok: true,
+        spendTransaction: updatedTx ?? spendTx,
+        session: freshSession ?? { ...session, status: 'payment_complete' },
+        resumed: !didWin,
+        paymentOperation: prepFresh
+          ? spendPaymentOperationClientSummary(prepFresh)
+          : undefined,
+      };
+    }
+
+    const nowIso = new Date().toISOString();
+    if (isAmbiguousSpendPaymentVerifyFailure(verify.reason)) {
+      const opRow = await patchSpendPaymentPrepare(preparedOp.id, {
+        status: 'needs_review',
+        lastFailureReason: verify.reason,
+        lastFailureAt: nowIso,
+        lastAmbiguityMetadata: {
+          spend_transaction_id: spendTx?.id,
+          verify_reason: verify.reason,
+        },
+      });
+      return {
+        ok: false,
+        error:
+          'We could not fully verify this payment yet. Please contact support and do not send another payment.',
+        httpStatus: 400,
+        details: {
+          paymentOperation: spendPaymentOperationClientSummary(opRow),
+        },
+      };
+    }
+
+    if (spendTx) {
+      await finalizeFailure({
+        spendTransactionId: spendTx.id,
+        sessionId: session.id,
+        distinctId,
+        analytics: {
+          ...stellarAnalyticsBase,
+          spend_transaction_id: spendTx.id,
+          payment_tx_hash: ledgerHash,
+        },
+        reason: verify.reason,
+      });
+    }
+    await applyStellarPrepareTerminal('failed', {
+      lastFailureReason: verify.reason,
+      lastFailureAt: nowIso,
+      lastAmbiguityMetadata: null,
+    });
+    const opAfter = await getSpendPaymentPrepareBySessionId(session.id);
+    return {
+      ok: false,
+      error:
+        'Payment could not be verified on-chain. If funds left your wallet, contact support with your transaction hash.',
+      httpStatus: 400,
+      details: opAfter
+        ? { paymentOperation: spendPaymentOperationClientSummary(opAfter) }
+        : undefined,
+    };
+  };
+
+  // Resume: already submitted on-chain; verify only (no second Privy submit).
+  if (
+    spendTx?.status === 'submitted' &&
+    preparedOp.status === 'submitted' &&
+    isStellarTransactionHash(spendTx.payment_tx_hash)
+  ) {
+    const ledgerHash = spendTx.payment_tx_hash!.trim().toLowerCase();
+    const verify = await verifySpendStellarUsdcPaymentTx({
+      txHash: ledgerHash,
+      expectedFrom: snap.from_wallet,
+      expectedTo: snap.receiving_wallet,
+      expectedUsdcAmount: snap.usdc_amount,
+      usdcIssuer: issuerLive,
+      usdcCode: codeLive,
+    });
+    await updateSpendSessionStatus(session.id, 'payment_pending');
+    return handleVerifyOutcome(ledgerHash, verify);
+  }
+
+  const railGate = assertSpendRailAllowsMutatingSpendWork(session.spend_rail);
+  if (!railGate.ok) {
+    trackSpendPilotRailMutationBlocked(distinctId, {
+      mutation: 'payment_confirm',
+      ...railGate.analytics,
+      spend_experience_id: spendExperience.id,
+      event_id: spendExperience.event_id,
+      user_id: authUserId,
+      wallet_address: normalizedWallet,
+      spend_session_id: session.id,
+      point_conversion_id: fundedConversion?.id,
+    });
+    return {
+      ok: false,
+      error: railGate.error,
+      httpStatus: 400,
+    };
+  }
+
+  if (spendTx?.status === 'confirmed') {
+    const fresh = await getSpendSessionById(session.id);
+    const prepOp = await getSpendPaymentPrepareBySessionId(session.id);
+    return {
+      ok: true,
+      spendTransaction: spendTx,
+      session: fresh ?? { ...session, status: 'payment_complete' },
+      resumed: true,
+      paymentOperation: prepOp
+        ? spendPaymentOperationClientSummary(prepOp)
+        : undefined,
+    };
+  }
+
+  const railConfirm = await spendPaymentRail.confirmPayment({
+    spendSessionId: session.id,
+    spendExperienceId: spendExperience.id,
+    sessionOwnerPrivyUserId: authUserId,
+    railUserWalletAddress: session.rail_user_wallet_address,
+    usdcAmount: snap.usdc_amount,
+  });
+
+  if (!railConfirm.ok) {
+    return {
+      ok: false,
+      error: railConfirm.error.userMessage,
+      httpStatus: 400,
+      details: {
+        paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+      },
+    };
+  }
+
+  const outcome = railConfirm.value;
+  const ledgerRef = outcome.ledgerTxReference?.trim() ?? '';
+  if (!ledgerRef || !isStellarTransactionHash(ledgerRef)) {
+    return {
+      ok: false,
+      error: 'Payment submission did not return a ledger reference.',
+      httpStatus: 500,
+    };
+  }
+
+  if (outcome.status !== 'submitted') {
+    return {
+      ok: false,
+      error: 'Unexpected payment submission state.',
+      httpStatus: 500,
+    };
+  }
+
+  let resumed = false;
+  if (!spendTx) {
+    const inserted = await insertSpendTransactionSubmitted({
+      spendExperienceId: spendExperience.id,
+      spendSessionId: session.id,
+      userId: authUserId,
+      usdcAmount: snap.usdc_amount,
+      fromWalletAddress: snap.from_wallet,
+      toWalletAddress: snap.receiving_wallet,
+      paymentTxHash: ledgerRef,
+      spendRail: session.spend_rail,
+    });
+    if (inserted === 'session_duplicate') {
+      spendTx = await getSpendTransactionBySessionId(session.id);
+      resumed = true;
+    } else {
+      spendTx = inserted;
+    }
+  } else if (spendTx.status === 'failed') {
+    await updateSpendTransactionFields(spendTx.id, {
+      status: 'submitted',
+      payment_tx_hash: ledgerRef,
+      failed_reason: null,
+      completed_at: null,
+      explorer_tx_url: explorerTxUrlForSpendLedger(
+        session.spend_rail,
+        ledgerRef
+      ),
+    });
+    spendTx = await getSpendTransactionBySessionId(session.id);
+  }
+
+  if (!spendTx) {
+    return {
+      ok: false,
+      error: 'Failed to load payment record',
+      httpStatus: 500,
+    };
+  }
+
+  await patchSpendPaymentPrepare(preparedOp.id, { status: 'submitted' });
+  await updateSpendSessionStatus(session.id, 'payment_pending');
+
+  trackSpendPaymentConfirmed(distinctId, {
+    ...stellarAnalyticsBase,
+    spend_transaction_id: spendTx.id,
+    payment_tx_hash: ledgerRef,
+  });
+
+  const verify = await verifySpendStellarUsdcPaymentTx({
+    txHash: ledgerRef,
+    expectedFrom: snap.from_wallet,
+    expectedTo: snap.receiving_wallet,
+    expectedUsdcAmount: snap.usdc_amount,
+    usdcIssuer: issuerLive,
+    usdcCode: codeLive,
+  });
+
+  const verifyResult = await handleVerifyOutcome(ledgerRef, verify);
+  if (verifyResult.ok) {
+    return { ...verifyResult, resumed: verifyResult.resumed || resumed };
+  }
+  return verifyResult;
+}
+
 /**
  * Records and verifies a user USDC payment to the experience receiving wallet (PRD sections 9 and 11).
  */
@@ -137,15 +582,12 @@ export async function runSpendPaymentConfirm(input: {
   normalizedWallet: string;
   authUserId: string;
   distinctId: string;
-  paymentTxHash: string;
+  paymentTxHash?: string;
   usdcAmount: number;
+  stellarBackendConfirm?: boolean;
 }): Promise<SpendPaymentConfirmResult> {
   const { session, spendExperience, normalizedWallet, authUserId, distinctId } =
     input;
-  const txHash = normalizeTxHash(input.paymentTxHash);
-  if (!txHash) {
-    return { ok: false, error: 'Invalid paymentTxHash', httpStatus: 400 };
-  }
 
   if (session.user_id !== authUserId) {
     return { ok: false, error: 'Forbidden', httpStatus: 403 };
@@ -173,17 +615,6 @@ export async function runSpendPaymentConfirm(input: {
     };
   }
 
-  const spendPaymentRail = getSpendPaymentRail(spendExperience.spend_rail);
-  const userSignedConfirmGate =
-    spendPaymentRail.assertUserSignedOnchainPaymentConfirmSupported();
-  if (!userSignedConfirmGate.ok) {
-    return {
-      ok: false,
-      error: userSignedConfirmGate.error.userMessage,
-      httpStatus: 400,
-    };
-  }
-
   const pointConversion = await getPointConversionBySessionId(session.id);
   const fundedConversion =
     pointConversion?.status === 'funded' ? pointConversion : null;
@@ -202,9 +633,6 @@ export async function runSpendPaymentConfirm(input: {
     }
   }
 
-  // Do not accept direct USDC payment while a points conversion is still in flight for this
-  // session (points may already be deducted and treasury funding may complete). Otherwise the
-  // user could receive treasury-funded USDC and still pass payment confirm with the same wallet.
   if (
     payingWithOwnUsdc &&
     pointConversion &&
@@ -251,11 +679,49 @@ export async function runSpendPaymentConfirm(input: {
   const receivingLive = getSpendReceivingWalletAddress(
     spendExperience.spend_rail
   ).trim();
+
+  if (session.spend_rail === 'stellar_usdc') {
+    if (!stellarWalletAddressSchema.safeParse(receivingLive).success) {
+      return {
+        ok: false,
+        error: 'Invalid receiving wallet configuration',
+        httpStatus: 500,
+      };
+    }
+    return runSpendPaymentConfirmStellarUsdc({
+      session,
+      spendExperience,
+      normalizedWallet,
+      authUserId,
+      distinctId,
+      usdcAmount: input.usdcAmount,
+      paymentTxHash: input.paymentTxHash,
+      stellarBackendConfirm: input.stellarBackendConfirm,
+      deps: { fundedConversion, receivingLive },
+    });
+  }
+
   if (!isEvmAddress(receivingLive)) {
     return {
       ok: false,
       error: 'Invalid receiving wallet configuration',
       httpStatus: 500,
+    };
+  }
+
+  const txHash = normalizeTxHash(input.paymentTxHash ?? '');
+  if (!txHash) {
+    return { ok: false, error: 'Invalid paymentTxHash', httpStatus: 400 };
+  }
+
+  const spendPaymentRail = getSpendPaymentRail(spendExperience.spend_rail);
+  const userSignedConfirmGate =
+    spendPaymentRail.assertUserSignedOnchainPaymentConfirmSupported();
+  if (!userSignedConfirmGate.ok) {
+    return {
+      ok: false,
+      error: userSignedConfirmGate.error.userMessage,
+      httpStatus: 400,
     };
   }
 
@@ -266,7 +732,7 @@ export async function runSpendPaymentConfirm(input: {
   let spendTx: SpendTransaction | null = null;
   let basePaymentPrepare: SpendPaymentPrepareOperation | null = null;
 
-  if (session.spend_rail === 'base_usdc') {
+  {
     const [preparedOp, tx] = await Promise.all([
       getSpendPaymentPrepareBySessionId(session.id),
       getSpendTransactionBySessionId(session.id),
@@ -357,11 +823,6 @@ export async function runSpendPaymentConfirm(input: {
     fromAddr = snap.from_wallet as `0x${string}`;
     toAddr = snap.receiving_wallet as `0x${string}`;
     usdcAmount = snap.usdc_amount;
-  } else {
-    spendTx = await getSpendTransactionBySessionId(session.id);
-    fromAddr = normalizedWallet as `0x${string}`;
-    toAddr = receivingLive as `0x${string}`;
-    usdcAmount = input.usdcAmount;
   }
   const requestedHashLower = txHash.toLowerCase();
 

--- a/lib/spend-payment-prepare-types.ts
+++ b/lib/spend-payment-prepare-types.ts
@@ -1,5 +1,37 @@
 import type { SpendRail } from '@/lib/types';
 
+/** v1 prepared action: server submits the final Stellar USDC payment after POST confirm (IRL-24). */
+export type SpendStellarUsdcBackendSubmitPreparedActionV1 = {
+  v: 1;
+  spend_rail: 'stellar_usdc';
+  payment_channel: 'backend_submit';
+  /** POST-only second step; same route as Base but without client `paymentTxHash`. */
+  confirm: {
+    method: 'POST';
+    /** Relative API path including `/api` prefix; `sessionId` is duplicated for simple clients. */
+    path: string;
+    session_id: string;
+  };
+  display: {
+    pay_label: string;
+    submitting_label: string;
+  };
+};
+
+/**
+ * Immutable verification binding for Stellar USDC backend submit payment (IRL-24).
+ * Confirm rebuilds + verifies against this snapshot and live rail config.
+ */
+export type SpendStellarUsdcPaymentVerificationSnapshotV1 = {
+  v: 1;
+  spend_rail: 'stellar_usdc';
+  from_wallet: string;
+  receiving_wallet: string;
+  usdc_amount: number;
+  usdc_asset_code: string;
+  usdc_issuer: string;
+};
+
 /** JSON-serializable Privy / viem-compatible USDC transfer on Base (bigint `gas` as string). */
 export type SpendPreparedBaseUsdcEvmTransactionRequestJson = {
   chainId: number;
@@ -46,6 +78,44 @@ export function isSpendBaseUsdcVerificationSnapshotV1(
   );
 }
 
+export function isSpendStellarUsdcBackendSubmitPreparedActionV1(
+  value: unknown
+): value is SpendStellarUsdcBackendSubmitPreparedActionV1 {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  if (o.v !== 1 || o.spend_rail !== 'stellar_usdc') return false;
+  if (o.payment_channel !== 'backend_submit') return false;
+  const c = o.confirm;
+  if (!c || typeof c !== 'object') return false;
+  const cr = c as Record<string, unknown>;
+  if (cr.method !== 'POST') return false;
+  if (typeof cr.path !== 'string' || typeof cr.session_id !== 'string') {
+    return false;
+  }
+  const d = o.display;
+  if (!d || typeof d !== 'object') return false;
+  const dr = d as Record<string, unknown>;
+  return (
+    typeof dr.pay_label === 'string' && typeof dr.submitting_label === 'string'
+  );
+}
+
+export function isSpendStellarUsdcVerificationSnapshotV1(
+  value: unknown
+): value is SpendStellarUsdcPaymentVerificationSnapshotV1 {
+  if (!value || typeof value !== 'object') return false;
+  const o = value as Record<string, unknown>;
+  return (
+    o.v === 1 &&
+    o.spend_rail === 'stellar_usdc' &&
+    typeof o.from_wallet === 'string' &&
+    typeof o.receiving_wallet === 'string' &&
+    typeof o.usdc_amount === 'number' &&
+    typeof o.usdc_asset_code === 'string' &&
+    typeof o.usdc_issuer === 'string'
+  );
+}
+
 export function isSpendPaymentPrepareStoredActionV1(
   value: unknown
 ): value is SpendPaymentPrepareStoredActionV1 {
@@ -77,5 +147,21 @@ export function spendBaseUsdcSnapshotMatchesLiveRail(params: {
     s.receiving_wallet === params.liveReceivingLower &&
     s.usdc_contract === params.liveUsdcContractLower &&
     s.chain_id === params.liveChainId
+  );
+}
+
+export function spendStellarUsdcSnapshotMatchesLiveRail(params: {
+  snapshot: SpendStellarUsdcPaymentVerificationSnapshotV1;
+  liveSpendRail: SpendRail;
+  liveReceiving: string;
+  liveUsdcIssuer: string;
+  liveUsdcCode: string;
+}): boolean {
+  const s = params.snapshot;
+  if (s.spend_rail !== params.liveSpendRail) return false;
+  return (
+    s.receiving_wallet === params.liveReceiving &&
+    s.usdc_issuer === params.liveUsdcIssuer &&
+    s.usdc_asset_code === params.liveUsdcCode
   );
 }

--- a/lib/spend-payment-prepare.ts
+++ b/lib/spend-payment-prepare.ts
@@ -19,7 +19,11 @@ import {
   getSpendRailBaseUsdcContractAddress,
   getSpendReceivingWalletAddress,
 } from '@/lib/spend-rail-config';
-import { spendBaseUsdcSnapshotMatchesLiveRail } from '@/lib/spend-payment-prepare-types';
+import { stellarWalletAddressSchema } from '@/lib/schemas/player';
+import {
+  spendBaseUsdcSnapshotMatchesLiveRail,
+  spendStellarUsdcSnapshotMatchesLiveRail,
+} from '@/lib/spend-payment-prepare-types';
 import {
   isEvmAddress,
   POSTER_CHECKOUT_CHAIN_ID,
@@ -141,15 +145,6 @@ export async function runSpendPaymentPrepare(input: {
   }
 
   const spendPaymentRail = getSpendPaymentRail(spendExperience.spend_rail);
-  const userSignedGate =
-    spendPaymentRail.assertUserSignedOnchainPaymentConfirmSupported();
-  if (!userSignedGate.ok) {
-    return {
-      ok: false,
-      error: userSignedGate.error.userMessage,
-      httpStatus: 400,
-    };
-  }
 
   const { usdcAmount } = computeConversionAmounts(spendExperience);
 
@@ -202,10 +197,26 @@ export async function runSpendPaymentPrepare(input: {
   const receiving = getSpendReceivingWalletAddress(
     spendExperience.spend_rail
   ).trim();
-  if (!isEvmAddress(receiving)) {
+  if (spendExperience.spend_rail === 'base_usdc') {
+    if (!isEvmAddress(receiving)) {
+      return {
+        ok: false,
+        error: 'Invalid receiving wallet configuration',
+        httpStatus: 500,
+      };
+    }
+  } else if (spendExperience.spend_rail === 'stellar_usdc') {
+    if (!stellarWalletAddressSchema.safeParse(receiving).success) {
+      return {
+        ok: false,
+        error: 'Invalid receiving wallet configuration',
+        httpStatus: 500,
+      };
+    }
+  } else {
     return {
       ok: false,
-      error: 'Invalid receiving wallet configuration',
+      error: 'Invalid payment rail configuration',
       httpStatus: 500,
     };
   }
@@ -234,6 +245,8 @@ export async function runSpendPaymentPrepare(input: {
     spendExperienceId: spendExperience.id,
     embeddedEvmWalletAddress: session.wallet_address,
     privyNormalizedWalletAddressLower: normalizedWallet,
+    sessionOwnerPrivyUserId: authUserId,
+    railUserWalletAddress: session.rail_user_wallet_address,
     usdcAmount,
   });
 
@@ -245,7 +258,7 @@ export async function runSpendPaymentPrepare(input: {
     };
   }
 
-  if (railPrepare.value.status !== 'prepared' || !railPrepare.value.baseUsdc) {
+  if (railPrepare.value.status !== 'prepared') {
     return {
       ok: false,
       error: 'Payment preparation is not available for this session',
@@ -253,29 +266,76 @@ export async function runSpendPaymentPrepare(input: {
     };
   }
 
-  const { preparedAction, verificationSnapshot } = railPrepare.value.baseUsdc;
+  let newAction: Record<string, unknown>;
+  let newSnap: Record<string, unknown>;
 
-  const liveReceiving = receiving.toLowerCase();
-  const liveUsdc = getSpendRailBaseUsdcContractAddress().toLowerCase();
+  if (session.spend_rail === 'base_usdc') {
+    if (!railPrepare.value.baseUsdc) {
+      return {
+        ok: false,
+        error: 'Payment preparation is not available for this session',
+        httpStatus: 400,
+      };
+    }
+    const { preparedAction, verificationSnapshot } = railPrepare.value.baseUsdc;
 
-  if (
-    !spendBaseUsdcSnapshotMatchesLiveRail({
-      snapshot: verificationSnapshot,
-      liveSpendRail: session.spend_rail,
-      liveReceivingLower: liveReceiving,
-      liveUsdcContractLower: liveUsdc,
-      liveChainId: POSTER_CHECKOUT_CHAIN_ID,
-    })
-  ) {
+    const liveReceiving = receiving.toLowerCase();
+    const liveUsdc = getSpendRailBaseUsdcContractAddress().toLowerCase();
+
+    if (
+      !spendBaseUsdcSnapshotMatchesLiveRail({
+        snapshot: verificationSnapshot,
+        liveSpendRail: session.spend_rail,
+        liveReceivingLower: liveReceiving,
+        liveUsdcContractLower: liveUsdc,
+        liveChainId: POSTER_CHECKOUT_CHAIN_ID,
+      })
+    ) {
+      return {
+        ok: false,
+        error: 'Invalid payment rail configuration',
+        httpStatus: 500,
+      };
+    }
+
+    newAction = { ...preparedAction } as Record<string, unknown>;
+    newSnap = { ...verificationSnapshot } as Record<string, unknown>;
+  } else if (session.spend_rail === 'stellar_usdc') {
+    if (!railPrepare.value.stellarUsdc) {
+      return {
+        ok: false,
+        error: 'Payment preparation is not available for this session',
+        httpStatus: 400,
+      };
+    }
+    const { preparedAction, verificationSnapshot } =
+      railPrepare.value.stellarUsdc;
+    const usdcIssuer = verificationSnapshot.usdc_issuer;
+    const usdcCode = verificationSnapshot.usdc_asset_code;
+    if (
+      !spendStellarUsdcSnapshotMatchesLiveRail({
+        snapshot: verificationSnapshot,
+        liveSpendRail: session.spend_rail,
+        liveReceiving: receiving,
+        liveUsdcIssuer: usdcIssuer,
+        liveUsdcCode: usdcCode,
+      })
+    ) {
+      return {
+        ok: false,
+        error: 'Invalid payment rail configuration',
+        httpStatus: 500,
+      };
+    }
+    newAction = { ...preparedAction } as Record<string, unknown>;
+    newSnap = { ...verificationSnapshot } as Record<string, unknown>;
+  } else {
     return {
       ok: false,
-      error: 'Invalid payment rail configuration',
-      httpStatus: 500,
+      error: 'Payment preparation is not available for this session',
+      httpStatus: 400,
     };
   }
-
-  const newAction = { ...preparedAction } as Record<string, unknown>;
-  const newSnap = { ...verificationSnapshot } as Record<string, unknown>;
 
   const { row: initialRow, created } = await insertSpendPaymentPrepareOrGet({
     spendSessionId: session.id,

--- a/lib/spend-payment-verify-ambiguous.ts
+++ b/lib/spend-payment-verify-ambiguous.ts
@@ -8,6 +8,8 @@ export function isAmbiguousSpendPaymentVerifyFailure(reason: string): boolean {
     r.includes('timeout') ||
     r.includes('rpc not configured') ||
     r.includes('receipt wait') ||
-    r.includes('wait failed')
+    r.includes('wait failed') ||
+    r.includes('horizon_tx_pending_timeout') ||
+    r.includes('horizon_payments_fetch_failed')
   );
 }

--- a/lib/spend-payment-verify-stellar.ts
+++ b/lib/spend-payment-verify-stellar.ts
@@ -1,0 +1,92 @@
+import type { Horizon } from '@stellar/stellar-sdk';
+import { createStellarSpendHorizonServer } from '@/lib/spend/stellar-wallet-readiness-config';
+
+const HORIZON_TX_POLL_ATTEMPTS = 8;
+const HORIZON_TX_POLL_INTERVAL_MS = 1500;
+
+export type SpendStellarPaymentTxVerifyResult =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+async function waitForHorizonTxSuccess(
+  server: Horizon.Server,
+  txHash: string
+): Promise<'success' | 'failed' | 'pending'> {
+  const h = txHash.trim().toLowerCase();
+  for (let i = 0; i < HORIZON_TX_POLL_ATTEMPTS; i += 1) {
+    try {
+      const tx = await server.transactions().transaction(h).call();
+      if (tx.successful) return 'success';
+      return 'failed';
+    } catch (e: unknown) {
+      const status = (e as { response?: { status?: number } })?.response
+        ?.status;
+      if (status === 404) {
+        await new Promise((r) => setTimeout(r, HORIZON_TX_POLL_INTERVAL_MS));
+        continue;
+      }
+      return 'pending';
+    }
+  }
+  return 'pending';
+}
+
+function amountsRoughlyEqual(a: string, b: string): boolean {
+  return Math.abs(Number(a) - Number(b)) < 1e-7;
+}
+
+/**
+ * Confirms a Stellar USDC payment transaction on Horizon (IRL-24), separate from EVM receipt checks.
+ */
+export async function verifySpendStellarUsdcPaymentTx(params: {
+  txHash: string;
+  expectedFrom: string;
+  expectedTo: string;
+  expectedUsdcAmount: number;
+  usdcIssuer: string;
+  usdcCode: string;
+  server?: Horizon.Server;
+}): Promise<SpendStellarPaymentTxVerifyResult> {
+  const server = params.server ?? createStellarSpendHorizonServer();
+  const h = params.txHash.trim().toLowerCase();
+
+  const inclusion = await waitForHorizonTxSuccess(server, h);
+  if (inclusion === 'pending') {
+    return { ok: false, reason: 'horizon_tx_pending_timeout' };
+  }
+  if (inclusion === 'failed') {
+    return { ok: false, reason: 'transaction_failed_on_network' };
+  }
+
+  const wantAmount = params.expectedUsdcAmount.toFixed(7);
+  const fromW = params.expectedFrom.trim();
+  const toW = params.expectedTo.trim();
+
+  try {
+    const page = await server.payments().forTransaction(h).call();
+    for (const p of page.records) {
+      if (p.type !== 'payment' || !('from' in p)) continue;
+      const rec = p as Horizon.ServerApi.PaymentOperationRecord;
+      if (rec.from !== fromW || rec.to !== toW) continue;
+      if (
+        rec.asset_type !== 'credit_alphanum4' &&
+        rec.asset_type !== 'credit_alphanum12'
+      ) {
+        continue;
+      }
+      if (
+        rec.asset_code !== params.usdcCode ||
+        rec.asset_issuer !== params.usdcIssuer
+      ) {
+        continue;
+      }
+      if (!amountsRoughlyEqual(rec.amount, wantAmount)) continue;
+      if (!rec.transaction_successful) continue;
+      return { ok: true };
+    }
+    return { ok: false, reason: 'no_matching_usdc_payment' };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, reason: `horizon_payments_fetch_failed: ${msg}` };
+  }
+}

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -11,6 +11,8 @@ import type {
 import type {
   SpendBaseUsdcPaymentVerificationSnapshotV1,
   SpendPaymentPrepareStoredActionV1,
+  SpendStellarUsdcBackendSubmitPreparedActionV1,
+  SpendStellarUsdcPaymentVerificationSnapshotV1,
 } from '@/lib/spend-payment-prepare-types';
 
 /** Successful `preparePayment` payload (Base USDC fills `baseUsdc`; other rails omit). */
@@ -20,6 +22,19 @@ export type SpendPaymentPrepareRailValue = {
     preparedAction: SpendPaymentPrepareStoredActionV1;
     verificationSnapshot: SpendBaseUsdcPaymentVerificationSnapshotV1;
   };
+  stellarUsdc?: {
+    preparedAction: SpendStellarUsdcBackendSubmitPreparedActionV1;
+    verificationSnapshot: SpendStellarUsdcPaymentVerificationSnapshotV1;
+  };
+};
+
+/** `confirmPayment` rail outcome (Base is verify-only; Stellar may return `needs_review`). */
+export type SpendPaymentConfirmRailValue = {
+  status: SpendRailPaymentOperationStatus;
+  /** Ledger reference when known (Stellar 64-hex hash; Base uses client hash in orchestration). */
+  ledgerTxReference?: string | null;
+  /** Ambiguous verification reason for `needs_review` (Stellar). */
+  verifyFailureReason?: string | null;
 };
 
 export type SpendRailResult<T> =
@@ -66,20 +81,20 @@ export interface SpendPaymentRail {
   >;
 
   /**
-   * Prepare a payment action (idempotent descriptor). Unsupported on Base until IRL-19;
-   * Stellar returns **not supported** until backend submit metadata exists.
+   * Prepare a payment action (idempotent descriptor). Base returns wallet transaction data;
+   * Stellar returns backend-submit metadata (IRL-24).
    */
   preparePayment(
     ctx: SpendPaymentRailSessionContext
   ): Promise<SpendRailResult<SpendPaymentPrepareRailValue>>;
 
   /**
-   * Confirm on-chain payment evidence (user-submitted tx hash on Base USDC). Stellar remains
-   * unsupported at this boundary until server-controlled confirmation exists on the rail.
+   * Confirm on-chain payment evidence. Base USDC: user-submitted tx hash. Stellar USDC:
+   * server submit only (IRL-24); orchestration verifies on Horizon after `submitted`.
    */
   confirmPayment(
     ctx: SpendPaymentRailSessionContext
-  ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>>;
+  ): Promise<SpendRailResult<SpendPaymentConfirmRailValue>>;
 
   /** Canonical explorer URL for a ledger transaction reference, when known. */
   explorerUrlForLedgerTx(txReference: string | null | undefined): string | null;

--- a/lib/spend/payment-rails/stellar-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.test.ts
@@ -51,6 +51,27 @@ vi.mock('@/lib/spend/stellar-treasury-funding', () => ({
     hoistedTreasury.submit(...a),
 }));
 
+vi.mock('@/lib/spend-rail-config', () => ({
+  getSpendReceivingWalletAddress: () =>
+    'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H',
+}));
+
+vi.mock(
+  '@/lib/spend/stellar-wallet-readiness-config',
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import('@/lib/spend/stellar-wallet-readiness-config')
+      >();
+    return {
+      ...actual,
+      getStellarSpendUsdcIssuer: () =>
+        'GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN',
+      getStellarSpendUsdcAssetCode: () => 'USDC',
+    };
+  }
+);
+
 import { createStellarUsdcSpendPaymentRail } from './stellar-usdc-rail';
 
 const sessionId = '770e8400-e29b-41d4-a716-446655440000';
@@ -289,5 +310,34 @@ describe('createStellarUsdcSpendPaymentRail — treasury funding (IRL-16)', () =
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('expected err');
     expect(res.error.category).toBe('wallet_readiness_failed');
+  });
+});
+
+describe('createStellarUsdcSpendPaymentRail — final payment prepare (IRL-24)', () => {
+  it('preparePayment returns backend_submit v1 payload bound to session + env receiver', async () => {
+    const rail = createStellarUsdcSpendPaymentRail();
+    const out = await rail.preparePayment({
+      spendSessionId: sessionId,
+      railUserWalletAddress: STELLAR_G,
+      usdcAmount: 1.5,
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) throw new Error('expected ok');
+    expect(out.value.status).toBe('prepared');
+    const su = out.value.stellarUsdc;
+    if (!su) throw new Error('expected stellarUsdc');
+    expect(su.preparedAction.payment_channel).toBe('backend_submit');
+    expect(su.preparedAction.display.pay_label).toBe(
+      'Pay 1.50 USDC on Stellar'
+    );
+    expect(su.preparedAction.confirm.session_id).toBe(sessionId);
+    expect(su.preparedAction.confirm.path).toContain(
+      encodeURIComponent(sessionId)
+    );
+    expect(su.verificationSnapshot.from_wallet).toBe(STELLAR_G);
+    expect(su.verificationSnapshot.receiving_wallet).toBe(
+      'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H'
+    );
+    expect(su.verificationSnapshot.usdc_amount).toBe(1.5);
   });
 });

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -9,6 +9,7 @@ import {
   errSpendRail,
   okSpendRail,
   spendPaymentRailExplorerUrl,
+  type SpendPaymentConfirmRailValue,
   type SpendPaymentPrepareRailValue,
   type SpendPaymentRail,
   type SpendRailResult,
@@ -16,7 +17,9 @@ import {
 import {
   isSpendRailError,
   spendRailErrorFundingFailed,
+  spendRailErrorInvalidReceivingWallet,
   spendRailErrorNetworkUnavailable,
+  spendRailErrorPaymentFailed,
   spendRailErrorStellarTreasuryCannotFundSpend,
   spendRailErrorRailOperationNotSupported,
   spendRailErrorWalletReadinessFailed,
@@ -26,7 +29,6 @@ import type {
   SpendPaymentRailReconcileContext,
   SpendPaymentRailSessionContext,
   SpendRailFundingOperationStatus,
-  SpendRailPaymentOperationStatus,
 } from '@/lib/spend/payment-rails/types';
 import { runStellarUsdcWalletReadinessOrchestration } from '@/lib/spend/stellar-wallet-readiness-orchestration';
 import {
@@ -34,6 +36,14 @@ import {
   readStellarTreasuryConfirmedUsdcBalance,
   submitStellarTreasuryUsdcFunding,
 } from '@/lib/spend/stellar-treasury-funding';
+import { getSpendReceivingWalletAddress } from '@/lib/spend-rail-config';
+import { resolveStellarPrivyWalletIdForUser } from '@/lib/privy/stellar-rail-wallet';
+import { submitSponsoredStellarUsdcPaymentFromUser } from '@/lib/spend/stellar-spend-payment-submit';
+import {
+  getStellarSpendUsdcAssetCode,
+  getStellarSpendUsdcIssuer,
+} from '@/lib/spend/stellar-wallet-readiness-config';
+import type { SpendStellarUsdcBackendSubmitPreparedActionV1 } from '@/lib/spend-payment-prepare-types';
 
 const unsupported = (): SpendRailResult<never> =>
   errSpendRail(spendRailErrorRailOperationNotSupported());
@@ -67,6 +77,18 @@ function internalDiagnosticsFromError(e: unknown): Record<string, unknown> {
 
 function isValidPositiveUsdcAmount(n: unknown): n is number {
   return typeof n === 'number' && Number.isFinite(n) && n > 0;
+}
+
+function classifyStellarPaymentSubmitReason(reason: string): SpendRailError {
+  const r = reason.toLowerCase();
+  if (
+    r.includes('network_submit_failed') ||
+    r.includes('horizon') ||
+    r.includes('fetch')
+  ) {
+    return spendRailErrorNetworkUnavailable();
+  }
+  return spendRailErrorPaymentFailed();
 }
 
 /**
@@ -262,15 +284,108 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
     async preparePayment(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<SpendPaymentPrepareRailValue>> {
-      void ctx;
-      return unsupported();
+      const sessionId = ctx.spendSessionId?.trim();
+      if (!sessionId) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+      if (!isValidPositiveUsdcAmount(ctx.usdcAmount)) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+      const fromRaw = ctx.railUserWalletAddress?.trim() ?? '';
+      const fromOk = stellarWalletAddressSchema.safeParse(fromRaw);
+      if (!fromOk.success) {
+        return errSpendRail(spendRailErrorWalletReadinessFailed());
+      }
+      const receivingRaw = getSpendReceivingWalletAddress(spendRail).trim();
+      const recvOk = stellarWalletAddressSchema.safeParse(receivingRaw);
+      if (!recvOk.success) {
+        return errSpendRail(spendRailErrorInvalidReceivingWallet());
+      }
+      const usdcIssuer = getStellarSpendUsdcIssuer();
+      if (!usdcIssuer) {
+        return errSpendRail(spendRailErrorInvalidReceivingWallet());
+      }
+      const usdcCode = getStellarSpendUsdcAssetCode();
+
+      const amt = ctx.usdcAmount;
+      const payLabel = `Pay ${amt.toFixed(2)} USDC on Stellar`;
+      const preparedAction: SpendStellarUsdcBackendSubmitPreparedActionV1 = {
+        v: 1,
+        spend_rail: 'stellar_usdc',
+        payment_channel: 'backend_submit',
+        confirm: {
+          method: 'POST',
+          path: `/api/spend-sessions/${encodeURIComponent(sessionId)}/payment/confirm`,
+          session_id: sessionId,
+        },
+        display: {
+          pay_label: payLabel,
+          submitting_label: 'Submitting your Stellar payment…',
+        },
+      };
+      const verificationSnapshot = {
+        v: 1 as const,
+        spend_rail: 'stellar_usdc' as const,
+        from_wallet: fromOk.data,
+        receiving_wallet: recvOk.data,
+        usdc_amount: amt,
+        usdc_asset_code: usdcCode,
+        usdc_issuer: usdcIssuer,
+      };
+      return okSpendRail({
+        status: 'prepared',
+        stellarUsdc: { preparedAction, verificationSnapshot },
+      });
     },
 
     async confirmPayment(
       ctx: SpendPaymentRailSessionContext
-    ): Promise<SpendRailResult<{ status: SpendRailPaymentOperationStatus }>> {
-      void ctx;
-      return unsupported();
+    ): Promise<SpendRailResult<SpendPaymentConfirmRailValue>> {
+      if (!isValidPositiveUsdcAmount(ctx.usdcAmount)) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+      const privyUserId = ctx.sessionOwnerPrivyUserId?.trim();
+      if (!privyUserId) {
+        return errSpendRail(spendRailErrorPaymentFailed());
+      }
+      const fromRaw = ctx.railUserWalletAddress?.trim() ?? '';
+      const fromOk = stellarWalletAddressSchema.safeParse(fromRaw);
+      if (!fromOk.success) {
+        return errSpendRail(spendRailErrorWalletReadinessFailed());
+      }
+      const receivingRaw = getSpendReceivingWalletAddress(spendRail).trim();
+      const recvOk = stellarWalletAddressSchema.safeParse(receivingRaw);
+      if (!recvOk.success) {
+        return errSpendRail(spendRailErrorInvalidReceivingWallet());
+      }
+
+      let walletId: string;
+      try {
+        walletId = await resolveStellarPrivyWalletIdForUser(
+          privyUserId,
+          fromOk.data
+        );
+      } catch (e) {
+        console.error('stellar_usdc confirmPayment wallet id:', e);
+        return errSpendRail(spendRailErrorWalletReadinessFailed());
+      }
+
+      const sub = await submitSponsoredStellarUsdcPaymentFromUser({
+        userPublicKey: fromOk.data,
+        privyStellarWalletId: walletId,
+        destinationPublicKey: recvOk.data,
+        usdcAmount: ctx.usdcAmount,
+      });
+
+      if (!sub.ok) {
+        console.error('stellar_usdc payment submit:', sub.internalMessage);
+        return errSpendRail(classifyStellarPaymentSubmitReason(sub.reason));
+      }
+
+      return okSpendRail({
+        status: 'submitted',
+        ledgerTxReference: sub.txHash,
+      });
     },
 
     explorerUrlForLedgerTx(

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -63,6 +63,11 @@ export type SpendPaymentRailSessionContext = {
   usdcAmount?: number;
   /** User-submitted canonical `0x` + 64 hex payment hash for `confirmPayment`. */
   paymentTxHash?: string;
+  /**
+   * Stellar USDC: canonical `G…` payer (`spend_sessions.rail_user_wallet_address`).
+   * Not used by Base USDC.
+   */
+  railUserWalletAddress?: string | null;
 };
 
 /**

--- a/lib/spend/stellar-spend-payment-submit.ts
+++ b/lib/spend/stellar-spend-payment-submit.ts
@@ -1,0 +1,194 @@
+import {
+  Asset,
+  Horizon,
+  Keypair,
+  Operation,
+  TransactionBuilder,
+  xdr,
+} from '@stellar/stellar-sdk';
+import { privyWalletRawSignTransactionHash } from '@/lib/privy-server-rest';
+import {
+  createStellarSpendHorizonServer,
+  getStellarSpendNetworkPassphrase,
+  getStellarSpendUsdcAssetCode,
+  getStellarSpendUsdcIssuer,
+  parseStellarSpendSponsorKeypair,
+} from '@/lib/spend/stellar-wallet-readiness-config';
+
+function formatUsdcAmountForStellar(amount: number): string {
+  const floored = Math.floor(amount * 1e7) / 1e7;
+  return floored.toFixed(7);
+}
+
+function classifySubmitMessage(raw: string): string {
+  const s = raw.toLowerCase();
+  if (
+    s.includes('fetch') ||
+    s.includes('econn') ||
+    s.includes('timeout') ||
+    s.includes('socket') ||
+    s.includes('502') ||
+    s.includes('503') ||
+    s.includes('504')
+  ) {
+    return 'network_submit_failed';
+  }
+  if (
+    s.includes('underfunded') ||
+    s.includes('op_underfunded') ||
+    s.includes('op_low_reserve') ||
+    s.includes('insufficient balance')
+  ) {
+    return 'insufficient_usdc_or_reserve';
+  }
+  return 'stellar_submit_failed';
+}
+
+async function loadAccountOrThrow(
+  server: Horizon.Server,
+  publicKey: string
+): Promise<Horizon.AccountResponse> {
+  try {
+    return await server.loadAccount(publicKey);
+  } catch (e: unknown) {
+    const status = (e as { response?: { status?: number } })?.response?.status;
+    if (status === 404) {
+      throw new Error('source_account_missing');
+    }
+    throw e;
+  }
+}
+
+/**
+ * One Horizon submit attempt: sponsored-fee USDC payment from the user's Stellar account
+ * to the configured receiver (IRL-24). User authorization is a single Privy `raw_sign` call.
+ */
+export async function submitSponsoredStellarUsdcPaymentFromUser(input: {
+  userPublicKey: string;
+  privyStellarWalletId: string;
+  destinationPublicKey: string;
+  usdcAmount: number;
+}): Promise<
+  | { ok: true; txHash: string }
+  | { ok: false; reason: string; internalMessage?: string }
+> {
+  const passphrase = getStellarSpendNetworkPassphrase();
+  const usdcIssuer = getStellarSpendUsdcIssuer();
+  if (!usdcIssuer) {
+    return { ok: false, reason: 'stellar_usdc_misconfigured' };
+  }
+  const usdcCode = getStellarSpendUsdcAssetCode();
+  const server = createStellarSpendHorizonServer();
+
+  let sponsor: Keypair;
+  try {
+    sponsor = parseStellarSpendSponsorKeypair();
+  } catch {
+    return { ok: false, reason: 'stellar_sponsor_misconfigured' };
+  }
+
+  const userPub = input.userPublicKey.trim();
+  const dest = input.destinationPublicKey.trim();
+  const usdcAsset = new Asset(usdcCode, usdcIssuer);
+  const payAmount = formatUsdcAmountForStellar(input.usdcAmount);
+
+  let userAccount: Horizon.AccountResponse;
+  try {
+    userAccount = await loadAccountOrThrow(server, userPub);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      reason: classifySubmitMessage(msg),
+      internalMessage: msg.slice(0, 500),
+    };
+  }
+
+  const inner = new TransactionBuilder(userAccount, {
+    fee: '0',
+    networkPassphrase: passphrase,
+  })
+    .addOperation(
+      Operation.beginSponsoringFutureReserves({
+        sponsoredId: userPub,
+        source: sponsor.publicKey(),
+      })
+    )
+    .addOperation(
+      Operation.payment({
+        destination: dest,
+        asset: usdcAsset,
+        amount: payAmount,
+      })
+    )
+    .addOperation(
+      Operation.endSponsoringFutureReserves({
+        source: sponsor.publicKey(),
+      })
+    )
+    .setTimeout(180)
+    .build();
+
+  inner.sign(sponsor);
+
+  const hash32 = inner.hash();
+  let userSig: Buffer;
+  try {
+    userSig = await privyWalletRawSignTransactionHash({
+      walletId: input.privyStellarWalletId,
+      hash32,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      reason: classifySubmitMessage(msg),
+      internalMessage: msg.slice(0, 500),
+    };
+  }
+
+  const userKp = Keypair.fromPublicKey(userPub);
+  inner.addDecoratedSignature(
+    new xdr.DecoratedSignature({
+      hint: userKp.signatureHint(),
+      signature: userSig,
+    })
+  );
+
+  let baseFee: string;
+  try {
+    baseFee = (await server.fetchBaseFee()).toString();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      reason: classifySubmitMessage(msg),
+      internalMessage: msg.slice(0, 500),
+    };
+  }
+
+  const feeBump = TransactionBuilder.buildFeeBumpTransaction(
+    sponsor,
+    (Number(baseFee) * 10).toString(),
+    inner,
+    passphrase
+  );
+  feeBump.sign(sponsor);
+
+  try {
+    const res = await server.submitTransaction(feeBump);
+    return { ok: true, txHash: res.hash };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const extras = (e as { response?: { data?: unknown } })?.response?.data;
+    const detail =
+      extras && typeof extras === 'object'
+        ? JSON.stringify(extras).slice(0, 800)
+        : '';
+    return {
+      ok: false,
+      reason: classifySubmitMessage(msg),
+      internalMessage: `${msg.slice(0, 400)} ${detail}`,
+    };
+  }
+}


### PR DESCRIPTION
Implement Stellar prepare/confirm: backend_submit descriptor, POST confirm with stellarBackendConfirm, Privy-sponsored submit, Horizon verification, prepare-operation lifecycle parity with Base, and spend UI rail gating.