### PR TITLE
feat(spend): rail-aware receipts, explorer URLs, and copy (IRL-27)

### DIFF
--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -24,8 +24,9 @@ import {
 } from '@/lib/spend-eligibility-messages';
 import type { SpendRailClientSummary } from '@/lib/spend-rail-config/types';
 import {
-  formatSpendPaymentExplorerUrl,
+  resolveSpendReceiptPaymentExplorerUrl,
   spendPaymentExplorerLinkLabel,
+  spendReceiptPaymentStatusLabel,
 } from '@/lib/spend-rail-explorer-url-client';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
@@ -105,6 +106,13 @@ type ReceiptResponse = {
 };
 
 const WALLET_STEP_TIMEOUT_MS = 180_000;
+
+const SPEND_TOAST_CONVERSION_ERROR =
+  "We couldn't complete that step. Please try again, or contact support if it keeps happening.";
+const SPEND_TOAST_PAYMENT_ERROR =
+  "We couldn't record your payment. Please try again, or contact support if it keeps happening.";
+const SPEND_TOAST_WALLET_ERROR =
+  'Something went wrong with your wallet or network. Please try again in a moment.';
 
 function isPaymentNeedsReviewFromApiError(error: unknown): boolean {
   if (!(error instanceof ApiError)) return false;
@@ -388,9 +396,8 @@ export function SpendExperiencePage({
       }
       await invalidateSpendQueries();
     },
-    onError: (e) => {
-      const msg = e instanceof ApiError ? e.message : String(e);
-      toast.error(msg);
+    onError: () => {
+      toast.error(SPEND_TOAST_CONVERSION_ERROR);
     },
   });
 
@@ -419,9 +426,8 @@ export function SpendExperiencePage({
       toast.success('Payment recorded. Thank you!');
       await invalidateSpendQueries();
     },
-    onError: (e) => {
-      const msg = e instanceof ApiError ? e.message : String(e);
-      toast.error(msg);
+    onError: () => {
+      toast.error(SPEND_TOAST_PAYMENT_ERROR);
     },
   });
 
@@ -434,9 +440,8 @@ export function SpendExperiencePage({
     if (isSpendStellarUsdcBackendSubmitPreparedActionV1(prepared)) {
       try {
         await paymentMutation.mutateAsync({ stellarBackendConfirm: true });
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        toast.error(msg);
+      } catch {
+        toast.error(SPEND_TOAST_PAYMENT_ERROR);
       }
       return;
     }
@@ -519,9 +524,8 @@ export function SpendExperiencePage({
         });
       }
       await paymentMutation.mutateAsync({ paymentTxHash: hash });
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : String(e);
-      toast.error(msg);
+    } catch {
+      toast.error(SPEND_TOAST_WALLET_ERROR);
     }
   }, [
     walletAddress,
@@ -574,7 +578,8 @@ export function SpendExperiencePage({
 
   const receiptSession = receiptPayload?.session ?? session;
   const receiptConversion = receiptPayload?.pointConversion;
-  const receiptPaymentHash = receiptPayload?.spendTransaction?.payment_tx_hash;
+  const receiptSpendTx = receiptPayload?.spendTransaction ?? null;
+  const receiptPaymentHash = receiptSpendTx?.payment_tx_hash;
 
   const isPaymentComplete =
     elig?.status === 'payment_complete' ||
@@ -614,13 +619,18 @@ export function SpendExperiencePage({
 
   const displayReceipt = isPaymentComplete;
 
-  const paymentExplorerUrl = formatSpendPaymentExplorerUrl(
-    spendRailSummary?.explorerTxUrlTemplate,
-    receiptPaymentHash
+  const receiptNetworkDisplay =
+    receiptSpendTx?.network?.trim() || walletNetworkLabel;
+  const receiptPaymentStatusLabel = spendReceiptPaymentStatusLabel(
+    receiptSpendTx?.status
   );
-  const paymentExplorerLabel = spendPaymentExplorerLinkLabel(
-    spendRailSummary?.explorerTxUrlTemplate
-  );
+
+  const paymentExplorerUrl = resolveSpendReceiptPaymentExplorerUrl({
+    persistedExplorerTxUrl: receiptSpendTx?.explorer_tx_url,
+    explorerTxUrlTemplate: spendRailSummary?.explorerTxUrlTemplate,
+    paymentTxHash: receiptPaymentHash,
+  });
+  const paymentExplorerLabel = spendPaymentExplorerLinkLabel();
 
   return (
     <SpendPageShell>
@@ -669,7 +679,8 @@ export function SpendExperiencePage({
                       className="size-4 shrink-0 animate-spin"
                       aria-hidden
                     />
-                    Checking your balance and event funds…
+                    Checking your balance on {walletNetworkLabel} and event
+                    funds…
                   </div>
                 )}
 
@@ -684,7 +695,8 @@ export function SpendExperiencePage({
                                 Pay
                               </span>
                               <span className="body-medium font-grotesk font-semibold text-[#171717]">
-                                ${preview.usdcAmount.toFixed(2)} {assetSymbol}
+                                ${preview.usdcAmount.toFixed(2)} {assetSymbol}{' '}
+                                on {walletNetworkLabel}
                               </span>
                             </div>
                             {preview.userUsdcBalance != null && (
@@ -718,7 +730,7 @@ export function SpendExperiencePage({
                                   </span>
                                   <span className="body-medium font-grotesk font-semibold text-[#171717]">
                                     ${preview.usdcAmount.toFixed(2)}{' '}
-                                    {assetSymbol}
+                                    {assetSymbol} on {walletNetworkLabel}
                                   </span>
                                 </div>
                               </>
@@ -768,7 +780,7 @@ export function SpendExperiencePage({
 
                     <p className={eligibilityToneClass(elig.status)}>
                       {elig.status === 'ready_for_payment' && preview
-                        ? `${preview.pointsRequired.toLocaleString()} points were converted to ${preview.usdcAmount.toFixed(2)} ${assetSymbol}.`
+                        ? `${preview.pointsRequired.toLocaleString()} points were converted to ${preview.usdcAmount.toFixed(2)} ${assetSymbol} on ${walletNetworkLabel}.`
                         : elig.message}
                     </p>
 
@@ -779,7 +791,7 @@ export function SpendExperiencePage({
                       >
                         {conversionMutation.isPending
                           ? 'Converting…'
-                          : `Convert points to ${assetSymbol}`}
+                          : `Convert points to ${assetSymbol} on ${walletNetworkLabel}`}
                       </SpendPrimaryButton>
                     )}
 
@@ -815,13 +827,13 @@ export function SpendExperiencePage({
                             )
                             ? paymentPrepareData.preparedAction.display
                                 .submitting_label
-                            : `Pay with ${assetSymbol}…`
+                            : `Pay with ${assetSymbol} on ${walletNetworkLabel}…`
                           : isSpendStellarUsdcBackendSubmitPreparedActionV1(
                                 paymentPrepareData?.preparedAction
                               )
                             ? paymentPrepareData.preparedAction.display
                                 .pay_label
-                            : `Spend $${preview.usdcAmount.toFixed(2)} ${assetSymbol}`}
+                            : `Spend $${preview.usdcAmount.toFixed(2)} ${assetSymbol} on ${walletNetworkLabel}`}
                       </SpendPrimaryButton>
                     )}
 
@@ -830,11 +842,11 @@ export function SpendExperiencePage({
                       !isPaymentComplete &&
                       (resolvedSpendRail === 'base_usdc' ||
                         resolvedSpendRail === 'stellar_usdc') && (
-                        <p className="body-small font-grotesk text-amber-900">
-                          We could not automatically confirm your last payment
-                          transaction. Please contact support with your
-                          transaction hash and do not pay again until support
-                          clears this session.
+                        <p className="body-small font-grotesk text-[#575757]">
+                          Your payment is still being confirmed. This can take a
+                          few minutes. If nothing changes, contact support
+                          before trying again, and avoid sending a duplicate
+                          payment.
                         </p>
                       )}
 
@@ -859,6 +871,22 @@ export function SpendExperiencePage({
                         </div>
                         <div className="flex justify-between gap-2">
                           <span className="body-small font-grotesk text-[#757575]">
+                            Network
+                          </span>
+                          <span className="body-medium font-grotesk font-semibold">
+                            {receiptNetworkDisplay}
+                          </span>
+                        </div>
+                        <div className="flex justify-between gap-2">
+                          <span className="body-small font-grotesk text-[#757575]">
+                            Payment status
+                          </span>
+                          <span className="body-medium font-grotesk font-semibold">
+                            {receiptPaymentStatusLabel}
+                          </span>
+                        </div>
+                        <div className="flex justify-between gap-2">
+                          <span className="body-small font-grotesk text-[#757575]">
                             Points used
                           </span>
                           <span className="body-medium font-grotesk font-semibold">
@@ -876,7 +904,7 @@ export function SpendExperiencePage({
                             {receiptSession?.id}
                           </p>
                         </div>
-                        {receiptPaymentHash && paymentExplorerUrl && (
+                        {paymentExplorerUrl && (
                           <a
                             href={paymentExplorerUrl}
                             target="_blank"

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -25,7 +25,7 @@ import {
 import type { SpendRailClientSummary } from '@/lib/spend-rail-config/types';
 import {
   resolveSpendReceiptPaymentExplorerUrl,
-  spendPaymentExplorerLinkLabel,
+  SPEND_RECEIPT_EXPLORER_LINK_LABEL,
   spendReceiptPaymentStatusLabel,
 } from '@/lib/spend-rail-explorer-url-client';
 import { isEvmAddress } from '@/lib/walletconnect-poster-direct-usdc';
@@ -630,7 +630,6 @@ export function SpendExperiencePage({
     explorerTxUrlTemplate: spendRailSummary?.explorerTxUrlTemplate,
     paymentTxHash: receiptPaymentHash,
   });
-  const paymentExplorerLabel = spendPaymentExplorerLinkLabel();
 
   return (
     <SpendPageShell>
@@ -911,7 +910,7 @@ export function SpendExperiencePage({
                             rel="noreferrer"
                             className="inline-flex items-center gap-1 body-medium font-grotesk font-semibold text-emerald-900 underline"
                           >
-                            {paymentExplorerLabel}
+                            {SPEND_RECEIPT_EXPLORER_LINK_LABEL}
                             <ExternalLink className="size-3.5 shrink-0" />
                           </a>
                         )}

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -426,9 +426,6 @@ export function SpendExperiencePage({
       toast.success('Payment recorded. Thank you!');
       await invalidateSpendQueries();
     },
-    onError: () => {
-      toast.error(SPEND_TOAST_PAYMENT_ERROR);
-    },
   });
 
   const sendUsdcPayment = useCallback(async () => {
@@ -523,7 +520,11 @@ export function SpendExperiencePage({
           sponsor: true,
         });
       }
-      await paymentMutation.mutateAsync({ paymentTxHash: hash });
+      try {
+        await paymentMutation.mutateAsync({ paymentTxHash: hash });
+      } catch {
+        toast.error(SPEND_TOAST_PAYMENT_ERROR);
+      }
     } catch {
       toast.error(SPEND_TOAST_WALLET_ERROR);
     }

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -72,6 +72,8 @@ describe('buildSpendEligibilityPreview', () => {
       now,
     });
     expect(r.status).toBe('eligible');
+    expect(r.message).toContain('Base');
+    expect(r.message).toContain('USDC');
     expect(r.preview?.pointsRequired).toBe(5000);
     expect(r.preview?.usdcAmount).toBe(5);
     expect(r.preview?.userUsdcBalance).toBeNull();

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -65,7 +65,7 @@ export type SpendConversionPreview = {
   receivingWalletAddress: string;
   treasuryWalletAddress: string;
   userPointsBalance: number | null;
-  /** Embedded wallet USDC on Base (null if unavailable). */
+  /** Wallet USDC balance on the active spend rail (null if unavailable). */
   userUsdcBalance: number | null;
   treasuryUsdcBalance: number | null;
 };
@@ -131,6 +131,11 @@ export function buildSpendEligibilityPreview(
 
   const railPublic = getSpendRailPublicMetadata(spendExperience.spend_rail);
   const { networkLabel, assetSymbol: railAssetSymbol } = railPublic;
+
+  const treasuryInsufficientMessage =
+    spendExperience.spend_rail === 'stellar_usdc'
+      ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
+      : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
 
   const basePreview = (): SpendConversionPreview => ({
     pointsRequired,
@@ -238,13 +243,9 @@ export function buildSpendEligibilityPreview(
       };
     }
     if (treasuryUsdcBalance === null || treasuryUsdcBalance < usdcAmount) {
-      const insufficientMsg =
-        spendExperience.spend_rail === 'stellar_usdc'
-          ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
-          : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
       return {
         status: 'treasury_insufficient',
-        message: insufficientMsg,
+        message: treasuryInsufficientMessage,
         preview: basePreview(),
       };
     }
@@ -297,13 +298,9 @@ export function buildSpendEligibilityPreview(
   }
 
   if (treasuryUsdcBalance === null || treasuryUsdcBalance < usdcAmount) {
-    const insufficientMsg =
-      spendExperience.spend_rail === 'stellar_usdc'
-        ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
-        : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
     return {
       status: 'treasury_insufficient',
-      message: insufficientMsg,
+      message: treasuryInsufficientMessage,
       preview: basePreview(),
     };
   }

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -12,6 +12,7 @@ import {
   getSpendRailBaseRpcUrl,
   getSpendRailBaseUsdcContractAddress,
   getSpendRailOperationalDiagnostics,
+  getSpendRailPublicMetadata,
   getSpendReceivingWalletAddress,
   getSpendTreasuryWalletAddress,
 } from '@/lib/spend-rail-config';
@@ -128,6 +129,9 @@ export function buildSpendEligibilityPreview(
   const { usdcAmount, pointsRequired } =
     computeConversionAmounts(spendExperience);
 
+  const railPublic = getSpendRailPublicMetadata(spendExperience.spend_rail);
+  const { networkLabel, assetSymbol: railAssetSymbol } = railPublic;
+
   const basePreview = (): SpendConversionPreview => ({
     pointsRequired,
     usdcAmount,
@@ -190,20 +194,20 @@ export function buildSpendEligibilityPreview(
     ) {
       return {
         status: 'payment_complete',
-        message: SPEND_ELIGIBILITY_MESSAGES.payment_complete,
+        message: `Your ${railAssetSymbol} payment on ${networkLabel} was received. You are all set for this event.`,
         preview: basePreview(),
       };
     }
     if (spendTransaction?.status === 'failed') {
       return {
         status: 'payment_failed',
-        message: SPEND_ELIGIBILITY_MESSAGES.payment_failed,
+        message: `Your last ${railAssetSymbol} payment on ${networkLabel} could not be verified on-chain. You can try sending payment again.`,
         preview: basePreview(),
       };
     }
     return {
       status: 'ready_for_payment',
-      message: SPEND_ELIGIBILITY_MESSAGES.ready_for_payment,
+      message: `Your points were converted to ${railAssetSymbol} on ${networkLabel}.`,
       preview: basePreview(),
     };
   }
@@ -264,7 +268,7 @@ export function buildSpendEligibilityPreview(
   if (userHasEnoughUsdc) {
     return {
       status: 'ready_for_payment_own_usdc',
-      message: SPEND_ELIGIBILITY_MESSAGES.ready_for_payment_own_usdc,
+      message: `You have enough ${railAssetSymbol} in your wallet on ${networkLabel} to complete this payment.`,
       preview: basePreview(),
     };
   }
@@ -306,7 +310,7 @@ export function buildSpendEligibilityPreview(
 
   return {
     status: 'eligible',
-    message: SPEND_ELIGIBILITY_MESSAGES.eligible,
+    message: `You can convert your points to ${railAssetSymbol} on ${networkLabel} for this event.`,
     preview: basePreview(),
   };
 }

--- a/lib/spend-rail-explorer-url-client.test.ts
+++ b/lib/spend-rail-explorer-url-client.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect } from 'vitest';
 import {
   formatSpendPaymentExplorerUrl,
+  isSafeSpendExplorerHttpsUrl,
+  resolveSpendReceiptPaymentExplorerUrl,
   spendPaymentExplorerLinkLabel,
+  spendReceiptPaymentStatusLabel,
 } from '@/lib/spend-rail-explorer-url-client';
 
 describe('formatSpendPaymentExplorerUrl', () => {
@@ -31,16 +34,73 @@ describe('formatSpendPaymentExplorerUrl', () => {
   });
 });
 
-describe('spendPaymentExplorerLinkLabel', () => {
-  it('extracts hostname from template', () => {
+describe('isSafeSpendExplorerHttpsUrl', () => {
+  it('accepts https URLs', () => {
     expect(
-      spendPaymentExplorerLinkLabel('https://basescan.org/tx/{txHash}')
-    ).toBe('View payment on basescan.org');
+      isSafeSpendExplorerHttpsUrl(
+        'https://stellar.expert/explorer/public/tx/abc'
+      )
+    ).toBe(true);
   });
 
-  it('falls back when template is unusable', () => {
-    expect(spendPaymentExplorerLinkLabel(null)).toBe(
-      'View payment transaction'
+  it('rejects javascript: and http', () => {
+    expect(isSafeSpendExplorerHttpsUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeSpendExplorerHttpsUrl('http://example.com/tx/1')).toBe(false);
+  });
+});
+
+describe('resolveSpendReceiptPaymentExplorerUrl', () => {
+  const tpl = 'https://basescan.org/tx/{txHash}';
+  const h =
+    '0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+  it('prefers a safe persisted URL over template substitution', () => {
+    const persisted = 'https://basescan.org/tx/custom-path-recorded';
+    expect(
+      resolveSpendReceiptPaymentExplorerUrl({
+        persistedExplorerTxUrl: persisted,
+        explorerTxUrlTemplate: tpl,
+        paymentTxHash: h,
+      })
+    ).toBe(persisted);
+  });
+
+  it('ignores persisted URL when not https and falls back to template', () => {
+    expect(
+      resolveSpendReceiptPaymentExplorerUrl({
+        persistedExplorerTxUrl: 'javascript:evil()',
+        explorerTxUrlTemplate: tpl,
+        paymentTxHash: h,
+      })
+    ).toBe(
+      'https://basescan.org/tx/0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb'
     );
+  });
+
+  it('prefers execution snapshot URL over persisted when both are safe', () => {
+    expect(
+      resolveSpendReceiptPaymentExplorerUrl({
+        executionSnapshotExplorerTxUrl: 'https://snapshot.example/tx/1',
+        persistedExplorerTxUrl: 'https://persisted.example/tx/2',
+        explorerTxUrlTemplate: tpl,
+        paymentTxHash: h,
+      })
+    ).toBe('https://snapshot.example/tx/1');
+  });
+});
+
+describe('spendPaymentExplorerLinkLabel', () => {
+  it('returns View transaction', () => {
+    expect(spendPaymentExplorerLinkLabel()).toBe('View transaction');
+  });
+});
+
+describe('spendReceiptPaymentStatusLabel', () => {
+  it('maps ledger statuses to receipt copy', () => {
+    expect(spendReceiptPaymentStatusLabel('confirmed')).toBe('Complete');
+    expect(spendReceiptPaymentStatusLabel('pending')).toBe('Confirming');
+    expect(spendReceiptPaymentStatusLabel('submitted')).toBe('Confirming');
+    expect(spendReceiptPaymentStatusLabel('failed')).toBe('Could not verify');
+    expect(spendReceiptPaymentStatusLabel(undefined)).toBe('Complete');
   });
 });

--- a/lib/spend-rail-explorer-url-client.test.ts
+++ b/lib/spend-rail-explorer-url-client.test.ts
@@ -3,7 +3,7 @@ import {
   formatSpendPaymentExplorerUrl,
   isSafeSpendExplorerHttpsUrl,
   resolveSpendReceiptPaymentExplorerUrl,
-  spendPaymentExplorerLinkLabel,
+  SPEND_RECEIPT_EXPLORER_LINK_LABEL,
   spendReceiptPaymentStatusLabel,
 } from '@/lib/spend-rail-explorer-url-client';
 
@@ -89,9 +89,9 @@ describe('resolveSpendReceiptPaymentExplorerUrl', () => {
   });
 });
 
-describe('spendPaymentExplorerLinkLabel', () => {
-  it('returns View transaction', () => {
-    expect(spendPaymentExplorerLinkLabel()).toBe('View transaction');
+describe('SPEND_RECEIPT_EXPLORER_LINK_LABEL', () => {
+  it('matches receipt explorer anchor copy', () => {
+    expect(SPEND_RECEIPT_EXPLORER_LINK_LABEL).toBe('View transaction');
   });
 });
 

--- a/lib/spend-rail-explorer-url-client.ts
+++ b/lib/spend-rail-explorer-url-client.ts
@@ -87,6 +87,4 @@ export function spendReceiptPaymentStatusLabel(
 }
 
 /** Link text for spend receipt explorer anchors (product copy). */
-export function spendPaymentExplorerLinkLabel(): string {
-  return 'View transaction';
-}
+export const SPEND_RECEIPT_EXPLORER_LINK_LABEL = 'View transaction';

--- a/lib/spend-rail-explorer-url-client.ts
+++ b/lib/spend-rail-explorer-url-client.ts
@@ -1,3 +1,5 @@
+import type { SpendTransaction } from '@/lib/types';
+
 /**
  * Builds a payment transaction explorer URL using a server-provided template.
  * Safe for client bundles (no env reads). Mirrors server substitution rules for spend payments.
@@ -21,20 +23,70 @@ export function formatSpendPaymentExplorerUrl(
   return tpl.replace('{txHash}', encodeURIComponent(raw));
 }
 
-/** Derives a short link label from an explorer URL template (hostname only). */
-export function spendPaymentExplorerLinkLabel(
-  explorerTxUrlTemplate: string | null | undefined
-): string {
-  const tpl = explorerTxUrlTemplate?.trim();
-  if (!tpl || !tpl.includes('{txHash}')) {
-    return 'View payment transaction';
-  }
+/** True when the URL is a safe https target for an outbound receipt link. */
+export function isSafeSpendExplorerHttpsUrl(
+  raw: string | null | undefined
+): boolean {
+  const s = raw?.trim();
+  if (!s) return false;
   try {
-    const prefix = tpl.split('{txHash}')[0];
-    const u = new URL(prefix.endsWith('/') ? prefix.slice(0, -1) : prefix);
-    const host = u.hostname.replace(/^www\./, '');
-    return host ? `View payment on ${host}` : 'View payment transaction';
+    const u = new URL(s);
+    return u.protocol === 'https:';
   } catch {
-    return 'View payment transaction';
+    return false;
   }
+}
+
+export type ResolveSpendReceiptPaymentExplorerUrlInput = {
+  /**
+   * Prefer immutable execution snapshot explorer URL (IRL-6) when present and safe.
+   * Checked before `persistedExplorerTxUrl`.
+   */
+  executionSnapshotExplorerTxUrl?: string | null;
+  /** Canonical `spend_transactions.explorer_tx_url` when set-once in DB. */
+  persistedExplorerTxUrl?: string | null;
+  explorerTxUrlTemplate?: string | null;
+  paymentTxHash?: string | null;
+};
+
+/**
+ * Receipt / “View transaction” URL: prefer persisted or snapshot https URLs, else template + hash.
+ */
+export function resolveSpendReceiptPaymentExplorerUrl(
+  input: ResolveSpendReceiptPaymentExplorerUrlInput
+): string | null {
+  const snapshot = input.executionSnapshotExplorerTxUrl?.trim();
+  if (snapshot && isSafeSpendExplorerHttpsUrl(snapshot)) {
+    return snapshot;
+  }
+  const persisted = input.persistedExplorerTxUrl?.trim();
+  if (persisted && isSafeSpendExplorerHttpsUrl(persisted)) {
+    return persisted;
+  }
+  return formatSpendPaymentExplorerUrl(
+    input.explorerTxUrlTemplate,
+    input.paymentTxHash
+  );
+}
+
+/** Spend receipt primary line for payment row status (user-facing). */
+export function spendReceiptPaymentStatusLabel(
+  status: SpendTransaction['status'] | null | undefined
+): string {
+  switch (status) {
+    case 'confirmed':
+      return 'Complete';
+    case 'pending':
+    case 'submitted':
+      return 'Confirming';
+    case 'failed':
+      return 'Could not verify';
+    default:
+      return 'Complete';
+  }
+}
+
+/** Link text for spend receipt explorer anchors (product copy). */
+export function spendPaymentExplorerLinkLabel(): string {
+  return 'View transaction';
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Rail-aware spend receipts, explorer URL resolution, and user-facing copy for Base vs Stellar (issue IRL-27).

### Summary

- Receipt card shows amount, network (ledger field or rail summary), payment status, and a **View transaction** link. Explorer URL prefers a safe persisted `https` `explorer_tx_url`, optional future execution snapshot URL, then the rail `explorerTxUrlTemplate` with `payment_tx_hash` (no hardcoded BaseScan in the receipt UI).
- Conversion preview, confirmation-style lines, pay CTAs, and loading copy include the active network label where scoped to this work.
- Server-built eligibility messages for eligible / ready-for-payment / own-USDC / payment complete and failed paths include network and asset from `getSpendRailPublicMetadata` in `lib/spend-conversion-preview.ts`.
- Payment prepare `needs_review` uses neutral “still confirming” copy with a support path; payment and conversion error toasts use generic messages instead of raw API or wallet errors.
- New helpers and tests in `lib/spend-rail-explorer-url-client.ts` (URL priority, https gate, receipt status label).

### Tests

- `yarn test lib/spend-rail-explorer-url-client.test.ts lib/spend-conversion-preview.test.ts`
- `yarn lint`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-27](https://linear.app/irlenergy/issue/IRL-27/make-receipts-and-user-copy-rail-aware)

<div><a href="https://cursor.com/agents/bc-5ec8213e-1798-478f-b7d9-d6b87aa0fd83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ec8213e-1798-478f-b7d9-d6b87aa0fd83"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

