### PR TITLE
feat(IRL-22): Vercel Cron spend rail pending operations reconcile

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,3 +1,11 @@
+# --- Vercel Cron (IRL-22: spend rail pending operations) ---
+# Required for GET /api/cron/spend-rail-reconcile. Vercel sends Authorization: Bearer <CRON_SECRET> when set in the project env.
+# CRON_SECRET=generate-a-long-random-secret
+# Optional tuning (defaults shown):
+# SPEND_RAIL_CRON_MIN_AGE_SECONDS=60
+# SPEND_RAIL_CRON_BACKOFF_SECONDS=120
+# SPEND_RAIL_CRON_BATCH_SIZE=25
+
 # Privy Configuration
 NEXT_PUBLIC_PRIVY_APP_ID=your_privy_app_id_here
 

--- a/app/api/cron/spend-rail-reconcile/__tests__/route.test.ts
+++ b/app/api/cron/spend-rail-reconcile/__tests__/route.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { GET } from '@/app/api/cron/spend-rail-reconcile/route';
+import { NextRequest } from 'next/server';
+
+vi.mock('@/lib/spend/reconcile-spend-rail-pending-operations', () => ({
+  runSpendRailReconciliationCron: vi.fn().mockResolvedValue({
+    candidateSessions: 0,
+    processedSessions: 0,
+    olderThanIso: '2020-01-01T00:00:00.000Z',
+    batchSize: 25,
+  }),
+}));
+
+describe('GET /api/cron/spend-rail-reconcile', () => {
+  const prevCron = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = 'test-cron-secret';
+  });
+
+  afterEach(() => {
+    process.env.CRON_SECRET = prevCron;
+  });
+
+  it('returns 401 without Bearer secret', async () => {
+    const req = new NextRequest(
+      'http://localhost/api/cron/spend-rail-reconcile'
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 401 with wrong secret', async () => {
+    const req = new NextRequest(
+      'http://localhost/api/cron/spend-rail-reconcile',
+      {
+        headers: { Authorization: 'Bearer wrong' },
+      }
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 200 with cron payload when authorized', async () => {
+    const req = new NextRequest(
+      'http://localhost/api/cron/spend-rail-reconcile',
+      {
+        headers: { Authorization: 'Bearer test-cron-secret' },
+      }
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      success: boolean;
+      data: { candidateSessions: number };
+    };
+    expect(body.success).toBe(true);
+    expect(body.data.candidateSessions).toBe(0);
+  });
+});

--- a/app/api/cron/spend-rail-reconcile/__tests__/route.test.ts
+++ b/app/api/cron/spend-rail-reconcile/__tests__/route.test.ts
@@ -30,6 +30,18 @@ describe('GET /api/cron/spend-rail-reconcile', () => {
     expect(res.status).toBe(401);
   });
 
+  it('returns 500 when CRON_SECRET is not configured', async () => {
+    delete process.env.CRON_SECRET;
+    const req = new NextRequest(
+      'http://localhost/api/cron/spend-rail-reconcile',
+      {
+        headers: { Authorization: 'Bearer test-cron-secret' },
+      }
+    );
+    const res = await GET(req);
+    expect(res.status).toBe(500);
+  });
+
   it('returns 401 with wrong secret', async () => {
     const req = new NextRequest(
       'http://localhost/api/cron/spend-rail-reconcile',

--- a/app/api/cron/spend-rail-reconcile/route.ts
+++ b/app/api/cron/spend-rail-reconcile/route.ts
@@ -1,0 +1,28 @@
+import type { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { runSpendRailReconciliationCron } from '@/lib/spend/reconcile-spend-rail-pending-operations';
+
+/**
+ * Vercel Cron: reconciles pending Stellar readiness, conversion funding confirmations,
+ * and submitted payment verifications (IRL-22). Requires `Authorization: Bearer` matching
+ * `CRON_SECRET`.
+ */
+export async function GET(request: NextRequest) {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) {
+    return apiError('Cron is not configured', 500);
+  }
+
+  const auth = request.headers.get('authorization')?.trim();
+  if (auth !== `Bearer ${secret}`) {
+    return apiError('Unauthorized', 401);
+  }
+
+  try {
+    const data = await runSpendRailReconciliationCron();
+    return apiSuccess(data);
+  } catch (e) {
+    console.error('spend-rail-reconcile cron:', e);
+    return apiError('Reconciliation failed', 500);
+  }
+}

--- a/app/api/cron/spend-rail-reconcile/route.ts
+++ b/app/api/cron/spend-rail-reconcile/route.ts
@@ -2,11 +2,7 @@ import type { NextRequest } from 'next/server';
 import { apiError, apiSuccess } from '@/lib/api/response';
 import { runSpendRailReconciliationCron } from '@/lib/spend/reconcile-spend-rail-pending-operations';
 
-/**
- * Vercel Cron: reconciles pending Stellar readiness, conversion funding confirmations,
- * and submitted payment verifications (IRL-22). Requires `Authorization: Bearer` matching
- * `CRON_SECRET`.
- */
+/** Vercel Cron (IRL-22): bounded spend-rail reconciliation; auth via `CRON_SECRET` Bearer. */
 export async function GET(request: NextRequest) {
   const secret = process.env.CRON_SECRET?.trim();
   if (!secret) {

--- a/lib/db/spend-payment-prepare.ts
+++ b/lib/db/spend-payment-prepare.ts
@@ -267,3 +267,29 @@ export function spendPaymentOperationClientSummary(
     last_failure_at: row.last_failure_at,
   };
 }
+
+/**
+ * Sessions with payment prepare rows that may need on-chain verification (IRL-22).
+ */
+export async function listSpendSessionIdsForStalePaymentPrepareReconcile(input: {
+  olderThanIso: string;
+  limit: number;
+}): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('spend_payment_prepare_operations')
+    .select('spend_session_id')
+    .in('status', ['submitted', 'prepared'])
+    .lt('updated_at', input.olderThanIso)
+    .order('updated_at', { ascending: true })
+    .limit(input.limit);
+
+  if (error) {
+    console.error('listSpendSessionIdsForStalePaymentPrepareReconcile:', error);
+    throw new Error(
+      error.message || 'Failed to list payment prepare candidates'
+    );
+  }
+  return (data ?? []).map((row) =>
+    String((row as { spend_session_id: string }).spend_session_id)
+  );
+}

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -518,3 +518,58 @@ export async function refundSpendConversionOnFundingFailure(input: {
     );
   }
 }
+
+/**
+ * Sessions whose point conversion may need funding confirmation (IRL-22).
+ */
+export async function listSpendSessionIdsForStaleConversionFundingReconcile(input: {
+  olderThanIso: string;
+  limit: number;
+}): Promise<string[]> {
+  const half = Math.max(1, Math.ceil(input.limit / 2));
+  const [edgeRes, pointsRes] = await Promise.all([
+    supabase
+      .from('point_conversions')
+      .select('spend_session_id')
+      .in('status', ['funding_pending', 'needs_review'])
+      .lt('updated_at', input.olderThanIso)
+      .order('updated_at', { ascending: true })
+      .limit(half),
+    supabase
+      .from('point_conversions')
+      .select('spend_session_id')
+      .eq('status', 'points_deducted')
+      .not('funding_tx_hash', 'is', null)
+      .lt('updated_at', input.olderThanIso)
+      .order('updated_at', { ascending: true })
+      .limit(half),
+  ]);
+
+  if (edgeRes.error) {
+    console.error(
+      'listSpendSessionIdsForStaleConversionFundingReconcile:',
+      edgeRes.error
+    );
+    throw new Error(
+      edgeRes.error.message || 'Failed to list conversion funding candidates'
+    );
+  }
+  if (pointsRes.error) {
+    console.error(
+      'listSpendSessionIdsForStaleConversionFundingReconcile:',
+      pointsRes.error
+    );
+    throw new Error(
+      pointsRes.error.message || 'Failed to list conversion funding candidates'
+    );
+  }
+
+  const ids = new Set<string>();
+  for (const row of edgeRes.data ?? []) {
+    ids.add(String((row as { spend_session_id: string }).spend_session_id));
+  }
+  for (const row of pointsRes.data ?? []) {
+    ids.add(String((row as { spend_session_id: string }).spend_session_id));
+  }
+  return Array.from(ids).slice(0, input.limit);
+}

--- a/lib/db/spend-wallet-readiness.ts
+++ b/lib/db/spend-wallet-readiness.ts
@@ -210,3 +210,28 @@ export async function updateSpendWalletReadinessFields(
   }
   return rowToSpendWalletReadinessOperation(data as Record<string, unknown>);
 }
+
+/**
+ * Spend session ids with Stellar wallet readiness still in-flight (IRL-22 reconcile).
+ */
+export async function listSpendSessionIdsForStaleStellarWalletReadiness(input: {
+  olderThanIso: string;
+  limit: number;
+}): Promise<string[]> {
+  const { data, error } = await supabase
+    .from('spend_wallet_readiness_operations')
+    .select('spend_session_id')
+    .eq('spend_rail', 'stellar_usdc')
+    .in('status', ['pending', 'needs_review'])
+    .lt('updated_at', input.olderThanIso)
+    .order('updated_at', { ascending: true })
+    .limit(input.limit);
+
+  if (error) {
+    console.error('listSpendSessionIdsForStaleStellarWalletReadiness:', error);
+    throw new Error(error.message || 'Failed to list readiness candidates');
+  }
+  return (data ?? []).map((row) =>
+    String((row as { spend_session_id: string }).spend_session_id)
+  );
+}

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -1185,6 +1185,49 @@ async function fundOrResumeUsdc(input: {
     conv = onward.conversion;
   }
 
+  return resumeSpendConversionFundingFromChainReferences({
+    pointConversion: conv,
+    session,
+    spendExperience,
+    treasuryMeta,
+    distinctId,
+    baseAnalytics,
+    privyResolveOptions: { timeoutMs: 120_000, pollIntervalMs: 1_000 },
+  });
+}
+
+type SpendTreasuryFundingWalletMeta = NonNullable<
+  ReturnType<typeof getSpendTreasuryFundingWalletMeta>
+>;
+
+/**
+ * Confirms conversion funding from stored tx references only (Privy pending
+ * resolution, on-chain recovery, receipt polling, finalize). Does not initiate
+ * new treasury sends or wallet readiness (IRL-22 cron / read-path reconcile).
+ */
+async function resumeSpendConversionFundingFromChainReferences(input: {
+  pointConversion: PointConversion;
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  treasuryMeta: SpendTreasuryFundingWalletMeta;
+  distinctId: string;
+  baseAnalytics: SpendPilotConversionEventProperties;
+  /** Defaults match interactive confirm polling. */
+  privyResolveOptions?: { timeoutMs: number; pollIntervalMs: number };
+}): Promise<
+  | { conversion: PointConversion; error: null }
+  | { error: SpendConversionConfirmResult; conversion?: never }
+> {
+  const {
+    session,
+    spendExperience,
+    treasuryMeta,
+    distinctId,
+    baseAnalytics,
+    privyResolveOptions,
+  } = input;
+  let conv = input.pointConversion;
+
   let hash = conv.funding_tx_hash?.trim();
   const pendingPrefix = 'pending:';
   const trimmedFunding = conv.funding_tx_hash?.trim() ?? '';
@@ -1199,7 +1242,10 @@ async function fundOrResumeUsdc(input: {
       try {
         const polled = await resolvePrivyServerTransactionHash(
           { transactionId: privyId },
-          { timeoutMs: 120_000, pollIntervalMs: 1_000 }
+          privyResolveOptions ?? {
+            timeoutMs: 120_000,
+            pollIntervalMs: 1_000,
+          }
         );
         const normalized = polled?.trim();
         if (normalized && isEvmTxHash(normalized)) {
@@ -1311,6 +1357,79 @@ async function fundOrResumeUsdc(input: {
   });
 
   return { conversion: done, error: null };
+}
+
+/**
+ * Background-safe conversion funding reconciliation (cron / read-path).
+ * Never starts readiness or a new funding send; only chain confirmation and
+ * hash discovery from existing references.
+ */
+export async function reconcileSpendConversionFundingBackground(input: {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  distinctId: string;
+}): Promise<'advanced' | 'unchanged'> {
+  const pointConversion = await getPointConversionBySessionId(input.session.id);
+  if (!pointConversion || !RESUMABLE.includes(pointConversion.status)) {
+    return 'unchanged';
+  }
+
+  const normalizedWallet = input.session.wallet_address.toLowerCase();
+  const { usdcAmount } = computeConversionAmounts(input.spendExperience);
+  const baseAnalytics: SpendPilotConversionEventProperties = {
+    spend_experience_id: input.spendExperience.id,
+    event_id: input.spendExperience.event_id,
+    user_id: input.session.user_id,
+    wallet_address: normalizedWallet,
+    points_amount: pointConversion.points_deducted,
+    usdc_amount: usdcAmount,
+    status: 'confirm',
+  };
+
+  const finalized = await tryFinalizePendingSpendConversion({
+    pointConversion,
+    session: input.session,
+    spendExperience: input.spendExperience,
+    normalizedWallet,
+    distinctId: input.distinctId,
+    baseAnalytics,
+  });
+  if (finalized) {
+    return 'advanced';
+  }
+
+  const conv = await getPointConversionBySessionId(input.session.id);
+  if (!conv || !RESUMABLE.includes(conv.status)) {
+    return 'unchanged';
+  }
+
+  const fundingRef = conv.funding_tx_hash?.trim() ?? '';
+  if (!fundingRef && conv.status === 'points_deducted') {
+    return 'unchanged';
+  }
+
+  const treasuryMeta = getSpendTreasuryFundingWalletMeta(input.spendExperience);
+  if (!treasuryMeta) {
+    return 'unchanged';
+  }
+
+  const res = await resumeSpendConversionFundingFromChainReferences({
+    pointConversion: conv,
+    session: input.session,
+    spendExperience: input.spendExperience,
+    treasuryMeta,
+    distinctId: input.distinctId,
+    baseAnalytics,
+    privyResolveOptions: { timeoutMs: 20_000, pollIntervalMs: 2_000 },
+  });
+
+  if ('conversion' in res) {
+    return 'advanced';
+  }
+  const failure = res as {
+    error: Extract<SpendConversionConfirmResult, { ok: false }>;
+  };
+  return failure.error.httpStatus === 409 ? 'unchanged' : 'advanced';
 }
 
 /**

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -1096,3 +1096,303 @@ export async function runSpendPaymentConfirm(input: {
     paymentOperation: paymentOpSummary,
   };
 }
+
+/**
+ * Confirms submitted on-chain payments from stored hashes only (cron / read-path).
+ * Does not submit new Stellar payments or accept new Base hashes.
+ */
+export async function reconcileSubmittedSpendPaymentBackground(input: {
+  session: SpendSession;
+  spendExperience: SpendExperience;
+  distinctId: string;
+}): Promise<'advanced' | 'unchanged'> {
+  const { session, spendExperience, distinctId } = input;
+  const [preparedOp, spendTx, fundedConversion] = await Promise.all([
+    getSpendPaymentPrepareBySessionId(session.id),
+    getSpendTransactionBySessionId(session.id),
+    getPointConversionBySessionId(session.id),
+  ]);
+
+  if (!preparedOp) {
+    return 'unchanged';
+  }
+
+  if (preparedOp.status === 'failed') {
+    return 'unchanged';
+  }
+
+  if (preparedOp.status === 'confirmed' && spendTx?.status === 'confirmed') {
+    return 'unchanged';
+  }
+
+  const receivingLive = getSpendReceivingWalletAddress(
+    spendExperience.spend_rail
+  ).trim();
+
+  if (session.spend_rail === 'stellar_usdc') {
+    if (
+      !stellarWalletAddressSchema.safeParse(receivingLive).success ||
+      preparedOp.status === 'needs_review'
+    ) {
+      return 'unchanged';
+    }
+
+    const snap = preparedOp.verification_snapshot;
+    if (!isSpendStellarUsdcVerificationSnapshotV1(snap)) {
+      return 'unchanged';
+    }
+
+    const railAddr = session.rail_user_wallet_address?.trim() ?? '';
+    if (!railAddr || snap.from_wallet !== railAddr) {
+      return 'unchanged';
+    }
+
+    const issuerLive = getStellarSpendUsdcIssuer();
+    const codeLive = getStellarSpendUsdcAssetCode();
+    if (
+      !issuerLive ||
+      !spendStellarUsdcSnapshotMatchesLiveRail({
+        snapshot: snap,
+        liveSpendRail: session.spend_rail,
+        liveReceiving: receivingLive,
+        liveUsdcIssuer: issuerLive,
+        liveUsdcCode: codeLive,
+      })
+    ) {
+      return 'unchanged';
+    }
+
+    const normalizedWallet = session.wallet_address.toLowerCase();
+    const stellarAnalyticsBase: SpendPilotPaymentEventProperties = {
+      spend_experience_id: spendExperience.id,
+      event_id: spendExperience.event_id,
+      user_id: session.user_id,
+      wallet_address: normalizedWallet,
+      points_amount: fundedConversion ? fundedConversion.points_deducted : 0,
+      usdc_amount: snap.usdc_amount,
+      status: 'submitted',
+      spend_session_id: session.id,
+      point_conversion_id: fundedConversion?.id,
+      payment_tx_hash: spendTx?.payment_tx_hash ?? '',
+    };
+
+    if (
+      spendTx?.status === 'submitted' &&
+      preparedOp.status === 'submitted' &&
+      spendTx.payment_tx_hash &&
+      isStellarTransactionHash(spendTx.payment_tx_hash)
+    ) {
+      const ledgerHash = spendTx.payment_tx_hash.trim().toLowerCase();
+      const verify = await verifySpendStellarUsdcPaymentTx({
+        txHash: ledgerHash,
+        expectedFrom: snap.from_wallet,
+        expectedTo: snap.receiving_wallet,
+        expectedUsdcAmount: snap.usdc_amount,
+        usdcIssuer: issuerLive,
+        usdcCode: codeLive,
+      });
+
+      if (verify.ok) {
+        await finalizeSuccess({
+          spendTransactionId: spendTx.id,
+          sessionId: session.id,
+          distinctId,
+          analytics: {
+            ...stellarAnalyticsBase,
+            spend_transaction_id: spendTx.id,
+            payment_tx_hash: ledgerHash,
+          },
+        });
+        await patchSpendPaymentPrepare(preparedOp.id, {
+          status: 'confirmed',
+          lastFailureReason: null,
+          lastFailureAt: null,
+          lastAmbiguityMetadata: null,
+        });
+        const updatedTx = await getSpendTransactionBySessionId(session.id);
+        if (updatedTx?.status === 'confirmed' && updatedTx.payment_tx_hash) {
+          void insertTreasuryReceivePaymentLedgerIfAbsent({
+            spendExperienceId: spendExperience.id,
+            spendRail: spendExperience.spend_rail,
+            amount: updatedTx.usdc_amount,
+            fromWalletAddress: updatedTx.from_wallet_address,
+            toWalletAddress: updatedTx.to_wallet_address,
+            txHash: updatedTx.payment_tx_hash,
+          });
+        }
+        return 'advanced';
+      }
+
+      const nowIso = new Date().toISOString();
+      if (isAmbiguousSpendPaymentVerifyFailure(verify.reason)) {
+        await patchSpendPaymentPrepare(preparedOp.id, {
+          status: 'needs_review',
+          lastFailureReason: verify.reason,
+          lastFailureAt: nowIso,
+          lastAmbiguityMetadata: {
+            spend_transaction_id: spendTx.id,
+            verify_reason: verify.reason,
+          },
+        });
+        return 'advanced';
+      }
+
+      await finalizeFailure({
+        spendTransactionId: spendTx.id,
+        sessionId: session.id,
+        distinctId,
+        analytics: {
+          ...stellarAnalyticsBase,
+          spend_transaction_id: spendTx.id,
+          payment_tx_hash: ledgerHash,
+        },
+        reason: verify.reason,
+      });
+      await patchSpendPaymentPrepare(preparedOp.id, {
+        status: 'failed',
+        lastFailureReason: verify.reason,
+        lastFailureAt: nowIso,
+        lastAmbiguityMetadata: null,
+      });
+      return 'advanced';
+    }
+
+    return 'unchanged';
+  }
+
+  if (session.spend_rail === 'base_usdc') {
+    if (!isEvmAddress(receivingLive)) {
+      return 'unchanged';
+    }
+    if (
+      !spendTx ||
+      spendTx.status !== 'submitted' ||
+      !spendTx.payment_tx_hash
+    ) {
+      return 'unchanged';
+    }
+    if (preparedOp.status !== 'submitted' && preparedOp.status !== 'prepared') {
+      return 'unchanged';
+    }
+
+    const snap = preparedOp.verification_snapshot;
+    if (!isSpendBaseUsdcVerificationSnapshotV1(snap)) {
+      return 'unchanged';
+    }
+
+    const normalizedWallet = session.wallet_address.toLowerCase();
+    if (snap.from_wallet !== normalizedWallet) {
+      return 'unchanged';
+    }
+    if (
+      !spendBaseUsdcSnapshotMatchesLiveRail({
+        snapshot: snap,
+        liveSpendRail: session.spend_rail,
+        liveReceivingLower: receivingLive.toLowerCase(),
+        liveUsdcContractLower:
+          getSpendRailBaseUsdcContractAddress().toLowerCase(),
+        liveChainId: POSTER_CHECKOUT_CHAIN_ID,
+      })
+    ) {
+      return 'unchanged';
+    }
+
+    const txHash = normalizeTxHash(spendTx.payment_tx_hash);
+    if (!txHash) {
+      return 'unchanged';
+    }
+
+    const fromAddr = snap.from_wallet as `0x${string}`;
+    const toAddr = snap.receiving_wallet as `0x${string}`;
+    const usdcAmount = snap.usdc_amount;
+    const requestedHashLower = txHash.toLowerCase();
+
+    const baseAnalytics: SpendPilotPaymentEventProperties = {
+      spend_experience_id: spendExperience.id,
+      event_id: spendExperience.event_id,
+      user_id: session.user_id,
+      wallet_address: normalizedWallet,
+      points_amount: fundedConversion ? fundedConversion.points_deducted : 0,
+      usdc_amount: usdcAmount,
+      status: 'submitted',
+      spend_session_id: session.id,
+      point_conversion_id: fundedConversion?.id,
+      payment_tx_hash: txHash,
+    };
+
+    const aligned =
+      (spendTx.payment_tx_hash ?? '').toLowerCase() === requestedHashLower;
+    if (preparedOp.status === 'prepared' && aligned) {
+      await patchSpendPaymentPrepare(preparedOp.id, { status: 'submitted' });
+    }
+
+    await updateSpendSessionStatus(session.id, 'payment_pending');
+
+    const verify = await verifySpendUsdcPaymentTx({
+      txHash,
+      expectedFrom: fromAddr,
+      expectedTo: toAddr,
+      expectedUsdcAmount: usdcAmount,
+    });
+
+    if (!verify.ok) {
+      const nowIso = new Date().toISOString();
+      if (isAmbiguousSpendPaymentVerifyFailure(verify.reason)) {
+        await patchSpendPaymentPrepare(preparedOp.id, {
+          status: 'needs_review',
+          lastFailureReason: verify.reason,
+          lastFailureAt: nowIso,
+          lastAmbiguityMetadata: {
+            spend_transaction_id: spendTx.id,
+            verify_reason: verify.reason,
+          },
+        });
+        return 'advanced';
+      }
+      await patchSpendPaymentPrepare(preparedOp.id, {
+        status: 'failed',
+        lastFailureReason: verify.reason,
+        lastFailureAt: nowIso,
+        lastAmbiguityMetadata: null,
+      });
+      await finalizeFailure({
+        spendTransactionId: spendTx.id,
+        sessionId: session.id,
+        distinctId,
+        analytics: { ...baseAnalytics, spend_transaction_id: spendTx.id },
+        reason: verify.reason,
+      });
+      return 'advanced';
+    }
+
+    await finalizeSuccess({
+      spendTransactionId: spendTx.id,
+      sessionId: session.id,
+      distinctId,
+      analytics: { ...baseAnalytics, spend_transaction_id: spendTx.id },
+    });
+
+    await patchSpendPaymentPrepare(preparedOp.id, {
+      status: 'confirmed',
+      lastFailureReason: null,
+      lastFailureAt: null,
+      lastAmbiguityMetadata: null,
+    });
+
+    const updatedTx = await getSpendTransactionBySessionId(session.id);
+    if (updatedTx?.status === 'confirmed' && updatedTx.payment_tx_hash) {
+      void insertTreasuryReceivePaymentLedgerIfAbsent({
+        spendExperienceId: spendExperience.id,
+        spendRail: spendExperience.spend_rail,
+        amount: updatedTx.usdc_amount,
+        fromWalletAddress: updatedTx.from_wallet_address,
+        toWalletAddress: updatedTx.to_wallet_address,
+        txHash: updatedTx.payment_tx_hash,
+      });
+    }
+
+    return 'advanced';
+  }
+
+  return 'unchanged';
+}

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -308,8 +308,9 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
     async reconcilePendingOperations(
       ctx: SpendPaymentRailReconcileContext
     ): Promise<SpendRailResult<void>> {
-      void ctx;
-      return okSpendRail(undefined);
+      const { reconcileSpendRailPendingOperationsFromRailContext } =
+        await import('@/lib/spend/reconcile-spend-rail-pending-operations');
+      return reconcileSpendRailPendingOperationsFromRailContext(ctx, spendRail);
     },
 
     assertUserSignedOnchainPaymentConfirmSupported(): SpendRailResult<void> {

--- a/lib/spend/payment-rails/payment-rails.test.ts
+++ b/lib/spend/payment-rails/payment-rails.test.ts
@@ -18,6 +18,12 @@ vi.mock('@/lib/spend/stellar-treasury-funding', () => ({
   getStellarTreasuryFundingTxOutcome: vi.fn(),
 }));
 
+vi.mock('@/lib/spend/reconcile-spend-rail-pending-operations', () => ({
+  reconcileSpendRailPendingOperationsFromRailContext: vi
+    .fn()
+    .mockResolvedValue({ ok: true }),
+}));
+
 import {
   SPEND_RAIL_ANALYTICS_CODES,
   spendRailErrorConversionFundingNotSupported,
@@ -145,7 +151,7 @@ describe('getSpendPaymentRail', () => {
     expect(gate.error.userMessage).toContain('not available in this release');
   });
 
-  it('Stellar rail rejects prepare/confirm/reconcile; treasury reads are rail-shaped', async () => {
+  it('Stellar rail rejects user-signed confirm; reconcile delegates to shared module', async () => {
     const rail = getSpendPaymentRail('stellar_usdc');
     const ctx = { spendSessionId: 's1', sessionOwnerPrivyUserId: 'p1' };
 
@@ -163,7 +169,7 @@ describe('getSpendPaymentRail', () => {
     });
     await expect(
       rail.reconcilePendingOperations({ spendSessionId: 's1' })
-    ).resolves.toMatchObject({ ok: false });
+    ).resolves.toMatchObject({ ok: true });
 
     expect(rail.explorerUrlForLedgerTx(null)).toBeNull();
   });

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -100,8 +100,8 @@ export interface SpendPaymentRail {
   explorerUrlForLedgerTx(txReference: string | null | undefined): string | null;
 
   /**
-   * Reconcile stale pending/submitted operations (cron). IRL-15: successful no-op on Base;
-   * unsupported outcome on Stellar until reconciliation is rail-backed.
+   * Reconcile stale pending/submitted operations (cron / read-path, IRL-22).
+   * Delegates to `lib/spend/reconcile-spend-rail-pending-operations.ts`.
    */
   reconcilePendingOperations(
     ctx: SpendPaymentRailReconcileContext

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -397,8 +397,9 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
     async reconcilePendingOperations(
       ctx: SpendPaymentRailReconcileContext
     ): Promise<SpendRailResult<void>> {
-      void ctx;
-      return unsupported();
+      const { reconcileSpendRailPendingOperationsFromRailContext } =
+        await import('@/lib/spend/reconcile-spend-rail-pending-operations');
+      return reconcileSpendRailPendingOperationsFromRailContext(ctx, spendRail);
     },
 
     assertUserSignedOnchainPaymentConfirmSupported(): SpendRailResult<void> {

--- a/lib/spend/reconcile-spend-rail-pending-operations.test.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.test.ts
@@ -9,9 +9,6 @@ describe('readSpendRailReconcileEnvConfig', () => {
   });
 
   it('returns defaults when env vars are unset', () => {
-    delete process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS;
-    delete process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS;
-    delete process.env.SPEND_RAIL_CRON_BATCH_SIZE;
     expect(readSpendRailReconcileEnvConfig()).toEqual({
       minAgeSeconds: 60,
       backoffSeconds: 120,

--- a/lib/spend/reconcile-spend-rail-pending-operations.test.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readSpendRailReconcileEnvConfig } from '@/lib/spend/reconcile-spend-rail-pending-operations';
+
+describe('readSpendRailReconcileEnvConfig', () => {
+  afterEach(() => {
+    delete process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS;
+    delete process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS;
+    delete process.env.SPEND_RAIL_CRON_BATCH_SIZE;
+  });
+
+  it('returns defaults when env vars are unset', () => {
+    delete process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS;
+    delete process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS;
+    delete process.env.SPEND_RAIL_CRON_BATCH_SIZE;
+    expect(readSpendRailReconcileEnvConfig()).toEqual({
+      minAgeSeconds: 60,
+      backoffSeconds: 120,
+      batchSize: 25,
+    });
+  });
+
+  it('parses overrides', () => {
+    process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS = '30';
+    process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS = '45';
+    process.env.SPEND_RAIL_CRON_BATCH_SIZE = '10';
+    expect(readSpendRailReconcileEnvConfig()).toEqual({
+      minAgeSeconds: 30,
+      backoffSeconds: 45,
+      batchSize: 10,
+    });
+  });
+
+  it('caps oversized batch', () => {
+    process.env.SPEND_RAIL_CRON_BATCH_SIZE = '9999';
+    expect(readSpendRailReconcileEnvConfig().batchSize).toBe(500);
+  });
+});

--- a/lib/spend/reconcile-spend-rail-pending-operations.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.ts
@@ -148,23 +148,22 @@ export async function reconcileSpendRailPendingOperationsForSession(input: {
       readiness &&
       (readiness.status === 'pending' || readiness.status === 'needs_review')
     ) {
-      if (
+      const skipReadinessOrchestration =
         input.olderThanIso != null &&
-        Date.parse(readiness.updated_at) > Date.parse(input.olderThanIso)
-      ) {
-        return okSpendRail(undefined);
-      }
-      await runAndLogErrors('stellar readiness reconcile', async () => {
-        const outcome = await runStellarUsdcWalletReadinessOrchestration({
-          readinessRow: readiness,
-          spendSessionId: session.id,
-          spendExperienceId: spendExperience.id,
-          sessionOwnerPrivyUserId: session.user_id,
+        Date.parse(readiness.updated_at) > Date.parse(input.olderThanIso);
+      if (!skipReadinessOrchestration) {
+        await runAndLogErrors('stellar readiness reconcile', async () => {
+          const outcome = await runStellarUsdcWalletReadinessOrchestration({
+            readinessRow: readiness,
+            spendSessionId: session.id,
+            spendExperienceId: spendExperience.id,
+            sessionOwnerPrivyUserId: session.user_id,
+          });
+          if (!outcome.ok) {
+            console.warn('stellar readiness reconcile: orchestration error');
+          }
         });
-        if (!outcome.ok) {
-          console.warn('stellar readiness reconcile: orchestration error');
-        }
-      });
+      }
     }
   }
 

--- a/lib/spend/reconcile-spend-rail-pending-operations.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.ts
@@ -21,7 +21,33 @@ import type { SpendPaymentRailReconcileContext } from '@/lib/spend/payment-rails
 const DEFAULT_MIN_AGE_SECONDS = 60;
 const DEFAULT_BACKOFF_SECONDS = 120;
 const DEFAULT_BATCH_SIZE = 25;
+const MAX_BATCH_SIZE = 500;
 const RECONCILE_DISTINCT_ID = 'spend_rail_reconcile';
+
+function parseNonNegativeIntEnv(
+  raw: string | undefined,
+  fallback: number
+): number {
+  const n = Number.parseInt(raw ?? `${fallback}`, 10);
+  return Number.isFinite(n) && n >= 0 ? n : fallback;
+}
+
+function parseBatchSizeEnv(raw: string | undefined, fallback: number): number {
+  const n = Number.parseInt(raw ?? `${fallback}`, 10);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.min(n, MAX_BATCH_SIZE);
+}
+
+async function runAndLogErrors(
+  label: string,
+  fn: () => Promise<unknown>
+): Promise<void> {
+  try {
+    await fn();
+  } catch (e) {
+    console.error(`${label}:`, e);
+  }
+}
 
 export type SpendRailReconcileEnvConfig = {
   minAgeSeconds: number;
@@ -30,29 +56,19 @@ export type SpendRailReconcileEnvConfig = {
 };
 
 export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
-  const minAge = Number.parseInt(
-    process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS ?? `${DEFAULT_MIN_AGE_SECONDS}`,
-    10
-  );
-  const backoff = Number.parseInt(
-    process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS ?? `${DEFAULT_BACKOFF_SECONDS}`,
-    10
-  );
-  const batch = Number.parseInt(
-    process.env.SPEND_RAIL_CRON_BATCH_SIZE ?? `${DEFAULT_BATCH_SIZE}`,
-    10
-  );
   return {
-    minAgeSeconds:
-      Number.isFinite(minAge) && minAge >= 0 ? minAge : DEFAULT_MIN_AGE_SECONDS,
-    backoffSeconds:
-      Number.isFinite(backoff) && backoff >= 0
-        ? backoff
-        : DEFAULT_BACKOFF_SECONDS,
-    batchSize:
-      Number.isFinite(batch) && batch > 0
-        ? Math.min(batch, 500)
-        : DEFAULT_BATCH_SIZE,
+    minAgeSeconds: parseNonNegativeIntEnv(
+      process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS,
+      DEFAULT_MIN_AGE_SECONDS
+    ),
+    backoffSeconds: parseNonNegativeIntEnv(
+      process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS,
+      DEFAULT_BACKOFF_SECONDS
+    ),
+    batchSize: parseBatchSizeEnv(
+      process.env.SPEND_RAIL_CRON_BATCH_SIZE,
+      DEFAULT_BATCH_SIZE
+    ),
   };
 }
 
@@ -99,6 +115,9 @@ async function collectReconcileCandidateSessionIds(input: {
  * Reconciles pending Stellar readiness, conversion funding confirmations, and
  * submitted payment verifications for a single spend session. Safe to call from
  * Vercel Cron, overlapping runs, and future read-path hooks (IRL-25).
+ *
+ * Missing or unknown sessions are treated as success (`okSpendRail(undefined)`) so
+ * callers and cron batches do not fail on deleted or stale ids.
  */
 export async function reconcileSpendRailPendingOperationsForSession(input: {
   spendSessionId: string;
@@ -135,7 +154,7 @@ export async function reconcileSpendRailPendingOperationsForSession(input: {
       ) {
         return okSpendRail(undefined);
       }
-      try {
+      await runAndLogErrors('stellar readiness reconcile', async () => {
         const outcome = await runStellarUsdcWalletReadinessOrchestration({
           readinessRow: readiness,
           spendSessionId: session.id,
@@ -145,37 +164,32 @@ export async function reconcileSpendRailPendingOperationsForSession(input: {
         if (!outcome.ok) {
           console.warn('stellar readiness reconcile: orchestration error');
         }
-      } catch (e) {
-        console.error('stellar readiness reconcile:', e);
-      }
+      });
     }
   }
 
-  try {
-    await reconcileSpendConversionFundingBackground({
+  await runAndLogErrors('conversion funding reconcile', () =>
+    reconcileSpendConversionFundingBackground({
       session,
       spendExperience,
       distinctId,
-    });
-  } catch (e) {
-    console.error('conversion funding reconcile:', e);
-  }
+    })
+  );
 
-  try {
-    await reconcileSubmittedSpendPaymentBackground({
+  await runAndLogErrors('payment reconcile', () =>
+    reconcileSubmittedSpendPaymentBackground({
       session,
       spendExperience,
       distinctId,
-    });
-  } catch (e) {
-    console.error('payment reconcile:', e);
-  }
+    })
+  );
 
   return okSpendRail(undefined);
 }
 
 export type SpendRailReconcileCronResult = {
   candidateSessions: number;
+  /** Sessions for which {@link reconcileSpendRailPendingOperationsForSession} returned `ok`. */
   processedSessions: number;
   olderThanIso: string;
   batchSize: number;

--- a/lib/spend/reconcile-spend-rail-pending-operations.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.ts
@@ -1,0 +1,231 @@
+import { listSpendSessionIdsForStaleConversionFundingReconcile } from '@/lib/db/spend-sessions';
+import { listSpendSessionIdsForStalePaymentPrepareReconcile } from '@/lib/db/spend-payment-prepare';
+import {
+  getSpendWalletReadinessBySessionId,
+  listSpendSessionIdsForStaleStellarWalletReadiness,
+} from '@/lib/db/spend-wallet-readiness';
+import {
+  reconcileSpendConversionFundingBackground,
+  getSpendContextOr404,
+} from '@/lib/spend-conversion-confirm';
+import { reconcileSubmittedSpendPaymentBackground } from '@/lib/spend-payment-confirm';
+import { runStellarUsdcWalletReadinessOrchestration } from '@/lib/spend/stellar-wallet-readiness-orchestration';
+import { isSpendRailOperational } from '@/lib/spend-rail-config';
+import type { SpendRail } from '@/lib/types';
+import {
+  okSpendRail,
+  type SpendRailResult,
+} from '@/lib/spend/payment-rails/spend-payment-rail';
+import type { SpendPaymentRailReconcileContext } from '@/lib/spend/payment-rails/types';
+
+const DEFAULT_MIN_AGE_SECONDS = 60;
+const DEFAULT_BACKOFF_SECONDS = 120;
+const DEFAULT_BATCH_SIZE = 25;
+const RECONCILE_DISTINCT_ID = 'spend_rail_reconcile';
+
+export type SpendRailReconcileEnvConfig = {
+  minAgeSeconds: number;
+  backoffSeconds: number;
+  batchSize: number;
+};
+
+export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
+  const minAge = Number.parseInt(
+    process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS ?? `${DEFAULT_MIN_AGE_SECONDS}`,
+    10
+  );
+  const backoff = Number.parseInt(
+    process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS ?? `${DEFAULT_BACKOFF_SECONDS}`,
+    10
+  );
+  const batch = Number.parseInt(
+    process.env.SPEND_RAIL_CRON_BATCH_SIZE ?? `${DEFAULT_BATCH_SIZE}`,
+    10
+  );
+  return {
+    minAgeSeconds:
+      Number.isFinite(minAge) && minAge >= 0 ? minAge : DEFAULT_MIN_AGE_SECONDS,
+    backoffSeconds:
+      Number.isFinite(backoff) && backoff >= 0
+        ? backoff
+        : DEFAULT_BACKOFF_SECONDS,
+    batchSize:
+      Number.isFinite(batch) && batch > 0
+        ? Math.min(batch, 500)
+        : DEFAULT_BATCH_SIZE,
+  };
+}
+
+function reconcileOlderThanIso(
+  nowMs: number,
+  cfg: SpendRailReconcileEnvConfig
+): string {
+  const deltaMs = Math.max(cfg.minAgeSeconds, cfg.backoffSeconds) * 1000;
+  return new Date(nowMs - deltaMs).toISOString();
+}
+
+async function collectReconcileCandidateSessionIds(input: {
+  olderThanIso: string;
+  batchSize: number;
+}): Promise<string[]> {
+  const perSource = Math.max(1, Math.ceil(input.batchSize / 3));
+  const [readiness, funding, payment] = await Promise.all([
+    listSpendSessionIdsForStaleStellarWalletReadiness({
+      olderThanIso: input.olderThanIso,
+      limit: perSource,
+    }),
+    listSpendSessionIdsForStaleConversionFundingReconcile({
+      olderThanIso: input.olderThanIso,
+      limit: perSource,
+    }),
+    listSpendSessionIdsForStalePaymentPrepareReconcile({
+      olderThanIso: input.olderThanIso,
+      limit: perSource,
+    }),
+  ]);
+
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const id of [...readiness, ...funding, ...payment]) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    out.push(id);
+    if (out.length >= input.batchSize) break;
+  }
+  return out;
+}
+
+/**
+ * Reconciles pending Stellar readiness, conversion funding confirmations, and
+ * submitted payment verifications for a single spend session. Safe to call from
+ * Vercel Cron, overlapping runs, and future read-path hooks (IRL-25).
+ */
+export async function reconcileSpendRailPendingOperationsForSession(input: {
+  spendSessionId: string;
+  olderThanIso?: string;
+  /** When set, no-ops if the session snapshot rail differs. */
+  spendRail?: SpendRail;
+  distinctId?: string;
+}): Promise<SpendRailResult<void>> {
+  const ctx = await getSpendContextOr404(input.spendSessionId);
+  if ('error' in ctx) {
+    return okSpendRail(undefined);
+  }
+
+  const { session, spendExperience } = ctx;
+  if (input.spendRail != null && session.spend_rail !== input.spendRail) {
+    return okSpendRail(undefined);
+  }
+
+  if (!isSpendRailOperational(session.spend_rail)) {
+    return okSpendRail(undefined);
+  }
+
+  const distinctId = input.distinctId ?? RECONCILE_DISTINCT_ID;
+
+  if (session.spend_rail === 'stellar_usdc') {
+    const readiness = await getSpendWalletReadinessBySessionId(session.id);
+    if (
+      readiness &&
+      (readiness.status === 'pending' || readiness.status === 'needs_review')
+    ) {
+      if (
+        input.olderThanIso != null &&
+        Date.parse(readiness.updated_at) > Date.parse(input.olderThanIso)
+      ) {
+        return okSpendRail(undefined);
+      }
+      try {
+        const outcome = await runStellarUsdcWalletReadinessOrchestration({
+          readinessRow: readiness,
+          spendSessionId: session.id,
+          spendExperienceId: spendExperience.id,
+          sessionOwnerPrivyUserId: session.user_id,
+        });
+        if (!outcome.ok) {
+          console.warn('stellar readiness reconcile: orchestration error');
+        }
+      } catch (e) {
+        console.error('stellar readiness reconcile:', e);
+      }
+    }
+  }
+
+  try {
+    await reconcileSpendConversionFundingBackground({
+      session,
+      spendExperience,
+      distinctId,
+    });
+  } catch (e) {
+    console.error('conversion funding reconcile:', e);
+  }
+
+  try {
+    await reconcileSubmittedSpendPaymentBackground({
+      session,
+      spendExperience,
+      distinctId,
+    });
+  } catch (e) {
+    console.error('payment reconcile:', e);
+  }
+
+  return okSpendRail(undefined);
+}
+
+export type SpendRailReconcileCronResult = {
+  candidateSessions: number;
+  processedSessions: number;
+  olderThanIso: string;
+  batchSize: number;
+};
+
+/**
+ * Bounded batch reconciliation for cron: collects stale session ids then runs
+ * {@link reconcileSpendRailPendingOperationsForSession} per id.
+ */
+export async function runSpendRailReconciliationCron(input?: {
+  nowMs?: number;
+  config?: SpendRailReconcileEnvConfig;
+}): Promise<SpendRailReconcileCronResult> {
+  const cfg = input?.config ?? readSpendRailReconcileEnvConfig();
+  const nowMs = input?.nowMs ?? Date.now();
+  const olderThanIso = reconcileOlderThanIso(nowMs, cfg);
+  const ids = await collectReconcileCandidateSessionIds({
+    olderThanIso,
+    batchSize: cfg.batchSize,
+  });
+
+  let processed = 0;
+  for (const spendSessionId of ids) {
+    const res = await reconcileSpendRailPendingOperationsForSession({
+      spendSessionId,
+      olderThanIso,
+      distinctId: RECONCILE_DISTINCT_ID,
+    });
+    if (res.ok) {
+      processed += 1;
+    }
+  }
+
+  return {
+    candidateSessions: ids.length,
+    processedSessions: processed,
+    olderThanIso,
+    batchSize: cfg.batchSize,
+  };
+}
+
+/** Adapter for {@link SpendPaymentRailReconcileContext} call sites. */
+export async function reconcileSpendRailPendingOperationsFromRailContext(
+  ctx: SpendPaymentRailReconcileContext,
+  spendRail: SpendRail
+): Promise<SpendRailResult<void>> {
+  return reconcileSpendRailPendingOperationsForSession({
+    spendSessionId: ctx.spendSessionId,
+    olderThanIso: ctx.olderThanIso,
+    spendRail,
+    distinctId: RECONCILE_DISTINCT_ID,
+  });
+}

--- a/vercel.json
+++ b/vercel.json
@@ -6,6 +6,10 @@
     {
       "path": "/api/update-airtable",
       "schedule": "0 0 * * *"
+    },
+    {
+      "path": "/api/cron/spend-rail-reconcile",
+      "schedule": "* * * * *"
     }
   ]
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Background reconciliation for Stellar wallet readiness, conversion funding (on-chain confirmation and Base hash discovery only), and submitted payment verification. Shared logic lives in `lib/spend/reconcile-spend-rail-pending-operations.ts` for cron and for `SpendPaymentRail.reconcilePendingOperations` (read-path reuse).

## Changes

- Secured `GET /api/cron/spend-rail-reconcile` with `Authorization: Bearer` matching `CRON_SECRET`; JSON via `apiSuccess` / `apiError`.
- `vercel.json` cron schedule `* * * * *` for the new path.
- Env: `CRON_SECRET`, `SPEND_RAIL_CRON_MIN_AGE_SECONDS`, `SPEND_RAIL_CRON_BACKOFF_SECONDS`, `SPEND_RAIL_CRON_BATCH_SIZE` in `.env.local.example`.
- Extracted `resumeSpendConversionFundingFromChainReferences`; added `reconcileSpendConversionFundingBackground` and `reconcileSubmittedSpendPaymentBackground`.
- Base and Stellar rails delegate `reconcilePendingOperations` via dynamic import.
- DB list helpers for stale readiness, conversion funding, and payment prepare sessions.

## Testing

Vitest: payment rails, cron route, reconcile env config, spend conversion confirm. Lint and production build pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-22](https://linear.app/irlenergy/issue/IRL-22/add-vercel-cron-reconciliation-for-pending-rail-operations)

<div><a href="https://cursor.com/agents/bc-a9af5c1f-98bc-4fcc-b85f-c5051c9a156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a9af5c1f-98bc-4fcc-b85f-c5051c9a156a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

