### PR TITLE
feat(spend): enrich spend pilot Mixpanel analytics (IRL-23)

### DIFF
--- a/app/api/admin/spend-experiences/[experienceId]/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/route.ts
@@ -13,6 +13,7 @@ import {
   assertSpendRailAllowsMutatingSpendWork,
 } from '@/lib/spend-rail-config';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 
 interface RouteParams {
   params: { experienceId: string };
@@ -83,6 +84,7 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
           {
             mutation: 'admin_spend_experience_update',
             ...railGate.analytics,
+            ...spendPilotRailMixpanelFields(existing.spend_rail),
             spend_experience_id: existing.id,
             event_id: existing.event_id,
             admin_actor: adminCheck.user?.email ?? null,

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/withdraw/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/spend-server-wallet';
 import { assertSpendRailAllowsMutatingSpendWork } from '@/lib/spend-rail-config';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 import {
   submitTreasuryUsdcTransfer,
   waitForTreasuryTxReceipt,
@@ -47,6 +48,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         {
           mutation: 'admin_treasury_withdraw',
           ...railGate.analytics,
+          ...spendPilotRailMixpanelFields(experience.spend_rail),
           spend_experience_id: experience.id,
           event_id: experience.event_id,
           admin_actor: adminCheck.user?.email ?? null,

--- a/app/api/admin/spend-experiences/route.ts
+++ b/app/api/admin/spend-experiences/route.ts
@@ -18,6 +18,7 @@ import {
   assertSpendRailAllowsMutatingSpendWork,
 } from '@/lib/spend-rail-config';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 
 function createIdempotencyKey(request: NextRequest): string {
   return (
@@ -82,6 +83,7 @@ export async function POST(request: NextRequest) {
         {
           mutation: 'admin_spend_experience_create',
           ...railGate.analytics,
+          ...spendPilotRailMixpanelFields(spendRail),
           admin_actor: adminCheck.user?.email ?? null,
         }
       );

--- a/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/__tests__/route.test.ts
@@ -35,6 +35,7 @@ vi.mock('@/lib/analytics/server', () => ({
 }));
 
 import { POST } from '../route';
+import * as spendRailConfig from '@/lib/spend-rail-config';
 
 const experience = {
   id: 'exp-uuid',
@@ -149,7 +150,18 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
     process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS =
       'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
     process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+    let railSpy:
+      | ReturnType<
+          typeof vi.spyOn<
+            typeof spendRailConfig,
+            'assertSpendRailAllowsMutatingSpendWork'
+          >
+        >
+      | undefined;
     try {
+      railSpy = vi
+        .spyOn(spendRailConfig, 'assertSpendRailAllowsMutatingSpendWork')
+        .mockReturnValue({ ok: true as const });
       const stellarExp = { ...experience, spend_rail: 'stellar_usdc' as const };
       const stellarSession = {
         ...session,
@@ -178,6 +190,7 @@ describe('POST /api/spend-experiences/[experienceId]/sessions', () => {
       expect(j.data.session.rail_user_wallet_address).toBeNull();
       expect(j.data.spendRailSummary.rail).toBe('stellar_usdc');
     } finally {
+      railSpy?.mockRestore();
       process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = prevEnabled;
       process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = prevRecv;
       process.env.NEXT_PUBLIC_STELLAR_NETWORK = prevNet;

--- a/app/api/spend-experiences/[experienceId]/sessions/route.ts
+++ b/app/api/spend-experiences/[experienceId]/sessions/route.ts
@@ -15,6 +15,7 @@ import {
   trackSpendSessionCreated,
   resolveServerIdentity,
 } from '@/lib/analytics/server';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 
 export const dynamic = 'force-dynamic';
 
@@ -74,6 +75,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     trackSpendPilotRailMutationBlocked(distinctId, {
       mutation: 'spend_session_create',
       ...railGate.analytics,
+      ...spendPilotRailMixpanelFields(experience.spend_rail),
       spend_experience_id: experienceId,
       event_id: experience.event_id,
       user_id: auth.userId,
@@ -106,6 +108,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
         wallet_address: trimmedWallet.toLowerCase(),
         spend_session_id: session.id,
         created: true,
+        ...spendPilotRailMixpanelFields(experience.spend_rail),
       });
     }
 

--- a/app/api/spend-sessions/[sessionId]/conversion/preview/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/preview/route.ts
@@ -17,6 +17,11 @@ import {
   trackSpendUserAlreadyConverted,
   resolveServerIdentity,
 } from '@/lib/analytics/server';
+import {
+  spendPilotRailMixpanelFields,
+  spendPilotSanitizedRailErrorFields,
+} from '@/lib/analytics/spend-pilot-rail-context';
+import { spendRailErrorTreasuryInsufficientFunds } from '@/lib/spend/payment-rails/errors';
 import { spendConversionPreviewBodySchema } from '@/lib/schemas/spend-session';
 import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 
@@ -95,6 +100,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       normalizedWallet,
       distinctId,
       baseAnalytics: {
+        ...spendPilotRailMixpanelFields(session.spend_rail),
         spend_experience_id: spendExperience.id,
         event_id: spendExperience.event_id,
         user_id: auth.userId,
@@ -113,7 +119,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       spendExperience,
     });
 
+    const railFields = spendPilotRailMixpanelFields(responseSession.spend_rail);
     const baseProps = {
+      ...railFields,
       spend_experience_id: spendExperience.id,
       event_id: spendExperience.event_id,
       user_id: auth.userId,
@@ -131,7 +139,12 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       trackSpendUserAlreadyConverted(distinctId, baseProps);
     }
     if (eligibility.status === 'treasury_insufficient') {
-      trackSpendTreasuryInsufficientFunds(distinctId, baseProps);
+      trackSpendTreasuryInsufficientFunds(distinctId, {
+        ...baseProps,
+        ...spendPilotSanitizedRailErrorFields(
+          spendRailErrorTreasuryInsufficientFunds()
+        ),
+      });
     }
 
     return apiSuccess({

--- a/app/api/spend-sessions/[sessionId]/receipt/route.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/route.ts
@@ -12,6 +12,7 @@ import {
   resolveServerIdentity,
   trackSpendReceiptViewed,
 } from '@/lib/analytics/server';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 
 export const dynamic = 'force-dynamic';
@@ -64,6 +65,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       walletAddress: session.wallet_address.toLowerCase(),
     });
     trackSpendReceiptViewed(distinctId, {
+      ...spendPilotRailMixpanelFields(session.spend_rail),
       spend_experience_id: spendExperience.id,
       event_id: spendExperience.event_id,
       user_id: userId,

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -22,8 +22,8 @@ import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 import type { SpendRailClientSummary } from '@/lib/spend-rail-config/types';
-import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 import {
   formatSpendPaymentExplorerUrl,
   spendPaymentExplorerLinkLabel,
@@ -541,17 +541,15 @@ export function SpendExperiencePage({
       if (token) {
         await initMixpanel(token);
       }
-      const railSummary = getSpendRailClientSummary(
-        initialExperience.spend_rail
-      );
+      const rail = spendPilotRailMixpanelFields(initialExperience.spend_rail);
       trackEvent(ANALYTICS_EVENTS.SPEND_EXPERIENCE_QR_SCANNED, {
         spend_experience_id: experienceId,
         event_id: initialExperience.event_id ?? undefined,
         user_id: user?.id,
         wallet_address: walletAddress ?? undefined,
-        spend_rail: railSummary.rail,
-        network: railSummary.networkLabel,
-        asset: railSummary.assetSymbol,
+        spend_rail: rail.spend_rail,
+        network: rail.network,
+        asset: rail.asset,
       });
       setTrackedScan(true);
     };

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -23,6 +23,7 @@ import {
   type SpendEligibilityStatus,
 } from '@/lib/spend-eligibility-messages';
 import type { SpendRailClientSummary } from '@/lib/spend-rail-config/types';
+import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
 import {
   formatSpendPaymentExplorerUrl,
   spendPaymentExplorerLinkLabel,
@@ -540,11 +541,17 @@ export function SpendExperiencePage({
       if (token) {
         await initMixpanel(token);
       }
+      const railSummary = getSpendRailClientSummary(
+        initialExperience.spend_rail
+      );
       trackEvent(ANALYTICS_EVENTS.SPEND_EXPERIENCE_QR_SCANNED, {
         spend_experience_id: experienceId,
         event_id: initialExperience.event_id ?? undefined,
         user_id: user?.id,
         wallet_address: walletAddress ?? undefined,
+        spend_rail: railSummary.rail,
+        network: railSummary.networkLabel,
+        asset: railSummary.assetSymbol,
       });
       setTrackedScan(true);
     };
@@ -552,6 +559,7 @@ export function SpendExperiencePage({
   }, [
     experienceId,
     initialExperience.event_id,
+    initialExperience.spend_rail,
     user?.id,
     walletAddress,
     trackedScan,

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -52,6 +52,10 @@ export const ANALYTICS_EVENTS = {
   SPEND_RECEIPT_VIEWED: 'spend_receipt_viewed',
   /** Spend rail disabled/misconfigured blocked a mutating API path (IRL-10). */
   SPEND_PILOT_RAIL_MUTATION_BLOCKED: 'spend_pilot_rail_mutation_blocked',
+  /** Wallet readiness funnel (IRL-23): Base = sync validation; Stellar = async orchestration. */
+  SPEND_WALLET_READINESS_STARTED: 'spend_wallet_readiness_started',
+  SPEND_WALLET_READINESS_COMPLETED: 'spend_wallet_readiness_completed',
+  SPEND_WALLET_READINESS_FAILED: 'spend_wallet_readiness_failed',
 } as const;
 
 export type AnalyticsEventName =

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -15,6 +15,7 @@ import type {
   SpendPilotConversionEventProperties,
   SpendPilotPaymentEventProperties,
   SpendPilotRailMutationBlockedProperties,
+  SpendPilotWalletReadinessEventProperties,
 } from './types';
 import { ANALYTICS_EVENTS } from './events';
 import { resolveDistinctId, type IdentityInput } from './identity';
@@ -366,6 +367,39 @@ export function trackSpendPilotRailMutationBlocked(
   trackEvent(
     distinctId,
     ANALYTICS_EVENTS.SPEND_PILOT_RAIL_MUTATION_BLOCKED,
+    properties
+  );
+}
+
+export function trackSpendWalletReadinessStarted(
+  distinctId: string,
+  properties: SpendPilotWalletReadinessEventProperties
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPEND_WALLET_READINESS_STARTED,
+    properties
+  );
+}
+
+export function trackSpendWalletReadinessCompleted(
+  distinctId: string,
+  properties: SpendPilotWalletReadinessEventProperties
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPEND_WALLET_READINESS_COMPLETED,
+    properties
+  );
+}
+
+export function trackSpendWalletReadinessFailed(
+  distinctId: string,
+  properties: SpendPilotWalletReadinessEventProperties
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPEND_WALLET_READINESS_FAILED,
     properties
   );
 }

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -371,35 +371,37 @@ export function trackSpendPilotRailMutationBlocked(
   );
 }
 
+const SPEND_WALLET_READINESS_EVENTS = {
+  started: ANALYTICS_EVENTS.SPEND_WALLET_READINESS_STARTED,
+  completed: ANALYTICS_EVENTS.SPEND_WALLET_READINESS_COMPLETED,
+  failed: ANALYTICS_EVENTS.SPEND_WALLET_READINESS_FAILED,
+} as const;
+
+function trackSpendWalletReadiness(
+  phase: keyof typeof SPEND_WALLET_READINESS_EVENTS,
+  distinctId: string,
+  properties: SpendPilotWalletReadinessEventProperties
+): void {
+  trackEvent(distinctId, SPEND_WALLET_READINESS_EVENTS[phase], properties);
+}
+
 export function trackSpendWalletReadinessStarted(
   distinctId: string,
   properties: SpendPilotWalletReadinessEventProperties
 ): void {
-  trackEvent(
-    distinctId,
-    ANALYTICS_EVENTS.SPEND_WALLET_READINESS_STARTED,
-    properties
-  );
+  trackSpendWalletReadiness('started', distinctId, properties);
 }
 
 export function trackSpendWalletReadinessCompleted(
   distinctId: string,
   properties: SpendPilotWalletReadinessEventProperties
 ): void {
-  trackEvent(
-    distinctId,
-    ANALYTICS_EVENTS.SPEND_WALLET_READINESS_COMPLETED,
-    properties
-  );
+  trackSpendWalletReadiness('completed', distinctId, properties);
 }
 
 export function trackSpendWalletReadinessFailed(
   distinctId: string,
   properties: SpendPilotWalletReadinessEventProperties
 ): void {
-  trackEvent(
-    distinctId,
-    ANALYTICS_EVENTS.SPEND_WALLET_READINESS_FAILED,
-    properties
-  );
+  trackSpendWalletReadiness('failed', distinctId, properties);
 }

--- a/lib/analytics/spend-pilot-rail-context.ts
+++ b/lib/analytics/spend-pilot-rail-context.ts
@@ -1,5 +1,10 @@
+import type { SpendPilotSanitizedErrorFields } from '@/lib/analytics/types';
 import type { SpendRail } from '@/lib/types';
-import type { SpendRailError } from '@/lib/spend/payment-rails/errors';
+import type {
+  SpendRailAnalyticsCode,
+  SpendRailError,
+  SpendRailErrorCategory,
+} from '@/lib/spend/payment-rails/errors';
 
 const SPEND_RAIL_MIXPANEL_STATIC: Record<
   SpendRail,
@@ -19,12 +24,8 @@ export function spendPilotRailMixpanelFields(spendRail: SpendRail): {
   network: string;
   asset: string;
 } {
-  const x = SPEND_RAIL_MIXPANEL_STATIC[spendRail];
-  return {
-    spend_rail: spendRail,
-    network: x.network,
-    asset: x.asset,
-  };
+  const { network, asset } = SPEND_RAIL_MIXPANEL_STATIC[spendRail];
+  return { spend_rail: spendRail, network, asset };
 }
 
 export function spendPilotSanitizedRailErrorFields(error: SpendRailError): {
@@ -35,4 +36,22 @@ export function spendPilotSanitizedRailErrorFields(error: SpendRailError): {
     sanitized_error_category: error.category,
     sanitized_error_code: error.analyticsCode,
   };
+}
+
+/**
+ * Maps persisted wallet-readiness row strings to Mixpanel-safe error fields,
+ * or falls back when the row predates sanitized columns.
+ */
+export function spendPilotSanitizedFieldsFromWalletReadinessRow(
+  category: string | null | undefined,
+  code: string | null | undefined,
+  fallbackError: SpendRailError
+): SpendPilotSanitizedErrorFields {
+  if (category != null && code != null) {
+    return {
+      sanitized_error_category: category as SpendRailErrorCategory,
+      sanitized_error_code: code as SpendRailAnalyticsCode,
+    };
+  }
+  return spendPilotSanitizedRailErrorFields(fallbackError);
 }

--- a/lib/analytics/spend-pilot-rail-context.ts
+++ b/lib/analytics/spend-pilot-rail-context.ts
@@ -1,0 +1,38 @@
+import type { SpendRail } from '@/lib/types';
+import type { SpendRailError } from '@/lib/spend/payment-rails/errors';
+
+const SPEND_RAIL_MIXPANEL_STATIC: Record<
+  SpendRail,
+  { network: string; asset: string }
+> = {
+  base_usdc: { network: 'Base', asset: 'USDC' },
+  stellar_usdc: { network: 'Stellar', asset: 'USDC' },
+};
+
+/**
+ * Mixpanel-safe rail slice aligned with `SpendRail` + USDC (IRL-23).
+ * Uses stable labels matching `getSpendRailPublicMetadata` defaults (no env reads)
+ * so unit tests can mock `@/lib/spend-rail-config` without this helper.
+ */
+export function spendPilotRailMixpanelFields(spendRail: SpendRail): {
+  spend_rail: SpendRail;
+  network: string;
+  asset: string;
+} {
+  const x = SPEND_RAIL_MIXPANEL_STATIC[spendRail];
+  return {
+    spend_rail: spendRail,
+    network: x.network,
+    asset: x.asset,
+  };
+}
+
+export function spendPilotSanitizedRailErrorFields(error: SpendRailError): {
+  sanitized_error_category: SpendRailError['category'];
+  sanitized_error_code: SpendRailError['analyticsCode'];
+} {
+  return {
+    sanitized_error_category: error.category,
+    sanitized_error_code: error.analyticsCode,
+  };
+}

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -2,6 +2,24 @@
  * Analytics event types and interfaces
  */
 
+import type { SpendRail } from '@/lib/types';
+import type {
+  SpendRailAnalyticsCode,
+  SpendRailErrorCategory,
+} from '@/lib/spend/payment-rails/errors';
+
+/** Shared optional rail + error metadata for spend pilot Mixpanel payloads (IRL-23). */
+export type SpendPilotRailMixpanelFields = {
+  spend_rail: SpendRail;
+  network: string;
+  asset: string;
+};
+
+export type SpendPilotSanitizedErrorFields = {
+  sanitized_error_category: SpendRailErrorCategory;
+  sanitized_error_code: SpendRailAnalyticsCode;
+};
+
 export interface AnalyticsEvent {
   name: string;
   properties?: Record<string, any>;
@@ -147,6 +165,9 @@ export interface SpendPilotSessionEventProperties {
   spend_session_id?: string;
   /** True when the session row was newly inserted (not idempotent return). */
   created?: boolean;
+  spend_rail?: SpendRail;
+  network?: string;
+  asset?: string;
 }
 
 /** Spend pilot: conversion preview / eligibility analytics */
@@ -164,6 +185,14 @@ export interface SpendPilotConversionEventProperties {
   spend_session_id?: string;
   /** On-chain USDC funding tx */
   funding_tx_hash?: string | null;
+  spend_rail?: SpendRail;
+  network?: string;
+  asset?: string;
+  sanitized_error_category?: SpendRailErrorCategory;
+  sanitized_error_code?: SpendRailAnalyticsCode;
+  wallet_readiness_operation_id?: string;
+  sponsor_treasury_transaction_id?: string | null;
+  trustline_treasury_transaction_id?: string | null;
 }
 
 /** Spend pilot: user payment to receiving wallet (PRD §13). */
@@ -180,6 +209,13 @@ export interface SpendPilotPaymentEventProperties {
   point_conversion_id?: string;
   spend_transaction_id?: string;
   payment_tx_hash?: string | null;
+  spend_rail?: SpendRail;
+  network?: string;
+  asset?: string;
+  sanitized_error_category?: SpendRailErrorCategory;
+  sanitized_error_code?: SpendRailAnalyticsCode;
+  /** `spend_payment_prepare_operations.id` when a prepare row exists for the session. */
+  spend_payment_prepare_operation_id?: string;
 }
 
 /** Server-only: mutating spend blocked because the session rail is not operational. */
@@ -194,7 +230,7 @@ export interface SpendPilotRailMutationBlockedProperties {
     | 'admin_spend_experience_create'
     | 'admin_spend_experience_update'
     | 'admin_treasury_withdraw';
-  spend_rail: string;
+  spend_rail: SpendRail;
   rail_operational: false;
   /** Curated, non-secret reason labels (see spend-rail-config admin mapping). */
   unavailable_reason_codes: string[];
@@ -205,4 +241,32 @@ export interface SpendPilotRailMutationBlockedProperties {
   wallet_address?: string;
   point_conversion_id?: string;
   admin_actor?: string | null;
+  network?: string;
+  asset?: string;
+}
+
+/** Spend pilot wallet readiness funnel (IRL-23). */
+export interface SpendPilotWalletReadinessEventProperties {
+  spend_experience_id?: string;
+  event_id?: string | null;
+  user_id?: string;
+  wallet_address?: string;
+  spend_session_id: string;
+  point_conversion_id?: string;
+  spend_rail: SpendRail;
+  network: string;
+  asset: string;
+  /**
+   * Base USDC: synchronous validation-only gate (no `spend_wallet_readiness_operations` row).
+   * Stellar USDC: persisted readiness row id when available.
+   */
+  wallet_readiness_operation_id?: string;
+  sponsor_treasury_transaction_id?: string | null;
+  trustline_treasury_transaction_id?: string | null;
+  /** Base: `base_validation_sync`. Stellar: `stellar_async_orchestration`. */
+  wallet_readiness_mode: 'base_validation_sync' | 'stellar_async_orchestration';
+  sanitized_error_category?: SpendRailErrorCategory;
+  sanitized_error_code?: SpendRailAnalyticsCode;
+  /** True when Stellar readiness was already `completed` in the database (no new orchestration). */
+  resumed_from_completed_row?: boolean;
 }

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -30,6 +30,7 @@ import {
 } from '@/lib/spend-treasury-usdc-transfer';
 import { getSpendTreasuryFundingWalletMeta } from '@/lib/spend-server-wallet';
 import { insertTreasuryFundUserLedgerIfAbsent } from '@/lib/db/treasury-transactions';
+import { getSpendWalletReadinessBySessionId } from '@/lib/db/spend-wallet-readiness';
 import {
   explorerTxUrlForSpendLedger,
   isStellarTransactionHash,
@@ -41,7 +42,8 @@ import { getStellarTreasuryFundingTxOutcome } from '@/lib/spend/stellar-treasury
 import type { SpendPaymentRailSessionContext } from '@/lib/spend/payment-rails/types';
 import {
   spendRailErrorCategoryToHttpStatus,
-  type SpendRailErrorCategory,
+  spendRailErrorTreasuryInsufficientFunds,
+  type SpendRailError,
 } from '@/lib/spend/payment-rails/errors';
 import {
   assertSpendRailAllowsMutatingSpendWork,
@@ -56,6 +58,10 @@ import {
   trackSpendTreasuryInsufficientFunds,
 } from '@/lib/analytics/server';
 import type { SpendPilotConversionEventProperties } from '@/lib/analytics/types';
+import {
+  spendPilotRailMixpanelFields,
+  spendPilotSanitizedRailErrorFields,
+} from '@/lib/analytics/spend-pilot-rail-context';
 import type {
   PointConversion,
   PointConversionLastFailure,
@@ -162,8 +168,7 @@ async function conversionRailFailureOutcome(input: {
   session: SpendSession;
   distinctId: string;
   baseAnalytics: SpendPilotConversionEventProperties;
-  category: SpendRailErrorCategory;
-  userMessage: string;
+  railError: SpendRailError;
 }): Promise<{
   kind: 'error';
   value: SpendConversionConfirmResult;
@@ -173,27 +178,43 @@ async function conversionRailFailureOutcome(input: {
   const refundOk = await refundSpendConversionPointsBestEffort({
     conversion: input.conv,
     session: input.session,
-    failedReason: `${prefix}:${input.category}:${input.userMessage}`,
+    failedReason: `${prefix}:${input.railError.category}:${input.railError.userMessage}`,
   });
   void persistConversionLastFailure({
     conversionId: input.conv.id,
     phase: input.phase,
-    category: input.category,
-    reasonSnippet: input.userMessage,
+    category: input.railError.category,
+    reasonSnippet: input.railError.userMessage,
   });
+  let walletReadinessOperationId: string | undefined;
+  if (
+    input.phase === 'readiness' &&
+    input.session.spend_rail === 'stellar_usdc'
+  ) {
+    try {
+      const w = await getSpendWalletReadinessBySessionId(input.session.id);
+      walletReadinessOperationId = w?.id;
+    } catch {
+      // best-effort analytics only
+    }
+  }
   trackSpendConversionFailed(input.distinctId, {
     ...input.baseAnalytics,
     point_conversion_id: input.conv.id,
     spend_session_id: input.session.id,
     status: 'failed',
-    error_reason: `${prefix}_failed:${input.category}`,
+    error_reason: `${prefix}_failed:${input.railError.category}`,
+    ...spendPilotSanitizedRailErrorFields(input.railError),
+    ...(walletReadinessOperationId
+      ? { wallet_readiness_operation_id: walletReadinessOperationId }
+      : {}),
   });
   return {
     kind: 'error',
     value: {
       ok: false,
-      httpStatus: spendRailErrorCategoryToHttpStatus(input.category),
-      error: input.userMessage,
+      httpStatus: spendRailErrorCategoryToHttpStatus(input.railError.category),
+      error: input.railError.userMessage,
     },
     ...(refundOk
       ? { pointsRefunded: Math.ceil(Number(input.conv.points_deducted)) }
@@ -243,6 +264,7 @@ async function runWalletReadinessAndUserFunding(input: {
       trackSpendPilotRailMutationBlocked(distinctId, {
         mutation: 'conversion_confirm',
         ...railGate.analytics,
+        ...spendPilotRailMixpanelFields(session.spend_rail),
         spend_experience_id: spendExperience.id,
         event_id: spendExperience.event_id,
         user_id: session.user_id,
@@ -291,6 +313,7 @@ async function runWalletReadinessAndUserFunding(input: {
     privyNormalizedWalletAddressLower: normalizedWallet,
     sessionOwnerPrivyUserId: session.user_id,
     usdcAmount,
+    analyticsDistinctId: distinctId,
   };
 
   const readiness = await rail.runWalletReadinessOrchestration(ctx);
@@ -301,8 +324,7 @@ async function runWalletReadinessAndUserFunding(input: {
       session,
       distinctId,
       baseAnalytics,
-      category: readiness.error.category,
-      userMessage: readiness.error.userMessage,
+      railError: readiness.error,
     });
   }
 
@@ -337,8 +359,7 @@ async function runWalletReadinessAndUserFunding(input: {
       session,
       distinctId,
       baseAnalytics,
-      category: funding.error.category,
-      userMessage: funding.error.userMessage,
+      railError: funding.error,
     });
   }
 
@@ -584,6 +605,7 @@ export async function finalizePendingSpendConversion(input: {
     normalizedWallet: input.walletAddress,
     distinctId: input.distinctId,
     baseAnalytics: {
+      ...spendPilotRailMixpanelFields(input.session.spend_rail),
       spend_experience_id: input.spendExperience.id,
       event_id: input.spendExperience.event_id,
       user_id: input.session.user_id,
@@ -615,6 +637,7 @@ export async function runSpendConversionConfirm(
   const now = new Date();
 
   const baseAnalytics: SpendPilotConversionEventProperties = {
+    ...spendPilotRailMixpanelFields(session.spend_rail),
     spend_experience_id: spendExperience.id,
     event_id: spendExperience.event_id,
     user_id: authUserId,
@@ -676,6 +699,9 @@ export async function runSpendConversionConfirm(
     if (retryEligibility.status === 'treasury_insufficient') {
       trackSpendTreasuryInsufficientFunds(distinctId, {
         ...baseAnalytics,
+        ...spendPilotSanitizedRailErrorFields(
+          spendRailErrorTreasuryInsufficientFunds()
+        ),
         status: 'treasury_insufficient',
         error_reason: 'treasury_insufficient',
       });
@@ -688,6 +714,7 @@ export async function runSpendConversionConfirm(
           trackSpendPilotRailMutationBlocked(distinctId, {
             mutation: 'conversion_confirm',
             ...rg.analytics,
+            ...spendPilotRailMixpanelFields(session.spend_rail),
             spend_experience_id: spendExperience.id,
             event_id: spendExperience.event_id,
             user_id: authUserId,
@@ -710,6 +737,7 @@ export async function runSpendConversionConfirm(
       trackSpendPilotRailMutationBlocked(distinctId, {
         mutation: 'conversion_confirm',
         ...retryRailGate.analytics,
+        ...spendPilotRailMixpanelFields(session.spend_rail),
         spend_experience_id: spendExperience.id,
         event_id: spendExperience.event_id,
         user_id: authUserId,
@@ -739,6 +767,9 @@ export async function runSpendConversionConfirm(
     if (retryBal === null || retryBal < usdcAmount) {
       trackSpendTreasuryInsufficientFunds(distinctId, {
         ...baseAnalytics,
+        ...spendPilotSanitizedRailErrorFields(
+          spendRailErrorTreasuryInsufficientFunds()
+        ),
         status: 'treasury_insufficient',
         error_reason: 'treasury_insufficient_at_confirm_retry',
       });
@@ -917,6 +948,9 @@ export async function runSpendConversionConfirm(
   if (eligibility.status === 'treasury_insufficient') {
     trackSpendTreasuryInsufficientFunds(distinctId, {
       ...baseAnalytics,
+      ...spendPilotSanitizedRailErrorFields(
+        spendRailErrorTreasuryInsufficientFunds()
+      ),
       status: 'treasury_insufficient',
       error_reason: 'treasury_insufficient',
     });
@@ -929,6 +963,7 @@ export async function runSpendConversionConfirm(
         trackSpendPilotRailMutationBlocked(distinctId, {
           mutation: 'conversion_confirm',
           ...rg.analytics,
+          ...spendPilotRailMixpanelFields(session.spend_rail),
           spend_experience_id: spendExperience.id,
           event_id: spendExperience.event_id,
           user_id: authUserId,
@@ -960,6 +995,9 @@ export async function runSpendConversionConfirm(
   if (bal === null || bal < usdcAmount) {
     trackSpendTreasuryInsufficientFunds(distinctId, {
       ...baseAnalytics,
+      ...spendPilotSanitizedRailErrorFields(
+        spendRailErrorTreasuryInsufficientFunds()
+      ),
       status: 'treasury_insufficient',
       error_reason: 'treasury_insufficient_at_confirm',
     });
@@ -1113,6 +1151,7 @@ async function fundOrResumeUsdc(input: {
     trackSpendPilotRailMutationBlocked(distinctId, {
       mutation: 'conversion_resume',
       ...railGate.analytics,
+      ...spendPilotRailMixpanelFields(session.spend_rail),
       spend_experience_id: spendExperience.id,
       event_id: spendExperience.event_id,
       user_id: session.user_id,

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -59,6 +59,11 @@ import {
   trackSpendPilotRailMutationBlocked,
 } from '@/lib/analytics/server';
 import type { SpendPilotPaymentEventProperties } from '@/lib/analytics/types';
+import {
+  spendPilotRailMixpanelFields,
+  spendPilotSanitizedRailErrorFields,
+} from '@/lib/analytics/spend-pilot-rail-context';
+import { spendRailErrorPaymentFailed } from '@/lib/spend/payment-rails/errors';
 import type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
 
 export type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
@@ -131,8 +136,10 @@ async function finalizeFailure(params: {
     failed_reason: params.reason,
   });
   await updateSpendSessionStatus(params.sessionId, 'payment_pending');
+  const paymentFailed = spendRailErrorPaymentFailed();
   trackSpendPaymentFailed(params.distinctId, {
     ...params.analytics,
+    ...spendPilotSanitizedRailErrorFields(paymentFailed),
     status: 'failed',
     error_reason: params.reason,
   });
@@ -286,6 +293,7 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   let spendTx: SpendTransaction | null = spendTxInitial;
 
   const stellarAnalyticsBase: SpendPilotPaymentEventProperties = {
+    ...spendPilotRailMixpanelFields(session.spend_rail),
     spend_experience_id: spendExperience.id,
     event_id: spendExperience.event_id,
     user_id: authUserId,
@@ -296,6 +304,7 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
     spend_session_id: session.id,
     point_conversion_id: fundedConversion?.id,
     payment_tx_hash: spendTx?.payment_tx_hash ?? '',
+    spend_payment_prepare_operation_id: preparedOp.id,
   };
 
   const applyStellarPrepareTerminal = async (
@@ -443,6 +452,7 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
     trackSpendPilotRailMutationBlocked(distinctId, {
       mutation: 'payment_confirm',
       ...railGate.analytics,
+      ...spendPilotRailMixpanelFields(session.spend_rail),
       spend_experience_id: spendExperience.id,
       event_id: spendExperience.event_id,
       user_id: authUserId,
@@ -480,6 +490,12 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   });
 
   if (!railConfirm.ok) {
+    trackSpendPaymentFailed(distinctId, {
+      ...stellarAnalyticsBase,
+      status: 'failed',
+      error_reason: 'payment_submit_rejected',
+      ...spendPilotSanitizedRailErrorFields(railConfirm.error),
+    });
     return {
       ok: false,
       error: railConfirm.error.userMessage,
@@ -493,6 +509,13 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   const outcome = railConfirm.value;
   const ledgerRef = outcome.ledgerTxReference?.trim() ?? '';
   if (!ledgerRef || !isStellarTransactionHash(ledgerRef)) {
+    trackSpendPaymentFailed(distinctId, {
+      ...stellarAnalyticsBase,
+      ...(spendTx ? { spend_transaction_id: spendTx.id } : {}),
+      status: 'failed',
+      error_reason: 'payment_submit_missing_ledger_ref',
+      ...spendPilotSanitizedRailErrorFields(spendRailErrorPaymentFailed()),
+    });
     return {
       ok: false,
       error: 'Payment submission did not return a ledger reference.',
@@ -501,6 +524,13 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   }
 
   if (outcome.status !== 'submitted') {
+    trackSpendPaymentFailed(distinctId, {
+      ...stellarAnalyticsBase,
+      ...(spendTx ? { spend_transaction_id: spendTx.id } : {}),
+      status: 'failed',
+      error_reason: 'payment_submit_unexpected_state',
+      ...spendPilotSanitizedRailErrorFields(spendRailErrorPaymentFailed()),
+    });
     return {
       ok: false,
       error: 'Unexpected payment submission state.',
@@ -839,6 +869,7 @@ export async function runSpendPaymentConfirm(input: {
   };
 
   const baseAnalytics: SpendPilotPaymentEventProperties = {
+    ...spendPilotRailMixpanelFields(session.spend_rail),
     spend_experience_id: spendExperience.id,
     event_id: spendExperience.event_id,
     user_id: authUserId,
@@ -849,6 +880,9 @@ export async function runSpendPaymentConfirm(input: {
     spend_session_id: session.id,
     point_conversion_id: fundedConversion?.id,
     payment_tx_hash: txHash,
+    ...(basePaymentPrepare
+      ? { spend_payment_prepare_operation_id: basePaymentPrepare.id }
+      : {}),
   };
 
   if (!spendTx) {
@@ -857,6 +891,7 @@ export async function runSpendPaymentConfirm(input: {
       trackSpendPilotRailMutationBlocked(distinctId, {
         mutation: 'payment_confirm',
         ...railGate.analytics,
+        ...spendPilotRailMixpanelFields(session.spend_rail),
         spend_experience_id: spendExperience.id,
         event_id: spendExperience.event_id,
         user_id: authUserId,

--- a/lib/spend-payment-prepare.ts
+++ b/lib/spend-payment-prepare.ts
@@ -29,6 +29,7 @@ import {
   POSTER_CHECKOUT_CHAIN_ID,
 } from '@/lib/walletconnect-poster-direct-usdc';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
+import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 import type { SpendPilotApiHttpStatus } from '@/lib/spend-pilot-http-status';
 import type {
   SpendExperience,
@@ -226,6 +227,7 @@ export async function runSpendPaymentPrepare(input: {
     trackSpendPilotRailMutationBlocked(distinctId, {
       mutation: 'payment_prepare',
       ...railGate.analytics,
+      ...spendPilotRailMixpanelFields(session.spend_rail),
       spend_experience_id: spendExperience.id,
       event_id: spendExperience.event_id,
       user_id: authUserId,

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -33,6 +33,15 @@ import {
   type SpendPaymentRail,
   type SpendRailResult,
 } from '@/lib/spend/payment-rails/spend-payment-rail';
+import {
+  spendPilotRailMixpanelFields,
+  spendPilotSanitizedRailErrorFields,
+} from '@/lib/analytics/spend-pilot-rail-context';
+import {
+  trackSpendWalletReadinessCompleted,
+  trackSpendWalletReadinessFailed,
+  trackSpendWalletReadinessStarted,
+} from '@/lib/analytics/server';
 import type {
   SpendPaymentRailReconcileContext,
   SpendPaymentRailSessionContext,
@@ -109,17 +118,67 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
     async runWalletReadinessOrchestration(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>> {
+      /**
+       * IRL-23: Base wallet “readiness” is synchronous validation only (no
+       * `spend_wallet_readiness_operations` row). Mixpanel started/completed/failed
+       * mirror that validation gate for funnel parity with Stellar.
+       */
+      const distinctId = ctx.analyticsDistinctId?.trim();
+      const railFields = spendPilotRailMixpanelFields(spendRail);
+      const walletReadinessBase = () => ({
+        spend_session_id: ctx.spendSessionId?.trim() ?? '',
+        spend_experience_id: ctx.spendExperienceId,
+        point_conversion_id: ctx.pointConversionId,
+        user_id: ctx.sessionOwnerPrivyUserId,
+        wallet_address: (
+          ctx.privyNormalizedWalletAddressLower ??
+          ctx.embeddedEvmWalletAddress ??
+          ''
+        )
+          .trim()
+          .toLowerCase(),
+        wallet_readiness_mode: 'base_validation_sync' as const,
+        ...railFields,
+      });
+
+      if (distinctId && ctx.spendSessionId?.trim()) {
+        trackSpendWalletReadinessStarted(distinctId, walletReadinessBase());
+      }
+
       if (!ctx.spendSessionId?.trim()) {
-        return errSpendRail(spendRailErrorWalletReadinessFailed());
+        const err = spendRailErrorWalletReadinessFailed();
+        if (distinctId) {
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...walletReadinessBase(),
+            ...spendPilotSanitizedRailErrorFields(err),
+          });
+        }
+        return errSpendRail(err);
       }
       const embeddedRes = embeddedEvmFromContext(ctx);
       if (!embeddedRes.ok) {
+        if (distinctId) {
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...walletReadinessBase(),
+            ...spendPilotSanitizedRailErrorFields(embeddedRes.error),
+          });
+        }
         return embeddedRes;
       }
       const embedded = embeddedRes.value;
       const authLower = ctx.privyNormalizedWalletAddressLower?.trim();
       if (authLower && embedded.toLowerCase() !== authLower.toLowerCase()) {
-        return errSpendRail(spendRailErrorWalletUnavailable());
+        const err = spendRailErrorWalletUnavailable();
+        if (distinctId) {
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...walletReadinessBase(),
+            ...spendPilotSanitizedRailErrorFields(err),
+          });
+        }
+        return errSpendRail(err);
+      }
+      if (distinctId) {
+        trackSpendWalletReadinessCompleted(distinctId, walletReadinessBase());
       }
       return okSpendRail({ status: 'completed' });
     },

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -302,15 +302,22 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
         }
 
         if (distinctId && outcome.ok && outcome.status === 'completed') {
-          const fresh = await getSpendWalletReadinessBySessionId(sessionId);
-          trackSpendWalletReadinessCompleted(distinctId, {
-            ...readinessProps(fresh?.id ?? row.id),
-            wallet_readiness_operation_id: fresh?.id ?? row.id,
-            sponsor_treasury_transaction_id:
-              fresh?.sponsor_treasury_transaction_id ?? null,
-            trustline_treasury_transaction_id:
-              fresh?.trustline_treasury_transaction_id ?? null,
-          });
+          try {
+            const fresh = await getSpendWalletReadinessBySessionId(sessionId);
+            trackSpendWalletReadinessCompleted(distinctId, {
+              ...readinessProps(fresh?.id ?? row.id),
+              wallet_readiness_operation_id: fresh?.id ?? row.id,
+              sponsor_treasury_transaction_id:
+                fresh?.sponsor_treasury_transaction_id ?? null,
+              trustline_treasury_transaction_id:
+                fresh?.trustline_treasury_transaction_id ?? null,
+            });
+          } catch (analyticsErr) {
+            console.error(
+              'stellar_usdc readiness completed analytics:',
+              analyticsErr
+            );
+          }
         }
 
         return okSpendRail({ status: outcome.status });

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -24,6 +24,8 @@ import {
   spendRailErrorRailOperationNotSupported,
   spendRailErrorWalletReadinessFailed,
   type SpendRailError,
+  type SpendRailErrorCategory,
+  type SpendRailAnalyticsCode,
 } from '@/lib/spend/payment-rails/errors';
 import type {
   SpendPaymentRailReconcileContext,
@@ -44,6 +46,17 @@ import {
   getStellarSpendUsdcIssuer,
 } from '@/lib/spend/stellar-wallet-readiness-config';
 import type { SpendStellarUsdcBackendSubmitPreparedActionV1 } from '@/lib/spend-payment-prepare-types';
+import type { SpendPilotWalletReadinessEventProperties } from '@/lib/analytics/types';
+import { getSpendWalletReadinessBySessionId } from '@/lib/db/spend-wallet-readiness';
+import {
+  spendPilotRailMixpanelFields,
+  spendPilotSanitizedRailErrorFields,
+} from '@/lib/analytics/spend-pilot-rail-context';
+import {
+  trackSpendWalletReadinessCompleted,
+  trackSpendWalletReadinessFailed,
+  trackSpendWalletReadinessStarted,
+} from '@/lib/analytics/server';
 
 const unsupported = (): SpendRailResult<never> =>
   errSpendRail(spendRailErrorRailOperationNotSupported());
@@ -119,13 +132,50 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
     async runWalletReadinessOrchestration(
       ctx: SpendPaymentRailSessionContext
     ): Promise<SpendRailResult<{ status: SpendWalletReadinessStatus }>> {
+      const distinctId = ctx.analyticsDistinctId?.trim();
+      const railFields = spendPilotRailMixpanelFields(spendRail);
+      const walletLower = (
+        ctx.privyNormalizedWalletAddressLower ??
+        ctx.embeddedEvmWalletAddress ??
+        ''
+      )
+        .trim()
+        .toLowerCase();
+
+      const readinessProps = (
+        operationId: string | undefined
+      ): SpendPilotWalletReadinessEventProperties => ({
+        spend_session_id: ctx.spendSessionId?.trim() ?? '',
+        spend_experience_id: ctx.spendExperienceId,
+        point_conversion_id: ctx.pointConversionId,
+        user_id: ctx.sessionOwnerPrivyUserId,
+        wallet_address: walletLower,
+        wallet_readiness_mode: 'stellar_async_orchestration',
+        ...railFields,
+        ...(operationId ? { wallet_readiness_operation_id: operationId } : {}),
+      });
+
       const sessionId = ctx.spendSessionId?.trim();
       if (!sessionId) {
-        return errSpendRail(spendRailErrorWalletReadinessFailed());
+        const err = spendRailErrorWalletReadinessFailed();
+        if (distinctId) {
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...readinessProps(undefined),
+            ...spendPilotSanitizedRailErrorFields(err),
+          });
+        }
+        return errSpendRail(err);
       }
       const privyUserId = ctx.sessionOwnerPrivyUserId?.trim();
       if (!privyUserId) {
-        return errSpendRail(spendRailErrorWalletReadinessFailed());
+        const err = spendRailErrorWalletReadinessFailed();
+        if (distinctId) {
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...readinessProps(undefined),
+            ...spendPilotSanitizedRailErrorFields(err),
+          });
+        }
+        return errSpendRail(err);
       }
 
       const { row } = await insertPendingSpendWalletReadinessOrGet({
@@ -145,14 +195,67 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
               'stellar_usdc completed readiness session address sync:',
               e
             );
-            return errSpendRail(classifyStellarReadinessException(e));
+            const syncErr = classifyStellarReadinessException(e);
+            if (distinctId) {
+              trackSpendWalletReadinessFailed(distinctId, {
+                ...readinessProps(row.id),
+                wallet_readiness_operation_id: row.id,
+                sponsor_treasury_transaction_id:
+                  row.sponsor_treasury_transaction_id,
+                trustline_treasury_transaction_id:
+                  row.trustline_treasury_transaction_id,
+                ...spendPilotSanitizedRailErrorFields(syncErr),
+              });
+            }
+            return errSpendRail(syncErr);
           }
+        }
+        if (distinctId) {
+          trackSpendWalletReadinessCompleted(distinctId, {
+            ...readinessProps(row.id),
+            wallet_readiness_operation_id: row.id,
+            sponsor_treasury_transaction_id:
+              row.sponsor_treasury_transaction_id,
+            trustline_treasury_transaction_id:
+              row.trustline_treasury_transaction_id,
+            resumed_from_completed_row: true,
+          });
         }
         return okSpendRail({ status: 'completed' });
       }
 
       if (row.status === 'failed') {
+        if (distinctId) {
+          const hasSanitized =
+            row.sanitized_error_category != null &&
+            row.sanitized_error_code != null;
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...readinessProps(row.id),
+            wallet_readiness_operation_id: row.id,
+            sponsor_treasury_transaction_id:
+              row.sponsor_treasury_transaction_id,
+            trustline_treasury_transaction_id:
+              row.trustline_treasury_transaction_id,
+            ...(hasSanitized
+              ? {
+                  sanitized_error_category:
+                    row.sanitized_error_category as SpendRailErrorCategory,
+                  sanitized_error_code:
+                    row.sanitized_error_code as SpendRailAnalyticsCode,
+                }
+              : spendPilotSanitizedRailErrorFields(
+                  spendRailErrorWalletReadinessFailed()
+                )),
+          });
+        }
         return errSpendRail(spendRailErrorWalletReadinessFailed());
+      }
+
+      if (distinctId) {
+        trackSpendWalletReadinessStarted(distinctId, {
+          ...readinessProps(row.id),
+          wallet_readiness_operation_id: row.id,
+        });
       }
 
       try {
@@ -177,6 +280,13 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
               persistErr
             );
           }
+          if (distinctId) {
+            trackSpendWalletReadinessFailed(distinctId, {
+              ...readinessProps(row.id),
+              wallet_readiness_operation_id: row.id,
+              ...spendPilotSanitizedRailErrorFields(outcome.error),
+            });
+          }
           return errSpendRail(outcome.error);
         }
 
@@ -188,8 +298,28 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
             );
           } catch (e) {
             console.error('stellar_usdc readiness session address sync:', e);
-            return errSpendRail(classifyStellarReadinessException(e));
+            const syncErr = classifyStellarReadinessException(e);
+            if (distinctId) {
+              trackSpendWalletReadinessFailed(distinctId, {
+                ...readinessProps(row.id),
+                wallet_readiness_operation_id: row.id,
+                ...spendPilotSanitizedRailErrorFields(syncErr),
+              });
+            }
+            return errSpendRail(syncErr);
           }
+        }
+
+        if (distinctId && outcome.ok && outcome.status === 'completed') {
+          const fresh = await getSpendWalletReadinessBySessionId(sessionId);
+          trackSpendWalletReadinessCompleted(distinctId, {
+            ...readinessProps(fresh?.id ?? row.id),
+            wallet_readiness_operation_id: fresh?.id ?? row.id,
+            sponsor_treasury_transaction_id:
+              fresh?.sponsor_treasury_transaction_id ?? null,
+            trustline_treasury_transaction_id:
+              fresh?.trustline_treasury_transaction_id ?? null,
+          });
         }
 
         return okSpendRail({ status: outcome.status });
@@ -208,6 +338,13 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
             'stellar_usdc readiness failure metadata persist:',
             persistErr
           );
+        }
+        if (distinctId) {
+          trackSpendWalletReadinessFailed(distinctId, {
+            ...readinessProps(row.id),
+            wallet_readiness_operation_id: row.id,
+            ...spendPilotSanitizedRailErrorFields(railErr),
+          });
         }
         return errSpendRail(railErr);
       }

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -24,8 +24,6 @@ import {
   spendRailErrorRailOperationNotSupported,
   spendRailErrorWalletReadinessFailed,
   type SpendRailError,
-  type SpendRailErrorCategory,
-  type SpendRailAnalyticsCode,
 } from '@/lib/spend/payment-rails/errors';
 import type {
   SpendPaymentRailReconcileContext,
@@ -50,6 +48,7 @@ import type { SpendPilotWalletReadinessEventProperties } from '@/lib/analytics/t
 import { getSpendWalletReadinessBySessionId } from '@/lib/db/spend-wallet-readiness';
 import {
   spendPilotRailMixpanelFields,
+  spendPilotSanitizedFieldsFromWalletReadinessRow,
   spendPilotSanitizedRailErrorFields,
 } from '@/lib/analytics/spend-pilot-rail-context';
 import {
@@ -226,9 +225,6 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
 
       if (row.status === 'failed') {
         if (distinctId) {
-          const hasSanitized =
-            row.sanitized_error_category != null &&
-            row.sanitized_error_code != null;
           trackSpendWalletReadinessFailed(distinctId, {
             ...readinessProps(row.id),
             wallet_readiness_operation_id: row.id,
@@ -236,16 +232,11 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
               row.sponsor_treasury_transaction_id,
             trustline_treasury_transaction_id:
               row.trustline_treasury_transaction_id,
-            ...(hasSanitized
-              ? {
-                  sanitized_error_category:
-                    row.sanitized_error_category as SpendRailErrorCategory,
-                  sanitized_error_code:
-                    row.sanitized_error_code as SpendRailAnalyticsCode,
-                }
-              : spendPilotSanitizedRailErrorFields(
-                  spendRailErrorWalletReadinessFailed()
-                )),
+            ...spendPilotSanitizedFieldsFromWalletReadinessRow(
+              row.sanitized_error_category,
+              row.sanitized_error_code,
+              spendRailErrorWalletReadinessFailed()
+            ),
           });
         }
         return errSpendRail(spendRailErrorWalletReadinessFailed());

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -68,6 +68,10 @@ export type SpendPaymentRailSessionContext = {
    * Not used by Base USDC.
    */
   railUserWalletAddress?: string | null;
+  /**
+   * When set, wallet readiness rails may emit Mixpanel readiness funnel events (IRL-23).
+   */
+  analyticsDistinctId?: string;
 };
 
 /**


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Spend pilot Mixpanel payloads now include rail context (`spend_rail`, `network`, `asset`), non-secret operation identifiers where available, curated `sanitized_error_category` / `sanitized_error_code` from `SpendRailError` / `SPEND_RAIL_ANALYTICS_CODES`, and three new wallet readiness events for Base (sync validation) and Stellar (async orchestration). Existing spend pilot event names are unchanged except for the new readiness events.

## Changes

- New events: `spend_wallet_readiness_started`, `spend_wallet_readiness_completed`, `spend_wallet_readiness_failed`.
- Extended spend pilot TypeScript payload types; `SpendPilotRailMutationBlockedProperties.spend_rail` is now `SpendRail`.
- New helper `lib/analytics/spend-pilot-rail-context.ts` with stable rail labels for analytics (keeps Vitest mocks that stub `@/lib/spend-rail-config` working) plus `spendPilotSanitizedRailErrorFields`.
- `SpendPaymentRailSessionContext` accepts optional `analyticsDistinctId` for readiness Mixpanel from conversion flows.
- Wired rail and sanitized fields through conversion confirm, payment confirm/prepare, preview and session API routes, receipt, admin rail-blocked paths, Base/Stellar payment rails, and client QR scan. Kept existing `error_reason` where it was already emitted.
- Session route test: spy `assertSpendRailAllowsMutatingSpendWork` in the Stellar case so the test asserts session-create behavior without a full operational Stellar environment.

## Verification

Targeted `yarn test` for spend session, preview, receipt, conversion/payment confirm, and Stellar/Base rail tests; `yarn eslint` on changed files; production build passed via pre-commit hook.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-23](https://linear.app/irlenergy/issue/IRL-23/enrich-spend-analytics-with-rail-operation-ids-and-sanitized-errors)

<div><a href="https://cursor.com/agents/bc-d20a4eb5-d762-4ee1-bccf-36d8dbf65688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d20a4eb5-d762-4ee1-bccf-36d8dbf65688"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

