### PR TITLE
feat(spend): opportunistic rail reconcile on session and receipt reads (IRL-25)

### DIFF
--- a/app/api/spend-sessions/[sessionId]/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/__tests__/route.test.ts
@@ -19,6 +19,13 @@ vi.mock('@/lib/db/spend-experiences', () => ({
   getSpendExperienceById: (...a: unknown[]) => mockGetExperience(...a),
 }));
 
+const mockMaybeReconcile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/spend/opportunistic-spend-rail-reconcile-on-read', () => ({
+  maybeReconcileSpendRailOnAuthorizedSessionRead: (...a: unknown[]) =>
+    mockMaybeReconcile(...a),
+}));
+
 import { GET } from '../route';
 
 const session = {
@@ -42,6 +49,7 @@ describe('GET /api/spend-sessions/[sessionId]', () => {
     mockGetSession.mockResolvedValue(session);
     mockGetConversion.mockResolvedValue(null);
     mockGetExperience.mockResolvedValue({ id: 'exp-1', title: 'E' });
+    mockMaybeReconcile.mockResolvedValue(undefined);
   });
 
   it('returns 401 without token', async () => {
@@ -71,5 +79,29 @@ describe('GET /api/spend-sessions/[sessionId]', () => {
     expect(res.status).toBe(200);
     expect(j.data.session).toEqual(session);
     expect(j.data.spendExperience).toEqual({ id: 'exp-1', title: 'E' });
+    expect(mockMaybeReconcile).toHaveBeenCalledWith({
+      spendSessionId: 'sess-1',
+      session,
+    });
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('returns post-reconcile session from the second load', async () => {
+    const pending = { ...session, status: 'payment_pending' as const };
+    const complete = { ...session, status: 'payment_complete' as const };
+    mockGetSession
+      .mockResolvedValueOnce(pending)
+      .mockResolvedValueOnce(complete);
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1'
+    );
+    const res = await GET(req, { params: { sessionId: 'sess-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.data.session).toEqual(complete);
+    expect(mockMaybeReconcile).toHaveBeenCalledWith({
+      spendSessionId: 'sess-1',
+      session: pending,
+    });
   });
 });

--- a/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/__tests__/route.test.ts
@@ -31,6 +31,13 @@ vi.mock('@/lib/analytics/server', () => ({
   trackSpendReceiptViewed: vi.fn(),
 }));
 
+const mockMaybeReconcile = vi.fn().mockResolvedValue(undefined);
+
+vi.mock('@/lib/spend/opportunistic-spend-rail-reconcile-on-read', () => ({
+  maybeReconcileSpendRailOnAuthorizedSessionRead: (...a: unknown[]) =>
+    mockMaybeReconcile(...a),
+}));
+
 import { GET } from '../route';
 
 const session = {
@@ -59,6 +66,7 @@ describe('GET /api/spend-sessions/[sessionId]/receipt', () => {
       message: 'ok',
       preview: null,
     });
+    mockMaybeReconcile.mockResolvedValue(undefined);
   });
 
   it('returns receipt payload with eligibility', async () => {
@@ -71,5 +79,30 @@ describe('GET /api/spend-sessions/[sessionId]/receipt', () => {
     expect(j.data.session).toEqual(session);
     expect(j.data.eligibility.status).toBe('eligible');
     expect(j.data.spendRailSummary.rail).toBe('base_usdc');
+    expect(mockMaybeReconcile).toHaveBeenCalledWith({
+      spendSessionId: 'sess-1',
+      session,
+    });
+    expect(mockGetSession).toHaveBeenCalledTimes(2);
+  });
+
+  it('loads eligibility from refreshed session after reconcile hook', async () => {
+    const pending = { ...session, status: 'payment_pending' as const };
+    const complete = { ...session, status: 'payment_complete' as const };
+    mockGetSession
+      .mockResolvedValueOnce(pending)
+      .mockResolvedValueOnce(complete);
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/receipt'
+    );
+    const res = await GET(req, { params: { sessionId: 'sess-1' } });
+    const j = await res.json();
+    expect(res.status).toBe(200);
+    expect(j.data.session).toEqual(complete);
+    expect(mockLoadEligibility).toHaveBeenCalledWith(
+      expect.objectContaining({
+        session: complete,
+      })
+    );
   });
 });

--- a/app/api/spend-sessions/[sessionId]/receipt/route.ts
+++ b/app/api/spend-sessions/[sessionId]/receipt/route.ts
@@ -14,6 +14,7 @@ import {
 } from '@/lib/analytics/server';
 import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
 import { getSpendRailClientSummary } from '@/lib/spend-rail-config';
+import { maybeReconcileSpendRailOnAuthorizedSessionRead } from '@/lib/spend/opportunistic-spend-rail-reconcile-on-read';
 
 export const dynamic = 'force-dynamic';
 
@@ -43,9 +44,19 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return apiError('Forbidden', 403);
   }
 
+  await maybeReconcileSpendRailOnAuthorizedSessionRead({
+    spendSessionId: sessionId,
+    session,
+  });
+
+  const refreshed = await getSpendSessionById(sessionId);
+  if (!refreshed) {
+    return apiError('Spend session not found', 404);
+  }
+
   const [spendExperience, pointConversion, spendTransaction] =
     await Promise.all([
-      getSpendExperienceById(session.spend_experience_id),
+      getSpendExperienceById(refreshed.spend_experience_id),
       getPointConversionBySessionId(sessionId),
       getSpendTransactionBySessionId(sessionId),
     ]);
@@ -56,36 +67,36 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 
   try {
     const eligibility = await loadSpendEligibilityForSession({
-      session,
+      session: refreshed,
       spendExperience,
     });
 
     const distinctId = resolveServerIdentity({
       privyUserId: userId,
-      walletAddress: session.wallet_address.toLowerCase(),
+      walletAddress: refreshed.wallet_address.toLowerCase(),
     });
     trackSpendReceiptViewed(distinctId, {
-      ...spendPilotRailMixpanelFields(session.spend_rail),
+      ...spendPilotRailMixpanelFields(refreshed.spend_rail),
       spend_experience_id: spendExperience.id,
       event_id: spendExperience.event_id,
       user_id: userId,
-      wallet_address: session.wallet_address.toLowerCase(),
+      wallet_address: refreshed.wallet_address.toLowerCase(),
       points_amount: pointConversion?.points_deducted ?? 0,
       usdc_amount: pointConversion?.usdc_amount ?? 0,
-      status: session.status,
-      spend_session_id: session.id,
+      status: refreshed.status,
+      spend_session_id: refreshed.id,
       point_conversion_id: pointConversion?.id,
       spend_transaction_id: spendTransaction?.id,
       payment_tx_hash: spendTransaction?.payment_tx_hash ?? null,
     });
 
     return apiSuccess({
-      session,
+      session: refreshed,
       spendExperience,
       pointConversion,
       spendTransaction,
       eligibility,
-      spendRailSummary: getSpendRailClientSummary(session.spend_rail),
+      spendRailSummary: getSpendRailClientSummary(refreshed.spend_rail),
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Failed to load receipt state';

--- a/app/api/spend-sessions/[sessionId]/route.ts
+++ b/app/api/spend-sessions/[sessionId]/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/db/spend-sessions';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import { apiSuccess, apiError } from '@/lib/api/response';
+import { maybeReconcileSpendRailOnAuthorizedSessionRead } from '@/lib/spend/opportunistic-spend-rail-reconcile-on-read';
 
 export const dynamic = 'force-dynamic';
 
@@ -35,10 +36,24 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return apiError('Forbidden', 403);
   }
 
+  await maybeReconcileSpendRailOnAuthorizedSessionRead({
+    spendSessionId: sessionId,
+    session,
+  });
+
+  const refreshed = await getSpendSessionById(sessionId);
+  if (!refreshed) {
+    return apiError('Spend session not found', 404);
+  }
+
   const [spendExperience, pointConversion] = await Promise.all([
-    getSpendExperienceById(session.spend_experience_id),
+    getSpendExperienceById(refreshed.spend_experience_id),
     getPointConversionBySessionId(sessionId),
   ]);
 
-  return apiSuccess({ session, spendExperience, pointConversion });
+  return apiSuccess({
+    session: refreshed,
+    spendExperience,
+    pointConversion,
+  });
 }

--- a/lib/spend/opportunistic-spend-rail-reconcile-on-read.test.ts
+++ b/lib/spend/opportunistic-spend-rail-reconcile-on-read.test.ts
@@ -25,7 +25,10 @@ import {
   maybeReconcileSpendRailOnAuthorizedSessionRead,
   spendSessionStatusAllowsOpportunisticRailReconcile,
 } from '@/lib/spend/opportunistic-spend-rail-reconcile-on-read';
-import { computeSpendRailReconcileOlderThanIso } from '@/lib/spend/reconcile-spend-rail-pending-operations';
+import {
+  computeSpendRailReconcileOlderThanIso,
+  readSpendRailReconcileAgeWindowEnv,
+} from '@/lib/spend/reconcile-spend-rail-pending-operations';
 
 function baseSession(over: Partial<SpendSession>): SpendSession {
   return {
@@ -96,15 +99,14 @@ describe('maybeReconcileSpendRailOnAuthorizedSessionRead', () => {
     });
     expect(mockReconcileForSession).toHaveBeenCalledTimes(1);
     const arg = mockReconcileForSession.mock.calls[0][0];
-    expect(arg.spendSessionId).toBe('sess-1');
-    expect(arg.distinctId).toBeUndefined();
-    const cfg = {
-      minAgeSeconds: 60,
-      backoffSeconds: 120,
-      batchSize: 25,
-    };
-    expect(arg.olderThanIso).toBe(
-      computeSpendRailReconcileOlderThanIso(nowMs, cfg)
+    expect(arg).toEqual(
+      expect.objectContaining({
+        spendSessionId: 'sess-1',
+        olderThanIso: computeSpendRailReconcileOlderThanIso(
+          nowMs,
+          readSpendRailReconcileAgeWindowEnv()
+        ),
+      })
     );
   });
 
@@ -119,11 +121,10 @@ describe('maybeReconcileSpendRailOnAuthorizedSessionRead', () => {
     });
     const arg = mockReconcileForSession.mock.calls[0][0];
     expect(arg.olderThanIso).toBe(
-      computeSpendRailReconcileOlderThanIso(nowMs, {
-        minAgeSeconds: 300,
-        backoffSeconds: 10,
-        batchSize: 25,
-      })
+      computeSpendRailReconcileOlderThanIso(
+        nowMs,
+        readSpendRailReconcileAgeWindowEnv()
+      )
     );
   });
 });

--- a/lib/spend/opportunistic-spend-rail-reconcile-on-read.test.ts
+++ b/lib/spend/opportunistic-spend-rail-reconcile-on-read.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import type { SpendSession } from '@/lib/types';
+
+const mockReconcileForSession = vi.fn().mockResolvedValue({ ok: true });
+
+vi.mock(
+  '@/lib/spend/reconcile-spend-rail-pending-operations',
+  async (importOriginal) => {
+    const mod =
+      await importOriginal<
+        typeof import('@/lib/spend/reconcile-spend-rail-pending-operations')
+      >();
+    return {
+      ...mod,
+      reconcileSpendRailPendingOperationsForSession: (
+        ...args: Parameters<
+          typeof mod.reconcileSpendRailPendingOperationsForSession
+        >
+      ) => mockReconcileForSession(...args),
+    };
+  }
+);
+
+import {
+  maybeReconcileSpendRailOnAuthorizedSessionRead,
+  spendSessionStatusAllowsOpportunisticRailReconcile,
+} from '@/lib/spend/opportunistic-spend-rail-reconcile-on-read';
+import { computeSpendRailReconcileOlderThanIso } from '@/lib/spend/reconcile-spend-rail-pending-operations';
+
+function baseSession(over: Partial<SpendSession>): SpendSession {
+  return {
+    id: 'sess-1',
+    spend_experience_id: 'exp-1',
+    user_id: 'privy-1',
+    wallet_address: '0xabc',
+    spend_rail: 'base_usdc',
+    rail_user_wallet_address: '0xabc',
+    status: 'created',
+    qr_token_hash: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    expires_at: '2026-01-02T00:00:00.000Z',
+    completed_at: null,
+    ...over,
+  };
+}
+
+describe('spendSessionStatusAllowsOpportunisticRailReconcile', () => {
+  it('is false for terminal session statuses', () => {
+    expect(
+      spendSessionStatusAllowsOpportunisticRailReconcile('payment_complete')
+    ).toBe(false);
+    expect(spendSessionStatusAllowsOpportunisticRailReconcile('failed')).toBe(
+      false
+    );
+    expect(spendSessionStatusAllowsOpportunisticRailReconcile('expired')).toBe(
+      false
+    );
+  });
+
+  it('is true for non-terminal statuses', () => {
+    expect(spendSessionStatusAllowsOpportunisticRailReconcile('created')).toBe(
+      true
+    );
+    expect(
+      spendSessionStatusAllowsOpportunisticRailReconcile('payment_pending')
+    ).toBe(true);
+  });
+});
+
+describe('maybeReconcileSpendRailOnAuthorizedSessionRead', () => {
+  beforeEach(() => {
+    mockReconcileForSession.mockClear();
+    delete process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS;
+    delete process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS;
+  });
+
+  afterEach(() => {
+    delete process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS;
+    delete process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS;
+  });
+
+  it('skips reconcileSpendRailPendingOperationsForSession for terminal sessions', async () => {
+    await maybeReconcileSpendRailOnAuthorizedSessionRead({
+      spendSessionId: 'sess-1',
+      session: baseSession({ status: 'payment_complete' }),
+    });
+    expect(mockReconcileForSession).not.toHaveBeenCalled();
+  });
+
+  it('invokes reconcile with olderThanIso matching cron policy', async () => {
+    const nowMs = 1_700_000_000_000;
+    await maybeReconcileSpendRailOnAuthorizedSessionRead({
+      spendSessionId: 'sess-1',
+      session: baseSession({ status: 'payment_pending' }),
+      nowMs,
+    });
+    expect(mockReconcileForSession).toHaveBeenCalledTimes(1);
+    const arg = mockReconcileForSession.mock.calls[0][0];
+    expect(arg.spendSessionId).toBe('sess-1');
+    expect(arg.distinctId).toBeUndefined();
+    const cfg = {
+      minAgeSeconds: 60,
+      backoffSeconds: 120,
+      batchSize: 25,
+    };
+    expect(arg.olderThanIso).toBe(
+      computeSpendRailReconcileOlderThanIso(nowMs, cfg)
+    );
+  });
+
+  it('honours env-backed reconcile config for the cutoff', async () => {
+    process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS = '300';
+    process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS = '10';
+    const nowMs = 9_000_000;
+    await maybeReconcileSpendRailOnAuthorizedSessionRead({
+      spendSessionId: 'sess-1',
+      session: baseSession({ status: 'conversion_pending' }),
+      nowMs,
+    });
+    const arg = mockReconcileForSession.mock.calls[0][0];
+    expect(arg.olderThanIso).toBe(
+      computeSpendRailReconcileOlderThanIso(nowMs, {
+        minAgeSeconds: 300,
+        backoffSeconds: 10,
+        batchSize: 25,
+      })
+    );
+  });
+});

--- a/lib/spend/opportunistic-spend-rail-reconcile-on-read.ts
+++ b/lib/spend/opportunistic-spend-rail-reconcile-on-read.ts
@@ -1,0 +1,45 @@
+import type { SpendSession, SpendSessionStatus } from '@/lib/types';
+import {
+  computeSpendRailReconcileOlderThanIso,
+  readSpendRailReconcileEnvConfig,
+  reconcileSpendRailPendingOperationsForSession,
+} from '@/lib/spend/reconcile-spend-rail-pending-operations';
+
+const TERMINAL_STATUSES: ReadonlySet<SpendSessionStatus> = new Set([
+  'payment_complete',
+  'failed',
+  'expired',
+]);
+
+export function spendSessionStatusAllowsOpportunisticRailReconcile(
+  status: SpendSessionStatus
+): boolean {
+  return !TERMINAL_STATUSES.has(status);
+}
+
+/**
+ * One bounded reconciliation pass for GET session / GET receipt (IRL-25).
+ *
+ * Uses the same {@link computeSpendRailReconcileOlderThanIso} cutoff as
+ * {@link runSpendRailReconciliationCron}. Terminal session rows are skipped here to
+ * avoid pointless work; there is no cross-instance request throttle in v1 (no new DB
+ * columns) — staleness and safe no-ops remain inside reconciliation helpers.
+ */
+export async function maybeReconcileSpendRailOnAuthorizedSessionRead(input: {
+  spendSessionId: string;
+  session: SpendSession;
+  nowMs?: number;
+}): Promise<void> {
+  if (
+    !spendSessionStatusAllowsOpportunisticRailReconcile(input.session.status)
+  ) {
+    return;
+  }
+  const cfg = readSpendRailReconcileEnvConfig();
+  const nowMs = input.nowMs ?? Date.now();
+  const olderThanIso = computeSpendRailReconcileOlderThanIso(nowMs, cfg);
+  await reconcileSpendRailPendingOperationsForSession({
+    spendSessionId: input.spendSessionId,
+    olderThanIso,
+  });
+}

--- a/lib/spend/opportunistic-spend-rail-reconcile-on-read.ts
+++ b/lib/spend/opportunistic-spend-rail-reconcile-on-read.ts
@@ -35,8 +35,12 @@ export async function maybeReconcileSpendRailOnAuthorizedSessionRead(input: {
   const cfg = readSpendRailReconcileAgeWindowEnv();
   const nowMs = input.nowMs ?? Date.now();
   const olderThanIso = computeSpendRailReconcileOlderThanIso(nowMs, cfg);
-  await reconcileSpendRailPendingOperationsForSession({
-    spendSessionId: input.spendSessionId,
-    olderThanIso,
-  });
+  try {
+    await reconcileSpendRailPendingOperationsForSession({
+      spendSessionId: input.spendSessionId,
+      olderThanIso,
+    });
+  } catch (e) {
+    console.error('opportunistic spend rail reconcile on read:', e);
+  }
 }

--- a/lib/spend/opportunistic-spend-rail-reconcile-on-read.ts
+++ b/lib/spend/opportunistic-spend-rail-reconcile-on-read.ts
@@ -1,7 +1,7 @@
 import type { SpendSession, SpendSessionStatus } from '@/lib/types';
 import {
   computeSpendRailReconcileOlderThanIso,
-  readSpendRailReconcileEnvConfig,
+  readSpendRailReconcileAgeWindowEnv,
   reconcileSpendRailPendingOperationsForSession,
 } from '@/lib/spend/reconcile-spend-rail-pending-operations';
 
@@ -19,11 +19,8 @@ export function spendSessionStatusAllowsOpportunisticRailReconcile(
 
 /**
  * One bounded reconciliation pass for GET session / GET receipt (IRL-25).
- *
- * Uses the same {@link computeSpendRailReconcileOlderThanIso} cutoff as
- * {@link runSpendRailReconciliationCron}. Terminal session rows are skipped here to
- * avoid pointless work; there is no cross-instance request throttle in v1 (no new DB
- * columns) — staleness and safe no-ops remain inside reconciliation helpers.
+ * Same env age window as cron; terminal sessions skipped. v1 has no per-request
+ * cross-instance throttle (no new DB columns).
  */
 export async function maybeReconcileSpendRailOnAuthorizedSessionRead(input: {
   spendSessionId: string;
@@ -35,7 +32,7 @@ export async function maybeReconcileSpendRailOnAuthorizedSessionRead(input: {
   ) {
     return;
   }
-  const cfg = readSpendRailReconcileEnvConfig();
+  const cfg = readSpendRailReconcileAgeWindowEnv();
   const nowMs = input.nowMs ?? Date.now();
   const olderThanIso = computeSpendRailReconcileOlderThanIso(nowMs, cfg);
   await reconcileSpendRailPendingOperationsForSession({

--- a/lib/spend/reconcile-spend-rail-pending-operations.test.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { readSpendRailReconcileEnvConfig } from '@/lib/spend/reconcile-spend-rail-pending-operations';
+import {
+  computeSpendRailReconcileOlderThanIso,
+  readSpendRailReconcileEnvConfig,
+} from '@/lib/spend/reconcile-spend-rail-pending-operations';
 
 describe('readSpendRailReconcileEnvConfig', () => {
   afterEach(() => {
@@ -30,5 +33,22 @@ describe('readSpendRailReconcileEnvConfig', () => {
   it('caps oversized batch', () => {
     process.env.SPEND_RAIL_CRON_BATCH_SIZE = '9999';
     expect(readSpendRailReconcileEnvConfig().batchSize).toBe(500);
+  });
+});
+
+describe('computeSpendRailReconcileOlderThanIso', () => {
+  it('matches cron policy: max(minAgeSeconds, backoffSeconds) seconds before nowMs', () => {
+    const nowMs = 1_700_000_000_000;
+    const cfg = { minAgeSeconds: 60, backoffSeconds: 120, batchSize: 25 };
+    const iso = computeSpendRailReconcileOlderThanIso(nowMs, cfg);
+    expect(iso).toBe(new Date(nowMs - 120_000).toISOString());
+  });
+
+  it('uses minAge when it exceeds backoff', () => {
+    const nowMs = 5_000_000;
+    const cfg = { minAgeSeconds: 300, backoffSeconds: 10, batchSize: 25 };
+    expect(computeSpendRailReconcileOlderThanIso(nowMs, cfg)).toBe(
+      new Date(nowMs - 300_000).toISOString()
+    );
   });
 });

--- a/lib/spend/reconcile-spend-rail-pending-operations.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.ts
@@ -55,7 +55,13 @@ export type SpendRailReconcileEnvConfig = {
   batchSize: number;
 };
 
-export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
+/** Env-driven min/backoff window shared by cron and opportunistic read reconcile. */
+export type SpendRailReconcileAgeWindow = Pick<
+  SpendRailReconcileEnvConfig,
+  'minAgeSeconds' | 'backoffSeconds'
+>;
+
+export function readSpendRailReconcileAgeWindowEnv(): SpendRailReconcileAgeWindow {
   return {
     minAgeSeconds: parseNonNegativeIntEnv(
       process.env.SPEND_RAIL_CRON_MIN_AGE_SECONDS,
@@ -65,6 +71,12 @@ export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
       process.env.SPEND_RAIL_CRON_BACKOFF_SECONDS,
       DEFAULT_BACKOFF_SECONDS
     ),
+  };
+}
+
+export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
+  return {
+    ...readSpendRailReconcileAgeWindowEnv(),
     batchSize: parseBatchSizeEnv(
       process.env.SPEND_RAIL_CRON_BATCH_SIZE,
       DEFAULT_BATCH_SIZE
@@ -72,13 +84,10 @@ export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
   };
 }
 
-/**
- * ISO cutoff for “stale enough to reconcile” — identical to
- * {@link runSpendRailReconciliationCron} (IRL-22 / IRL-25).
- */
+/** ISO cutoff for “stale enough to reconcile” (IRL-22 / IRL-25). */
 export function computeSpendRailReconcileOlderThanIso(
   nowMs: number,
-  cfg: SpendRailReconcileEnvConfig
+  cfg: SpendRailReconcileAgeWindow
 ): string {
   const deltaMs = Math.max(cfg.minAgeSeconds, cfg.backoffSeconds) * 1000;
   return new Date(nowMs - deltaMs).toISOString();

--- a/lib/spend/reconcile-spend-rail-pending-operations.ts
+++ b/lib/spend/reconcile-spend-rail-pending-operations.ts
@@ -72,7 +72,11 @@ export function readSpendRailReconcileEnvConfig(): SpendRailReconcileEnvConfig {
   };
 }
 
-function reconcileOlderThanIso(
+/**
+ * ISO cutoff for “stale enough to reconcile” — identical to
+ * {@link runSpendRailReconciliationCron} (IRL-22 / IRL-25).
+ */
+export function computeSpendRailReconcileOlderThanIso(
   nowMs: number,
   cfg: SpendRailReconcileEnvConfig
 ): string {
@@ -204,7 +208,7 @@ export async function runSpendRailReconciliationCron(input?: {
 }): Promise<SpendRailReconcileCronResult> {
   const cfg = input?.config ?? readSpendRailReconcileEnvConfig();
   const nowMs = input?.nowMs ?? Date.now();
-  const olderThanIso = reconcileOlderThanIso(nowMs, cfg);
+  const olderThanIso = computeSpendRailReconcileOlderThanIso(nowMs, cfg);
   const ids = await collectReconcileCandidateSessionIds({
     olderThanIso,
     batchSize: cfg.batchSize,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-25: authorized spend session and receipt GET handlers run one pass of shared spend-rail reconciliation before building the response, using the same `olderThanIso` policy as `runSpendRailReconciliationCron`, then re-read the session so payloads reflect post-reconcile DB state.

## Changes

- Export `computeSpendRailReconcileOlderThanIso` from `lib/spend/reconcile-spend-rail-pending-operations.ts` (same formula as cron; avoids drift).
- Add `lib/spend/opportunistic-spend-rail-reconcile-on-read.ts`: gate on non-terminal session statuses (`payment_complete`, `failed`, `expired` skipped); document v1 trade-off (no cross-instance throttle column); call `reconcileSpendRailPendingOperationsForSession` with env-derived cutoff and default `distinctId` (cron constant inside reconcile).
- Wire both GET handlers to await the helper and use a fresh `getSpendSessionById` for the returned session and downstream receipt fields (eligibility, analytics, rail summary).

## Tests

- Unit: opportunistic helper (skip vs invoke, `olderThanIso` vs `computeSpendRailReconcileOlderThanIso` + env).
- Unit: `computeSpendRailReconcileOlderThanIso` cases in existing reconcile env test file.
- Route: session/receipt assert hook invocation, second load used for response and eligibility.

## Verification

- `yarn test` on touched test files; `yarn lint` (warnings only, pre-existing).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-25](https://linear.app/irlenergy/issue/IRL-25/opportunistically-reconcile-stale-pending-operations-on-session-and)

<div><a href="https://cursor.com/agents/bc-b29b3f6c-42c9-4e7e-9377-b19b7fcfc9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b29b3f6c-42c9-4e7e-9377-b19b7fcfc9f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

