### PR TITLE
feat(admin): per-experience rail ops visibility (IRL-26)

### DIFF
--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -21,99 +21,24 @@ import type {
   PointConversion,
   SpendExperience,
   SpendRail,
-  SpendSession,
   SpendTransaction,
   TreasuryTransaction,
 } from '@/lib/types';
 import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
-import { explorerTxUrlForSpendLedger } from '@/lib/spend-ledger-explorer-url';
-
-type ActivityTotals = {
-  usersConverted: number;
-  totalUsdcDistributed: number;
-  totalUsdcReceivedAtEventWallet: number;
-  spendSessionsCount: number;
-};
-
-type ActivitySessionRow = {
-  session: SpendSession;
-  conversion: PointConversion | null;
-  payment: SpendTransaction | null;
-};
-
-type RailOpsSummary = {
-  walletReadiness: { pending: number; needsReview: number };
-  conversions: {
-    pending: number;
-    pointsDeducted: number;
-    fundingPending: number;
-    needsReview: number;
-    inFlightTotal: number;
-  };
-  spendTransactions: { pending: number; submitted: number };
-  fundedUnpaidSessions: number;
-};
-
-type RailVisibilityRow = {
-  operationKind: 'wallet_readiness' | 'conversion' | 'payment';
-  operationId: string;
-  spendExperienceId: string;
-  spendSessionId: string;
-  userId: string;
-  spendRail: SpendRail;
-  networkLabel: string;
-  usdcAmount: number | null;
-  status: string;
-  createdAt: string;
-  updatedAt: string;
-  safeErrorSummary: string | null;
-  txHash: string | null;
-  explorerTxUrl: string | null;
-};
-
-type FundedUnpaidRow = {
-  spendExperienceId: string;
-  spendSessionId: string;
-  userId: string;
-  spendRail: SpendRail;
-  networkLabel: string;
-  usdcAmount: number;
-  sessionStatus: SpendSession['status'] | null;
-  conversion: {
-    id: string;
-    status: string;
-    createdAt: string;
-    updatedAt: string;
-    fundingTxHash: string | null;
-    explorerTxUrl: string | null;
-    safeErrorSummary: string | null;
-  };
-  payment: {
-    id: string;
-    status: string;
-    createdAt: string;
-    updatedAt: string;
-    paymentTxHash: string | null;
-    explorerTxUrl: string | null;
-    safeErrorSummary: string | null;
-  } | null;
-};
-
-type RailVisibilityPayload = {
-  summary: RailOpsSummary;
-  walletReadiness: RailVisibilityRow[];
-  conversionsInFlight: RailVisibilityRow[];
-  spendTransactionsInFlight: RailVisibilityRow[];
-  fundedUnpaid: FundedUnpaidRow[];
-};
+import { spendLedgerTxExplorerUrl } from '@/lib/spend-ledger-explorer-url';
+import type {
+  SpendPilotAdminRailVisibility,
+  SpendPilotAdminTotals,
+  SpendPilotSessionActivityRow,
+} from '@/lib/db/spend-admin';
 
 type ActivityPayload = {
   spendExperienceId: string;
-  totals: ActivityTotals;
-  sessions: ActivitySessionRow[];
+  totals: SpendPilotAdminTotals;
+  sessions: SpendPilotSessionActivityRow[];
   failedConversions: PointConversion[];
   failedPayments: SpendTransaction[];
-  railVisibility?: RailVisibilityPayload;
+  railVisibility?: SpendPilotAdminRailVisibility;
   mixpanelInsightUrl?: string;
 };
 
@@ -151,16 +76,6 @@ function shortenAddr(a: string): string {
   return `${t.slice(0, 6)}…${t.slice(-4)}`;
 }
 
-function spendLedgerTxHref(
-  spendRail: SpendRail,
-  explorerTxUrl: string | null | undefined,
-  txHash: string | null | undefined
-): string | null {
-  const persisted = explorerTxUrl?.trim();
-  if (persisted) return persisted;
-  return explorerTxUrlForSpendLedger(spendRail, txHash);
-}
-
 /** Age from `createdAt` (ISO), consistent with API contract (IRL-26). */
 function formatAgeFromIso(createdAt: string): string {
   const ms = Date.now() - new Date(createdAt).getTime();
@@ -174,10 +89,6 @@ function formatAgeFromIso(createdAt: string): string {
   return `${days}d`;
 }
 
-async function copyText(value: string): Promise<void> {
-  await navigator.clipboard.writeText(value);
-}
-
 function LedgerTxLink({
   spendRail,
   explorerTxUrl,
@@ -189,7 +100,7 @@ function LedgerTxLink({
   txHash: string;
   className?: string;
 }) {
-  const href = spendLedgerTxHref(spendRail, explorerTxUrl, txHash);
+  const href = spendLedgerTxExplorerUrl(spendRail, explorerTxUrl, txHash);
   const label = shortenAddr(txHash);
   if (!href) {
     return (
@@ -298,11 +209,12 @@ export default function SpendExperienceDetailPage() {
     const verify = async () => {
       if (user?.email?.address) {
         setIsAdmin(await checkAdminStatus());
-        setAdminLoading(false);
-      } else if (user === null) {
+      } else if (!user) {
         setIsAdmin(false);
-        setAdminLoading(false);
+      } else {
+        setIsAdmin(false);
       }
+      setAdminLoading(false);
     };
     void verify();
   }, [user, checkAdminStatus]);
@@ -519,7 +431,9 @@ export default function SpendExperienceDetailPage() {
               variant="outline"
               size="sm"
               className="gap-1 bg-white"
-              onClick={() => void copyText(funding.serverWalletAddress)}
+              onClick={() =>
+                void navigator.clipboard.writeText(funding.serverWalletAddress)
+              }
             >
               <Copy className="size-3.5" />
               Copy

--- a/app/admin/spend-experiences/[experienceId]/page.tsx
+++ b/app/admin/spend-experiences/[experienceId]/page.tsx
@@ -20,11 +20,13 @@ import { Label } from '@/components/ui/label';
 import type {
   PointConversion,
   SpendExperience,
+  SpendRail,
   SpendSession,
   SpendTransaction,
   TreasuryTransaction,
 } from '@/lib/types';
 import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
+import { explorerTxUrlForSpendLedger } from '@/lib/spend-ledger-explorer-url';
 
 type ActivityTotals = {
   usersConverted: number;
@@ -39,12 +41,79 @@ type ActivitySessionRow = {
   payment: SpendTransaction | null;
 };
 
+type RailOpsSummary = {
+  walletReadiness: { pending: number; needsReview: number };
+  conversions: {
+    pending: number;
+    pointsDeducted: number;
+    fundingPending: number;
+    needsReview: number;
+    inFlightTotal: number;
+  };
+  spendTransactions: { pending: number; submitted: number };
+  fundedUnpaidSessions: number;
+};
+
+type RailVisibilityRow = {
+  operationKind: 'wallet_readiness' | 'conversion' | 'payment';
+  operationId: string;
+  spendExperienceId: string;
+  spendSessionId: string;
+  userId: string;
+  spendRail: SpendRail;
+  networkLabel: string;
+  usdcAmount: number | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  safeErrorSummary: string | null;
+  txHash: string | null;
+  explorerTxUrl: string | null;
+};
+
+type FundedUnpaidRow = {
+  spendExperienceId: string;
+  spendSessionId: string;
+  userId: string;
+  spendRail: SpendRail;
+  networkLabel: string;
+  usdcAmount: number;
+  sessionStatus: SpendSession['status'] | null;
+  conversion: {
+    id: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    fundingTxHash: string | null;
+    explorerTxUrl: string | null;
+    safeErrorSummary: string | null;
+  };
+  payment: {
+    id: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    paymentTxHash: string | null;
+    explorerTxUrl: string | null;
+    safeErrorSummary: string | null;
+  } | null;
+};
+
+type RailVisibilityPayload = {
+  summary: RailOpsSummary;
+  walletReadiness: RailVisibilityRow[];
+  conversionsInFlight: RailVisibilityRow[];
+  spendTransactionsInFlight: RailVisibilityRow[];
+  fundedUnpaid: FundedUnpaidRow[];
+};
+
 type ActivityPayload = {
   spendExperienceId: string;
   totals: ActivityTotals;
   sessions: ActivitySessionRow[];
   failedConversions: PointConversion[];
   failedPayments: SpendTransaction[];
+  railVisibility?: RailVisibilityPayload;
   mixpanelInsightUrl?: string;
 };
 
@@ -82,25 +151,60 @@ function shortenAddr(a: string): string {
   return `${t.slice(0, 6)}…${t.slice(-4)}`;
 }
 
-function baseScanTxUrl(hash: string): string {
-  const h = hash.trim().toLowerCase();
-  return `https://basescan.org/tx/${h}`;
+function spendLedgerTxHref(
+  spendRail: SpendRail,
+  explorerTxUrl: string | null | undefined,
+  txHash: string | null | undefined
+): string | null {
+  const persisted = explorerTxUrl?.trim();
+  if (persisted) return persisted;
+  return explorerTxUrlForSpendLedger(spendRail, txHash);
+}
+
+/** Age from `createdAt` (ISO), consistent with API contract (IRL-26). */
+function formatAgeFromIso(createdAt: string): string {
+  const ms = Date.now() - new Date(createdAt).getTime();
+  if (!Number.isFinite(ms) || ms < 0) return '—';
+  const mins = Math.floor(ms / 60000);
+  if (mins < 1) return '<1m';
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.floor(mins / 60);
+  if (hrs < 48) return `${hrs}h`;
+  const days = Math.floor(hrs / 24);
+  return `${days}d`;
 }
 
 async function copyText(value: string): Promise<void> {
   await navigator.clipboard.writeText(value);
 }
 
-function TxHashShortLink({
-  hash,
+function LedgerTxLink({
+  spendRail,
+  explorerTxUrl,
+  txHash,
   className,
 }: {
-  hash: string;
+  spendRail: SpendRail;
+  explorerTxUrl?: string | null;
+  txHash: string;
   className?: string;
 }) {
+  const href = spendLedgerTxHref(spendRail, explorerTxUrl, txHash);
+  const label = shortenAddr(txHash);
+  if (!href) {
+    return (
+      <span
+        className={
+          className ?? 'font-mono text-[11px] text-neutral-600 tabular-nums'
+        }
+      >
+        {label}
+      </span>
+    );
+  }
   return (
     <a
-      href={baseScanTxUrl(hash)}
+      href={href}
       target="_blank"
       rel="noopener noreferrer"
       className={
@@ -108,7 +212,7 @@ function TxHashShortLink({
         'inline-flex items-center gap-0.5 text-blue-700 hover:underline'
       }
     >
-      {shortenAddr(hash)}
+      {label}
       <ExternalLink className="size-3" />
     </a>
   );
@@ -127,14 +231,14 @@ function SessionConversionCell({
       <div>{conversion.status}</div>
       <div className="text-neutral-600">{fmtUsdc(conversion.usdc_amount)}</div>
       {conversion.funding_tx_hash && (
-        <a
-          href={baseScanTxUrl(conversion.funding_tx_hash)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          Tx
-        </a>
+        <div className="mt-0.5">
+          <LedgerTxLink
+            spendRail={conversion.spend_rail}
+            explorerTxUrl={conversion.explorer_tx_url}
+            txHash={conversion.funding_tx_hash}
+            className="text-blue-600 hover:underline"
+          />
+        </div>
       )}
     </>
   );
@@ -149,14 +253,14 @@ function SessionPaymentCell({ payment }: { payment: SpendTransaction | null }) {
       <div>{payment.status}</div>
       <div className="text-neutral-600">{fmtUsdc(payment.usdc_amount)}</div>
       {payment.payment_tx_hash && (
-        <a
-          href={baseScanTxUrl(payment.payment_tx_hash)}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="text-blue-600 hover:underline"
-        >
-          Tx
-        </a>
+        <div className="mt-0.5">
+          <LedgerTxLink
+            spendRail={payment.spend_rail}
+            explorerTxUrl={payment.explorer_tx_url}
+            txHash={payment.payment_tx_hash}
+            className="text-blue-600 hover:underline"
+          />
+        </div>
       )}
     </>
   );
@@ -547,8 +651,10 @@ export default function SpendExperienceDetailPage() {
                       {fmtUsdc(row.amount)}
                     </span>
                     {row.tx_hash ? (
-                      <TxHashShortLink
-                        hash={row.tx_hash}
+                      <LedgerTxLink
+                        spendRail={row.spend_rail}
+                        explorerTxUrl={row.explorer_tx_url}
+                        txHash={row.tx_hash}
                         className="inline-flex items-center gap-0.5 font-mono text-blue-600 hover:underline"
                       />
                     ) : (
@@ -577,6 +683,374 @@ export default function SpendExperienceDetailPage() {
         </p>
       )}
 
+      {activityData?.railVisibility && (
+        <section className="mb-8 space-y-6">
+          <div>
+            <h2 className="text-lg font-semibold text-[#171717]">
+              In-flight rail work & funded (unpaid)
+            </h2>
+            <p className="mt-1 text-xs text-neutral-500">
+              Read-only visibility for this experience. Age uses each row&apos;s{' '}
+              <span className="font-mono text-[11px]">created_at</span>. Lists
+              are capped (oldest in-flight queues first; funded-unpaid by newest
+              conversion activity).
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
+            <div className="rounded-lg border border-amber-200 bg-amber-50/60 p-3 text-sm">
+              <div className="text-xs font-medium uppercase tracking-wide text-amber-900/80">
+                Wallet readiness
+              </div>
+              <div className="mt-1 text-neutral-800">
+                pending{' '}
+                <span className="font-semibold tabular-nums">
+                  {activityData.railVisibility.summary.walletReadiness.pending}
+                </span>
+                <span className="mx-1 text-neutral-400">·</span>
+                needs_review{' '}
+                <span className="font-semibold tabular-nums">
+                  {
+                    activityData.railVisibility.summary.walletReadiness
+                      .needsReview
+                  }
+                </span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-violet-200 bg-violet-50/60 p-3 text-sm">
+              <div className="text-xs font-medium uppercase tracking-wide text-violet-900/80">
+                Conversions (in-flight)
+              </div>
+              <div className="mt-1 text-neutral-800">
+                total{' '}
+                <span className="font-semibold tabular-nums">
+                  {
+                    activityData.railVisibility.summary.conversions
+                      .inFlightTotal
+                  }
+                </span>
+                <div className="mt-0.5 text-[11px] text-neutral-600">
+                  pnd {activityData.railVisibility.summary.conversions.pending}{' '}
+                  · pts{' '}
+                  {
+                    activityData.railVisibility.summary.conversions
+                      .pointsDeducted
+                  }{' '}
+                  · fund{' '}
+                  {
+                    activityData.railVisibility.summary.conversions
+                      .fundingPending
+                  }{' '}
+                  · rev{' '}
+                  {activityData.railVisibility.summary.conversions.needsReview}
+                </div>
+              </div>
+            </div>
+            <div className="rounded-lg border border-sky-200 bg-sky-50/60 p-3 text-sm">
+              <div className="text-xs font-medium uppercase tracking-wide text-sky-900/80">
+                Payments (ledger)
+              </div>
+              <div className="mt-1 text-neutral-800">
+                pending{' '}
+                <span className="font-semibold tabular-nums">
+                  {
+                    activityData.railVisibility.summary.spendTransactions
+                      .pending
+                  }
+                </span>
+                <span className="mx-1 text-neutral-400">·</span>
+                submitted{' '}
+                <span className="font-semibold tabular-nums">
+                  {
+                    activityData.railVisibility.summary.spendTransactions
+                      .submitted
+                  }
+                </span>
+              </div>
+            </div>
+            <div className="rounded-lg border border-orange-200 bg-orange-50/60 p-3 text-sm">
+              <div className="text-xs font-medium uppercase tracking-wide text-orange-900/80">
+                Funded — payment not confirmed
+              </div>
+              <div className="mt-1 text-2xl font-semibold tabular-nums text-neutral-900">
+                {activityData.railVisibility.summary.fundedUnpaidSessions}
+              </div>
+              <div className="text-[11px] text-neutral-600">sessions</div>
+            </div>
+          </div>
+
+          {activityData.railVisibility.walletReadiness.length > 0 && (
+            <div className="rounded-lg border border-neutral-200 bg-white">
+              <div className="border-b border-neutral-100 px-4 py-2 text-sm font-medium text-neutral-800">
+                Wallet readiness (pending / needs_review)
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[720px] text-left text-xs">
+                  <thead className="border-b border-neutral-100 bg-neutral-50/80 text-[10px] uppercase text-neutral-500">
+                    <tr>
+                      <th className="px-2 py-1.5 font-medium">Rail</th>
+                      <th className="px-2 py-1.5 font-medium">Network</th>
+                      <th className="px-2 py-1.5 font-medium">User</th>
+                      <th className="px-2 py-1.5 font-medium">Session</th>
+                      <th className="px-2 py-1.5 font-medium">Status</th>
+                      <th className="px-2 py-1.5 font-medium">Age</th>
+                      <th className="px-2 py-1.5 font-medium">Safe error</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {activityData.railVisibility.walletReadiness.map((r) => (
+                      <tr
+                        key={r.operationId}
+                        className="border-b border-neutral-50 last:border-0"
+                      >
+                        <td className="px-2 py-1.5 font-mono text-[11px]">
+                          {r.spendRail}
+                        </td>
+                        <td className="px-2 py-1.5">{r.networkLabel}</td>
+                        <td className="px-2 py-1.5 font-mono text-[11px]">
+                          {shortenAddr(r.userId)}
+                        </td>
+                        <td className="px-2 py-1.5 font-mono text-[11px]">
+                          {shortenAddr(r.spendSessionId)}
+                        </td>
+                        <td className="px-2 py-1.5">{r.status}</td>
+                        <td className="px-2 py-1.5 tabular-nums text-neutral-600">
+                          {formatAgeFromIso(r.createdAt)}
+                        </td>
+                        <td className="max-w-[200px] truncate px-2 py-1.5 text-neutral-700">
+                          {r.safeErrorSummary ?? '—'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {activityData.railVisibility.conversionsInFlight.length > 0 && (
+            <div className="rounded-lg border border-neutral-200 bg-white">
+              <div className="border-b border-neutral-100 px-4 py-2 text-sm font-medium text-neutral-800">
+                Conversions (in-flight statuses)
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[880px] text-left text-xs">
+                  <thead className="border-b border-neutral-100 bg-neutral-50/80 text-[10px] uppercase text-neutral-500">
+                    <tr>
+                      <th className="px-2 py-1.5 font-medium">Rail</th>
+                      <th className="px-2 py-1.5 font-medium">Network</th>
+                      <th className="px-2 py-1.5 font-medium">USDC</th>
+                      <th className="px-2 py-1.5 font-medium">User</th>
+                      <th className="px-2 py-1.5 font-medium">Session</th>
+                      <th className="px-2 py-1.5 font-medium">Status</th>
+                      <th className="px-2 py-1.5 font-medium">Age</th>
+                      <th className="px-2 py-1.5 font-medium">Safe error</th>
+                      <th className="px-2 py-1.5 font-medium">Tx</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {activityData.railVisibility.conversionsInFlight.map(
+                      (r) => (
+                        <tr
+                          key={r.operationId}
+                          className="border-b border-neutral-50 last:border-0"
+                        >
+                          <td className="px-2 py-1.5 font-mono text-[11px]">
+                            {r.spendRail}
+                          </td>
+                          <td className="px-2 py-1.5">{r.networkLabel}</td>
+                          <td className="px-2 py-1.5 tabular-nums">
+                            {fmtUsdc(r.usdcAmount)}
+                          </td>
+                          <td className="px-2 py-1.5 font-mono text-[11px]">
+                            {shortenAddr(r.userId)}
+                          </td>
+                          <td className="px-2 py-1.5 font-mono text-[11px]">
+                            {shortenAddr(r.spendSessionId)}
+                          </td>
+                          <td className="px-2 py-1.5">{r.status}</td>
+                          <td className="px-2 py-1.5 tabular-nums text-neutral-600">
+                            {formatAgeFromIso(r.createdAt)}
+                          </td>
+                          <td className="max-w-[180px] truncate px-2 py-1.5 text-neutral-700">
+                            {r.safeErrorSummary ?? '—'}
+                          </td>
+                          <td className="px-2 py-1.5">
+                            {r.txHash ? (
+                              <LedgerTxLink
+                                spendRail={r.spendRail}
+                                explorerTxUrl={r.explorerTxUrl}
+                                txHash={r.txHash}
+                                className="text-blue-600 hover:underline"
+                              />
+                            ) : (
+                              '—'
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {activityData.railVisibility.spendTransactionsInFlight.length > 0 && (
+            <div className="rounded-lg border border-neutral-200 bg-white">
+              <div className="border-b border-neutral-100 px-4 py-2 text-sm font-medium text-neutral-800">
+                Spend transactions (pending / submitted)
+              </div>
+              <div className="overflow-x-auto">
+                <table className="w-full min-w-[880px] text-left text-xs">
+                  <thead className="border-b border-neutral-100 bg-neutral-50/80 text-[10px] uppercase text-neutral-500">
+                    <tr>
+                      <th className="px-2 py-1.5 font-medium">Rail</th>
+                      <th className="px-2 py-1.5 font-medium">Network</th>
+                      <th className="px-2 py-1.5 font-medium">USDC</th>
+                      <th className="px-2 py-1.5 font-medium">User</th>
+                      <th className="px-2 py-1.5 font-medium">Session</th>
+                      <th className="px-2 py-1.5 font-medium">Status</th>
+                      <th className="px-2 py-1.5 font-medium">Age</th>
+                      <th className="px-2 py-1.5 font-medium">Safe error</th>
+                      <th className="px-2 py-1.5 font-medium">Tx</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {activityData.railVisibility.spendTransactionsInFlight.map(
+                      (r) => (
+                        <tr
+                          key={r.operationId}
+                          className="border-b border-neutral-50 last:border-0"
+                        >
+                          <td className="px-2 py-1.5 font-mono text-[11px]">
+                            {r.spendRail}
+                          </td>
+                          <td className="px-2 py-1.5">{r.networkLabel}</td>
+                          <td className="px-2 py-1.5 tabular-nums">
+                            {fmtUsdc(r.usdcAmount)}
+                          </td>
+                          <td className="px-2 py-1.5 font-mono text-[11px]">
+                            {shortenAddr(r.userId)}
+                          </td>
+                          <td className="px-2 py-1.5 font-mono text-[11px]">
+                            {shortenAddr(r.spendSessionId)}
+                          </td>
+                          <td className="px-2 py-1.5">{r.status}</td>
+                          <td className="px-2 py-1.5 tabular-nums text-neutral-600">
+                            {formatAgeFromIso(r.createdAt)}
+                          </td>
+                          <td className="max-w-[180px] truncate px-2 py-1.5 text-neutral-700">
+                            {r.safeErrorSummary ?? '—'}
+                          </td>
+                          <td className="px-2 py-1.5">
+                            {r.txHash ? (
+                              <LedgerTxLink
+                                spendRail={r.spendRail}
+                                explorerTxUrl={r.explorerTxUrl}
+                                txHash={r.txHash}
+                                className="text-blue-600 hover:underline"
+                              />
+                            ) : (
+                              '—'
+                            )}
+                          </td>
+                        </tr>
+                      )
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          {activityData.railVisibility.fundedUnpaid.length > 0 && (
+            <div className="rounded-lg border border-orange-200 bg-orange-50/40">
+              <div className="border-b border-orange-100 px-4 py-2 text-sm font-medium text-orange-950">
+                Funded — payment not confirmed (sessions)
+              </div>
+              <div className="overflow-x-auto bg-white/80">
+                <table className="w-full min-w-[960px] text-left text-xs">
+                  <thead className="border-b border-orange-100 bg-orange-50/80 text-[10px] uppercase text-orange-900/70">
+                    <tr>
+                      <th className="px-2 py-1.5 font-medium">Rail</th>
+                      <th className="px-2 py-1.5 font-medium">Network</th>
+                      <th className="px-2 py-1.5 font-medium">USDC</th>
+                      <th className="px-2 py-1.5 font-medium">User</th>
+                      <th className="px-2 py-1.5 font-medium">Session</th>
+                      <th className="px-2 py-1.5 font-medium">
+                        Session status
+                      </th>
+                      <th className="px-2 py-1.5 font-medium">Pay status</th>
+                      <th className="px-2 py-1.5 font-medium">Age (conv.)</th>
+                      <th className="px-2 py-1.5 font-medium">Funding tx</th>
+                      <th className="px-2 py-1.5 font-medium">Payment tx</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {activityData.railVisibility.fundedUnpaid.map((row) => (
+                      <tr
+                        key={row.conversion.id}
+                        className="border-b border-orange-50/80 last:border-0"
+                      >
+                        <td className="px-2 py-1.5 font-mono text-[11px]">
+                          {row.spendRail}
+                        </td>
+                        <td className="px-2 py-1.5">{row.networkLabel}</td>
+                        <td className="px-2 py-1.5 tabular-nums">
+                          {fmtUsdc(row.usdcAmount)}
+                        </td>
+                        <td className="px-2 py-1.5 font-mono text-[11px]">
+                          {shortenAddr(row.userId)}
+                        </td>
+                        <td className="px-2 py-1.5 font-mono text-[11px]">
+                          {shortenAddr(row.spendSessionId)}
+                        </td>
+                        <td className="px-2 py-1.5">
+                          {row.sessionStatus
+                            ? row.sessionStatus.replace(/_/g, ' ')
+                            : '—'}
+                        </td>
+                        <td className="px-2 py-1.5">
+                          {row.payment?.status ?? '—'}
+                        </td>
+                        <td className="px-2 py-1.5 tabular-nums text-neutral-600">
+                          {formatAgeFromIso(row.conversion.createdAt)}
+                        </td>
+                        <td className="px-2 py-1.5">
+                          {row.conversion.fundingTxHash ? (
+                            <LedgerTxLink
+                              spendRail={row.spendRail}
+                              explorerTxUrl={row.conversion.explorerTxUrl}
+                              txHash={row.conversion.fundingTxHash}
+                              className="text-blue-600 hover:underline"
+                            />
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                        <td className="px-2 py-1.5">
+                          {row.payment?.paymentTxHash ? (
+                            <LedgerTxLink
+                              spendRail={row.spendRail}
+                              explorerTxUrl={row.payment.explorerTxUrl}
+                              txHash={row.payment.paymentTxHash}
+                              className="text-blue-600 hover:underline"
+                            />
+                          ) : (
+                            '—'
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+        </section>
+      )}
+
       {activityData &&
         (activityData.failedConversions.length > 0 ||
           activityData.failedPayments.length > 0) && (
@@ -585,8 +1059,8 @@ export default function SpendExperienceDetailPage() {
               Failed transactions
             </h2>
             <p className="mt-1 text-sm text-red-800/90">
-              Reasons are truncated server-side; use tx hashes on BaseScan for
-              full detail.
+              Reasons are truncated server-side; use the explorer links for
+              chain detail.
             </p>
             <div className="mt-4 grid gap-6 md:grid-cols-2">
               {activityData.failedConversions.length > 0 && (
@@ -608,7 +1082,11 @@ export default function SpendExperienceDetailPage() {
                         </div>
                         {c.funding_tx_hash && (
                           <div className="mt-1">
-                            <TxHashShortLink hash={c.funding_tx_hash} />
+                            <LedgerTxLink
+                              spendRail={c.spend_rail}
+                              explorerTxUrl={c.explorer_tx_url}
+                              txHash={c.funding_tx_hash}
+                            />
                           </div>
                         )}
                       </li>
@@ -635,7 +1113,11 @@ export default function SpendExperienceDetailPage() {
                         </div>
                         {p.payment_tx_hash && (
                           <div className="mt-1">
-                            <TxHashShortLink hash={p.payment_tx_hash} />
+                            <LedgerTxLink
+                              spendRail={p.spend_rail}
+                              explorerTxUrl={p.explorer_tx_url}
+                              txHash={p.payment_tx_hash}
+                            />
                           </div>
                         )}
                       </li>

--- a/app/api/admin/spend-experiences/[experienceId]/activity/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/activity/__tests__/route.test.ts
@@ -5,6 +5,7 @@ const mockRequireAdmin = vi.fn();
 const mockGetSpendExperienceById = vi.fn();
 const mockGetTotals = vi.fn();
 const mockListActivity = vi.fn();
+const mockGetRailVisibility = vi.fn();
 
 vi.mock('@/lib/auth', () => ({
   requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
@@ -19,6 +20,8 @@ vi.mock('@/lib/db/spend-admin', () => ({
   getSpendPilotAdminTotals: (...args: unknown[]) => mockGetTotals(...args),
   listSpendPilotActivityForExperience: (...args: unknown[]) =>
     mockListActivity(...args),
+  getSpendPilotAdminRailVisibility: (...args: unknown[]) =>
+    mockGetRailVisibility(...args),
 }));
 
 import { GET } from '../route';
@@ -45,6 +48,24 @@ describe('GET /api/admin/spend-experiences/[experienceId]/activity', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv('NEXT_PUBLIC_MIXPANEL_TOKEN', 'proj-token');
+    mockGetRailVisibility.mockResolvedValue({
+      summary: {
+        walletReadiness: { pending: 0, needsReview: 0 },
+        conversions: {
+          pending: 0,
+          pointsDeducted: 0,
+          fundingPending: 0,
+          needsReview: 0,
+          inFlightTotal: 0,
+        },
+        spendTransactions: { pending: 0, submitted: 0 },
+        fundedUnpaidSessions: 0,
+      },
+      walletReadiness: [],
+      conversionsInFlight: [],
+      spendTransactionsInFlight: [],
+      fundedUnpaid: [],
+    });
   });
 
   it('returns totals and activity when admin', async () => {
@@ -77,6 +98,8 @@ describe('GET /api/admin/spend-experiences/[experienceId]/activity', () => {
     expect(res.status).toBe(200);
     expect(j.data.totals.usersConverted).toBe(2);
     expect(j.data.mixpanelInsightUrl).toContain('proj-token');
+    expect(mockGetRailVisibility).toHaveBeenCalledWith('exp-1');
+    expect(j.data.railVisibility.summary.fundedUnpaidSessions).toBe(0);
   });
 
   it('returns 404 when experience missing', async () => {

--- a/app/api/admin/spend-experiences/[experienceId]/activity/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/activity/route.ts
@@ -14,7 +14,7 @@ interface RouteParams {
 
 /**
  * GET /api/admin/spend-experiences/{experienceId}/activity
- * Sessions (recent), failed conversion/payment rows, and aggregate totals (PRD §12).
+ * Recent sessions, failed rows, totals, and rail ops visibility (IRL-26).
  */
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {

--- a/app/api/admin/spend-experiences/[experienceId]/activity/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/activity/route.ts
@@ -2,6 +2,7 @@ import { NextRequest } from 'next/server';
 import { getSpendExperienceById } from '@/lib/db/spend-experiences';
 import {
   getSpendPilotAdminTotals,
+  getSpendPilotAdminRailVisibility,
   listSpendPilotActivityForExperience,
 } from '@/lib/db/spend-admin';
 import { apiSuccess, apiError } from '@/lib/api/response';
@@ -27,9 +28,10 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       return apiError('Spend experience not found', 404);
     }
 
-    const [totals, activity] = await Promise.all([
+    const [totals, activity, railVisibility] = await Promise.all([
       getSpendPilotAdminTotals(experience.id),
       listSpendPilotActivityForExperience(experience.id),
+      getSpendPilotAdminRailVisibility(experience.id),
     ]);
 
     const mixpanelProjectId = process.env.NEXT_PUBLIC_MIXPANEL_TOKEN?.trim();
@@ -43,6 +45,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       sessions: activity.sessions,
       failedConversions: activity.failedConversions,
       failedPayments: activity.failedPayments,
+      railVisibility,
       mixpanelInsightUrl,
     });
   } catch (error) {

--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -11,7 +11,7 @@ import {
 import { normalizeSpendRail } from './spend-rail';
 import { WALLET_READINESS_ADMIN_SESSION_JOIN_SELECT } from './spend-wallet-readiness';
 import {
-  explorerTxUrlForSpendLedger,
+  spendLedgerTxExplorerUrl,
   spendLedgerNetworkLabel,
 } from '@/lib/spend-ledger-explorer-url';
 import type {
@@ -302,16 +302,6 @@ export type SpendPilotAdminRailVisibility = {
   fundedUnpaid: SpendPilotAdminFundedUnpaidRow[];
 };
 
-function adminLedgerExplorerUrl(
-  spendRail: SpendRail,
-  persistedUrl: string | null | undefined,
-  txHash: string | null | undefined
-): string | null {
-  const persisted = persistedUrl?.trim();
-  if (persisted) return persisted;
-  return explorerTxUrlForSpendLedger(spendRail, txHash);
-}
-
 function safeConversionErrorSummary(c: PointConversion): string | null {
   const lf = c.conversion_last_failure;
   if (lf) {
@@ -565,7 +555,7 @@ export async function getSpendPilotAdminRailVisibility(
       updatedAt: c.updated_at,
       safeErrorSummary: safeConversionErrorSummary(c),
       txHash: c.funding_tx_hash,
-      explorerTxUrl: adminLedgerExplorerUrl(
+      explorerTxUrl: spendLedgerTxExplorerUrl(
         c.spend_rail,
         c.explorer_tx_url,
         c.funding_tx_hash
@@ -591,7 +581,7 @@ export async function getSpendPilotAdminRailVisibility(
       updatedAt: p.updated_at,
       safeErrorSummary: safePaymentErrorSummary(p),
       txHash: p.payment_tx_hash,
-      explorerTxUrl: adminLedgerExplorerUrl(
+      explorerTxUrl: spendLedgerTxExplorerUrl(
         p.spend_rail,
         p.explorer_tx_url,
         p.payment_tx_hash
@@ -603,20 +593,32 @@ export async function getSpendPilotAdminRailVisibility(
   const fundedSessionIds = [...latestFundedBySession.keys()];
 
   const paymentsBySession = new Map<string, SpendTransaction>();
-  for (const chunk of chunkIds(fundedSessionIds, 200)) {
-    if (chunk.length === 0) continue;
-    const { data, error } = await supabase
-      .from('spend_transactions')
-      .select(SPEND_TX_COLS)
-      .eq('spend_experience_id', spendExperienceId)
-      .in('spend_session_id', chunk);
-    if (error) {
-      console.error('getSpendPilotAdminRailVisibility funded payments:', error);
-      throw new Error(error.message || 'Failed to load payment rows');
-    }
-    for (const row of data ?? []) {
-      const p = rowToSpendTransaction(row as Record<string, unknown>);
-      paymentsBySession.set(p.spend_session_id, p);
+  const paymentChunks = chunkIds(fundedSessionIds, 200).filter(
+    (chunk) => chunk.length > 0
+  );
+  if (paymentChunks.length > 0) {
+    const paymentRowsByChunk = await Promise.all(
+      paymentChunks.map(async (chunk) => {
+        const { data, error } = await supabase
+          .from('spend_transactions')
+          .select(SPEND_TX_COLS)
+          .eq('spend_experience_id', spendExperienceId)
+          .in('spend_session_id', chunk);
+        if (error) {
+          console.error(
+            'getSpendPilotAdminRailVisibility funded payments:',
+            error
+          );
+          throw new Error(error.message || 'Failed to load payment rows');
+        }
+        return data ?? [];
+      })
+    );
+    for (const rows of paymentRowsByChunk) {
+      for (const row of rows) {
+        const p = rowToSpendTransaction(row as Record<string, unknown>);
+        paymentsBySession.set(p.spend_session_id, p);
+      }
     }
   }
 
@@ -627,27 +629,37 @@ export async function getSpendPilotAdminRailVisibility(
 
   const fundedUnpaidSessionsCount = fundedUnpaidCandidates.length;
 
-  const fundedUnpaidForList = [...fundedUnpaidCandidates]
+  const fundedUnpaidForList = fundedUnpaidCandidates
+    .slice()
     .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
     .slice(0, RAIL_OPS_DETAIL_LIMIT);
   const listSessionIds = [
     ...new Set(fundedUnpaidForList.map((c) => c.spend_session_id)),
   ];
   const sessionStatusById = new Map<string, SpendSession['status']>();
-  for (const chunk of chunkIds(listSessionIds, 200)) {
-    if (chunk.length === 0) continue;
-    const { data, error } = await supabase
-      .from('spend_sessions')
-      .select('id, status')
-      .eq('spend_experience_id', spendExperienceId)
-      .in('id', chunk);
-    if (error) {
-      console.error('getSpendPilotAdminRailVisibility sessions:', error);
-      throw new Error(error.message || 'Failed to load sessions');
-    }
-    for (const row of data ?? []) {
-      const rec = row as { id: string; status: SpendSession['status'] };
-      sessionStatusById.set(String(rec.id), rec.status);
+  const sessionChunks = chunkIds(listSessionIds, 200).filter(
+    (chunk) => chunk.length > 0
+  );
+  if (sessionChunks.length > 0) {
+    const sessionRowsByChunk = await Promise.all(
+      sessionChunks.map(async (chunk) => {
+        const { data, error } = await supabase
+          .from('spend_sessions')
+          .select('id, status')
+          .eq('spend_experience_id', spendExperienceId)
+          .in('id', chunk);
+        if (error) {
+          console.error('getSpendPilotAdminRailVisibility sessions:', error);
+          throw new Error(error.message || 'Failed to load sessions');
+        }
+        return data ?? [];
+      })
+    );
+    for (const rows of sessionRowsByChunk) {
+      for (const row of rows) {
+        const rec = row as { id: string; status: SpendSession['status'] };
+        sessionStatusById.set(String(rec.id), rec.status);
+      }
     }
   }
 
@@ -668,7 +680,7 @@ export async function getSpendPilotAdminRailVisibility(
           createdAt: c.created_at,
           updatedAt: c.updated_at,
           fundingTxHash: c.funding_tx_hash,
-          explorerTxUrl: adminLedgerExplorerUrl(
+          explorerTxUrl: spendLedgerTxExplorerUrl(
             c.spend_rail,
             c.explorer_tx_url,
             c.funding_tx_hash
@@ -682,7 +694,7 @@ export async function getSpendPilotAdminRailVisibility(
               createdAt: p.created_at,
               updatedAt: p.updated_at,
               paymentTxHash: p.payment_tx_hash,
-              explorerTxUrl: adminLedgerExplorerUrl(
+              explorerTxUrl: spendLedgerTxExplorerUrl(
                 p.spend_rail,
                 p.explorer_tx_url,
                 p.payment_tx_hash

--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -8,8 +8,16 @@ import {
   rowToSpendTransaction,
   toNum,
 } from './spend-ledger-rows';
+import { normalizeSpendRail } from './spend-rail';
+import { WALLET_READINESS_ADMIN_SESSION_JOIN_SELECT } from './spend-wallet-readiness';
+import {
+  explorerTxUrlForSpendLedger,
+  spendLedgerNetworkLabel,
+} from '@/lib/spend-ledger-explorer-url';
 import type {
   PointConversion,
+  PointConversionStatus,
+  SpendRail,
   SpendSession,
   SpendTransaction,
 } from '@/lib/types';
@@ -206,5 +214,507 @@ export async function listSpendPilotActivityForExperience(
     failedPayments: (failedPayRes.data ?? []).map((row) =>
       rowToSpendTransaction(row as Record<string, unknown>)
     ),
+  };
+}
+
+const RAIL_OPS_DETAIL_LIMIT = 150;
+
+/** Non-terminal conversion rows surfaced to admin ops (IRL-26). */
+const CONVERSION_IN_FLIGHT_STATUSES: PointConversionStatus[] = [
+  'pending',
+  'points_deducted',
+  'funding_pending',
+  'needs_review',
+];
+
+export type SpendPilotAdminRailOperationKind =
+  | 'wallet_readiness'
+  | 'conversion'
+  | 'payment';
+
+/**
+ * Read-only admin row for rail / ledger work (no `internal_diagnostics` or other
+ * server-only payloads). Age is derived client-side from `createdAt` (IRL-26).
+ */
+export type SpendPilotAdminRailVisibilityRow = {
+  operationKind: SpendPilotAdminRailOperationKind;
+  operationId: string;
+  spendExperienceId: string;
+  spendSessionId: string;
+  userId: string;
+  spendRail: SpendRail;
+  networkLabel: string;
+  usdcAmount: number | null;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  safeErrorSummary: string | null;
+  txHash: string | null;
+  explorerTxUrl: string | null;
+};
+
+export type SpendPilotAdminFundedUnpaidRow = {
+  spendExperienceId: string;
+  spendSessionId: string;
+  userId: string;
+  spendRail: SpendRail;
+  networkLabel: string;
+  usdcAmount: number;
+  sessionStatus: SpendSession['status'] | null;
+  conversion: {
+    id: string;
+    status: PointConversionStatus;
+    createdAt: string;
+    updatedAt: string;
+    fundingTxHash: string | null;
+    explorerTxUrl: string | null;
+    safeErrorSummary: string | null;
+  };
+  payment: {
+    id: string;
+    status: SpendTransaction['status'];
+    createdAt: string;
+    updatedAt: string;
+    paymentTxHash: string | null;
+    explorerTxUrl: string | null;
+    safeErrorSummary: string | null;
+  } | null;
+};
+
+export type SpendPilotAdminRailOpsSummary = {
+  walletReadiness: { pending: number; needsReview: number };
+  conversions: {
+    pending: number;
+    pointsDeducted: number;
+    fundingPending: number;
+    needsReview: number;
+    inFlightTotal: number;
+  };
+  spendTransactions: { pending: number; submitted: number };
+  fundedUnpaidSessions: number;
+};
+
+export type SpendPilotAdminRailVisibility = {
+  summary: SpendPilotAdminRailOpsSummary;
+  walletReadiness: SpendPilotAdminRailVisibilityRow[];
+  conversionsInFlight: SpendPilotAdminRailVisibilityRow[];
+  spendTransactionsInFlight: SpendPilotAdminRailVisibilityRow[];
+  fundedUnpaid: SpendPilotAdminFundedUnpaidRow[];
+};
+
+function adminLedgerExplorerUrl(
+  spendRail: SpendRail,
+  persistedUrl: string | null | undefined,
+  txHash: string | null | undefined
+): string | null {
+  const persisted = persistedUrl?.trim();
+  if (persisted) return persisted;
+  return explorerTxUrlForSpendLedger(spendRail, txHash);
+}
+
+function safeConversionErrorSummary(c: PointConversion): string | null {
+  const lf = c.conversion_last_failure;
+  if (lf) {
+    return `${lf.category}: ${lf.reason_snippet}`;
+  }
+  const fr = c.failed_reason?.trim();
+  return fr || null;
+}
+
+function safePaymentErrorSummary(p: SpendTransaction): string | null {
+  return p.failed_reason?.trim() || null;
+}
+
+function walletReadinessSafeError(
+  category: string | null | undefined,
+  code: string | null | undefined
+): string | null {
+  const parts = [category?.trim(), code?.trim()].filter(Boolean) as string[];
+  return parts.length ? parts.join(' · ') : null;
+}
+
+async function countWalletReadinessForExperience(
+  spendExperienceId: string,
+  status: 'pending' | 'needs_review'
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('spend_wallet_readiness_operations')
+    .select('id, spend_sessions!inner(spend_experience_id)', {
+      count: 'exact',
+      head: true,
+    })
+    .eq('spend_sessions.spend_experience_id', spendExperienceId)
+    .eq('status', status);
+
+  if (error) {
+    console.error('countWalletReadinessForExperience:', error);
+    throw new Error(error.message || 'Failed to count wallet readiness');
+  }
+  return count ?? 0;
+}
+
+async function countConversionsByStatus(
+  spendExperienceId: string,
+  status: PointConversionStatus
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('point_conversions')
+    .select('id', { count: 'exact', head: true })
+    .eq('spend_experience_id', spendExperienceId)
+    .eq('status', status);
+
+  if (error) {
+    console.error('countConversionsByStatus:', error);
+    throw new Error(error.message || 'Failed to count conversions');
+  }
+  return count ?? 0;
+}
+
+async function countSpendTxByStatus(
+  spendExperienceId: string,
+  status: SpendTransaction['status']
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('spend_transactions')
+    .select('id', { count: 'exact', head: true })
+    .eq('spend_experience_id', spendExperienceId)
+    .eq('status', status);
+
+  if (error) {
+    console.error('countSpendTxByStatus:', error);
+    throw new Error(error.message || 'Failed to count spend transactions');
+  }
+  return count ?? 0;
+}
+
+function chunkIds<T>(items: T[], size: number): T[][] {
+  const out: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    out.push(items.slice(i, i + size));
+  }
+  return out;
+}
+
+/**
+ * Paginates all `funded` conversions for an experience and keeps the newest
+ * `updated_at` row per `spend_session_id` (handles duplicate rows if any).
+ */
+async function loadLatestFundedConversionBySession(
+  spendExperienceId: string
+): Promise<Map<string, PointConversion>> {
+  const latestBySession = new Map<string, PointConversion>();
+  const pageSize = 500;
+  for (let from = 0; ; from += pageSize) {
+    const { data, error } = await supabase
+      .from('point_conversions')
+      .select(CONVERSION_COLS)
+      .eq('spend_experience_id', spendExperienceId)
+      .eq('status', 'funded')
+      .order('updated_at', { ascending: false })
+      .range(from, from + pageSize - 1);
+
+    if (error) {
+      console.error('loadLatestFundedConversionBySession:', error);
+      throw new Error(error.message || 'Failed to load funded conversions');
+    }
+    const rows = data ?? [];
+    if (rows.length === 0) break;
+
+    for (const row of rows) {
+      const c = rowToConversion(row as Record<string, unknown>);
+      const prev = latestBySession.get(c.spend_session_id);
+      if (!prev || prev.updated_at < c.updated_at) {
+        latestBySession.set(c.spend_session_id, c);
+      }
+    }
+    if (rows.length < pageSize) break;
+  }
+  return latestBySession;
+}
+
+/**
+ * In-flight / needs_review wallet readiness, conversions, spend_transactions,
+ * and funded-but-unpaid sessions for a single spend experience (IRL-26).
+ */
+export async function getSpendPilotAdminRailVisibility(
+  spendExperienceId: string
+): Promise<SpendPilotAdminRailVisibility> {
+  const [
+    wrPendingCount,
+    wrNeedsReviewCount,
+    convPendingCount,
+    convPointsDeductedCount,
+    convFundingPendingCount,
+    convNeedsReviewCount,
+    payPendingCount,
+    paySubmittedCount,
+  ] = await Promise.all([
+    countWalletReadinessForExperience(spendExperienceId, 'pending'),
+    countWalletReadinessForExperience(spendExperienceId, 'needs_review'),
+    countConversionsByStatus(spendExperienceId, 'pending'),
+    countConversionsByStatus(spendExperienceId, 'points_deducted'),
+    countConversionsByStatus(spendExperienceId, 'funding_pending'),
+    countConversionsByStatus(spendExperienceId, 'needs_review'),
+    countSpendTxByStatus(spendExperienceId, 'pending'),
+    countSpendTxByStatus(spendExperienceId, 'submitted'),
+  ]);
+
+  const conversionInFlightTotal =
+    convPendingCount +
+    convPointsDeductedCount +
+    convFundingPendingCount +
+    convNeedsReviewCount;
+
+  const [wrListRes, convListRes, payListRes, latestFundedBySession] =
+    await Promise.all([
+      supabase
+        .from('spend_wallet_readiness_operations')
+        .select(WALLET_READINESS_ADMIN_SESSION_JOIN_SELECT)
+        .eq('spend_sessions.spend_experience_id', spendExperienceId)
+        .in('status', ['pending', 'needs_review'])
+        .order('created_at', { ascending: true })
+        .limit(RAIL_OPS_DETAIL_LIMIT),
+      supabase
+        .from('point_conversions')
+        .select(CONVERSION_COLS)
+        .eq('spend_experience_id', spendExperienceId)
+        .in('status', CONVERSION_IN_FLIGHT_STATUSES)
+        .order('created_at', { ascending: true })
+        .limit(RAIL_OPS_DETAIL_LIMIT),
+      supabase
+        .from('spend_transactions')
+        .select(SPEND_TX_COLS)
+        .eq('spend_experience_id', spendExperienceId)
+        .in('status', ['pending', 'submitted'])
+        .order('created_at', { ascending: true })
+        .limit(RAIL_OPS_DETAIL_LIMIT),
+      loadLatestFundedConversionBySession(spendExperienceId),
+    ]);
+
+  if (wrListRes.error) {
+    console.error('getSpendPilotAdminRailVisibility wr list:', wrListRes.error);
+    throw new Error(
+      wrListRes.error.message || 'Failed to load wallet readiness'
+    );
+  }
+  if (convListRes.error) {
+    console.error(
+      'getSpendPilotAdminRailVisibility conv list:',
+      convListRes.error
+    );
+    throw new Error(convListRes.error.message || 'Failed to load conversions');
+  }
+  if (payListRes.error) {
+    console.error(
+      'getSpendPilotAdminRailVisibility pay list:',
+      payListRes.error
+    );
+    throw new Error(
+      payListRes.error.message || 'Failed to load spend transactions'
+    );
+  }
+  const walletReadinessRows: SpendPilotAdminRailVisibilityRow[] = (
+    wrListRes.data ?? []
+  ).map((raw) => {
+    const row = raw as Record<string, unknown>;
+    const nestedRaw = row.spend_sessions as
+      | { spend_experience_id: string }
+      | { spend_experience_id: string }[]
+      | undefined;
+    const nested = Array.isArray(nestedRaw) ? nestedRaw[0] : nestedRaw;
+    const spendExperienceIdFromJoin = nested?.spend_experience_id
+      ? String(nested.spend_experience_id)
+      : spendExperienceId;
+    const spendRail = normalizeSpendRail(row.spend_rail);
+    return {
+      operationKind: 'wallet_readiness' as const,
+      operationId: String(row.id),
+      spendExperienceId: spendExperienceIdFromJoin,
+      spendSessionId: String(row.spend_session_id),
+      userId: String(row.user_id),
+      spendRail,
+      networkLabel: spendLedgerNetworkLabel(spendRail),
+      usdcAmount: null,
+      status: String(row.status),
+      createdAt: String(row.created_at),
+      updatedAt: String(row.updated_at),
+      safeErrorSummary: walletReadinessSafeError(
+        row.sanitized_error_category as string | null,
+        row.sanitized_error_code as string | null
+      ),
+      txHash: null,
+      explorerTxUrl: null,
+    };
+  });
+
+  const conversionsInFlight: SpendPilotAdminRailVisibilityRow[] = (
+    convListRes.data ?? []
+  ).map((r) => {
+    const c = rowToConversion(r as Record<string, unknown>);
+    return {
+      operationKind: 'conversion' as const,
+      operationId: c.id,
+      spendExperienceId: c.spend_experience_id,
+      spendSessionId: c.spend_session_id,
+      userId: c.user_id,
+      spendRail: c.spend_rail,
+      networkLabel: c.network,
+      usdcAmount: c.usdc_amount,
+      status: c.status,
+      createdAt: c.created_at,
+      updatedAt: c.updated_at,
+      safeErrorSummary: safeConversionErrorSummary(c),
+      txHash: c.funding_tx_hash,
+      explorerTxUrl: adminLedgerExplorerUrl(
+        c.spend_rail,
+        c.explorer_tx_url,
+        c.funding_tx_hash
+      ),
+    };
+  });
+
+  const spendTransactionsInFlight: SpendPilotAdminRailVisibilityRow[] = (
+    payListRes.data ?? []
+  ).map((r) => {
+    const p = rowToSpendTransaction(r as Record<string, unknown>);
+    return {
+      operationKind: 'payment' as const,
+      operationId: p.id,
+      spendExperienceId: p.spend_experience_id,
+      spendSessionId: p.spend_session_id,
+      userId: p.user_id,
+      spendRail: p.spend_rail,
+      networkLabel: p.network,
+      usdcAmount: p.usdc_amount,
+      status: p.status,
+      createdAt: p.created_at,
+      updatedAt: p.updated_at,
+      safeErrorSummary: safePaymentErrorSummary(p),
+      txHash: p.payment_tx_hash,
+      explorerTxUrl: adminLedgerExplorerUrl(
+        p.spend_rail,
+        p.explorer_tx_url,
+        p.payment_tx_hash
+      ),
+    };
+  });
+
+  const fundedConversions = [...latestFundedBySession.values()];
+  const fundedSessionIds = [...latestFundedBySession.keys()];
+
+  const paymentsBySession = new Map<string, SpendTransaction>();
+  for (const chunk of chunkIds(fundedSessionIds, 200)) {
+    if (chunk.length === 0) continue;
+    const { data, error } = await supabase
+      .from('spend_transactions')
+      .select(SPEND_TX_COLS)
+      .eq('spend_experience_id', spendExperienceId)
+      .in('spend_session_id', chunk);
+    if (error) {
+      console.error('getSpendPilotAdminRailVisibility funded payments:', error);
+      throw new Error(error.message || 'Failed to load payment rows');
+    }
+    for (const row of data ?? []) {
+      const p = rowToSpendTransaction(row as Record<string, unknown>);
+      paymentsBySession.set(p.spend_session_id, p);
+    }
+  }
+
+  const fundedUnpaidCandidates = fundedConversions.filter((c) => {
+    const p = paymentsBySession.get(c.spend_session_id);
+    return !p || p.status !== 'confirmed';
+  });
+
+  const fundedUnpaidSessionsCount = fundedUnpaidCandidates.length;
+
+  const fundedUnpaidForList = [...fundedUnpaidCandidates]
+    .sort((a, b) => b.updated_at.localeCompare(a.updated_at))
+    .slice(0, RAIL_OPS_DETAIL_LIMIT);
+  const listSessionIds = [
+    ...new Set(fundedUnpaidForList.map((c) => c.spend_session_id)),
+  ];
+  const sessionStatusById = new Map<string, SpendSession['status']>();
+  for (const chunk of chunkIds(listSessionIds, 200)) {
+    if (chunk.length === 0) continue;
+    const { data, error } = await supabase
+      .from('spend_sessions')
+      .select('id, status')
+      .eq('spend_experience_id', spendExperienceId)
+      .in('id', chunk);
+    if (error) {
+      console.error('getSpendPilotAdminRailVisibility sessions:', error);
+      throw new Error(error.message || 'Failed to load sessions');
+    }
+    for (const row of data ?? []) {
+      const rec = row as { id: string; status: SpendSession['status'] };
+      sessionStatusById.set(String(rec.id), rec.status);
+    }
+  }
+
+  const fundedUnpaid: SpendPilotAdminFundedUnpaidRow[] =
+    fundedUnpaidForList.map((c) => {
+      const p = paymentsBySession.get(c.spend_session_id) ?? null;
+      return {
+        spendExperienceId: c.spend_experience_id,
+        spendSessionId: c.spend_session_id,
+        userId: c.user_id,
+        spendRail: c.spend_rail,
+        networkLabel: c.network,
+        usdcAmount: c.usdc_amount,
+        sessionStatus: sessionStatusById.get(c.spend_session_id) ?? null,
+        conversion: {
+          id: c.id,
+          status: c.status,
+          createdAt: c.created_at,
+          updatedAt: c.updated_at,
+          fundingTxHash: c.funding_tx_hash,
+          explorerTxUrl: adminLedgerExplorerUrl(
+            c.spend_rail,
+            c.explorer_tx_url,
+            c.funding_tx_hash
+          ),
+          safeErrorSummary: safeConversionErrorSummary(c),
+        },
+        payment: p
+          ? {
+              id: p.id,
+              status: p.status,
+              createdAt: p.created_at,
+              updatedAt: p.updated_at,
+              paymentTxHash: p.payment_tx_hash,
+              explorerTxUrl: adminLedgerExplorerUrl(
+                p.spend_rail,
+                p.explorer_tx_url,
+                p.payment_tx_hash
+              ),
+              safeErrorSummary: safePaymentErrorSummary(p),
+            }
+          : null,
+      };
+    });
+
+  return {
+    summary: {
+      walletReadiness: {
+        pending: wrPendingCount,
+        needsReview: wrNeedsReviewCount,
+      },
+      conversions: {
+        pending: convPendingCount,
+        pointsDeducted: convPointsDeductedCount,
+        fundingPending: convFundingPendingCount,
+        needsReview: convNeedsReviewCount,
+        inFlightTotal: conversionInFlightTotal,
+      },
+      spendTransactions: {
+        pending: payPendingCount,
+        submitted: paySubmittedCount,
+      },
+      fundedUnpaidSessions: fundedUnpaidSessionsCount,
+    },
+    walletReadiness: walletReadinessRows,
+    conversionsInFlight,
+    spendTransactionsInFlight,
+    fundedUnpaid,
   };
 }

--- a/lib/db/spend-wallet-readiness.ts
+++ b/lib/db/spend-wallet-readiness.ts
@@ -24,6 +24,28 @@ export const WALLET_READINESS_COLS = `
   updated_at
 `;
 
+/** Admin reads: same as full row mapping but omit `internal_diagnostics` from selects. */
+export const WALLET_READINESS_ADMIN_COLS = `
+  id,
+  spend_session_id,
+  user_id,
+  spend_rail,
+  rail_user_wallet_address,
+  status,
+  step_metadata,
+  sanitized_error_category,
+  sanitized_error_code,
+  idempotency_key,
+  sponsor_treasury_transaction_id,
+  trustline_treasury_transaction_id,
+  created_at,
+  updated_at
+`;
+
+/** Literal for typed `.select()` with `spend_sessions` join (no template interpolation). */
+export const WALLET_READINESS_ADMIN_SESSION_JOIN_SELECT =
+  'id, spend_session_id, user_id, spend_rail, rail_user_wallet_address, status, step_metadata, sanitized_error_category, sanitized_error_code, idempotency_key, sponsor_treasury_transaction_id, trustline_treasury_transaction_id, created_at, updated_at, spend_sessions!inner(spend_experience_id)' as const;
+
 function parseJsonObject(value: unknown): Record<string, unknown> | null {
   if (value == null) return null;
   if (typeof value === 'object' && !Array.isArray(value)) {

--- a/lib/db/spend-wallet-readiness.ts
+++ b/lib/db/spend-wallet-readiness.ts
@@ -24,24 +24,6 @@ export const WALLET_READINESS_COLS = `
   updated_at
 `;
 
-/** Admin reads: same as full row mapping but omit `internal_diagnostics` from selects. */
-export const WALLET_READINESS_ADMIN_COLS = `
-  id,
-  spend_session_id,
-  user_id,
-  spend_rail,
-  rail_user_wallet_address,
-  status,
-  step_metadata,
-  sanitized_error_category,
-  sanitized_error_code,
-  idempotency_key,
-  sponsor_treasury_transaction_id,
-  trustline_treasury_transaction_id,
-  created_at,
-  updated_at
-`;
-
 /** Literal for typed `.select()` with `spend_sessions` join (no template interpolation). */
 export const WALLET_READINESS_ADMIN_SESSION_JOIN_SELECT =
   'id, spend_session_id, user_id, spend_rail, rail_user_wallet_address, status, step_metadata, sanitized_error_category, sanitized_error_code, idempotency_key, sponsor_treasury_transaction_id, trustline_treasury_transaction_id, created_at, updated_at, spend_sessions!inner(spend_experience_id)' as const;

--- a/lib/spend-ledger-explorer-url.ts
+++ b/lib/spend-ledger-explorer-url.ts
@@ -1,4 +1,8 @@
 import type { SpendRail } from '@/lib/types';
+import {
+  formatExplorerTxUrlForSpendLedger,
+  spendLedgerNetworkLabel,
+} from '@/lib/spend-rail-config';
 
 const EVM_TX_HASH_RE = /^0x[a-fA-F0-9]{64}$/;
 const STELLAR_TX_HASH_RE = /^[a-fA-F0-9]{64}$/;
@@ -28,7 +32,21 @@ export function isValidSpendConversionFundingTxReference(
   return false;
 }
 
+/**
+ * Prefer a persisted explorer URL from a ledger row; otherwise derive from rail
+ * and tx hash (shared by admin DB mapping and the spend admin UI).
+ */
+export function spendLedgerTxExplorerUrl(
+  spendRail: SpendRail,
+  persistedExplorerTxUrl: string | null | undefined,
+  txHash: string | null | undefined
+): string | null {
+  const persisted = persistedExplorerTxUrl?.trim();
+  if (persisted) return persisted;
+  return formatExplorerTxUrlForSpendLedger(spendRail, txHash);
+}
+
 export {
   spendLedgerNetworkLabel,
   formatExplorerTxUrlForSpendLedger as explorerTxUrlForSpendLedger,
-} from '@/lib/spend-rail-config';
+};


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Read-only admin visibility on the per-experience spend Activity page and its activity API for wallet readiness, in-flight conversions, in-flight spend ledger rows, and funded sessions without a confirmed payment (IRL-26).

## Changes

- **`lib/db/spend-admin.ts`**: `getSpendPilotAdminRailVisibility()` returns summary counts, capped detail lists (150), and funded-unpaid rows. Explorer URLs prefer persisted `explorer_tx_url`, then `explorerTxUrlForSpendLedger`. Surfaces only safe error fields (no `internal_diagnostics`).
- **`lib/db/spend-wallet-readiness.ts`**: Admin column list without `internal_diagnostics`, plus a static select literal for the `spend_sessions` inner join (required by Supabase generated types).
- **`GET /api/admin/spend-experiences/[experienceId]/activity`**: adds `railVisibility` to the response.
- **`app/admin/spend-experiences/[experienceId]/page.tsx`**: summary cards and read-only tables; transaction links use persisted explorer URL or rail-aware helper across sessions, failures, treasury ledger, and new sections.
- **Tests**: activity route mocks the new DB helper.

## Out of scope

No separate list for `spend_payment_prepare_operations`, and no new retry or reconciliation actions on this page or API.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-26](https://linear.app/irlenergy/issue/IRL-26/add-minimal-admin-visibility-for-pending-needs-review-and-funded)

<div><a href="https://cursor.com/agents/bc-464bf586-6604-4ea6-80bd-6aff1bf0b967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-464bf586-6604-4ea6-80bd-6aff1bf0b967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

