### PR TITLE
fix: tolerate missing point_conversions retry audit columns on read

### DIFF
--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -1,6 +1,7 @@
 import { supabase } from './client';
 import {
   fetchPointConversionWithSelectFallback,
+  pointConversionRowsFromSelectData,
   SESSION_COLS,
   SPEND_TX_COLS,
   rowToConversion,
@@ -154,9 +155,8 @@ export async function listSpendPilotActivityForExperience(
       throw new Error(payRes.error.message || 'Failed to load payments');
     }
 
-    for (const row of (convRes.data as Record<string, unknown>[] | null) ??
-      []) {
-      const c = rowToConversion(row as Record<string, unknown>);
+    for (const row of pointConversionRowsFromSelectData(convRes.data)) {
+      const c = rowToConversion(row);
       conversionsBySession.set(c.spend_session_id, c);
     }
     for (const row of payRes.data ?? []) {
@@ -213,8 +213,8 @@ export async function listSpendPilotActivityForExperience(
 
   return {
     sessions: activitySessions,
-    failedConversions: (
-      (failedConvRes.data as Record<string, unknown>[] | null) ?? []
+    failedConversions: pointConversionRowsFromSelectData(
+      failedConvRes.data
     ).map((row) => rowToConversion(row)),
     failedPayments: (failedPayRes.data ?? []).map((row) =>
       rowToSpendTransaction(row as Record<string, unknown>)
@@ -415,11 +415,11 @@ async function loadLatestFundedConversionBySession(
       console.error('loadLatestFundedConversionBySession:', error);
       throw new Error(error.message || 'Failed to load funded conversions');
     }
-    const rows = (data as Record<string, unknown>[] | null | undefined) ?? [];
+    const rows = pointConversionRowsFromSelectData(data);
     if (rows.length === 0) break;
 
     for (const row of rows) {
-      const c = rowToConversion(row as Record<string, unknown>);
+      const c = rowToConversion(row);
       const prev = latestBySession.get(c.spend_session_id);
       if (!prev || prev.updated_at < c.updated_at) {
         latestBySession.set(c.spend_session_id, c);
@@ -547,31 +547,30 @@ export async function getSpendPilotAdminRailVisibility(
     };
   });
 
-  const conversionsInFlight: SpendPilotAdminRailVisibilityRow[] = (
-    (convListRes.data as Record<string, unknown>[] | null) ?? []
-  ).map((r) => {
-    const c = rowToConversion(r as Record<string, unknown>);
-    return {
-      operationKind: 'conversion' as const,
-      operationId: c.id,
-      spendExperienceId: c.spend_experience_id,
-      spendSessionId: c.spend_session_id,
-      userId: c.user_id,
-      spendRail: c.spend_rail,
-      networkLabel: c.network,
-      usdcAmount: c.usdc_amount,
-      status: c.status,
-      createdAt: c.created_at,
-      updatedAt: c.updated_at,
-      safeErrorSummary: safeConversionErrorSummary(c),
-      txHash: c.funding_tx_hash,
-      explorerTxUrl: spendLedgerTxExplorerUrl(
-        c.spend_rail,
-        c.explorer_tx_url,
-        c.funding_tx_hash
-      ),
-    };
-  });
+  const conversionsInFlight: SpendPilotAdminRailVisibilityRow[] =
+    pointConversionRowsFromSelectData(convListRes.data).map((r) => {
+      const c = rowToConversion(r);
+      return {
+        operationKind: 'conversion' as const,
+        operationId: c.id,
+        spendExperienceId: c.spend_experience_id,
+        spendSessionId: c.spend_session_id,
+        userId: c.user_id,
+        spendRail: c.spend_rail,
+        networkLabel: c.network,
+        usdcAmount: c.usdc_amount,
+        status: c.status,
+        createdAt: c.created_at,
+        updatedAt: c.updated_at,
+        safeErrorSummary: safeConversionErrorSummary(c),
+        txHash: c.funding_tx_hash,
+        explorerTxUrl: spendLedgerTxExplorerUrl(
+          c.spend_rail,
+          c.explorer_tx_url,
+          c.funding_tx_hash
+        ),
+      };
+    });
 
   const spendTransactionsInFlight: SpendPilotAdminRailVisibilityRow[] = (
     payListRes.data ?? []

--- a/lib/db/spend-admin.ts
+++ b/lib/db/spend-admin.ts
@@ -1,6 +1,6 @@
 import { supabase } from './client';
 import {
-  CONVERSION_COLS,
+  fetchPointConversionWithSelectFallback,
   SESSION_COLS,
   SPEND_TX_COLS,
   rowToConversion,
@@ -131,11 +131,13 @@ export async function listSpendPilotActivityForExperience(
 
   if (sessionIds.length > 0) {
     const [convRes, payRes] = await Promise.all([
-      supabase
-        .from('point_conversions')
-        .select(CONVERSION_COLS)
-        .eq('spend_experience_id', spendExperienceId)
-        .in('spend_session_id', sessionIds),
+      fetchPointConversionWithSelectFallback((cols) =>
+        supabase
+          .from('point_conversions')
+          .select(cols)
+          .eq('spend_experience_id', spendExperienceId)
+          .in('spend_session_id', sessionIds)
+      ),
       supabase
         .from('spend_transactions')
         .select(SPEND_TX_COLS)
@@ -152,7 +154,8 @@ export async function listSpendPilotActivityForExperience(
       throw new Error(payRes.error.message || 'Failed to load payments');
     }
 
-    for (const row of convRes.data ?? []) {
+    for (const row of (convRes.data as Record<string, unknown>[] | null) ??
+      []) {
       const c = rowToConversion(row as Record<string, unknown>);
       conversionsBySession.set(c.spend_session_id, c);
     }
@@ -171,13 +174,15 @@ export async function listSpendPilotActivityForExperience(
   );
 
   const [failedConvRes, failedPayRes] = await Promise.all([
-    supabase
-      .from('point_conversions')
-      .select(CONVERSION_COLS)
-      .eq('spend_experience_id', spendExperienceId)
-      .eq('status', 'failed')
-      .order('created_at', { ascending: false })
-      .limit(FAILED_LIMIT),
+    fetchPointConversionWithSelectFallback((cols) =>
+      supabase
+        .from('point_conversions')
+        .select(cols)
+        .eq('spend_experience_id', spendExperienceId)
+        .eq('status', 'failed')
+        .order('created_at', { ascending: false })
+        .limit(FAILED_LIMIT)
+    ),
     supabase
       .from('spend_transactions')
       .select(SPEND_TX_COLS)
@@ -208,9 +213,9 @@ export async function listSpendPilotActivityForExperience(
 
   return {
     sessions: activitySessions,
-    failedConversions: (failedConvRes.data ?? []).map((row) =>
-      rowToConversion(row as Record<string, unknown>)
-    ),
+    failedConversions: (
+      (failedConvRes.data as Record<string, unknown>[] | null) ?? []
+    ).map((row) => rowToConversion(row)),
     failedPayments: (failedPayRes.data ?? []).map((row) =>
       rowToSpendTransaction(row as Record<string, unknown>)
     ),
@@ -395,19 +400,22 @@ async function loadLatestFundedConversionBySession(
   const latestBySession = new Map<string, PointConversion>();
   const pageSize = 500;
   for (let from = 0; ; from += pageSize) {
-    const { data, error } = await supabase
-      .from('point_conversions')
-      .select(CONVERSION_COLS)
-      .eq('spend_experience_id', spendExperienceId)
-      .eq('status', 'funded')
-      .order('updated_at', { ascending: false })
-      .range(from, from + pageSize - 1);
+    const { data, error } = await fetchPointConversionWithSelectFallback(
+      (cols) =>
+        supabase
+          .from('point_conversions')
+          .select(cols)
+          .eq('spend_experience_id', spendExperienceId)
+          .eq('status', 'funded')
+          .order('updated_at', { ascending: false })
+          .range(from, from + pageSize - 1)
+    );
 
     if (error) {
       console.error('loadLatestFundedConversionBySession:', error);
       throw new Error(error.message || 'Failed to load funded conversions');
     }
-    const rows = data ?? [];
+    const rows = (data as Record<string, unknown>[] | null | undefined) ?? [];
     if (rows.length === 0) break;
 
     for (const row of rows) {
@@ -464,13 +472,15 @@ export async function getSpendPilotAdminRailVisibility(
         .in('status', ['pending', 'needs_review'])
         .order('created_at', { ascending: true })
         .limit(RAIL_OPS_DETAIL_LIMIT),
-      supabase
-        .from('point_conversions')
-        .select(CONVERSION_COLS)
-        .eq('spend_experience_id', spendExperienceId)
-        .in('status', CONVERSION_IN_FLIGHT_STATUSES)
-        .order('created_at', { ascending: true })
-        .limit(RAIL_OPS_DETAIL_LIMIT),
+      fetchPointConversionWithSelectFallback((cols) =>
+        supabase
+          .from('point_conversions')
+          .select(cols)
+          .eq('spend_experience_id', spendExperienceId)
+          .in('status', CONVERSION_IN_FLIGHT_STATUSES)
+          .order('created_at', { ascending: true })
+          .limit(RAIL_OPS_DETAIL_LIMIT)
+      ),
       supabase
         .from('spend_transactions')
         .select(SPEND_TX_COLS)
@@ -538,7 +548,7 @@ export async function getSpendPilotAdminRailVisibility(
   });
 
   const conversionsInFlight: SpendPilotAdminRailVisibilityRow[] = (
-    convListRes.data ?? []
+    (convListRes.data as Record<string, unknown>[] | null) ?? []
   ).map((r) => {
     const c = rowToConversion(r as Record<string, unknown>);
     return {

--- a/lib/db/spend-ledger-rows.ts
+++ b/lib/db/spend-ledger-rows.ts
@@ -46,16 +46,14 @@ export const CONVERSION_COLS_WITHOUT_RETRY_AUDIT = `
   completed_at,
   failed_reason,
   updated_at
-`;
+`.trim();
 
 /** Full `point_conversions` read including IRL-17 retry audit columns when present. */
-export const CONVERSION_COLS_WITH_RETRY_AUDIT = `
-  ${CONVERSION_COLS_WITHOUT_RETRY_AUDIT.trim()},
+export const CONVERSION_COLS_WITH_RETRY_AUDIT = `${CONVERSION_COLS_WITHOUT_RETRY_AUDIT},
   conversion_attempt_count,
-  conversion_last_failure
-`;
+  conversion_last_failure`;
 
-/** @deprecated Prefer {@link getPointConversionSelectColumns} with {@link fetchPointConversionWithSelectFallback}. */
+/** @deprecated Prefer {@link fetchPointConversionWithSelectFallback} instead of selecting this list directly. */
 export const CONVERSION_COLS = CONVERSION_COLS_WITH_RETRY_AUDIT;
 
 type PgLikeError = { code?: string; message?: string } | null | undefined;
@@ -74,17 +72,23 @@ export function isMissingPointConversionRetryAuditDbError(
 
 let pointConversionRetryAuditSelectEnabled = true;
 
-export function getPointConversionSelectColumns(): string {
+function pointConversionSelectColumnsForNextQuery(): string {
   return pointConversionRetryAuditSelectEnabled
     ? CONVERSION_COLS_WITH_RETRY_AUDIT
     : CONVERSION_COLS_WITHOUT_RETRY_AUDIT;
 }
 
-function disablePointConversionRetryAuditSelect(): void {
-  pointConversionRetryAuditSelectEnabled = false;
-}
-
 type PointConversionQueryResult = { data: unknown; error: PgLikeError };
+
+/**
+ * Normalizes PostgREST array results from {@link fetchPointConversionWithSelectFallback}.
+ */
+export function pointConversionRowsFromSelectData(
+  data: unknown
+): Record<string, unknown>[] {
+  if (!Array.isArray(data)) return [];
+  return data as Record<string, unknown>[];
+}
 
 /**
  * Runs a `point_conversions` PostgREST call with the broadest column list, then
@@ -93,12 +97,12 @@ type PointConversionQueryResult = { data: unknown; error: PgLikeError };
 export async function fetchPointConversionWithSelectFallback(
   run: (columns: string) => PromiseLike<PointConversionQueryResult>
 ): Promise<PointConversionQueryResult> {
-  const first = await run(getPointConversionSelectColumns());
+  const first = await run(pointConversionSelectColumnsForNextQuery());
   if (!first.error || !isMissingPointConversionRetryAuditDbError(first.error)) {
     return first;
   }
-  disablePointConversionRetryAuditSelect();
-  return run(getPointConversionSelectColumns());
+  pointConversionRetryAuditSelectEnabled = false;
+  return run(pointConversionSelectColumnsForNextQuery());
 }
 
 export const SPEND_TX_COLS = `

--- a/lib/db/spend-ledger-rows.ts
+++ b/lib/db/spend-ledger-rows.ts
@@ -21,7 +21,12 @@ export const SESSION_COLS = `
   completed_at
 `;
 
-export const CONVERSION_COLS = `
+/**
+ * `point_conversions` columns available before IRL-17 retry-audit fields
+ * (`database/point-conversions-retry-metadata.sql`). Prefer
+ * {@link fetchPointConversionWithSelectFallback} for reads so older DBs still work.
+ */
+export const CONVERSION_COLS_WITHOUT_RETRY_AUDIT = `
   id,
   spend_experience_id,
   spend_session_id,
@@ -37,13 +42,64 @@ export const CONVERSION_COLS = `
   funding_tx_hash,
   explorer_tx_url,
   idempotency_key,
-  conversion_attempt_count,
-  conversion_last_failure,
   created_at,
   completed_at,
   failed_reason,
   updated_at
 `;
+
+/** Full `point_conversions` read including IRL-17 retry audit columns when present. */
+export const CONVERSION_COLS_WITH_RETRY_AUDIT = `
+  ${CONVERSION_COLS_WITHOUT_RETRY_AUDIT.trim()},
+  conversion_attempt_count,
+  conversion_last_failure
+`;
+
+/** @deprecated Prefer {@link getPointConversionSelectColumns} with {@link fetchPointConversionWithSelectFallback}. */
+export const CONVERSION_COLS = CONVERSION_COLS_WITH_RETRY_AUDIT;
+
+type PgLikeError = { code?: string; message?: string } | null | undefined;
+
+/** PostgreSQL `undefined_column` (e.g. missing IRL-17 migration). */
+export function isMissingPointConversionRetryAuditDbError(
+  error: PgLikeError
+): boolean {
+  if (!error || String(error.code) !== '42703') return false;
+  const msg = (error.message ?? '').toLowerCase();
+  return (
+    msg.includes('conversion_attempt_count') ||
+    msg.includes('conversion_last_failure')
+  );
+}
+
+let pointConversionRetryAuditSelectEnabled = true;
+
+export function getPointConversionSelectColumns(): string {
+  return pointConversionRetryAuditSelectEnabled
+    ? CONVERSION_COLS_WITH_RETRY_AUDIT
+    : CONVERSION_COLS_WITHOUT_RETRY_AUDIT;
+}
+
+function disablePointConversionRetryAuditSelect(): void {
+  pointConversionRetryAuditSelectEnabled = false;
+}
+
+type PointConversionQueryResult = { data: unknown; error: PgLikeError };
+
+/**
+ * Runs a `point_conversions` PostgREST call with the broadest column list, then
+ * retries without IRL-17 retry-audit columns if the DB has not applied that migration.
+ */
+export async function fetchPointConversionWithSelectFallback(
+  run: (columns: string) => PromiseLike<PointConversionQueryResult>
+): Promise<PointConversionQueryResult> {
+  const first = await run(getPointConversionSelectColumns());
+  if (!first.error || !isMissingPointConversionRetryAuditDbError(first.error)) {
+    return first;
+  }
+  disablePointConversionRetryAuditSelect();
+  return run(getPointConversionSelectColumns());
+}
 
 export const SPEND_TX_COLS = `
   id,

--- a/lib/db/spend-sessions.ts
+++ b/lib/db/spend-sessions.ts
@@ -1,6 +1,6 @@
 import { supabase } from './client';
 import {
-  CONVERSION_COLS,
+  fetchPointConversionWithSelectFallback,
   SESSION_COLS,
   SPEND_TX_COLS,
   rowToConversion,
@@ -58,11 +58,13 @@ export async function getSpendTransactionBySessionId(
 export async function getPointConversionBySessionId(
   sessionId: string
 ): Promise<PointConversion | null> {
-  const { data, error } = await supabase
-    .from('point_conversions')
-    .select(CONVERSION_COLS)
-    .eq('spend_session_id', sessionId)
-    .maybeSingle();
+  const { data, error } = await fetchPointConversionWithSelectFallback((cols) =>
+    supabase
+      .from('point_conversions')
+      .select(cols)
+      .eq('spend_session_id', sessionId)
+      .maybeSingle()
+  );
 
   if (error) {
     console.error('getPointConversionBySessionId error:', error);
@@ -79,13 +81,15 @@ export async function getFundedPointConversionForUserExperience(
   spendExperienceId: string,
   userId: string
 ): Promise<PointConversion | null> {
-  const { data, error } = await supabase
-    .from('point_conversions')
-    .select(CONVERSION_COLS)
-    .eq('spend_experience_id', spendExperienceId)
-    .eq('user_id', userId)
-    .eq('status', 'funded')
-    .maybeSingle();
+  const { data, error } = await fetchPointConversionWithSelectFallback((cols) =>
+    supabase
+      .from('point_conversions')
+      .select(cols)
+      .eq('spend_experience_id', spendExperienceId)
+      .eq('user_id', userId)
+      .eq('status', 'funded')
+      .maybeSingle()
+  );
 
   if (error) {
     console.error('getFundedPointConversionForUserExperience error:', error);
@@ -321,12 +325,14 @@ export async function updatePointConversionFields(
     >
   >
 ): Promise<PointConversion> {
-  const { data, error } = await supabase
-    .from('point_conversions')
-    .update(patch)
-    .eq('id', conversionId)
-    .select(CONVERSION_COLS)
-    .single();
+  const { data, error } = await fetchPointConversionWithSelectFallback((cols) =>
+    supabase
+      .from('point_conversions')
+      .update(patch)
+      .eq('id', conversionId)
+      .select(cols)
+      .single()
+  );
 
   if (error || !data) {
     console.error('updatePointConversionFields:', error);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Admin spend activity (`listSpendPilotActivityForExperience`) and other `point_conversions` reads used a fixed `.select()` list that included IRL-17 columns `conversion_attempt_count` and `conversion_last_failure`. Deployments that have not applied `database/point-conversions-retry-metadata.sql` return PostgreSQL error `42703` (undefined column), which broke the admin activity API.

## Changes

- Split column lists in `lib/db/spend-ledger-rows.ts`: `CONVERSION_COLS_WITHOUT_RETRY_AUDIT` and `CONVERSION_COLS_WITH_RETRY_AUDIT` (legacy `CONVERSION_COLS` remains an alias for the full list).
- Added `fetchPointConversionWithSelectFallback`, which retries the same query without the retry-audit columns when error `42703` references those column names, then caches the narrower list for the remainder of the process.
- Routed all full `point_conversions` reads in `lib/db/spend-admin.ts` and `lib/db/spend-sessions.ts` through this helper.

## Follow-up

Applying `database/point-conversions-retry-metadata.sql` on Supabase remains the right long-term fix for retry metadata and RPCs that depend on those columns. This change only makes read paths resilient when that migration is missing.

## Testing

- `yarn build`
- `yarn test app/api/admin/spend-experiences/[experienceId]/activity/__tests__/route.test.ts` (passed in an earlier run with related suite)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5458aec6-2e27-4433-b362-881cec2ef0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5458aec6-2e27-4433-b362-881cec2ef0b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

