### PR TITLE
fix: show spend conversion API errors

### DIFF
--- a/components/spend/spend-experience-page.test.tsx
+++ b/components/spend/spend-experience-page.test.tsx
@@ -1,0 +1,181 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { toast } from 'sonner';
+import { SpendExperiencePage } from '@/components/spend/spend-experience-page';
+import type { SpendExperience, SpendSession } from '@/lib/types';
+import type { SpendRailClientSummary } from '@/lib/spend-rail-config/types';
+
+const mocks = vi.hoisted(() => ({
+  getAccessToken: vi.fn(),
+  login: vi.fn(),
+  sendTransaction: vi.fn(),
+}));
+
+vi.mock('@privy-io/react-auth', () => ({
+  usePrivy: () => ({
+    user: {
+      id: 'privy-1',
+      wallet: { address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' },
+    },
+    login: mocks.login,
+    getAccessToken: mocks.getAccessToken,
+  }),
+  useSendTransaction: () => ({ sendTransaction: mocks.sendTransaction }),
+  useWallets: () => ({ wallets: [] }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  initMixpanel: vi.fn(),
+  trackEvent: vi.fn(),
+}));
+
+const spendExperience = {
+  id: 'exp-1',
+  title: 'IRL Spend',
+  description: null,
+  event_id: 'event-1',
+  status: 'active',
+  spend_rail: 'base_usdc',
+  points_to_usdc_rate: 1000,
+  max_usdc_per_user: 5,
+  treasury_wallet_address: '0x1111111111111111111111111111111111111111',
+  receiving_wallet_address: '0x2222222222222222222222222222222222222222',
+  privy_server_wallet_id: 'wallet-1',
+  server_wallet_address: '0x3333333333333333333333333333333333333333',
+  server_wallet_chain: 'base',
+  server_wallet_created_at: null,
+  spend_create_idempotency_key: null,
+  start_time: '2026-01-01T00:00:00.000Z',
+  end_time: '2026-01-02T00:00:00.000Z',
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+} satisfies SpendExperience;
+
+const session = {
+  id: 'sess-1',
+  spend_experience_id: spendExperience.id,
+  user_id: 'privy-1',
+  wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  spend_rail: 'base_usdc',
+  rail_user_wallet_address: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+  status: 'created',
+  qr_token_hash: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  expires_at: '2026-01-02T00:00:00.000Z',
+  completed_at: null,
+} satisfies SpendSession;
+
+const spendRailSummary = {
+  rail: 'base_usdc',
+  displayName: 'Base USDC',
+  networkLabel: 'Base',
+  assetSymbol: 'USDC',
+  explorerTxUrlTemplate: null,
+} satisfies SpendRailClientSummary;
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function renderSpendExperiencePage() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <SpendExperiencePage
+        experienceId={spendExperience.id}
+        initialExperience={spendExperience}
+      />
+    </QueryClientProvider>
+  );
+}
+
+describe('SpendExperiencePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getAccessToken.mockResolvedValue('token-1');
+  });
+
+  it('shows the conversion confirm API error message in the toast', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input);
+      if (url === `/api/spend-experiences/${spendExperience.id}/sessions`) {
+        return jsonResponse({
+          success: true,
+          data: {
+            session,
+            spendExperience,
+            created: false,
+            spendRailSummary,
+          },
+        });
+      }
+      if (url === `/api/spend-sessions/${session.id}/conversion/preview`) {
+        return jsonResponse({
+          success: true,
+          data: {
+            eligibility: {
+              status: 'eligible',
+              message: 'Ready to convert.',
+              preview: {
+                pointsRequired: 5000,
+                usdcAmount: 5,
+                receivingWalletAddress: session.wallet_address,
+                treasuryWalletAddress: spendExperience.treasury_wallet_address,
+                userPointsBalance: 7000,
+                userUsdcBalance: 0,
+                treasuryUsdcBalance: 100,
+              },
+            },
+            spendExperience,
+            session: {
+              id: session.id,
+              status: session.status,
+              expires_at: session.expires_at,
+            },
+            spendRailSummary,
+          },
+        });
+      }
+      if (url === `/api/spend-sessions/${session.id}/conversion/confirm`) {
+        return jsonResponse(
+          { success: false, error: 'This session has expired.' },
+          400
+        );
+      }
+
+      throw new Error(`Unexpected request: ${url}`);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    renderSpendExperiencePage();
+
+    await userEvent.click(
+      await screen.findByRole('button', {
+        name: /convert points to usdc on base/i,
+      })
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('This session has expired.');
+    });
+  });
+});

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -35,6 +35,7 @@ import {
   isSpendPaymentPrepareStoredActionV1,
   isSpendStellarUsdcBackendSubmitPreparedActionV1,
 } from '@/lib/spend-payment-prepare-types';
+import { getSpendConversionErrorMessage } from '@/lib/spend-conversion-error-message';
 
 type SpendExperiencePageProps = {
   experienceId: string;
@@ -108,8 +109,6 @@ type ReceiptResponse = {
 
 const WALLET_STEP_TIMEOUT_MS = 180_000;
 
-const SPEND_TOAST_CONVERSION_ERROR =
-  "We couldn't complete that step. Please try again, or contact support if it keeps happening.";
 const SPEND_TOAST_PAYMENT_ERROR =
   "We couldn't record your payment. Please try again, or contact support if it keeps happening.";
 const SPEND_TOAST_WALLET_ERROR =
@@ -397,8 +396,8 @@ export function SpendExperiencePage({
       }
       await invalidateSpendQueries();
     },
-    onError: () => {
-      toast.error(SPEND_TOAST_CONVERSION_ERROR);
+    onError: (error) => {
+      toast.error(getSpendConversionErrorMessage(error));
     },
   });
 

--- a/lib/spend-conversion-error-message.test.ts
+++ b/lib/spend-conversion-error-message.test.ts
@@ -27,4 +27,10 @@ describe('getSpendConversionErrorMessage', () => {
       SPEND_TOAST_CONVERSION_ERROR
     );
   });
+
+  it('falls back to the generic message when the API error body is blank', () => {
+    expect(getSpendConversionErrorMessage(new ApiError(400, '   '))).toBe(
+      SPEND_TOAST_CONVERSION_ERROR
+    );
+  });
 });

--- a/lib/spend-conversion-error-message.test.ts
+++ b/lib/spend-conversion-error-message.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import { ApiError } from '@/lib/api/client';
+import {
+  getSpendConversionErrorMessage,
+  SPEND_TOAST_CONVERSION_ERROR,
+} from '@/lib/spend-conversion-error-message';
+
+describe('getSpendConversionErrorMessage', () => {
+  it('surfaces expected API client errors from conversion confirm', () => {
+    expect(
+      getSpendConversionErrorMessage(
+        new ApiError(400, 'This session has expired.')
+      )
+    ).toBe('This session has expired.');
+  });
+
+  it('falls back to the generic message for server errors', () => {
+    expect(
+      getSpendConversionErrorMessage(
+        new ApiError(500, 'Internal treasury details')
+      )
+    ).toBe(SPEND_TOAST_CONVERSION_ERROR);
+  });
+
+  it('falls back to the generic message for non-API errors', () => {
+    expect(getSpendConversionErrorMessage(new Error('Network failed'))).toBe(
+      SPEND_TOAST_CONVERSION_ERROR
+    );
+  });
+});

--- a/lib/spend-conversion-error-message.ts
+++ b/lib/spend-conversion-error-message.ts
@@ -4,12 +4,12 @@ export const SPEND_TOAST_CONVERSION_ERROR =
   "We couldn't complete that step. Please try again, or contact support if it keeps happening.";
 
 export function getSpendConversionErrorMessage(error: unknown): string {
-  if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
-    const message = error.message.trim();
-    if (message) {
-      return message;
-    }
+  if (!(error instanceof ApiError)) {
+    return SPEND_TOAST_CONVERSION_ERROR;
   }
-
-  return SPEND_TOAST_CONVERSION_ERROR;
+  if (error.status < 400 || error.status >= 500) {
+    return SPEND_TOAST_CONVERSION_ERROR;
+  }
+  const message = error.message.trim();
+  return message || SPEND_TOAST_CONVERSION_ERROR;
 }

--- a/lib/spend-conversion-error-message.ts
+++ b/lib/spend-conversion-error-message.ts
@@ -1,0 +1,15 @@
+import { ApiError } from '@/lib/api/client';
+
+export const SPEND_TOAST_CONVERSION_ERROR =
+  "We couldn't complete that step. Please try again, or contact support if it keeps happening.";
+
+export function getSpendConversionErrorMessage(error: unknown): string {
+  if (error instanceof ApiError && error.status >= 400 && error.status < 500) {
+    const message = error.message.trim();
+    if (message) {
+      return message;
+    }
+  }
+
+  return SPEND_TOAST_CONVERSION_ERROR;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Surface expected spend conversion confirm API errors in the conversion toast.
- Keep the generic conversion toast for server and non-API failures.
- Add focused helper and spend page coverage for conversion toast message selection.

## Testing
- `yarn build` (via pre-commit hook)
- `yarn test components/spend/spend-experience-page.test.tsx lib/spend-conversion-error-message.test.ts "app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts"`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-89ee0a46-3f3f-44db-b2bf-72b995017603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-89ee0a46-3f3f-44db-b2bf-72b995017603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

