### PR TITLE
fix(map): interactive map geolocation, bounds seeding, and WebGL errors

### DIFF
--- a/components/location-lists-drawer.tsx
+++ b/components/location-lists-drawer.tsx
@@ -46,6 +46,8 @@ interface UserLocation {
 /** Include list locations within this distance (km) of the visible viewport, not only strictly inside it. */
 const VIEWPORT_NEARBY_RADIUS_KM = 25;
 
+const isDev = process.env.NODE_ENV === 'development';
+
 interface LocationListsDrawerProps {
   walletAddress?: string | null;
   onLocationFocus?: (location: DrawerLocationSummary) => void;
@@ -90,7 +92,9 @@ const isLocationInBounds = (
 ): boolean => {
   const coords = toLngLat(location);
   if (!coords) {
-    console.log('[Filter] Location missing coordinates:', location.name);
+    if (isDev) {
+      console.log('[Filter] Location missing coordinates:', location.name);
+    }
     return false;
   }
 
@@ -100,11 +104,16 @@ const isLocationInBounds = (
   // Check latitude bounds
   const latInBounds = latitude >= south && latitude <= north;
   if (!latInBounds) {
-    console.log(`[Filter] Location "${location.name}" FAILED latitude check:`, {
-      locationLat: latitude,
-      boundsSouth: south,
-      boundsNorth: north,
-    });
+    if (isDev) {
+      console.log(
+        `[Filter] Location "${location.name}" FAILED latitude check:`,
+        {
+          locationLat: latitude,
+          boundsSouth: south,
+          boundsNorth: north,
+        }
+      );
+    }
     return false;
   }
 
@@ -120,18 +129,22 @@ const isLocationInBounds = (
   }
 
   if (!lonInBounds) {
-    console.log(
-      `[Filter] Location "${location.name}" FAILED longitude check:`,
-      { locationLon: longitude, boundsWest: west, boundsEast: east }
-    );
+    if (isDev) {
+      console.log(
+        `[Filter] Location "${location.name}" FAILED longitude check:`,
+        { locationLon: longitude, boundsWest: west, boundsEast: east }
+      );
+    }
     return false;
   }
 
-  console.log(`[Filter] Location "${location.name}" PASSED:`, {
-    lat: latitude,
-    lon: longitude,
-    bounds,
-  });
+  if (isDev) {
+    console.log(`[Filter] Location "${location.name}" PASSED:`, {
+      lat: latitude,
+      lon: longitude,
+      bounds,
+    });
+  }
   return true;
 };
 
@@ -171,7 +184,7 @@ function expandMapBoundsByKm(bounds: MapBounds, radiusKm: number): MapBounds {
 
 /**
  * Effective bounds for filtering: visible viewport expanded by {@link VIEWPORT_NEARBY_RADIUS_KM}.
- * Returns null until the map has reported bounds.
+ * Returns null when the parent has not supplied bounds yet (briefly on first paint).
  */
 const getEffectiveBounds = (
   mapBounds: MapBounds | null | undefined,
@@ -227,35 +240,45 @@ export default function LocationListsDrawer({
 
   // Filter locations based on map bounds
   const filteredLists = useMemo(() => {
-    console.log('[Filter] Starting filter with mapBounds:', mapBounds);
+    if (isDev) {
+      console.log('[Filter] Starting filter with mapBounds:', mapBounds);
+    }
     const effectiveBounds = getEffectiveBounds(mapBounds, userLocation);
-    console.log('[Filter] Effective bounds:', effectiveBounds);
+    if (isDev) {
+      console.log('[Filter] Effective bounds:', effectiveBounds);
+    }
 
     if (!effectiveBounds) {
       return [];
     }
 
-    console.log(
-      `[Filter] Filtering ${lists.length} lists with bounds:`,
-      effectiveBounds
-    );
+    if (isDev) {
+      console.log(
+        `[Filter] Filtering ${lists.length} lists with bounds:`,
+        effectiveBounds
+      );
+    }
 
     const filtered = lists
       .filter((list) => (list.locations?.length ?? 0) > 0)
       .map((list) => {
         const locs = list.locations ?? [];
         const totalLocations = locs.length;
-        console.log(
-          `[Filter] Filtering list "${list.title}" with ${totalLocations} locations`
-        );
+        if (isDev) {
+          console.log(
+            `[Filter] Filtering list "${list.title}" with ${totalLocations} locations`
+          );
+        }
 
         const filteredLocations = locs.filter((location) =>
           isLocationInBounds(location, effectiveBounds)
         );
 
-        console.log(
-          `[Filter] List "${list.title}": ${filteredLocations.length}/${totalLocations} locations passed filter`
-        );
+        if (isDev) {
+          console.log(
+            `[Filter] List "${list.title}": ${filteredLocations.length}/${totalLocations} locations passed filter`
+          );
+        }
 
         return {
           ...list,
@@ -272,11 +295,13 @@ export default function LocationListsDrawer({
       0
     );
 
-    console.log(
-      `[Filter] Filtering complete. ${totalFiltered}/${totalOriginal} locations passed filter`
-    );
+    if (isDev) {
+      console.log(
+        `[Filter] Filtering complete. ${totalFiltered}/${totalOriginal} locations passed filter`
+      );
+    }
 
-    if (totalFiltered === 0 && totalOriginal > 0) {
+    if (isDev && totalFiltered === 0 && totalOriginal > 0) {
       console.warn(
         `[Filter] ⚠️ All ${totalOriginal} locations were filtered out!`,
         `No list locations within viewport + ${VIEWPORT_NEARBY_RADIUS_KM}km buffer.`,

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -219,13 +219,15 @@ export default function InteractiveMap({
     longitude: number;
   } | null>(null);
 
-  // Don't initialize bounds - wait for map to load and provide actual viewport bounds
+  // Seeded from viewState on mount; refined from the map instance when WebGL is available.
   const [mapBounds, setMapBounds] = useState<{
     north: number;
     south: number;
     east: number;
     west: number;
   } | null>(null);
+  /** Set when Mapbox / WebGL fails so we can show guidance instead of a blank map. */
+  const [mapRenderError, setMapRenderError] = useState<string | null>(null);
 
   const mapRef = useRef<any>(null);
   const hasSetInitialLocationRef = useRef(false);
@@ -274,9 +276,16 @@ export default function InteractiveMap({
         }));
       },
       (error) => {
-        console.warn('Geolocation error:', error);
+        // Code 2 (POSITION_UNAVAILABLE) is common on desktop without a precise fix; avoid noisy logs.
+        if (
+          process.env.NODE_ENV === 'development' &&
+          error.code !== error.POSITION_UNAVAILABLE
+        ) {
+          console.warn('Geolocation error:', error);
+        }
       },
-      { enableHighAccuracy: true, timeout: 10000, maximumAge: 30000 }
+      // Low accuracy works far more reliably than GPS-style fixes on laptops / Wi‑Fi.
+      { enableHighAccuracy: false, timeout: 15000, maximumAge: 300000 }
     );
   }, [initialLatitude, initialLongitude]);
 
@@ -447,10 +456,12 @@ export default function InteractiveMap({
                 east: bounds.getEast(),
                 west: bounds.getWest(),
               };
-              console.log(
-                '[MapBounds] Calculated from map instance:',
-                calculatedBounds
-              );
+              if (process.env.NODE_ENV === 'development') {
+                console.log(
+                  '[MapBounds] Calculated from map instance:',
+                  calculatedBounds
+                );
+              }
               return calculatedBounds;
             }
           }
@@ -464,10 +475,12 @@ export default function InteractiveMap({
                 east: bounds.getEast(),
                 west: bounds.getWest(),
               };
-              console.log(
-                '[MapBounds] Calculated from ref.getBounds():',
-                calculatedBounds
-              );
+              if (process.env.NODE_ENV === 'development') {
+                console.log(
+                  '[MapBounds] Calculated from ref.getBounds():',
+                  calculatedBounds
+                );
+              }
               return calculatedBounds;
             }
           }
@@ -495,15 +508,32 @@ export default function InteractiveMap({
         east: longitude + viewportWidthDegrees / 2,
         west: longitude - viewportWidthDegrees / 2,
       };
-      console.log('[MapBounds] Calculated fallback from viewState:', {
-        center: { latitude, longitude },
-        zoom,
-        bounds: fallbackBounds,
-      });
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[MapBounds] Calculated fallback from viewState:', {
+          center: { latitude, longitude },
+          zoom,
+          bounds: fallbackBounds,
+        });
+      }
       return fallbackBounds;
     },
     [viewState]
   );
+
+  // Keep list-drawer bounds in sync before the map fires move/load (slow init or WebGL failure).
+  useEffect(() => {
+    const bounds = calculateMapBounds(viewState);
+    if (bounds) {
+      setMapBounds(bounds);
+    }
+    // Intentionally lat/lng/zoom only: full viewState changes every pan frame while onMove already updates bounds when WebGL is active.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    viewState.latitude,
+    viewState.longitude,
+    viewState.zoom,
+    calculateMapBounds,
+  ]);
 
   // Handle deep link to specific location via placeId URL param
   const deepLinkHandledRef = useRef(false);
@@ -958,7 +988,6 @@ export default function InteractiveMap({
         setIsLocating(false);
       },
       (error) => {
-        console.warn('Geolocation error:', error);
         let errorMessage = 'Unable to retrieve your location.';
 
         switch (error.code) {
@@ -1747,14 +1776,19 @@ export default function InteractiveMap({
         onMoveEnd={() => {
           // Update map bounds when map movement ends - this ensures accurate bounds
           // This is the most accurate as it uses the actual map instance
-          console.log('[MapBounds] onMoveEnd triggered');
+          if (process.env.NODE_ENV === 'development') {
+            console.log('[MapBounds] onMoveEnd triggered');
+          }
           const bounds = calculateMapBounds();
           if (bounds) {
-            console.log('[MapBounds] Setting bounds from onMoveEnd:', bounds);
+            if (process.env.NODE_ENV === 'development') {
+              console.log('[MapBounds] Setting bounds from onMoveEnd:', bounds);
+            }
             setMapBounds(bounds);
           }
         }}
         onLoad={() => {
+          setMapRenderError(null);
           // Calculate initial bounds after map loads
           setTimeout(() => {
             const bounds = calculateMapBounds();
@@ -1762,6 +1796,25 @@ export default function InteractiveMap({
               setMapBounds(bounds);
             }
           }, 100);
+        }}
+        onError={(evt) => {
+          const raw =
+            evt && typeof evt === 'object' && 'error' in evt
+              ? (evt as { error?: unknown }).error
+              : evt;
+          const msg =
+            raw instanceof Error
+              ? raw.message
+              : typeof raw === 'string'
+                ? raw
+                : 'Unable to load the map.';
+          if (msg.toLowerCase().includes('webgl')) {
+            setMapRenderError(
+              'This map requires WebGL. Enable hardware acceleration in your browser settings, update your graphics drivers, or try a different browser.'
+            );
+          } else {
+            setMapRenderError(msg);
+          }
         }}
         onClick={onMapClick}
         mapStyle="mapbox://styles/mapbox/streets-v12"
@@ -1893,6 +1946,17 @@ export default function InteractiveMap({
           </Marker>
         )}
       </Map>
+
+      {mapRenderError ? (
+        <div
+          role="alert"
+          className="pointer-events-auto absolute inset-0 z-[25] flex items-center justify-center bg-black/80 px-4 py-8 text-center"
+        >
+          <p className="max-w-md text-sm leading-relaxed text-white">
+            {mapRenderError}
+          </p>
+        </div>
+      ) : null}
 
       {popupInfo && (
         <div className={mapCardBottomOverlayClassName}>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Chrome desktop issues seen on `/interactive-map`: noisy or failing geolocation, `mapBounds` staying null when Mapbox never emits move/load (including WebGL init failure), and unhelpful console output.

## Changes

- **Geolocation on first load:** Use `enableHighAccuracy: false`, a longer timeout, and allow cached positions (`maximumAge`) so laptops without a GPS-style fix are less likely to hit `POSITION_UNAVAILABLE` (code 2). Suppress routine `console.warn` for that code in production builds.
- **Map bounds:** After `calculateMapBounds` is defined, sync `mapBounds` from the current camera whenever latitude, longitude, or zoom change so `LocationListsDrawer` gets approximate viewport bounds even if `onMove` / `onLoad` never run (e.g. WebGL failure).
- **WebGL:** Handle Map `onError`, clear the message on successful `onLoad`, and show a full-screen overlay with guidance when the error mentions WebGL.
- **Console noise:** Gate `[MapBounds]` and `[Filter]` debug logs behind `NODE_ENV === 'development'`.

## Notes

- **CoreLocation / code 2:** The browser/OS cannot supply a position; the app cannot fix that, but we avoid high-accuracy requests that often trigger it on desktop and we avoid logging it as a warning in production.
- **Sentry CSP** from the screenshot is unchanged here; that would be a separate `connect-src` update in Next config if you want ingest allowed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d9109af9-fd10-4122-a038-91303dc23c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d9109af9-fd10-4122-a038-91303dc23c8f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

