### PR TITLE
fix(admin): Stellar treasury USDC balance on spend treasury API

### DIFF
--- a/lib/spend-server-wallet.test.ts
+++ b/lib/spend-server-wallet.test.ts
@@ -1,8 +1,28 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { spendServerWalletFundingMetadata } from './spend-server-wallet';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { readStellarTreasuryConfirmedUsdcBalance } from '@/lib/spend/stellar-treasury-funding';
+import { fetchUsdcBalanceOnBase } from '@/lib/walletconnect-poster-direct-usdc';
+
+vi.mock('@/lib/spend/stellar-treasury-funding');
+vi.mock('@/lib/walletconnect-poster-direct-usdc', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/walletconnect-poster-direct-usdc')
+    >();
+  return {
+    ...actual,
+    fetchUsdcBalanceOnBase: vi.fn(),
+  };
+});
+
+import {
+  fetchServerWalletUsdcBalanceSafe,
+  spendServerWalletFundingMetadata,
+} from './spend-server-wallet';
 
 const VALID_STELLAR =
   'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+const BASE_TREASURY = '0x1414141414141414141414141414141414141414' as const;
 
 describe('spendServerWalletFundingMetadata', () => {
   it('includes Base-specific funding copy and chain for base_usdc', () => {
@@ -53,5 +73,86 @@ describe('spendServerWalletFundingMetadata', () => {
     expect(m.fundingCalloutTitle).toBe('Fund the Stellar treasury');
     expect(m.fundingCalloutBody).toContain('Stellar');
     expect(m.fundingCalloutBody).not.toContain('Base');
+  });
+
+  it('marks stellar_usdc as funded when balance meets max_usdc_per_user', () => {
+    const m = spendServerWalletFundingMetadata(
+      { spend_rail: 'stellar_usdc', max_usdc_per_user: 5 },
+      5
+    );
+    expect(m.funded).toBe(true);
+    expect(m.usdcBalance).toBe(5);
+  });
+
+  it('marks stellar_usdc as funded when balance exceeds max_usdc_per_user', () => {
+    const m = spendServerWalletFundingMetadata(
+      { spend_rail: 'stellar_usdc', max_usdc_per_user: 2 },
+      10.5
+    );
+    expect(m.funded).toBe(true);
+  });
+
+  it('marks stellar_usdc as not funded when balance is below minimum', () => {
+    const m = spendServerWalletFundingMetadata(
+      { spend_rail: 'stellar_usdc', max_usdc_per_user: 5 },
+      4.99
+    );
+    expect(m.funded).toBe(false);
+  });
+});
+
+describe('fetchServerWalletUsdcBalanceSafe', () => {
+  const prevBaseTreasury =
+    process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS = BASE_TREASURY;
+  });
+
+  afterEach(() => {
+    if (prevBaseTreasury === undefined) {
+      delete process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS;
+    } else {
+      process.env.SPEND_RAIL_BASE_USDC_TREASURY_WALLET_ADDRESS =
+        prevBaseTreasury;
+    }
+  });
+
+  it('uses fetchUsdcBalanceOnBase for base_usdc', async () => {
+    vi.mocked(fetchUsdcBalanceOnBase).mockResolvedValue(42.25);
+    const balance = await fetchServerWalletUsdcBalanceSafe({
+      spend_rail: 'base_usdc',
+    });
+    expect(balance).toBe(42.25);
+    expect(fetchUsdcBalanceOnBase).toHaveBeenCalledTimes(1);
+    expect(readStellarTreasuryConfirmedUsdcBalance).not.toHaveBeenCalled();
+  });
+
+  it('uses readStellarTreasuryConfirmedUsdcBalance for stellar_usdc', async () => {
+    vi.mocked(readStellarTreasuryConfirmedUsdcBalance).mockResolvedValue(88);
+    const balance = await fetchServerWalletUsdcBalanceSafe({
+      spend_rail: 'stellar_usdc',
+    });
+    expect(balance).toBe(88);
+    expect(readStellarTreasuryConfirmedUsdcBalance).toHaveBeenCalledTimes(1);
+    expect(fetchUsdcBalanceOnBase).not.toHaveBeenCalled();
+  });
+
+  it('returns null and logs when Stellar balance read fails', async () => {
+    const err = new Error('horizon down');
+    vi.mocked(readStellarTreasuryConfirmedUsdcBalance).mockRejectedValue(err);
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const balance = await fetchServerWalletUsdcBalanceSafe({
+      spend_rail: 'stellar_usdc',
+    });
+
+    expect(balance).toBeNull();
+    expect(spy).toHaveBeenCalledWith(
+      'fetchServerWalletUsdcBalanceSafe stellar:',
+      err
+    );
+    spy.mockRestore();
   });
 });

--- a/lib/spend-server-wallet.test.ts
+++ b/lib/spend-server-wallet.test.ts
@@ -39,65 +39,75 @@ describe('spendServerWalletFundingMetadata', () => {
     expect(m.fundingCalloutBody).not.toMatch(/Privy/i);
   });
 
-  const prevStellar: Record<string, string | undefined> = {};
+  describe('stellar_usdc', () => {
+    const prevStellar: Record<string, string | undefined> = {};
 
-  beforeEach(() => {
-    for (const k of [
-      'SPEND_RAIL_STELLAR_USDC_ENABLED',
-      'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
-      'SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS',
-    ]) {
-      prevStellar[k] = process.env[k];
-    }
-    process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
-    process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
-    delete process.env.SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS;
-  });
+    beforeEach(() => {
+      for (const k of [
+        'SPEND_RAIL_STELLAR_USDC_ENABLED',
+        'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
+        'SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS',
+      ]) {
+        prevStellar[k] = process.env[k];
+      }
+      process.env.SPEND_RAIL_STELLAR_USDC_ENABLED = 'true';
+      process.env.SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS = VALID_STELLAR;
+      delete process.env.SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS;
+    });
 
-  afterEach(() => {
-    for (const [k, v] of Object.entries(prevStellar)) {
-      if (v === undefined) delete process.env[k];
-      else process.env[k] = v;
-    }
-  });
+    afterEach(() => {
+      for (const [k, v] of Object.entries(prevStellar)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    });
 
-  it('includes Stellar treasury copy for stellar_usdc', () => {
-    const m = spendServerWalletFundingMetadata(
-      { spend_rail: 'stellar_usdc', max_usdc_per_user: 3 },
-      null
+    it('includes Stellar treasury copy for stellar_usdc', () => {
+      const m = spendServerWalletFundingMetadata(
+        { spend_rail: 'stellar_usdc', max_usdc_per_user: 3 },
+        null
+      );
+      expect(m.spendRail).toBe('stellar_usdc');
+      expect(m.chain).toBe('stellar');
+      expect(m.paymentNetworkDisplayName).toBe('Stellar USDC');
+      expect(m.fundingNetworkLabel).toBe('Stellar');
+      expect(m.fundingCalloutTitle).toBe('Fund the Stellar treasury');
+      expect(m.fundingCalloutBody).toContain('Stellar');
+      expect(m.fundingCalloutBody).not.toContain('Base');
+    });
+
+    it.each([
+      {
+        max: 5,
+        balance: 5,
+        funded: true,
+        expectedUsdcBalance: 5,
+      },
+      {
+        max: 2,
+        balance: 10.5,
+        funded: true,
+        expectedUsdcBalance: undefined,
+      },
+      {
+        max: 5,
+        balance: 4.99,
+        funded: false,
+        expectedUsdcBalance: undefined,
+      },
+    ])(
+      'marks funded=$funded when balance=$balance vs max=$max',
+      ({ max, balance, funded, expectedUsdcBalance }) => {
+        const m = spendServerWalletFundingMetadata(
+          { spend_rail: 'stellar_usdc', max_usdc_per_user: max },
+          balance
+        );
+        expect(m.funded).toBe(funded);
+        if (expectedUsdcBalance !== undefined) {
+          expect(m.usdcBalance).toBe(expectedUsdcBalance);
+        }
+      }
     );
-    expect(m.spendRail).toBe('stellar_usdc');
-    expect(m.chain).toBe('stellar');
-    expect(m.paymentNetworkDisplayName).toBe('Stellar USDC');
-    expect(m.fundingNetworkLabel).toBe('Stellar');
-    expect(m.fundingCalloutTitle).toBe('Fund the Stellar treasury');
-    expect(m.fundingCalloutBody).toContain('Stellar');
-    expect(m.fundingCalloutBody).not.toContain('Base');
-  });
-
-  it('marks stellar_usdc as funded when balance meets max_usdc_per_user', () => {
-    const m = spendServerWalletFundingMetadata(
-      { spend_rail: 'stellar_usdc', max_usdc_per_user: 5 },
-      5
-    );
-    expect(m.funded).toBe(true);
-    expect(m.usdcBalance).toBe(5);
-  });
-
-  it('marks stellar_usdc as funded when balance exceeds max_usdc_per_user', () => {
-    const m = spendServerWalletFundingMetadata(
-      { spend_rail: 'stellar_usdc', max_usdc_per_user: 2 },
-      10.5
-    );
-    expect(m.funded).toBe(true);
-  });
-
-  it('marks stellar_usdc as not funded when balance is below minimum', () => {
-    const m = spendServerWalletFundingMetadata(
-      { spend_rail: 'stellar_usdc', max_usdc_per_user: 5 },
-      4.99
-    );
-    expect(m.funded).toBe(false);
   });
 });
 
@@ -143,16 +153,18 @@ describe('fetchServerWalletUsdcBalanceSafe', () => {
     const err = new Error('horizon down');
     vi.mocked(readStellarTreasuryConfirmedUsdcBalance).mockRejectedValue(err);
     const spy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    try {
+      const balance = await fetchServerWalletUsdcBalanceSafe({
+        spend_rail: 'stellar_usdc',
+      });
 
-    const balance = await fetchServerWalletUsdcBalanceSafe({
-      spend_rail: 'stellar_usdc',
-    });
-
-    expect(balance).toBeNull();
-    expect(spy).toHaveBeenCalledWith(
-      'fetchServerWalletUsdcBalanceSafe stellar:',
-      err
-    );
-    spy.mockRestore();
+      expect(balance).toBeNull();
+      expect(spy).toHaveBeenCalledWith(
+        'fetchServerWalletUsdcBalanceSafe stellar:',
+        err
+      );
+    } finally {
+      spy.mockRestore();
+    }
   });
 });

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -1,3 +1,4 @@
+import { readStellarTreasuryConfirmedUsdcBalance } from '@/lib/spend/stellar-treasury-funding';
 import {
   fetchUsdcBalanceOnBase,
   isEvmAddress,
@@ -174,9 +175,17 @@ export async function getServerWalletFundingStatus(params: {
   };
 }
 
-export function fetchServerWalletUsdcBalanceSafe(
+export async function fetchServerWalletUsdcBalanceSafe(
   experience: Pick<SpendExperience, 'spend_rail'>
 ): Promise<number | null> {
+  if (experience.spend_rail === 'stellar_usdc') {
+    try {
+      return await readStellarTreasuryConfirmedUsdcBalance();
+    } catch (error) {
+      console.error('fetchServerWalletUsdcBalanceSafe stellar:', error);
+      return null;
+    }
+  }
   return fetchUsdcBalanceSafe(
     experience.spend_rail,
     getSpendTreasuryWalletAddress(experience.spend_rail),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stellar spend experiences showed `—` for **Server wallet USDC** because `fetchServerWalletUsdcBalanceSafe` only resolved on-chain USDC for Base. This change uses the existing Horizon-backed reader for Stellar so the admin treasury endpoint returns the same live balance for both rails.

## Changes

- **`lib/spend-server-wallet.ts`**: For `spend_rail === 'stellar_usdc'`, call `readStellarTreasuryConfirmedUsdcBalance()` from `stellar-treasury-funding` (Horizon via `createStellarSpendHorizonServer`). On failure, log with the prefix `fetchServerWalletUsdcBalanceSafe stellar:` and return `null`. Base behavior is unchanged.
- **`lib/spend-server-wallet.test.ts`**: Tests for Base vs Stellar code paths, Stellar errors yielding `null`, and `spendServerWalletFundingMetadata` marking Stellar as funded when `usdcBalance >= max_usdc_per_user`.

No changes were required to `app/api/admin/spend-experiences/[experienceId]/treasury/route.ts`; it already passes the fetched balance into `spendServerWalletFundingMetadata` and exposes `serverWalletUsdcBalance`, `treasuryUsdcBalance`, and `funding.usdcBalance`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ac6a5035-58e7-4b65-8043-d70b5df4fb64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac6a5035-58e7-4b65-8043-d70b5df4fb64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

