### PR TITLE
fix(csp): allow Sentry ingest in Content-Security-Policy connect-src

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,13 +1,13 @@
 /**
- * Content Security Policy for the application. Allows Privy and Google Fonts
- * while restricting other sources.
+ * Content Security Policy for the application. Allows Privy, Google Fonts,
+ * Sentry ingest, and other required third parties while restricting other sources.
  * script-src uses 'unsafe-inline' because Next.js/React inject many inline scripts
  * whose hashes change per build; hash allowlists would need constant updates.
  */
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-eval' 'unsafe-inline' blob: https://*.privy.io https://api.mapbox.com https://*.mapbox.com https://www.googletagmanager.com https://*.googletagmanager.com;
-  connect-src 'self' https://*.privy.io https://*.privy.systems https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://*.mapbox.com https://api.developer.coinbase.com https://www.google-analytics.com https://*.google-analytics.com https://*.walletconnect.com https://api.pay.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://mainnet.base.org https://*.base.org https://*.alchemy.com https://*.publicnode.com https://*.llamarpc.com https://*.tenderly.co https://*.infura.io https://*.onfinality.io https://*.syndicate.io https://horizon.stellar.org https://horizon-testnet.stellar.org https://horizon-futurenet.stellar.org https://friendbot.stellar.org https://friendbot-futurenet.stellar.org https://rpc-futurenet.stellar.org https://*.stellar.org https://api-js.mixpanel.com https://api.mixpanel.com https://decide.mixpanel.com;
+  connect-src 'self' https://*.privy.io https://*.privy.systems https://api.mapbox.com https://events.mapbox.com https://*.tiles.mapbox.com https://*.mapbox.com https://api.developer.coinbase.com https://www.google-analytics.com https://*.google-analytics.com https://*.walletconnect.com https://api.pay.walletconnect.com https://*.walletconnect.org wss://*.walletconnect.com wss://*.walletconnect.org https://mainnet.base.org https://*.base.org https://*.alchemy.com https://*.publicnode.com https://*.llamarpc.com https://*.tenderly.co https://*.infura.io https://*.onfinality.io https://*.syndicate.io https://horizon.stellar.org https://horizon-testnet.stellar.org https://horizon-futurenet.stellar.org https://friendbot.stellar.org https://friendbot-futurenet.stellar.org https://rpc-futurenet.stellar.org https://*.stellar.org https://api-js.mixpanel.com https://api.mixpanel.com https://decide.mixpanel.com https://*.ingest.sentry.io https://*.ingest.us.sentry.io https://*.ingest.de.sentry.io;
   img-src 'self' data: blob: https:;
   object-src 'self' data: blob:;
   style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://api.mapbox.com https://*.mapbox.com;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,6 +1,8 @@
 /**
- * Content Security Policy for the application. Allows Privy, Google Fonts,
- * Sentry ingest, and other required third parties while restricting other sources.
+ * Content Security Policy for the application: allowlisted third parties the app
+ * depends on (Privy, Mapbox, wallets, analytics, Sentry, etc.) with restrictive defaults.
+ * Sentry needs explicit regional ingest patterns (e.g. *.ingest.us.sentry.io); a bare
+ * *.sentry.io entry does not match those multi-label hostnames under CSP wildcard rules.
  * script-src uses 'unsafe-inline' because Next.js/React inject many inline scripts
  * whose hashes change per build; hash allowlists would need constant updates.
  */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

In production, the browser console showed repeated failures when the Sentry Next.js SDK tried to `fetch` error envelopes to hosts such as `https://o*.ingest.us.sentry.io/...`. The response was blocked because those origins were not listed in `connect-src`.

## Change

Extended `connect-src` in `next.config.mjs` with Sentry ingest host patterns for default (`*.ingest.sentry.io`), US (`*.ingest.us.sentry.io`), and EU (`*.ingest.de.sentry.io`) regions. A generic `*.sentry.io` entry would not match these multi-label ingest hostnames under CSP wildcard rules.

## Verification

- `yarn lint` (pre-commit also ran `yarn build` successfully).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cdc960f-1a3a-4880-8e63-205dc2d2d294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cdc960f-1a3a-4880-8e63-205dc2d2d294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

