### PR TITLE
fix: use experience server wallet for Base spend funding

### DIFF
--- a/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
@@ -6,10 +6,10 @@ import { requireAdmin } from '@/lib/auth';
 import type { TreasuryTransaction } from '@/lib/types';
 import {
   fetchServerWalletUsdcBalanceSafe,
+  getSpendServerWalletTransferConfig,
   spendServerWalletFundingMetadata,
 } from '@/lib/spend-server-wallet';
 import {
-  getSpendBaseTreasuryPrivyTransferConfig,
   getSpendReceivingWalletAddress,
   getSpendTreasuryWalletAddress,
 } from '@/lib/spend-rail-config';
@@ -54,10 +54,13 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     }
 
     const rail = experience.spend_rail;
-    const treasuryWalletAddress = getSpendTreasuryWalletAddress(rail).trim();
+    const baseWalletCfg =
+      rail === 'base_usdc'
+        ? getSpendServerWalletTransferConfig(experience)
+        : null;
+    const treasuryWalletAddress =
+      baseWalletCfg?.address ?? getSpendTreasuryWalletAddress(rail).trim();
     const receivingWalletAddress = getSpendReceivingWalletAddress(rail).trim();
-    const privyCfg =
-      rail === 'base_usdc' ? getSpendBaseTreasuryPrivyTransferConfig() : null;
 
     const [serverWalletUsdcBalance, ledger] = await Promise.all([
       fetchServerWalletUsdcBalanceSafe(experience),
@@ -74,9 +77,10 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       spendExperienceId: experience.id,
       spendRail: rail,
       serverWalletAddress: treasuryWalletAddress,
-      privyServerWalletId: privyCfg?.walletId ?? null,
+      privyServerWalletId: baseWalletCfg?.walletId ?? null,
       serverWalletChain: rail === 'base_usdc' ? funding.chain : null,
-      serverWalletCreatedAt: null,
+      serverWalletCreatedAt:
+        rail === 'base_usdc' ? experience.server_wallet_created_at : null,
       serverWalletUsdcBalance,
       funding,
       treasuryWalletAddress,

--- a/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
+++ b/app/api/admin/spend-experiences/[experienceId]/treasury/route.ts
@@ -39,7 +39,8 @@ function ledgerTotalsFromRows(rows: TreasuryTransaction[]): {
 
 /**
  * GET /api/admin/spend-experiences/{experienceId}/treasury
- * Global rail treasury wallet (Base USDC), live USDC balance when applicable, optional ledger (PRD §12).
+ * Live treasury USDC balance, optional ledger, and funding metadata (PRD §12).
+ * For Base USDC, the funding wallet is the experience server wallet when configured, otherwise env rail treasury.
  */
 export async function GET(_request: NextRequest, { params }: RouteParams) {
   try {

--- a/app/api/admin/spend-experiences/__tests__/route.test.ts
+++ b/app/api/admin/spend-experiences/__tests__/route.test.ts
@@ -198,7 +198,7 @@ describe('POST /api/admin/spend-experiences', () => {
       })
     );
     expect(j.data.funding.serverWalletAddress).toBe(
-      '0x4444444444444444444444444444444444444444'
+      '0x9999999999999999999999999999999999999999'
     );
   });
 

--- a/lib/db/spend-experiences.ts
+++ b/lib/db/spend-experiences.ts
@@ -183,7 +183,10 @@ export async function createSpendExperience(
     spend_rail: input.spend_rail,
     points_to_usdc_rate: input.points_to_usdc_rate,
     max_usdc_per_user: input.max_usdc_per_user,
-    treasury_wallet_address: getSpendTreasuryWalletAddress(input.spend_rail),
+    treasury_wallet_address:
+      input.spend_rail === 'base_usdc'
+        ? input.server_wallet_address
+        : getSpendTreasuryWalletAddress(input.spend_rail),
     receiving_wallet_address: getSpendReceivingWalletAddress(input.spend_rail),
     privy_server_wallet_id: input.privy_server_wallet_id,
     server_wallet_address: input.server_wallet_address,

--- a/lib/spend-conversion-confirm.test.ts
+++ b/lib/spend-conversion-confirm.test.ts
@@ -19,6 +19,7 @@ const mockAssertSpendExperienceOpen = vi.fn();
 const mockAssertSpendRailAllows = vi.fn();
 const mockGetSpendPaymentRail = vi.fn();
 const mockGetTreasuryFundingMeta = vi.fn();
+const mockUpdatePointConversionFields = vi.fn();
 
 vi.mock('@/lib/db/spend-sessions', () => ({
   getPointConversionBySessionId: (...a: unknown[]) =>
@@ -29,7 +30,8 @@ vi.mock('@/lib/db/spend-sessions', () => ({
     mockRetryAtomic(...a),
   refundSpendConversionOnFundingFailure: vi.fn(),
   spendConversionFundingIdempotencyKey: (id: string) => `fund_user:${id}`,
-  updatePointConversionFields: vi.fn(),
+  updatePointConversionFields: (...a: unknown[]) =>
+    mockUpdatePointConversionFields(...a),
   updateSpendSessionStatus: vi.fn(),
 }));
 
@@ -188,6 +190,8 @@ describe('runSpendConversionConfirm (IRL-17 retry)', () => {
     mockAssertSpendExperienceOpen.mockReturnValue({ ok: true as const });
     mockAssertSpendRailAllows.mockReturnValue({ ok: true as const });
     mockGetTreasuryFundingMeta.mockReturnValue({
+      spendRail: 'base_usdc',
+      walletId: 'wallet-exp-1',
       treasuryAddress: '0x1111111111111111111111111111111111111111',
     });
     mockGetSpendPaymentRail.mockReturnValue({
@@ -289,6 +293,89 @@ describe('runSpendConversionConfirm (IRL-17 retry)', () => {
     expect(r.httpStatus).toBe(400);
     expect(r.error).toBe(
       SPEND_ELIGIBILITY_MESSAGES.conversion_failed_retry_exhausted
+    );
+  });
+
+  it('uses the experience Base server wallet for conversion RPC and rail funding', async () => {
+    const pointConversion: PointConversion = {
+      ...failedConversion(0, {
+        status: 'points_deducted',
+        conversion_attempt_count: 1,
+        completed_at: null,
+        failed_reason: null,
+        conversion_last_failure: null,
+      }),
+    };
+    const initiateUserFunding = vi.fn().mockResolvedValue({
+      ok: true as const,
+      value: {
+        status: 'pending' as const,
+        txReference: 'pending:privy-tx-1',
+      },
+    });
+    mockGetSpendPaymentRail.mockReturnValue({
+      getTreasurySpendableBalance: async () => ({
+        ok: true as const,
+        value: 100,
+      }),
+      runWalletReadinessOrchestration: vi.fn().mockResolvedValue({
+        ok: true as const,
+        value: { status: 'completed' as const },
+      }),
+      initiateUserFunding,
+    });
+    mockGetTreasuryFundingMeta.mockReturnValue({
+      spendRail: 'base_usdc',
+      walletId: 'wallet-exp-1',
+      treasuryAddress: '0x9999999999999999999999999999999999999999',
+    });
+    mockLoadEligibility.mockResolvedValue({
+      status: 'eligible',
+      message: 'eligible',
+      preview: {},
+    });
+    mockGetPlayerByWallet.mockResolvedValue({ total_points: 6000 });
+    mockConfirmAtomic.mockResolvedValue({
+      outcome: 'created',
+      conversionId: pointConversion.id,
+      playerTotalPoints: 1000,
+    });
+    mockGetPointConversion
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(pointConversion);
+    mockUpdatePointConversionFields.mockResolvedValue({
+      ...pointConversion,
+      status: 'needs_review',
+      funding_tx_hash: 'pending:privy-tx-1',
+    });
+
+    const r = await runSpendConversionConfirm({
+      session: baseSession,
+      spendExperience: {
+        ...baseExperience,
+        privy_server_wallet_id: 'wallet-exp-1',
+        server_wallet_address: '0x9999999999999999999999999999999999999999',
+      },
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'privy-1',
+      distinctId: 'd',
+      usdcAmount: 5,
+      pointsRequired: 5000,
+      intent: 'confirm',
+    });
+
+    expect(r.ok).toBe(true);
+    expect(mockConfirmAtomic).toHaveBeenCalledWith(
+      expect.objectContaining({
+        treasuryWalletAddress: '0x9999999999999999999999999999999999999999',
+      })
+    );
+    expect(initiateUserFunding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        treasuryFundingWalletId: 'wallet-exp-1',
+        treasuryFundingWalletAddress:
+          '0x9999999999999999999999999999999999999999',
+      })
     );
   });
 });

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -39,7 +39,10 @@ import {
 import { spendConversionResumeInvokesWalletReadinessOrchestration } from '@/lib/spend/spend-conversion-resume-policy';
 import { getSpendPaymentRail } from '@/lib/spend/payment-rails';
 import { getStellarTreasuryFundingTxOutcome } from '@/lib/spend/stellar-treasury-funding';
-import type { SpendPaymentRailSessionContext } from '@/lib/spend/payment-rails/types';
+import type {
+  SpendPaymentRailSessionContext,
+  SpendTreasuryBalanceRailContext,
+} from '@/lib/spend/payment-rails/types';
 import {
   spendRailErrorCategoryToHttpStatus,
   spendRailErrorTreasuryInsufficientFunds,
@@ -76,6 +79,17 @@ const RESUMABLE: PointConversion['status'][] = [
 ];
 const MISCONFIGURED_CONVERSION_ERROR =
   'Conversion is not configured correctly. Please contact support.';
+
+function baseTreasuryBalanceRailContext(
+  meta: ReturnType<typeof getSpendTreasuryFundingWalletMeta>
+): SpendTreasuryBalanceRailContext | undefined {
+  if (!meta || meta.spendRail !== 'base_usdc') return undefined;
+  return {
+    treasuryFundingWalletId: meta.walletId,
+    treasuryFundingWalletAddress: meta.treasuryAddress,
+  };
+}
+
 const FUNDING_ACKNOWLEDGED_MESSAGE =
   'USDC transfer submitted. We are confirming it on Base.';
 
@@ -754,9 +768,21 @@ export async function runSpendConversionConfirm(
       };
     }
 
+    const retryTreasuryMeta =
+      getSpendTreasuryFundingWalletMeta(spendExperience);
+    if (!retryTreasuryMeta) {
+      return {
+        ok: false,
+        httpStatus: 500,
+        error: MISCONFIGURED_CONVERSION_ERROR,
+      };
+    }
+
     const retryTreasury = await getSpendPaymentRail(
       session.spend_rail
-    ).getTreasurySpendableBalance();
+    ).getTreasurySpendableBalance(
+      baseTreasuryBalanceRailContext(retryTreasuryMeta)
+    );
     if (!retryTreasury.ok) {
       return {
         ok: false,
@@ -982,9 +1008,18 @@ export async function runSpendConversionConfirm(
     };
   }
 
+  const treasuryMeta = getSpendTreasuryFundingWalletMeta(spendExperience);
+  if (!treasuryMeta) {
+    return {
+      ok: false,
+      httpStatus: 500,
+      error: MISCONFIGURED_CONVERSION_ERROR,
+    };
+  }
+
   const confirmTreasury = await getSpendPaymentRail(
     session.spend_rail
-  ).getTreasurySpendableBalance();
+  ).getTreasurySpendableBalance(baseTreasuryBalanceRailContext(treasuryMeta));
   if (!confirmTreasury.ok) {
     return {
       ok: false,
@@ -1011,15 +1046,6 @@ export async function runSpendConversionConfirm(
         session.spend_rail === 'stellar_usdc'
           ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
           : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient,
-    };
-  }
-
-  const treasuryMeta = getSpendTreasuryFundingWalletMeta(spendExperience);
-  if (!treasuryMeta) {
-    return {
-      ok: false,
-      httpStatus: 500,
-      error: MISCONFIGURED_CONVERSION_ERROR,
     };
   }
 

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -309,6 +309,9 @@ async function runWalletReadinessAndUserFunding(input: {
     spendExperienceId: spendExperience.id,
     pointConversionId: conv.id,
     fundingReferenceId: fundingKey,
+    treasuryFundingWalletId:
+      treasuryMeta.spendRail === 'base_usdc' ? treasuryMeta.walletId : null,
+    treasuryFundingWalletAddress: treasuryMeta.treasuryAddress,
     embeddedEvmWalletAddress: embeddedSpendWalletForSession(session),
     privyNormalizedWalletAddressLower: normalizedWallet,
     sessionOwnerPrivyUserId: session.user_id,

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -455,9 +455,13 @@ describe('buildSpendEligibilityPreview', () => {
       for (const k of [
         'SPEND_RAIL_STELLAR_USDC_ENABLED',
         'SPEND_RAIL_STELLAR_USDC_RECEIVING_ADDRESS',
+        'SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS',
         'NEXT_PUBLIC_STELLAR_NETWORK',
+        'NEXT_PUBLIC_STELLAR_HORIZON_URL',
+        'NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE',
         'SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY',
         'SPEND_RAIL_STELLAR_USDC_TREASURY_SECRET_KEY',
+        'SPEND_RAIL_STELLAR_USDC_USDC_ISSUER',
       ]) {
         prev[k] = process.env[k];
       }
@@ -466,6 +470,11 @@ describe('buildSpendEligibilityPreview', () => {
       process.env.SPEND_RAIL_STELLAR_USDC_SPONSOR_SECRET_KEY = kp.secret();
       process.env.SPEND_RAIL_STELLAR_USDC_TREASURY_SECRET_KEY = kp.secret();
       process.env.NEXT_PUBLIC_STELLAR_NETWORK = 'PUBLIC';
+      delete process.env.SPEND_RAIL_STELLAR_USDC_TREASURY_ADDRESS;
+      delete process.env.NEXT_PUBLIC_STELLAR_HORIZON_URL;
+      delete process.env
+        .NEXT_PUBLIC_SPEND_RAIL_STELLAR_USDC_EXPLORER_TX_URL_TEMPLATE;
+      delete process.env.SPEND_RAIL_STELLAR_USDC_USDC_ISSUER;
     });
 
     afterEach(() => {

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -133,28 +133,28 @@ export function buildSpendEligibilityPreview(
   const railPublic = getSpendRailPublicMetadata(spendExperience.spend_rail);
   const { networkLabel, assetSymbol: railAssetSymbol } = railPublic;
 
+  const previewTreasuryFundingMeta =
+    getSpendTreasuryFundingWalletMeta(spendExperience);
+
   const treasuryInsufficientMessage =
     spendExperience.spend_rail === 'stellar_usdc'
       ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
       : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
 
-  const basePreview = (): SpendConversionPreview => {
-    const fundingMeta = getSpendTreasuryFundingWalletMeta(spendExperience);
-    return {
-      pointsRequired,
-      usdcAmount,
-      receivingWalletAddress: getSpendReceivingWalletAddress(
-        spendExperience.spend_rail
-      ),
-      treasuryWalletAddress:
-        fundingMeta?.treasuryAddress ??
-        getSpendTreasuryWalletAddress(spendExperience.spend_rail),
-      userPointsBalance:
-        player?.total_points != null ? Number(player.total_points) : null,
-      userUsdcBalance,
-      treasuryUsdcBalance,
-    };
-  };
+  const basePreview = (): SpendConversionPreview => ({
+    pointsRequired,
+    usdcAmount,
+    receivingWalletAddress: getSpendReceivingWalletAddress(
+      spendExperience.spend_rail
+    ),
+    treasuryWalletAddress:
+      previewTreasuryFundingMeta?.treasuryAddress ??
+      getSpendTreasuryWalletAddress(spendExperience.spend_rail),
+    userPointsBalance:
+      player?.total_points != null ? Number(player.total_points) : null,
+    userUsdcBalance,
+    treasuryUsdcBalance,
+  });
 
   const railDiag = getSpendRailOperationalDiagnostics(session.spend_rail);
   /** Confirmed on-chain payment: receipt/read paths stay accurate if the rail is later disabled. */

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -21,6 +21,7 @@ import {
   okSpendRail,
   type SpendRailResult,
 } from '@/lib/spend/payment-rails/spend-payment-rail';
+import { getSpendTreasuryFundingWalletMeta } from '@/lib/spend-server-wallet';
 import type {
   PointConversion,
   Player,
@@ -137,20 +138,23 @@ export function buildSpendEligibilityPreview(
       ? SPEND_STELLAR_TREASURY_INSUFFICIENT_MESSAGE
       : SPEND_ELIGIBILITY_MESSAGES.treasury_insufficient;
 
-  const basePreview = (): SpendConversionPreview => ({
-    pointsRequired,
-    usdcAmount,
-    receivingWalletAddress: getSpendReceivingWalletAddress(
-      spendExperience.spend_rail
-    ),
-    treasuryWalletAddress: getSpendTreasuryWalletAddress(
-      spendExperience.spend_rail
-    ),
-    userPointsBalance:
-      player?.total_points != null ? Number(player.total_points) : null,
-    userUsdcBalance,
-    treasuryUsdcBalance,
-  });
+  const basePreview = (): SpendConversionPreview => {
+    const fundingMeta = getSpendTreasuryFundingWalletMeta(spendExperience);
+    return {
+      pointsRequired,
+      usdcAmount,
+      receivingWalletAddress: getSpendReceivingWalletAddress(
+        spendExperience.spend_rail
+      ),
+      treasuryWalletAddress:
+        fundingMeta?.treasuryAddress ??
+        getSpendTreasuryWalletAddress(spendExperience.spend_rail),
+      userPointsBalance:
+        player?.total_points != null ? Number(player.total_points) : null,
+      userUsdcBalance,
+      treasuryUsdcBalance,
+    };
+  };
 
   const railDiag = getSpendRailOperationalDiagnostics(session.spend_rail);
   /** Confirmed on-chain payment: receipt/read paths stay accurate if the rail is later disabled. */

--- a/lib/spend-server-wallet.test.ts
+++ b/lib/spend-server-wallet.test.ts
@@ -1,10 +1,30 @@
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
-import { spendServerWalletFundingMetadata } from './spend-server-wallet';
+import {
+  getSpendServerWalletTransferConfig,
+  spendServerWalletFundingMetadata,
+} from './spend-server-wallet';
 
 const VALID_STELLAR =
   'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
 
 describe('spendServerWalletFundingMetadata', () => {
+  it('uses the Base server wallet stored on the experience before env fallback', () => {
+    const experience = {
+      spend_rail: 'base_usdc' as const,
+      max_usdc_per_user: 5,
+      privy_server_wallet_id: 'wallet-exp-1',
+      server_wallet_address: '0x9999999999999999999999999999999999999999',
+    };
+
+    expect(getSpendServerWalletTransferConfig(experience)).toEqual({
+      walletId: 'wallet-exp-1',
+      address: '0x9999999999999999999999999999999999999999',
+    });
+    expect(
+      spendServerWalletFundingMetadata(experience, null).serverWalletAddress
+    ).toBe('0x9999999999999999999999999999999999999999');
+  });
+
   it('includes Base-specific funding copy and chain for base_usdc', () => {
     const m = spendServerWalletFundingMetadata(
       { spend_rail: 'base_usdc', max_usdc_per_user: 5 },

--- a/lib/spend-server-wallet.ts
+++ b/lib/spend-server-wallet.ts
@@ -42,9 +42,18 @@ export type SpendServerWalletTransferConfig = {
   address: `0x${string}`;
 };
 
+type BaseWalletConfigSource = Pick<SpendExperience, 'spend_rail'> &
+  Partial<
+    Pick<SpendExperience, 'privy_server_wallet_id' | 'server_wallet_address'>
+  >;
+
 /** Treasury address used for conversion funding ledger + atomic RPC (rail-specific shape). */
 export type SpendTreasuryFundingWalletMeta =
-  | { spendRail: 'base_usdc'; treasuryAddress: `0x${string}` }
+  | {
+      spendRail: 'base_usdc';
+      walletId: string;
+      treasuryAddress: `0x${string}`;
+    }
   | { spendRail: 'stellar_usdc'; treasuryAddress: string };
 
 /**
@@ -52,12 +61,16 @@ export type SpendTreasuryFundingWalletMeta =
  * Base continues to use the Privy server wallet id + address pair via `getSpendServerWalletTransferConfig`.
  */
 export function getSpendTreasuryFundingWalletMeta(
-  experience: Pick<SpendExperience, 'spend_rail'>
+  experience: BaseWalletConfigSource
 ): SpendTreasuryFundingWalletMeta | null {
   if (experience.spend_rail === 'base_usdc') {
     const cfg = getSpendServerWalletTransferConfig(experience);
     if (!cfg) return null;
-    return { spendRail: 'base_usdc', treasuryAddress: cfg.address };
+    return {
+      spendRail: 'base_usdc',
+      walletId: cfg.walletId,
+      treasuryAddress: cfg.address,
+    };
   }
   if (experience.spend_rail === 'stellar_usdc') {
     const raw = getSpendTreasuryWalletAddress('stellar_usdc').trim();
@@ -108,13 +121,20 @@ function fundingCalloutCopy(
 }
 
 export function spendServerWalletFundingMetadata(
-  experience: Pick<SpendExperience, 'spend_rail' | 'max_usdc_per_user'>,
+  experience: Pick<SpendExperience, 'spend_rail' | 'max_usdc_per_user'> &
+    Partial<
+      Pick<SpendExperience, 'privy_server_wallet_id' | 'server_wallet_address'>
+    >,
   usdcBalance: number | null
 ): SpendServerWalletFundingMetadata {
   const minimumUsdc = Number(experience.max_usdc_per_user);
   const callout = fundingCalloutCopy(experience);
+  const serverWalletAddress =
+    experience.spend_rail === 'base_usdc'
+      ? (getSpendServerWalletTransferConfig(experience)?.address ?? '')
+      : getSpendTreasuryWalletAddress(experience.spend_rail);
   return {
-    serverWalletAddress: getSpendTreasuryWalletAddress(experience.spend_rail),
+    serverWalletAddress,
     minimumUsdc,
     usdcBalance,
     funded: usdcBalance !== null && usdcBalance >= minimumUsdc,
@@ -124,10 +144,15 @@ export function spendServerWalletFundingMetadata(
 }
 
 export function getSpendServerWalletTransferConfig(
-  experience: Pick<SpendExperience, 'spend_rail'>
+  experience: BaseWalletConfigSource
 ): SpendServerWalletTransferConfig | null {
   if (!supportsSpendRailBasePrivyTreasuryFunding(experience.spend_rail)) {
     return null;
+  }
+  const walletId = experience.privy_server_wallet_id?.trim();
+  const address = experience.server_wallet_address?.trim();
+  if (walletId && address && isEvmAddress(address)) {
+    return { walletId, address: address as `0x${string}` };
   }
   const cfg = getSpendBaseTreasuryPrivyTransferConfig();
   if (!cfg) return null;
@@ -175,11 +200,15 @@ export async function getServerWalletFundingStatus(params: {
 }
 
 export function fetchServerWalletUsdcBalanceSafe(
-  experience: Pick<SpendExperience, 'spend_rail'>
+  experience: BaseWalletConfigSource
 ): Promise<number | null> {
+  const walletAddress =
+    experience.spend_rail === 'base_usdc'
+      ? getSpendServerWalletTransferConfig(experience)?.address
+      : getSpendTreasuryWalletAddress(experience.spend_rail);
   return fetchUsdcBalanceSafe(
     experience.spend_rail,
-    getSpendTreasuryWalletAddress(experience.spend_rail),
+    walletAddress,
     'fetchServerWalletUsdcBalanceSafe'
   );
 }

--- a/lib/spend/payment-rails/base-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.test.ts
@@ -211,6 +211,30 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     );
   });
 
+  it('initiateUserFunding uses the per-experience treasury wallet config from context', async () => {
+    const experienceWallet = '0x9999999999999999999999999999999999999999';
+    vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
+      ok: true,
+      submittedPending: true,
+      privyTransactionId: 'ptx-exp',
+    });
+    const res = await rail.initiateUserFunding({
+      spendSessionId: 's1',
+      embeddedEvmWalletAddress: EMBEDDED,
+      privyNormalizedWalletAddressLower: EMBEDDED.toLowerCase(),
+      treasuryFundingWalletId: 'wallet-exp-1',
+      treasuryFundingWalletAddress: experienceWallet,
+      usdcAmount: 5,
+    });
+    expect(res.ok).toBe(true);
+    expect(submitTreasuryUsdcTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverWalletId: 'wallet-exp-1',
+        serverWalletAddress: experienceWallet,
+      })
+    );
+  });
+
   it('initiateUserFunding returns submitted with tx hash when receipt is not yet final', async () => {
     vi.mocked(submitTreasuryUsdcTransfer).mockResolvedValue({
       ok: true,

--- a/lib/spend/payment-rails/base-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.test.ts
@@ -71,6 +71,23 @@ describe('createBaseUsdcSpendPaymentRail', () => {
     expect(res.value).toBeNull();
   });
 
+  it('getTreasurySpendableBalance uses per-experience wallet from context when provided', async () => {
+    const expWallet =
+      '0x9999999999999999999999999999999999999999' as `0x${string}`;
+    vi.spyOn(posterUsdc, 'fetchUsdcBalanceOnBase').mockResolvedValue(42);
+    const res = await rail.getTreasurySpendableBalance({
+      treasuryFundingWalletId: 'wallet-exp-1',
+      treasuryFundingWalletAddress: expWallet,
+    });
+    expect(res.ok).toBe(true);
+    if (!res.ok) throw new Error('unexpected');
+    expect(res.value).toBe(42);
+    expect(posterUsdc.fetchUsdcBalanceOnBase).toHaveBeenCalledWith(
+      expWallet,
+      expect.any(Object)
+    );
+  });
+
   it('runWalletReadinessOrchestration fails without a valid embedded wallet', async () => {
     const res = await rail.runWalletReadinessOrchestration({
       spendSessionId: 's1',

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -90,6 +90,17 @@ function embeddedEvmFromContext(
   return okSpendRail(embedded);
 }
 
+function treasuryTransferConfigFromContext(
+  ctx: SpendPaymentRailSessionContext
+): ReturnType<typeof getSpendBaseTreasuryPrivyTransferConfig> {
+  const walletId = ctx.treasuryFundingWalletId?.trim();
+  const address = ctx.treasuryFundingWalletAddress?.trim();
+  if (walletId && address && isEvmAddress(address)) {
+    return { walletId, address: address as `0x${string}` };
+  }
+  return getSpendBaseTreasuryPrivyTransferConfig();
+}
+
 export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
   const spendRail: SpendRail = 'base_usdc';
 
@@ -199,7 +210,7 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
       }
       const usdcAmount = ctx.usdcAmount;
 
-      const transferCfg = getSpendBaseTreasuryPrivyTransferConfig();
+      const transferCfg = treasuryTransferConfigFromContext(ctx);
       if (!transferCfg) {
         return errSpendRail(spendRailErrorFundingFailed());
       }

--- a/lib/spend/payment-rails/base-usdc-rail.ts
+++ b/lib/spend/payment-rails/base-usdc-rail.ts
@@ -9,12 +9,12 @@ import {
 import { verifySpendUsdcPaymentTx } from '@/lib/spend-payment-verify';
 import { isLedgerCanonicalEvmTxHash } from '@/lib/spend-ledger-explorer-url';
 import {
-  getSpendBaseTreasuryPrivyTransferConfig,
   getSpendRailBaseRpcUrl,
   getSpendRailBaseUsdcContractAddress,
   getSpendReceivingWalletAddress,
   getSpendTreasuryWalletAddress,
 } from '@/lib/spend-rail-config';
+import { getSpendServerWalletTransferConfig } from '@/lib/spend-server-wallet';
 import {
   spendRailErrorFundingFailed,
   spendRailErrorInvalidReceivingWallet,
@@ -47,6 +47,7 @@ import type {
   SpendPaymentRailSessionContext,
   SpendRailFundingOperationStatus,
   SpendRailPaymentOperationStatus,
+  SpendTreasuryBalanceRailContext,
 } from '@/lib/spend/payment-rails/types';
 
 function classifyTreasurySubmitFailure(message: string): SpendRailError {
@@ -90,27 +91,23 @@ function embeddedEvmFromContext(
   return okSpendRail(embedded);
 }
 
-function treasuryTransferConfigFromContext(
-  ctx: SpendPaymentRailSessionContext
-): ReturnType<typeof getSpendBaseTreasuryPrivyTransferConfig> {
-  const walletId = ctx.treasuryFundingWalletId?.trim();
-  const address = ctx.treasuryFundingWalletAddress?.trim();
-  if (walletId && address && isEvmAddress(address)) {
-    return { walletId, address: address as `0x${string}` };
-  }
-  return getSpendBaseTreasuryPrivyTransferConfig();
-}
-
 export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
   const spendRail: SpendRail = 'base_usdc';
 
   return {
     spendRail,
 
-    async getTreasurySpendableBalance(): Promise<
-      SpendRailResult<number | null>
-    > {
-      const treasury = getSpendTreasuryWalletAddress(spendRail).trim();
+    async getTreasurySpendableBalance(
+      ctx?: SpendTreasuryBalanceRailContext
+    ): Promise<SpendRailResult<number | null>> {
+      const transferCfg = getSpendServerWalletTransferConfig({
+        spend_rail: 'base_usdc',
+        privy_server_wallet_id: ctx?.treasuryFundingWalletId ?? undefined,
+        server_wallet_address: ctx?.treasuryFundingWalletAddress ?? undefined,
+      });
+      const treasury = (
+        transferCfg?.address ?? getSpendTreasuryWalletAddress(spendRail).trim()
+      ).trim();
       if (!treasury || !isEvmAddress(treasury)) {
         return okSpendRail(null);
       }
@@ -210,7 +207,11 @@ export function createBaseUsdcSpendPaymentRail(): SpendPaymentRail {
       }
       const usdcAmount = ctx.usdcAmount;
 
-      const transferCfg = treasuryTransferConfigFromContext(ctx);
+      const transferCfg = getSpendServerWalletTransferConfig({
+        spend_rail: 'base_usdc',
+        privy_server_wallet_id: ctx.treasuryFundingWalletId ?? undefined,
+        server_wallet_address: ctx.treasuryFundingWalletAddress ?? undefined,
+      });
       if (!transferCfg) {
         return errSpendRail(spendRailErrorFundingFailed());
       }

--- a/lib/spend/payment-rails/spend-payment-rail.ts
+++ b/lib/spend/payment-rails/spend-payment-rail.ts
@@ -6,6 +6,7 @@ import type {
   SpendPaymentRailSessionContext,
   SpendRailFundingOperationStatus,
   SpendRailPaymentOperationStatus,
+  SpendTreasuryBalanceRailContext,
   SpendWalletReadinessStatus,
 } from '@/lib/spend/payment-rails/types';
 import type {
@@ -56,8 +57,13 @@ export interface SpendPaymentRail {
   /**
    * Treasury USDC (or rail asset) spendable balance when the rail can resolve it server-side.
    * `null` means unknown / not loaded at this boundary (not an error).
+   *
+   * Base USDC: pass `treasuryFundingWalletId` / `treasuryFundingWalletAddress` when resolving
+   * the per-experience server wallet; omit to use env rail treasury only.
    */
-  getTreasurySpendableBalance(): Promise<SpendRailResult<number | null>>;
+  getTreasurySpendableBalance(
+    ctx?: SpendTreasuryBalanceRailContext
+  ): Promise<SpendRailResult<number | null>>;
 
   /**
    * Coarse wallet readiness orchestration (e.g. sponsored account + trustline). Base USDC

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -29,6 +29,7 @@ import type {
   SpendPaymentRailReconcileContext,
   SpendPaymentRailSessionContext,
   SpendRailFundingOperationStatus,
+  SpendTreasuryBalanceRailContext,
 } from '@/lib/spend/payment-rails/types';
 import { runStellarUsdcWalletReadinessOrchestration } from '@/lib/spend/stellar-wallet-readiness-orchestration';
 import {
@@ -113,9 +114,10 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
   return {
     spendRail,
 
-    async getTreasurySpendableBalance(): Promise<
-      SpendRailResult<number | null>
-    > {
+    async getTreasurySpendableBalance(
+      ctx?: SpendTreasuryBalanceRailContext
+    ): Promise<SpendRailResult<number | null>> {
+      void ctx;
       try {
         const v = await readStellarTreasuryConfirmedUsdcBalance();
         return okSpendRail(v);

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -54,6 +54,10 @@ export type SpendPaymentRailSessionContext = {
   embeddedEvmWalletAddress?: string;
   /** When set, Base readiness requires a case-insensitive match to `embeddedEvmWalletAddress`. */
   privyNormalizedWalletAddressLower?: string;
+  /** Base treasury Privy wallet id for this spend experience. */
+  treasuryFundingWalletId?: string | null;
+  /** Base treasury Privy wallet address for this spend experience. */
+  treasuryFundingWalletAddress?: string | null;
   /**
    * Spend session owner (`spend_sessions.user_id`, Privy user id). Required for Stellar
    * wallet readiness orchestration (IRL-21).

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -54,9 +54,15 @@ export type SpendPaymentRailSessionContext = {
   embeddedEvmWalletAddress?: string;
   /** When set, Base readiness requires a case-insensitive match to `embeddedEvmWalletAddress`. */
   privyNormalizedWalletAddressLower?: string;
-  /** Base treasury Privy wallet id for this spend experience. */
+  /**
+   * Base: Privy server wallet id for this conversion (same source as `SpendExperience.privy_server_wallet_id`).
+   * Stellar rails ignore this field.
+   */
   treasuryFundingWalletId?: string | null;
-  /** Base treasury Privy wallet address for this spend experience. */
+  /**
+   * Base: server wallet address for conversion funding (same source as `SpendExperience.server_wallet_address`).
+   * Stellar rails ignore this field.
+   */
   treasuryFundingWalletAddress?: string | null;
   /**
    * Spend session owner (`spend_sessions.user_id`, Privy user id). Required for Stellar
@@ -77,6 +83,12 @@ export type SpendPaymentRailSessionContext = {
    */
   analyticsDistinctId?: string;
 };
+
+/** Optional Base treasury hints for `SpendPaymentRail.getTreasurySpendableBalance`. */
+export type SpendTreasuryBalanceRailContext = Pick<
+  SpendPaymentRailSessionContext,
+  'treasuryFundingWalletId' | 'treasuryFundingWalletAddress'
+>;
 
 /**
  * Inputs for reconciliation passes (e.g. cron). IRL-15 defines shape only; behavior is no-op


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Merged latest `origin/main` into the branch and resolved simple conflicts in `lib/spend-server-wallet.ts` and `lib/spend-server-wallet.test.ts`.
- Combined compatible intents: `main` adds Stellar treasury balance reads; this branch keeps per-experience Base server wallet resolution.
- No complicated/conflicting-intent conflicts remain.

## Testing
- `yarn vitest run lib/spend-server-wallet.test.ts lib/spend/payment-rails/base-usdc-rail.test.ts lib/spend-conversion-confirm.test.ts app/api/admin/spend-experiences/__tests__/route.test.ts app/api/admin/spend-experiences/[experienceId]/treasury/__tests__/route.test.ts app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts lib/spend-conversion-preview.test.ts`: passed.
- `yarn build` (via pre-commit hook): passed with existing lint warnings for hooks and `<img>` usage.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-063972bf-15fb-498f-b02d-65526814765d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-063972bf-15fb-498f-b02d-65526814765d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

