### PR TITLE
fix: use valid Stellar trustline limit

### DIFF
--- a/lib/spend/stellar-wallet-readiness-orchestration.test.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.test.ts
@@ -1,0 +1,24 @@
+import { Asset, Operation } from '@stellar/stellar-sdk';
+import { describe, expect, it } from 'vitest';
+import {
+  buildStellarUsdcChangeTrustOperation,
+  STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
+} from './stellar-wallet-readiness-orchestration';
+
+const VALID_STELLAR_PUBLIC_KEY =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+describe('Stellar wallet readiness orchestration', () => {
+  it('builds the USDC trustline operation with a Stellar amount limit', () => {
+    const usdcAsset = new Asset('USDC', VALID_STELLAR_PUBLIC_KEY);
+
+    expect(() =>
+      Operation.changeTrust({
+        asset: usdcAsset,
+        limit: '9223372036854775807',
+      })
+    ).toThrow(/limit argument/);
+    expect(STELLAR_USDC_TRUSTLINE_MAX_LIMIT).toBe('922337203685.4775807');
+    expect(() => buildStellarUsdcChangeTrustOperation(usdcAsset)).not.toThrow();
+  });
+});

--- a/lib/spend/stellar-wallet-readiness-orchestration.test.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.test.ts
@@ -1,24 +1,28 @@
 import { Asset, Operation } from '@stellar/stellar-sdk';
 import { describe, expect, it } from 'vitest';
-import {
-  buildStellarUsdcChangeTrustOperation,
-  STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
-} from './stellar-wallet-readiness-orchestration';
+import { STELLAR_USDC_TRUSTLINE_MAX_LIMIT } from './stellar-wallet-readiness-orchestration';
 
 const VALID_STELLAR_PUBLIC_KEY =
   'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
+/** Int64-style string rejected by the SDK; Stellar amounts use decimal/scientific format. */
+const INVALID_TRUSTLINE_LIMIT_FORMAT = '9223372036854775807';
+
 describe('Stellar wallet readiness orchestration', () => {
-  it('builds the USDC trustline operation with a Stellar amount limit', () => {
+  it('uses a Stellar-formatted max limit for USDC changeTrust', () => {
     const usdcAsset = new Asset('USDC', VALID_STELLAR_PUBLIC_KEY);
 
     expect(() =>
       Operation.changeTrust({
         asset: usdcAsset,
-        limit: '9223372036854775807',
+        limit: INVALID_TRUSTLINE_LIMIT_FORMAT,
       })
-    ).toThrow(/limit argument/);
-    expect(STELLAR_USDC_TRUSTLINE_MAX_LIMIT).toBe('922337203685.4775807');
-    expect(() => buildStellarUsdcChangeTrustOperation(usdcAsset)).not.toThrow();
+    ).toThrow();
+    expect(() =>
+      Operation.changeTrust({
+        asset: usdcAsset,
+        limit: STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
+      })
+    ).not.toThrow();
   });
 });

--- a/lib/spend/stellar-wallet-readiness-orchestration.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.ts
@@ -121,13 +121,6 @@ function hasUsdcTrustline(
   return false;
 }
 
-export function buildStellarUsdcChangeTrustOperation(asset: Asset) {
-  return Operation.changeTrust({
-    asset,
-    limit: STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
-  });
-}
-
 async function waitForHorizonTxSuccess(
   server: Horizon.Server,
   txHash: string
@@ -507,7 +500,12 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
         source: sponsor.publicKey(),
       })
     )
-    .addOperation(buildStellarUsdcChangeTrustOperation(usdcAsset))
+    .addOperation(
+      Operation.changeTrust({
+        asset: usdcAsset,
+        limit: STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
+      })
+    )
     .addOperation(
       Operation.endSponsoringFutureReserves({
         source: sponsor.publicKey(),

--- a/lib/spend/stellar-wallet-readiness-orchestration.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.ts
@@ -52,6 +52,7 @@ export type StellarWalletReadinessCurrentStep =
 
 const HORIZON_TX_POLL_ATTEMPTS = 8;
 const HORIZON_TX_POLL_INTERVAL_MS = 1500;
+export const STELLAR_USDC_TRUSTLINE_MAX_LIMIT = '922337203685.4775807';
 
 export type StellarWalletReadinessOrchestrationOutput =
   | { ok: true; status: 'completed'; address: string }
@@ -118,6 +119,13 @@ function hasUsdcTrustline(
     if (b.asset_code === code && b.asset_issuer === issuer) return true;
   }
   return false;
+}
+
+export function buildStellarUsdcChangeTrustOperation(asset: Asset) {
+  return Operation.changeTrust({
+    asset,
+    limit: STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
+  });
 }
 
 async function waitForHorizonTxSuccess(
@@ -499,12 +507,7 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
         source: sponsor.publicKey(),
       })
     )
-    .addOperation(
-      Operation.changeTrust({
-        asset: usdcAsset,
-        limit: '9223372036854775807',
-      })
-    )
+    .addOperation(buildStellarUsdcChangeTrustOperation(usdcAsset))
     .addOperation(
       Operation.endSponsoringFutureReserves({
         source: sponsor.publicKey(),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Use Stellar's decimal max trustline amount for USDC changeTrust operations.
- Add a regression test proving the old integer limit fails SDK validation and the new operation builder succeeds.

## Testing
- `yarn test lib/spend/stellar-wallet-readiness-orchestration.test.ts` passed.
- SDK smoke check rejected the old integer limit and accepted `922337203685.4775807`.
- `yarn test lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-conversion-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route build logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

