### PR TITLE
fix: externalize Stellar server packages

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -34,6 +34,13 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  experimental: {
+    serverComponentsExternalPackages: [
+      "@stellar/stellar-sdk",
+      "@stellar/stellar-base",
+      "@stellar/js-xdr",
+    ],
+  },
   images: {
     remotePatterns: [
       {

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -36,9 +36,9 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const nextConfig = {
   experimental: {
     serverComponentsExternalPackages: [
-      "@stellar/stellar-sdk",
-      "@stellar/stellar-base",
       "@stellar/js-xdr",
+      "@stellar/stellar-base",
+      "@stellar/stellar-sdk",
     ],
   },
   images: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Externalize Stellar server packages from App Router server bundles so conversion routes use Node package entrypoints instead of browser bundles that call deprecated `Buffer()` shims.

## Testing
- `node --trace-deprecation -e "require('./.next/server/app/api/spend-sessions/[sessionId]/conversion/confirm/route.js'); console.log('route import done')"` emitted no `DEP0005` Buffer warning after rebuild.
- `yarn test lib/spend/stellar-wallet-readiness-orchestration.test.ts lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-conversion-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.

## Notes
- The route import still surfaces a separate dependency `DEP0040` punycode warning from existing packages; this change targets the `DEP0005` Buffer warning reported on conversion confirm.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

