### PR TITLE
fix: retry failed Stellar wallet readiness

### DIFF
--- a/lib/spend/payment-rails/stellar-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.test.ts
@@ -77,7 +77,12 @@ import { createStellarUsdcSpendPaymentRail } from './stellar-usdc-rail';
 const sessionId = '770e8400-e29b-41d4-a716-446655440000';
 const STELLAR_G = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
-function pendingRow(opts?: { status?: 'pending' | 'completed' | 'failed' }) {
+function pendingRow(opts?: {
+  status?: 'pending' | 'completed' | 'failed';
+  sanitized_error_category?: string | null;
+  sanitized_error_code?: string | null;
+  step_metadata?: Record<string, unknown>;
+}) {
   const status = opts?.status ?? 'pending';
   return {
     id: '880e8400-e29b-41d4-a716-446655440001',
@@ -86,9 +91,9 @@ function pendingRow(opts?: { status?: 'pending' | 'completed' | 'failed' }) {
     spend_rail: 'stellar_usdc' as const,
     rail_user_wallet_address: null as string | null,
     status,
-    step_metadata: {},
-    sanitized_error_category: null,
-    sanitized_error_code: null,
+    step_metadata: opts?.step_metadata ?? {},
+    sanitized_error_category: opts?.sanitized_error_category ?? null,
+    sanitized_error_code: opts?.sanitized_error_code ?? null,
     internal_diagnostics: null,
     idempotency_key: `wallet_readiness:${sessionId}`,
     sponsor_treasury_transaction_id: null,
@@ -240,8 +245,13 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-18)', () =
 
   it('failed row resets to pending and retries orchestration', async () => {
     const retryRow = pendingRow();
+    const failedRow = pendingRow({
+      status: 'failed',
+      sanitized_error_category: 'wallet_readiness',
+      sanitized_error_code: 'READINESS_FAILED',
+    });
     hoisted.mockInsertOrGet.mockResolvedValue({
-      row: pendingRow({ status: 'failed' }),
+      row: failedRow,
       created: false,
     });
     hoisted.mockUpdateReadiness.mockResolvedValueOnce(retryRow);
@@ -249,9 +259,14 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-18)', () =
     const res = await rail.runWalletReadinessOrchestration(ctx);
     expect(res.ok).toBe(true);
     expect(hoisted.mockUpdateReadiness).toHaveBeenCalledWith(
-      pendingRow().id,
+      failedRow.id,
       expect.objectContaining({
         status: 'pending',
+        step_metadata: expect.objectContaining({
+          previous_sanitized_error_category: 'wallet_readiness',
+          previous_sanitized_error_code: 'READINESS_FAILED',
+          retried_from_failed_status_at: expect.any(String),
+        }),
         sanitized_error_category: null,
         sanitized_error_code: null,
         internal_diagnostics: null,

--- a/lib/spend/payment-rails/stellar-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.test.ts
@@ -238,15 +238,30 @@ describe('createStellarUsdcSpendPaymentRail — wallet readiness (IRL-18)', () =
     expect(hoisted.mockOrchestrator).toHaveBeenCalledTimes(1);
   });
 
-  it('failed row short-circuits without calling orchestration', async () => {
+  it('failed row resets to pending and retries orchestration', async () => {
+    const retryRow = pendingRow();
     hoisted.mockInsertOrGet.mockResolvedValue({
       row: pendingRow({ status: 'failed' }),
       created: false,
     });
+    hoisted.mockUpdateReadiness.mockResolvedValueOnce(retryRow);
     const rail = createStellarUsdcSpendPaymentRail();
     const res = await rail.runWalletReadinessOrchestration(ctx);
-    expect(res.ok).toBe(false);
-    expect(hoisted.mockOrchestrator).not.toHaveBeenCalled();
+    expect(res.ok).toBe(true);
+    expect(hoisted.mockUpdateReadiness).toHaveBeenCalledWith(
+      pendingRow().id,
+      expect.objectContaining({
+        status: 'pending',
+        sanitized_error_category: null,
+        sanitized_error_code: null,
+        internal_diagnostics: null,
+      })
+    );
+    expect(hoisted.mockOrchestrator).toHaveBeenCalledWith(
+      expect.objectContaining({
+        readinessRow: retryRow,
+      })
+    );
   });
 });
 

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -225,35 +225,53 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
         return okSpendRail({ status: 'completed' });
       }
 
+      let activeRow = row;
       if (row.status === 'failed') {
-        if (distinctId) {
-          trackSpendWalletReadinessFailed(distinctId, {
-            ...readinessProps(row.id),
-            wallet_readiness_operation_id: row.id,
-            sponsor_treasury_transaction_id:
-              row.sponsor_treasury_transaction_id,
-            trustline_treasury_transaction_id:
-              row.trustline_treasury_transaction_id,
-            ...spendPilotSanitizedFieldsFromWalletReadinessRow(
-              row.sanitized_error_category,
-              row.sanitized_error_code,
-              spendRailErrorWalletReadinessFailed()
-            ),
+        try {
+          activeRow = await updateSpendWalletReadinessFields(row.id, {
+            status: 'pending',
+            step_metadata: {
+              ...row.step_metadata,
+              retried_from_failed_status_at: new Date().toISOString(),
+              previous_sanitized_error_category: row.sanitized_error_category,
+              previous_sanitized_error_code: row.sanitized_error_code,
+            },
+            sanitized_error_category: null,
+            sanitized_error_code: null,
+            internal_diagnostics: null,
           });
+        } catch (e) {
+          console.error('stellar_usdc failed readiness retry reset:', e);
+          const retryErr = classifyStellarReadinessException(e);
+          if (distinctId) {
+            trackSpendWalletReadinessFailed(distinctId, {
+              ...readinessProps(row.id),
+              wallet_readiness_operation_id: row.id,
+              sponsor_treasury_transaction_id:
+                row.sponsor_treasury_transaction_id,
+              trustline_treasury_transaction_id:
+                row.trustline_treasury_transaction_id,
+              ...spendPilotSanitizedFieldsFromWalletReadinessRow(
+                row.sanitized_error_category,
+                row.sanitized_error_code,
+                retryErr
+              ),
+            });
+          }
+          return errSpendRail(retryErr);
         }
-        return errSpendRail(spendRailErrorWalletReadinessFailed());
       }
 
       if (distinctId) {
         trackSpendWalletReadinessStarted(distinctId, {
-          ...readinessProps(row.id),
-          wallet_readiness_operation_id: row.id,
+          ...readinessProps(activeRow.id),
+          wallet_readiness_operation_id: activeRow.id,
         });
       }
 
       try {
         const outcome = await runStellarUsdcWalletReadinessOrchestration({
-          readinessRow: row,
+          readinessRow: activeRow,
           spendSessionId: sessionId,
           spendExperienceId: ctx.spendExperienceId,
           sessionOwnerPrivyUserId: privyUserId,
@@ -261,7 +279,7 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
 
         if (!outcome.ok) {
           try {
-            await updateSpendWalletReadinessFields(row.id, {
+            await updateSpendWalletReadinessFields(activeRow.id, {
               status: 'failed',
               sanitized_error_category: outcome.error.category,
               sanitized_error_code: outcome.error.analyticsCode,
@@ -275,8 +293,8 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
           }
           if (distinctId) {
             trackSpendWalletReadinessFailed(distinctId, {
-              ...readinessProps(row.id),
-              wallet_readiness_operation_id: row.id,
+              ...readinessProps(activeRow.id),
+              wallet_readiness_operation_id: activeRow.id,
               ...spendPilotSanitizedRailErrorFields(outcome.error),
             });
           }
@@ -294,8 +312,8 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
             const syncErr = classifyStellarReadinessException(e);
             if (distinctId) {
               trackSpendWalletReadinessFailed(distinctId, {
-                ...readinessProps(row.id),
-                wallet_readiness_operation_id: row.id,
+                ...readinessProps(activeRow.id),
+                wallet_readiness_operation_id: activeRow.id,
                 ...spendPilotSanitizedRailErrorFields(syncErr),
               });
             }
@@ -307,8 +325,8 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
           try {
             const fresh = await getSpendWalletReadinessBySessionId(sessionId);
             trackSpendWalletReadinessCompleted(distinctId, {
-              ...readinessProps(fresh?.id ?? row.id),
-              wallet_readiness_operation_id: fresh?.id ?? row.id,
+              ...readinessProps(fresh?.id ?? activeRow.id),
+              wallet_readiness_operation_id: fresh?.id ?? activeRow.id,
               sponsor_treasury_transaction_id:
                 fresh?.sponsor_treasury_transaction_id ?? null,
               trustline_treasury_transaction_id:
@@ -327,7 +345,7 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
         console.error('stellar_usdc runWalletReadinessOrchestration:', e);
         const railErr = classifyStellarReadinessException(e);
         try {
-          await updateSpendWalletReadinessFields(row.id, {
+          await updateSpendWalletReadinessFields(activeRow.id, {
             status: 'failed',
             sanitized_error_category: railErr.category,
             sanitized_error_code: railErr.analyticsCode,
@@ -341,8 +359,8 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
         }
         if (distinctId) {
           trackSpendWalletReadinessFailed(distinctId, {
-            ...readinessProps(row.id),
-            wallet_readiness_operation_id: row.id,
+            ...readinessProps(activeRow.id),
+            wallet_readiness_operation_id: activeRow.id,
             ...spendPilotSanitizedRailErrorFields(railErr),
           });
         }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reset failed Stellar wallet-readiness rows back to pending before retrying orchestration.
- Preserve the previous sanitized readiness failure in step metadata for diagnostics.
- Update the Stellar rail test to cover retrying a failed readiness row.

## Production finding
- The reported session's `spend_wallet_readiness_operations` row is `failed` from the previous invalid trustline limit TypeError (`limit argument must be of type String...`). This patch lets that row retry through the now-fixed orchestration instead of returning the stale failure immediately.

## Testing
- `yarn test lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend/stellar-wallet-readiness-orchestration.test.ts lib/spend-conversion-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

