### PR TITLE
fix: use default Stellar trustline limit

### DIFF
--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -283,7 +283,6 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
               status: 'failed',
               sanitized_error_category: outcome.error.category,
               sanitized_error_code: outcome.error.analyticsCode,
-              internal_diagnostics: { phase: 'orchestration_pre_ledger' },
             });
           } catch (persistErr) {
             console.error(

--- a/lib/spend/stellar-wallet-readiness-orchestration.test.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.test.ts
@@ -1,15 +1,135 @@
-import { Asset, Operation } from '@stellar/stellar-sdk';
-import { describe, expect, it } from 'vitest';
-import { STELLAR_USDC_TRUSTLINE_MAX_LIMIT } from './stellar-wallet-readiness-orchestration';
+import { Account, Asset, Operation } from '@stellar/stellar-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const VALID_STELLAR_PUBLIC_KEY =
   'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const TRUSTLINE_TREASURY_ID = '990e8400-e29b-41d4-a716-446655440002';
 
 /** Int64-style string rejected by the SDK; Stellar amounts use decimal/scientific format. */
 const INVALID_TRUSTLINE_LIMIT_FORMAT = '9223372036854775807';
 
+const hoisted = vi.hoisted(() => ({
+  mockUpdateReadiness: vi.fn(),
+  mockUpdateSessionRail: vi.fn(),
+  mockInsertTreasury: vi.fn(),
+  mockFinalizeTreasury: vi.fn(),
+  mockEnsureWallet: vi.fn(),
+  mockResolveWalletId: vi.fn(),
+  mockRawSign: vi.fn(),
+  mockServer: {
+    loadAccount: vi.fn(),
+    fetchBaseFee: vi.fn(),
+    submitTransaction: vi.fn(),
+    transactions: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/db/spend-wallet-readiness', () => ({
+  updateSpendWalletReadinessFields: (...args: unknown[]) =>
+    hoisted.mockUpdateReadiness(...args),
+}));
+
+vi.mock('@/lib/db/spend-sessions', () => ({
+  updateSpendSessionRailUserWalletAddress: (...args: unknown[]) =>
+    hoisted.mockUpdateSessionRail(...args),
+}));
+
+vi.mock('@/lib/db/treasury-transactions', () => ({
+  insertTreasuryStellarSetupRow: (...args: unknown[]) =>
+    hoisted.mockInsertTreasury(...args),
+  finalizeTreasuryStellarSetupRow: (...args: unknown[]) =>
+    hoisted.mockFinalizeTreasury(...args),
+}));
+
+vi.mock('@/lib/privy/stellar-rail-wallet', () => ({
+  ensureStellarRailUserWallet: (...args: unknown[]) =>
+    hoisted.mockEnsureWallet(...args),
+  resolveStellarPrivyWalletIdForUser: (...args: unknown[]) =>
+    hoisted.mockResolveWalletId(...args),
+}));
+
+vi.mock('@/lib/privy-server-rest', () => ({
+  privyWalletRawSignTransactionHash: (...args: unknown[]) =>
+    hoisted.mockRawSign(...args),
+}));
+
+vi.mock('@/lib/spend/stellar-wallet-readiness-config', async () => {
+  const { Keypair, Networks } = await import('@stellar/stellar-sdk');
+  return {
+    createStellarSpendHorizonServer: () => hoisted.mockServer,
+    getStellarSpendCreateAccountStartingBalance: () => '3',
+    getStellarSpendNetworkPassphrase: () => Networks.TESTNET,
+    getStellarSpendUsdcAssetCode: () => 'USDC',
+    getStellarSpendUsdcIssuer: () =>
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    parseStellarSpendSponsorKeypair: () =>
+      Keypair.fromSecret(
+        'SAPTCMRTYYW4H6ZU5YPH6LDJZYGEIECEPJYTBYPAX7KCFRRIVHJHGJFL'
+      ),
+  };
+});
+
+import { runStellarUsdcWalletReadinessOrchestration } from './stellar-wallet-readiness-orchestration';
+
+const readinessRow = () => ({
+  id: '880e8400-e29b-41d4-a716-446655440001',
+  spend_session_id: '770e8400-e29b-41d4-a716-446655440000',
+  user_id: 'privy-1',
+  spend_rail: 'stellar_usdc' as const,
+  rail_user_wallet_address: null,
+  status: 'pending' as const,
+  step_metadata: {},
+  sanitized_error_category: null,
+  sanitized_error_code: null,
+  internal_diagnostics: null,
+  idempotency_key: 'wallet_readiness:770e8400-e29b-41d4-a716-446655440000',
+  sponsor_treasury_transaction_id: null,
+  trustline_treasury_transaction_id: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+});
+
+function accountWithoutTrustline() {
+  return Object.assign(new Account(VALID_STELLAR_PUBLIC_KEY, '1'), {
+    balances: [],
+  });
+}
+
+function diagnosticsPatchFor(phase: string) {
+  return hoisted.mockUpdateReadiness.mock.calls
+    .map((call) => call[1] as Record<string, unknown>)
+    .find(
+      (patch) =>
+        (patch.internal_diagnostics as { phase?: string } | undefined)
+          ?.phase === phase
+    );
+}
+
 describe('Stellar wallet readiness orchestration', () => {
-  it('uses a Stellar-formatted max limit for USDC changeTrust', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.mockEnsureWallet.mockResolvedValue({
+      address: VALID_STELLAR_PUBLIC_KEY,
+      walletId: 'privy-wallet-1',
+      provisioned: false,
+    });
+    hoisted.mockResolveWalletId.mockResolvedValue('privy-wallet-1');
+    hoisted.mockUpdateReadiness.mockImplementation(
+      async (_id: string, patch: Record<string, unknown>) => ({
+        ...readinessRow(),
+        ...patch,
+      })
+    );
+    hoisted.mockInsertTreasury.mockResolvedValue(TRUSTLINE_TREASURY_ID);
+    hoisted.mockRawSign.mockResolvedValue(Buffer.alloc(64));
+    hoisted.mockServer.loadAccount.mockResolvedValue(accountWithoutTrustline());
+    hoisted.mockServer.fetchBaseFee.mockResolvedValue(100);
+    hoisted.mockServer.submitTransaction.mockResolvedValue({
+      hash: 'a'.repeat(64),
+    });
+  });
+
+  it('lets the SDK use its default max limit for USDC changeTrust', () => {
     const usdcAsset = new Asset('USDC', VALID_STELLAR_PUBLIC_KEY);
 
     expect(() =>
@@ -18,11 +138,95 @@ describe('Stellar wallet readiness orchestration', () => {
         limit: INVALID_TRUSTLINE_LIMIT_FORMAT,
       })
     ).toThrow();
-    expect(() =>
-      Operation.changeTrust({
-        asset: usdcAsset,
-        limit: STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
+
+    const op = Operation.changeTrust({ asset: usdcAsset });
+    expect(op.body().changeTrustOp().limit().toString()).toBe(
+      INVALID_TRUSTLINE_LIMIT_FORMAT
+    );
+  });
+
+  it('persists diagnostics when Privy raw signing fails during trustline setup', async () => {
+    hoisted.mockRawSign.mockRejectedValue(new Error('raw sign failed'));
+
+    const result = await runStellarUsdcWalletReadinessOrchestration({
+      readinessRow: readinessRow(),
+      spendSessionId: '770e8400-e29b-41d4-a716-446655440000',
+      spendExperienceId: '990e8400-e29b-41d4-a716-446655440003',
+      sessionOwnerPrivyUserId: 'privy-1',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(diagnosticsPatchFor('trustline_raw_sign')).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        sanitized_error_category: 'wallet_readiness_failed',
+        internal_diagnostics: expect.objectContaining({
+          phase: 'trustline_raw_sign',
+          error_name: 'Error',
+          error_message: 'raw sign failed',
+          wallet_id_suffix: 'wallet-1',
+          user_public_key: VALID_STELLAR_PUBLIC_KEY,
+        }),
       })
-    ).not.toThrow();
+    );
+  });
+
+  it('persists diagnostics when fee-bump construction fails during trustline setup', async () => {
+    hoisted.mockServer.fetchBaseFee.mockRejectedValue(new Error('fee failed'));
+
+    const result = await runStellarUsdcWalletReadinessOrchestration({
+      readinessRow: readinessRow(),
+      spendSessionId: '770e8400-e29b-41d4-a716-446655440000',
+      spendExperienceId: '990e8400-e29b-41d4-a716-446655440003',
+      sessionOwnerPrivyUserId: 'privy-1',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(diagnosticsPatchFor('trustline_fee_bump_build')).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        sanitized_error_category: 'wallet_readiness_failed',
+        internal_diagnostics: expect.objectContaining({
+          phase: 'trustline_fee_bump_build',
+          error_message: 'fee failed',
+          user_public_key: VALID_STELLAR_PUBLIC_KEY,
+        }),
+      })
+    );
+  });
+
+  it('persists diagnostics when Horizon submit fails during trustline setup', async () => {
+    const submitError = Object.assign(new Error('submit failed'), {
+      response: {
+        status: 400,
+        data: {
+          title: 'Transaction Failed',
+          extras: { result_codes: { transaction: 'tx_failed' } },
+        },
+      },
+    });
+    hoisted.mockServer.submitTransaction.mockRejectedValue(submitError);
+
+    const result = await runStellarUsdcWalletReadinessOrchestration({
+      readinessRow: readinessRow(),
+      spendSessionId: '770e8400-e29b-41d4-a716-446655440000',
+      spendExperienceId: '990e8400-e29b-41d4-a716-446655440003',
+      sessionOwnerPrivyUserId: 'privy-1',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(diagnosticsPatchFor('trustline_horizon_submit')).toEqual(
+      expect.objectContaining({
+        status: 'failed',
+        sanitized_error_category: 'wallet_readiness_failed',
+        internal_diagnostics: expect.objectContaining({
+          phase: 'trustline_horizon_submit',
+          error_message: 'submit failed',
+          horizon_status: 400,
+          horizon_title: 'Transaction Failed',
+          trustline_treasury_transaction_id: TRUSTLINE_TREASURY_ID,
+        }),
+      })
+    );
   });
 });

--- a/lib/spend/stellar-wallet-readiness-orchestration.test.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.test.ts
@@ -55,6 +55,7 @@ vi.mock('@/lib/privy-server-rest', () => ({
 
 vi.mock('@/lib/spend/stellar-wallet-readiness-config', async () => {
   const { Keypair, Networks } = await import('@stellar/stellar-sdk');
+  const sponsorKeypair = Keypair.random();
   return {
     createStellarSpendHorizonServer: () => hoisted.mockServer,
     getStellarSpendCreateAccountStartingBalance: () => '3',
@@ -62,10 +63,7 @@ vi.mock('@/lib/spend/stellar-wallet-readiness-config', async () => {
     getStellarSpendUsdcAssetCode: () => 'USDC',
     getStellarSpendUsdcIssuer: () =>
       'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-    parseStellarSpendSponsorKeypair: () =>
-      Keypair.fromSecret(
-        'SAPTCMRTYYW4H6ZU5YPH6LDJZYGEIECEPJYTBYPAX7KCFRRIVHJHGJFL'
-      ),
+    parseStellarSpendSponsorKeypair: () => sponsorKeypair,
   };
 });
 
@@ -96,13 +94,19 @@ function accountWithoutTrustline() {
 }
 
 function diagnosticsPatchFor(phase: string) {
-  return hoisted.mockUpdateReadiness.mock.calls
-    .map((call) => call[1] as Record<string, unknown>)
-    .find(
-      (patch) =>
-        (patch.internal_diagnostics as { phase?: string } | undefined)
-          ?.phase === phase
-    );
+  const patches = hoisted.mockUpdateReadiness.mock.calls.map(
+    (call) => call[1] as Record<string, unknown>
+  );
+  for (let i = patches.length - 1; i >= 0; i -= 1) {
+    const patch = patches[i];
+    if (
+      (patch.internal_diagnostics as { phase?: string } | undefined)?.phase ===
+      phase
+    ) {
+      return patch;
+    }
+  }
+  return undefined;
 }
 
 describe('Stellar wallet readiness orchestration', () => {

--- a/lib/spend/stellar-wallet-readiness-orchestration.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.ts
@@ -52,7 +52,13 @@ export type StellarWalletReadinessCurrentStep =
 
 const HORIZON_TX_POLL_ATTEMPTS = 8;
 const HORIZON_TX_POLL_INTERVAL_MS = 1500;
-export const STELLAR_USDC_TRUSTLINE_MAX_LIMIT = '922337203685.4775807';
+
+type TrustlineSetupFailurePhase =
+  | 'trustline_transaction_build'
+  | 'trustline_raw_sign'
+  | 'trustline_signature_attach'
+  | 'trustline_fee_bump_build'
+  | 'trustline_horizon_submit';
 
 export type StellarWalletReadinessOrchestrationOutput =
   | { ok: true; status: 'completed'; address: string }
@@ -119,6 +125,67 @@ function hasUsdcTrustline(
     if (b.asset_code === code && b.asset_issuer === issuer) return true;
   }
   return false;
+}
+
+function diagnosticsFromTrustlineSetupError(
+  phase: TrustlineSetupFailurePhase,
+  e: unknown,
+  extra: Record<string, unknown> = {}
+): Record<string, unknown> {
+  const err = e instanceof Error ? e : null;
+  const response = (e as { response?: { status?: number; data?: unknown } })
+    ?.response;
+  const data =
+    response?.data && typeof response.data === 'object'
+      ? (response.data as Record<string, unknown>)
+      : null;
+  return {
+    phase,
+    ...extra,
+    ...(err
+      ? {
+          error_name: err.name,
+          error_message: err.message.slice(0, 4000),
+        }
+      : { error_message: String(e).slice(0, 4000) }),
+    ...(response?.status ? { horizon_status: response.status } : {}),
+    ...(typeof data?.title === 'string' ? { horizon_title: data.title } : {}),
+    ...(typeof data?.detail === 'string'
+      ? { horizon_detail: data.detail.slice(0, 1000) }
+      : {}),
+    ...(data?.extras && typeof data.extras === 'object'
+      ? { horizon_extras: data.extras }
+      : {}),
+  };
+}
+
+async function failTrustlineSetup(input: {
+  rowId: string;
+  stepMeta: Record<string, unknown>;
+  phase: TrustlineSetupFailurePhase;
+  error: unknown;
+  extra?: Record<string, unknown>;
+}): Promise<StellarWalletReadinessOrchestrationOutput> {
+  const railError = classifyHorizonSubmit(input.error);
+  try {
+    await updateSpendWalletReadinessFields(input.rowId, {
+      status: 'failed',
+      step_metadata: input.stepMeta,
+      sanitized_error_category: railError.category,
+      sanitized_error_code: railError.analyticsCode,
+      internal_diagnostics: diagnosticsFromTrustlineSetupError(
+        input.phase,
+        input.error,
+        input.extra
+      ),
+    });
+  } catch (persistErr) {
+    console.error('stellar_usdc trustline failure diagnostics persist:', {
+      phase: input.phase,
+      error: persistErr,
+    });
+  }
+  return { ok: false, error: railError };
 }
 
 async function waitForHorizonTxSuccess(
@@ -483,38 +550,51 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
     return { ok: true, status: 'needs_review', address: userPub };
   }
 
-  const usdcAsset = new Asset(usdcCode, usdcIssuer);
-
   stepMeta = mergeMeta(stepMeta, {
     current_step: STELLAR_WALLET_READINESS_CURRENT_STEP.trustline_submitting,
   });
   await updateSpendWalletReadinessFields(rowId, { step_metadata: stepMeta });
 
-  const inner = new TransactionBuilder(userAccount, {
-    fee: '0',
-    networkPassphrase: passphrase,
-  })
-    .addOperation(
-      Operation.beginSponsoringFutureReserves({
-        sponsoredId: userPub,
-        source: sponsor.publicKey(),
-      })
-    )
-    .addOperation(
-      Operation.changeTrust({
-        asset: usdcAsset,
-        limit: STELLAR_USDC_TRUSTLINE_MAX_LIMIT,
-      })
-    )
-    .addOperation(
-      Operation.endSponsoringFutureReserves({
-        source: sponsor.publicKey(),
-      })
-    )
-    .setTimeout(180)
-    .build();
-
-  inner.sign(sponsor);
+  let usdcAsset;
+  let inner;
+  try {
+    usdcAsset = new Asset(usdcCode, usdcIssuer);
+    inner = new TransactionBuilder(userAccount, {
+      fee: '0',
+      networkPassphrase: passphrase,
+    })
+      .addOperation(
+        Operation.beginSponsoringFutureReserves({
+          sponsoredId: userPub,
+          source: sponsor.publicKey(),
+        })
+      )
+      .addOperation(
+        Operation.changeTrust({
+          asset: usdcAsset,
+        })
+      )
+      .addOperation(
+        Operation.endSponsoringFutureReserves({
+          source: sponsor.publicKey(),
+        })
+      )
+      .setTimeout(180)
+      .build();
+    inner.sign(sponsor);
+  } catch (e) {
+    return failTrustlineSetup({
+      rowId,
+      stepMeta,
+      phase: 'trustline_transaction_build',
+      error: e,
+      extra: {
+        asset_code: usdcCode,
+        asset_issuer: usdcIssuer,
+        user_public_key: userPub,
+      },
+    });
+  }
 
   const hash32 = inner.hash();
   let userSig: Buffer;
@@ -524,25 +604,55 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
       hash32,
     });
   } catch (e) {
-    return { ok: false, error: classifyHorizonSubmit(e) };
+    return failTrustlineSetup({
+      rowId,
+      stepMeta,
+      phase: 'trustline_raw_sign',
+      error: e,
+      extra: {
+        wallet_id_suffix: walletId.slice(-8),
+        user_public_key: userPub,
+      },
+    });
   }
 
   const userKp = Keypair.fromPublicKey(userPub);
-  inner.addDecoratedSignature(
-    new xdr.DecoratedSignature({
-      hint: userKp.signatureHint(),
-      signature: userSig,
-    })
-  );
+  try {
+    inner.addDecoratedSignature(
+      new xdr.DecoratedSignature({
+        hint: userKp.signatureHint(),
+        signature: userSig,
+      })
+    );
+  } catch (e) {
+    return failTrustlineSetup({
+      rowId,
+      stepMeta,
+      phase: 'trustline_signature_attach',
+      error: e,
+      extra: { user_public_key: userPub },
+    });
+  }
 
-  const baseFee = (await server.fetchBaseFee()).toString();
-  const feeBump = TransactionBuilder.buildFeeBumpTransaction(
-    sponsor,
-    (Number(baseFee) * 10).toString(),
-    inner,
-    passphrase
-  );
-  feeBump.sign(sponsor);
+  let feeBump;
+  try {
+    const baseFee = (await server.fetchBaseFee()).toString();
+    feeBump = TransactionBuilder.buildFeeBumpTransaction(
+      sponsor,
+      (Number(baseFee) * 10).toString(),
+      inner,
+      passphrase
+    );
+    feeBump.sign(sponsor);
+  } catch (e) {
+    return failTrustlineSetup({
+      rowId,
+      stepMeta,
+      phase: 'trustline_fee_bump_build',
+      error: e,
+      extra: { user_public_key: userPub },
+    });
+  }
 
   let trustlineTreasuryId: string | null =
     readinessRow.trustline_treasury_transaction_id;
@@ -571,7 +681,16 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
     const res = await server.submitTransaction(feeBump);
     trustHash = res.hash;
   } catch (e) {
-    return { ok: false, error: classifyHorizonSubmit(e) };
+    return failTrustlineSetup({
+      rowId,
+      stepMeta,
+      phase: 'trustline_horizon_submit',
+      error: e,
+      extra: {
+        user_public_key: userPub,
+        trustline_treasury_transaction_id: trustlineTreasuryId,
+      },
+    });
   }
 
   stepMeta = mergeMeta(stepMeta, {

--- a/lib/spend/stellar-wallet-readiness-orchestration.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.ts
@@ -3,6 +3,7 @@ import {
   Horizon,
   Keypair,
   Operation,
+  Transaction,
   TransactionBuilder,
   xdr,
 } from '@stellar/stellar-sdk';
@@ -97,6 +98,15 @@ function classifyHorizonSubmit(e: unknown): SpendRailError {
   return spendRailErrorWalletReadinessFailed();
 }
 
+function horizonLikeErrorResponse(
+  e: unknown
+): { status?: number; data?: unknown } | undefined {
+  if (e === null || typeof e !== 'object') return undefined;
+  const response = (e as { response?: { status?: number; data?: unknown } })
+    .response;
+  return response && typeof response === 'object' ? response : undefined;
+}
+
 async function loadAccountOrNull(
   server: Horizon.Server,
   publicKey: string
@@ -104,7 +114,7 @@ async function loadAccountOrNull(
   try {
     return await server.loadAccount(publicKey);
   } catch (e: unknown) {
-    const status = (e as { response?: { status?: number } })?.response?.status;
+    const status = horizonLikeErrorResponse(e)?.status;
     if (status === 404) return null;
     throw e;
   }
@@ -133,8 +143,7 @@ function diagnosticsFromTrustlineSetupError(
   extra: Record<string, unknown> = {}
 ): Record<string, unknown> {
   const err = e instanceof Error ? e : null;
-  const response = (e as { response?: { status?: number; data?: unknown } })
-    ?.response;
+  const response = horizonLikeErrorResponse(e);
   const data =
     response?.data && typeof response.data === 'object'
       ? (response.data as Record<string, unknown>)
@@ -199,8 +208,7 @@ async function waitForHorizonTxSuccess(
       if (tx.successful) return 'success';
       return 'failed';
     } catch (e: unknown) {
-      const status = (e as { response?: { status?: number } })?.response
-        ?.status;
+      const status = horizonLikeErrorResponse(e)?.status;
       if (status === 404) {
         await new Promise((r) => setTimeout(r, HORIZON_TX_POLL_INTERVAL_MS));
         continue;
@@ -555,10 +563,9 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
   });
   await updateSpendWalletReadinessFields(rowId, { step_metadata: stepMeta });
 
-  let usdcAsset;
-  let inner;
+  let inner: Transaction;
   try {
-    usdcAsset = new Asset(usdcCode, usdcIssuer);
+    const usdcAsset = new Asset(usdcCode, usdcIssuer);
     inner = new TransactionBuilder(userAccount, {
       fee: '0',
       networkPassphrase: passphrase,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Remove the explicit Stellar USDC trustline limit and let `Operation.changeTrust` use the SDK default.
- Persist granular trustline setup diagnostics for transaction build, Privy raw signing, signature attachment, fee-bump build, and Horizon submit failures.
- Preserve detailed orchestration diagnostics by no longer overwriting them with generic `orchestration_pre_ledger` metadata in the rail wrapper.
- Expand Stellar readiness tests for default trustline construction and diagnostics persistence.

## Testing
- `yarn test lib/spend/stellar-wallet-readiness-orchestration.test.ts` passed.
- `yarn test lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-conversion-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

