### PR TITLE
fix: source Stellar sponsorship close from user

### DIFF
--- a/lib/spend/stellar-wallet-readiness-orchestration.test.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.test.ts
@@ -1,4 +1,9 @@
-import { Account, Asset, Operation } from '@stellar/stellar-sdk';
+import {
+  Account,
+  Asset,
+  FeeBumpTransaction,
+  Operation,
+} from '@stellar/stellar-sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const VALID_STELLAR_PUBLIC_KEY =
@@ -150,9 +155,9 @@ describe('Stellar wallet readiness orchestration', () => {
   });
 
   it('builds sponsored trustline operations with the expected source accounts', async () => {
-    hoisted.mockServer.submitTransaction.mockRejectedValue(
-      new Error('inspect submit')
-    );
+    const submit = hoisted.mockServer.submitTransaction;
+    // Reject after the fee bump is built so we can assert inner operations without submitting.
+    submit.mockRejectedValue(new Error('inspect submit'));
 
     const result = await runStellarUsdcWalletReadinessOrchestration({
       readinessRow: readinessRow(),
@@ -162,15 +167,15 @@ describe('Stellar wallet readiness orchestration', () => {
     });
 
     expect(result.ok).toBe(false);
-    const feeBump = hoisted.mockServer.submitTransaction.mock.calls[0]?.[0];
+    expect(submit).toHaveBeenCalledTimes(1);
+    const feeBump = submit.mock.calls[0]![0] as FeeBumpTransaction;
     const operations = feeBump.innerTransaction.operations;
-    expect(operations.map((op: { type: string }) => op.type)).toEqual([
+    expect(operations.map((op) => op.type)).toEqual([
       'beginSponsoringFutureReserves',
       'changeTrust',
       'endSponsoringFutureReserves',
     ]);
     expect(operations[0].source).toBe(feeBump.feeSource);
-    expect(operations[0].source).not.toBe(VALID_STELLAR_PUBLIC_KEY);
     expect(operations[1].source).toBeUndefined();
     expect(operations[2].source).toBe(VALID_STELLAR_PUBLIC_KEY);
   });

--- a/lib/spend/stellar-wallet-readiness-orchestration.test.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.test.ts
@@ -149,6 +149,32 @@ describe('Stellar wallet readiness orchestration', () => {
     );
   });
 
+  it('builds sponsored trustline operations with the expected source accounts', async () => {
+    hoisted.mockServer.submitTransaction.mockRejectedValue(
+      new Error('inspect submit')
+    );
+
+    const result = await runStellarUsdcWalletReadinessOrchestration({
+      readinessRow: readinessRow(),
+      spendSessionId: '770e8400-e29b-41d4-a716-446655440000',
+      spendExperienceId: '990e8400-e29b-41d4-a716-446655440003',
+      sessionOwnerPrivyUserId: 'privy-1',
+    });
+
+    expect(result.ok).toBe(false);
+    const feeBump = hoisted.mockServer.submitTransaction.mock.calls[0]?.[0];
+    const operations = feeBump.innerTransaction.operations;
+    expect(operations.map((op: { type: string }) => op.type)).toEqual([
+      'beginSponsoringFutureReserves',
+      'changeTrust',
+      'endSponsoringFutureReserves',
+    ]);
+    expect(operations[0].source).toBe(feeBump.feeSource);
+    expect(operations[0].source).not.toBe(VALID_STELLAR_PUBLIC_KEY);
+    expect(operations[1].source).toBeUndefined();
+    expect(operations[2].source).toBe(VALID_STELLAR_PUBLIC_KEY);
+  });
+
   it('persists diagnostics when Privy raw signing fails during trustline setup', async () => {
     hoisted.mockRawSign.mockRejectedValue(new Error('raw sign failed'));
 

--- a/lib/spend/stellar-wallet-readiness-orchestration.ts
+++ b/lib/spend/stellar-wallet-readiness-orchestration.ts
@@ -583,7 +583,7 @@ export async function runStellarUsdcWalletReadinessOrchestration(input: {
       )
       .addOperation(
         Operation.endSponsoringFutureReserves({
-          source: sponsor.publicKey(),
+          source: userPub,
         })
       )
       .setTimeout(180)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Source `Operation.endSponsoringFutureReserves` from the user Stellar wallet instead of the sponsor.
- Keep `beginSponsoringFutureReserves` sponsor-sourced, `changeTrust` default/user transaction-sourced, and the explicit trustline limit removed.
- Add a test that inspects the trustline fee-bump inner operation source accounts.

## Testing
- `yarn test lib/spend/stellar-wallet-readiness-orchestration.test.ts` passed.
- `yarn test lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-conversion-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

