### PR TITLE
fix: fund Stellar conversions to rail wallet

### DIFF
--- a/lib/db/spend-ledger-rows.ts
+++ b/lib/db/spend-ledger-rows.ts
@@ -200,20 +200,20 @@ function rowToConversionLastFailure(
   ) {
     return null;
   }
+  const rawDiagnostics = o.internal_diagnostics;
+  const internalDiagnostics =
+    rawDiagnostics &&
+    typeof rawDiagnostics === 'object' &&
+    !Array.isArray(rawDiagnostics)
+      ? (rawDiagnostics as Record<string, unknown>)
+      : undefined;
   return {
     recorded_at: recordedAt,
     phase,
     category,
     reason_snippet: reasonSnippet,
-    ...(o.internal_diagnostics &&
-    typeof o.internal_diagnostics === 'object' &&
-    !Array.isArray(o.internal_diagnostics)
-      ? {
-          internal_diagnostics: o.internal_diagnostics as Record<
-            string,
-            unknown
-          >,
-        }
+    ...(internalDiagnostics
+      ? { internal_diagnostics: internalDiagnostics }
       : {}),
   };
 }

--- a/lib/db/spend-ledger-rows.ts
+++ b/lib/db/spend-ledger-rows.ts
@@ -205,6 +205,16 @@ function rowToConversionLastFailure(
     phase,
     category,
     reason_snippet: reasonSnippet,
+    ...(o.internal_diagnostics &&
+    typeof o.internal_diagnostics === 'object' &&
+    !Array.isArray(o.internal_diagnostics)
+      ? {
+          internal_diagnostics: o.internal_diagnostics as Record<
+            string,
+            unknown
+          >,
+        }
+      : {}),
   };
 }
 

--- a/lib/spend-conversion-confirm.test.ts
+++ b/lib/spend-conversion-confirm.test.ts
@@ -378,4 +378,116 @@ describe('runSpendConversionConfirm (IRL-17 retry)', () => {
       })
     );
   });
+
+  it('uses fresh Stellar rail wallet after readiness before funding', async () => {
+    const evmWallet = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+    const stellarWallet =
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+    const staleSession: SpendSession = {
+      ...baseSession,
+      wallet_address: evmWallet,
+      spend_rail: 'stellar_usdc',
+      rail_user_wallet_address: null,
+    };
+    const freshSession: SpendSession = {
+      ...staleSession,
+      rail_user_wallet_address: stellarWallet,
+    };
+    const stellarExperience: SpendExperience = {
+      ...baseExperience,
+      spend_rail: 'stellar_usdc',
+      treasury_wallet_address: stellarWallet,
+      receiving_wallet_address: stellarWallet,
+      server_wallet_address: stellarWallet,
+      server_wallet_chain: 'stellar',
+      privy_server_wallet_id: null,
+    };
+    const pointConversion: PointConversion = {
+      ...failedConversion(0, {
+        status: 'points_deducted',
+        spend_rail: 'stellar_usdc',
+        network: 'Stellar',
+        treasury_wallet_address: stellarWallet,
+        user_wallet_address: evmWallet,
+        conversion_attempt_count: 1,
+        completed_at: null,
+        failed_reason: null,
+        conversion_last_failure: null,
+      }),
+    };
+    const runWalletReadinessOrchestration = vi.fn().mockResolvedValue({
+      ok: true as const,
+      value: { status: 'completed' as const },
+    });
+    const initiateUserFunding = vi.fn().mockResolvedValue({
+      ok: true as const,
+      value: {
+        status: 'submitted' as const,
+        txReference: 'a'.repeat(64),
+      },
+    });
+    mockGetSpendPaymentRail.mockReturnValue({
+      getTreasurySpendableBalance: async () => ({
+        ok: true as const,
+        value: 100,
+      }),
+      runWalletReadinessOrchestration,
+      initiateUserFunding,
+    });
+    mockGetTreasuryFundingMeta.mockReturnValue({
+      spendRail: 'stellar_usdc',
+      treasuryAddress: stellarWallet,
+    });
+    mockLoadEligibility.mockResolvedValue({
+      status: 'eligible',
+      message: 'eligible',
+      preview: {},
+    });
+    mockGetPlayerByWallet.mockResolvedValue({ total_points: 6000 });
+    mockConfirmAtomic.mockResolvedValue({
+      outcome: 'created',
+      conversionId: pointConversion.id,
+      playerTotalPoints: 1000,
+    });
+    mockGetPointConversion
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(pointConversion);
+    mockGetSpendSessionById.mockResolvedValue(freshSession);
+    mockUpdatePointConversionFields.mockResolvedValue({
+      ...pointConversion,
+      status: 'needs_review',
+      funding_tx_hash: 'a'.repeat(64),
+    });
+
+    const r = await runSpendConversionConfirm({
+      session: staleSession,
+      spendExperience: stellarExperience,
+      normalizedWallet: evmWallet.toLowerCase(),
+      authUserId: 'privy-1',
+      distinctId: 'd',
+      usdcAmount: 5,
+      pointsRequired: 5000,
+      intent: 'confirm',
+    });
+
+    expect(r.ok).toBe(true);
+    expect(runWalletReadinessOrchestration).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeddedEvmWalletAddress: evmWallet,
+        stellarFundingDestinationWalletAddress: null,
+      })
+    );
+    expect(initiateUserFunding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        embeddedEvmWalletAddress: stellarWallet,
+        stellarFundingDestinationWalletAddress: stellarWallet,
+        railUserWalletAddress: stellarWallet,
+      })
+    );
+    expect(initiateUserFunding).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        stellarFundingDestinationWalletAddress: evmWallet,
+      })
+    );
+  });
 });

--- a/lib/spend-conversion-confirm.ts
+++ b/lib/spend-conversion-confirm.ts
@@ -130,6 +130,7 @@ async function persistConversionLastFailure(input: {
   phase: PointConversionLastFailure['phase'];
   category: string;
   reasonSnippet: string;
+  internalDiagnostics?: Record<string, unknown>;
 }): Promise<void> {
   try {
     await updatePointConversionFields(input.conversionId, {
@@ -138,6 +139,9 @@ async function persistConversionLastFailure(input: {
         phase: input.phase,
         category: input.category,
         reason_snippet: input.reasonSnippet.slice(0, 500),
+        ...(input.internalDiagnostics
+          ? { internal_diagnostics: input.internalDiagnostics }
+          : {}),
       },
     });
   } catch (e) {
@@ -199,6 +203,7 @@ async function conversionRailFailureOutcome(input: {
     phase: input.phase,
     category: input.railError.category,
     reasonSnippet: input.railError.userMessage,
+    internalDiagnostics: input.railError.internalDiagnostics,
   });
   let walletReadinessOperationId: string | undefined;
   if (
@@ -318,22 +323,30 @@ async function runWalletReadinessAndUserFunding(input: {
   }
 
   const rail = getSpendPaymentRail(session.spend_rail);
-  const ctx: SpendPaymentRailSessionContext = {
-    spendSessionId: session.id,
+  const buildRailSessionContext = (
+    ctxSession: SpendSession
+  ): SpendPaymentRailSessionContext => ({
+    spendSessionId: ctxSession.id,
     spendExperienceId: spendExperience.id,
     pointConversionId: conv.id,
     fundingReferenceId: fundingKey,
     treasuryFundingWalletId:
       treasuryMeta.spendRail === 'base_usdc' ? treasuryMeta.walletId : null,
     treasuryFundingWalletAddress: treasuryMeta.treasuryAddress,
-    embeddedEvmWalletAddress: embeddedSpendWalletForSession(session),
+    embeddedEvmWalletAddress: embeddedSpendWalletForSession(ctxSession),
+    stellarFundingDestinationWalletAddress:
+      ctxSession.spend_rail === 'stellar_usdc'
+        ? ctxSession.rail_user_wallet_address
+        : null,
+    railUserWalletAddress: ctxSession.rail_user_wallet_address,
     privyNormalizedWalletAddressLower: normalizedWallet,
-    sessionOwnerPrivyUserId: session.user_id,
+    sessionOwnerPrivyUserId: ctxSession.user_id,
     usdcAmount,
     analyticsDistinctId: distinctId,
-  };
+  });
+  const readinessCtx = buildRailSessionContext(session);
 
-  const readiness = await rail.runWalletReadinessOrchestration(ctx);
+  const readiness = await rail.runWalletReadinessOrchestration(readinessCtx);
   if (!readiness.ok) {
     return conversionRailFailureOutcome({
       phase: 'readiness',
@@ -368,12 +381,17 @@ async function runWalletReadinessAndUserFunding(input: {
     };
   }
 
-  const funding = await rail.initiateUserFunding(ctx);
+  const fundingSession =
+    session.spend_rail === 'stellar_usdc'
+      ? ((await getSpendSessionById(session.id)) ?? session)
+      : session;
+  const fundingCtx = buildRailSessionContext(fundingSession);
+  const funding = await rail.initiateUserFunding(fundingCtx);
   if (!funding.ok) {
     return conversionRailFailureOutcome({
       phase: 'funding',
       conv,
-      session,
+      session: fundingSession,
       distinctId,
       baseAnalytics,
       railError: funding.error,
@@ -384,7 +402,9 @@ async function runWalletReadinessAndUserFunding(input: {
   const ref = (txReference ?? '').trim();
 
   if (status === 'confirmed') {
-    if (!isValidSpendConversionFundingTxReference(session.spend_rail, ref)) {
+    if (
+      !isValidSpendConversionFundingTxReference(fundingSession.spend_rail, ref)
+    ) {
       return {
         kind: 'error',
         value: {
@@ -397,7 +417,7 @@ async function runWalletReadinessAndUserFunding(input: {
     }
     const done = await finalizeSpendConversionFunding({
       pointConversion: { ...conv, funding_tx_hash: ref },
-      session,
+      session: fundingSession,
       spendExperience,
       treasuryFromWalletAddress: treasuryMeta.treasuryAddress,
       fundingTxReference: ref,
@@ -420,9 +440,9 @@ async function runWalletReadinessAndUserFunding(input: {
     }
     const updated = await updatePointConversionFields(conv.id, {
       status: 'needs_review',
-      ...pointConversionFundingHashPatch(session, ref),
+      ...pointConversionFundingHashPatch(fundingSession, ref),
     });
-    await updateSpendSessionStatus(session.id, 'conversion_pending');
+    await updateSpendSessionStatus(fundingSession.id, 'conversion_pending');
     return { kind: 'ambiguous_review', conversion: updated };
   }
 

--- a/lib/spend/payment-rails/errors.ts
+++ b/lib/spend/payment-rails/errors.ts
@@ -37,6 +37,7 @@ export type SpendRailError = {
   category: SpendRailErrorCategory;
   userMessage: string;
   analyticsCode: SpendRailAnalyticsCode;
+  internalDiagnostics?: Record<string, unknown>;
 };
 
 const err = (

--- a/lib/spend/payment-rails/errors.ts
+++ b/lib/spend/payment-rails/errors.ts
@@ -40,6 +40,23 @@ export type SpendRailError = {
   internalDiagnostics?: Record<string, unknown>;
 };
 
+/** Trailing characters of a long identifier for diagnostics only (not full keys). */
+export function spendRailDiagnosticKeySuffix(
+  value: string | null | undefined,
+  length = 8
+): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(-length) : null;
+}
+
+/** Return `error` with `internalDiagnostics` for support and conversion ledger rows. */
+export function spendRailErrorWithDiagnostics(
+  error: SpendRailError,
+  internalDiagnostics: Record<string, unknown>
+): SpendRailError {
+  return { ...error, internalDiagnostics };
+}
+
 const err = (
   category: SpendRailErrorCategory,
   userMessage: string,

--- a/lib/spend/payment-rails/stellar-usdc-rail.test.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.test.ts
@@ -319,27 +319,81 @@ describe('createStellarUsdcSpendPaymentRail — treasury funding (IRL-16)', () =
     const res = await rail.initiateUserFunding({
       spendSessionId: sessionId,
       fundingReferenceId: 'fund_user:cv-1',
-      embeddedEvmWalletAddress: STELLAR_G,
+      embeddedEvmWalletAddress: '0x1111111111111111111111111111111111111111',
+      stellarFundingDestinationWalletAddress: STELLAR_G,
+      treasuryFundingWalletAddress: STELLAR_G,
       usdcAmount: 10,
     });
     expect(res.ok).toBe(true);
     if (!res.ok) throw new Error('expected ok');
     expect(res.value.status).toBe('confirmed');
     expect(res.value.txReference?.toLowerCase()).toBe('a'.repeat(64));
+    expect(hoistedTreasury.submit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        destinationPublicKey: STELLAR_G,
+      })
+    );
   });
 
-  it('initiateUserFunding rejects invalid destination as readiness failure', async () => {
+  it('initiateUserFunding rejects the EVM auth wallet as Stellar funding destination', async () => {
     hoistedTreasury.readBal.mockResolvedValue(100);
     const rail = createStellarUsdcSpendPaymentRail();
     const res = await rail.initiateUserFunding({
       spendSessionId: sessionId,
       fundingReferenceId: 'fund_user:cv-1',
-      embeddedEvmWalletAddress: 'not-stellar',
+      embeddedEvmWalletAddress: '0x1111111111111111111111111111111111111111',
+      stellarFundingDestinationWalletAddress:
+        '0x1111111111111111111111111111111111111111',
+      treasuryFundingWalletAddress: STELLAR_G,
       usdcAmount: 10,
     });
     expect(res.ok).toBe(false);
     if (res.ok) throw new Error('expected err');
     expect(res.error.category).toBe('wallet_readiness_failed');
+    expect(res.error.internalDiagnostics).toEqual(
+      expect.objectContaining({
+        phase: 'stellar_funding_destination_validation',
+        destination_validation_result: 'invalid',
+        destination_public_key: '0x1111111111111111111111111111111111111111',
+      })
+    );
+    expect(hoistedTreasury.submit).not.toHaveBeenCalled();
+  });
+
+  it('initiateUserFunding preserves Stellar treasury submit diagnostics', async () => {
+    hoistedTreasury.readBal.mockResolvedValue(100);
+    hoistedTreasury.submit.mockResolvedValue({
+      kind: 'error',
+      error: {
+        category: 'wallet_readiness_failed',
+        userMessage: 'generic',
+        analyticsCode: SPEND_RAIL_ANALYTICS_CODES.wallet_readiness_failed,
+        internalDiagnostics: {
+          phase: 'stellar_funding_horizon_submit',
+          destination_public_key: STELLAR_G,
+          horizon_result_codes: {
+            transaction: 'tx_failed',
+            operations: ['op_no_trust'],
+          },
+        },
+      },
+    });
+    const rail = createStellarUsdcSpendPaymentRail();
+    const res = await rail.initiateUserFunding({
+      spendSessionId: sessionId,
+      fundingReferenceId: 'fund_user:cv-1',
+      stellarFundingDestinationWalletAddress: STELLAR_G,
+      treasuryFundingWalletAddress: STELLAR_G,
+      usdcAmount: 10,
+    });
+    expect(res.ok).toBe(false);
+    if (res.ok) throw new Error('expected err');
+    expect(res.error.internalDiagnostics).toEqual(
+      expect.objectContaining({
+        phase: 'stellar_funding_horizon_submit',
+        destination_public_key: STELLAR_G,
+      })
+    );
   });
 });
 

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -22,7 +22,9 @@ import {
   spendRailErrorPaymentFailed,
   spendRailErrorStellarTreasuryCannotFundSpend,
   spendRailErrorRailOperationNotSupported,
+  spendRailDiagnosticKeySuffix,
   spendRailErrorWalletReadinessFailed,
+  spendRailErrorWithDiagnostics,
   type SpendRailError,
 } from '@/lib/spend/payment-rails/errors';
 import type {
@@ -102,18 +104,6 @@ function classifyStellarPaymentSubmitReason(reason: string): SpendRailError {
     return spendRailErrorNetworkUnavailable();
   }
   return spendRailErrorPaymentFailed();
-}
-
-function suffix(value: string | null | undefined, length = 8): string | null {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed.slice(-length) : null;
-}
-
-function railErrorWithDiagnostics(
-  error: SpendRailError,
-  internalDiagnostics: Record<string, unknown>
-): SpendRailError {
-  return { ...error, internalDiagnostics };
 }
 
 /**
@@ -398,14 +388,14 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
       if (!destOk.success) {
         const usdcIssuer = getStellarSpendUsdcIssuer();
         return errSpendRail(
-          railErrorWithDiagnostics(spendRailErrorWalletReadinessFailed(), {
+          spendRailErrorWithDiagnostics(spendRailErrorWalletReadinessFailed(), {
             phase: 'stellar_funding_destination_validation',
             destination_public_key: destRaw || null,
             destination_validation_result: 'invalid',
-            treasury_public_key_suffix: suffix(
+            treasury_public_key_suffix: spendRailDiagnosticKeySuffix(
               ctx.treasuryFundingWalletAddress
             ),
-            usdc_issuer_suffix: suffix(usdcIssuer),
+            usdc_issuer_suffix: spendRailDiagnosticKeySuffix(usdcIssuer),
           })
         );
       }

--- a/lib/spend/payment-rails/stellar-usdc-rail.ts
+++ b/lib/spend/payment-rails/stellar-usdc-rail.ts
@@ -104,6 +104,18 @@ function classifyStellarPaymentSubmitReason(reason: string): SpendRailError {
   return spendRailErrorPaymentFailed();
 }
 
+function suffix(value: string | null | undefined, length = 8): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(-length) : null;
+}
+
+function railErrorWithDiagnostics(
+  error: SpendRailError,
+  internalDiagnostics: Record<string, unknown>
+): SpendRailError {
+  return { ...error, internalDiagnostics };
+}
+
 /**
  * Stellar USDC rail: hybrid readiness (IRL-18) — sponsor-funded account creation,
  * Privy-signed sponsored USDC trustline, ledger-confirmed completion, treasury audit rows.
@@ -381,10 +393,21 @@ export function createStellarUsdcSpendPaymentRail(): SpendPaymentRail {
         return errSpendRail(spendRailErrorFundingFailed());
       }
 
-      const destRaw = ctx.embeddedEvmWalletAddress?.trim() ?? '';
+      const destRaw = ctx.stellarFundingDestinationWalletAddress?.trim() ?? '';
       const destOk = stellarWalletAddressSchema.safeParse(destRaw);
       if (!destOk.success) {
-        return errSpendRail(spendRailErrorWalletReadinessFailed());
+        const usdcIssuer = getStellarSpendUsdcIssuer();
+        return errSpendRail(
+          railErrorWithDiagnostics(spendRailErrorWalletReadinessFailed(), {
+            phase: 'stellar_funding_destination_validation',
+            destination_public_key: destRaw || null,
+            destination_validation_result: 'invalid',
+            treasury_public_key_suffix: suffix(
+              ctx.treasuryFundingWalletAddress
+            ),
+            usdc_issuer_suffix: suffix(usdcIssuer),
+          })
+        );
       }
 
       let treasurySnapshot: Awaited<

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -52,6 +52,11 @@ export type SpendPaymentRailSessionContext = {
    * aligns with `SpendSession.wallet_address`; other rails ignore unset fields for now).
    */
   embeddedEvmWalletAddress?: string;
+  /**
+   * Stellar USDC conversion funding destination (`spend_sessions.rail_user_wallet_address`).
+   * This is the prepared Stellar rail wallet, not the EVM auth wallet.
+   */
+  stellarFundingDestinationWalletAddress?: string | null;
   /** When set, Base readiness requires a case-insensitive match to `embeddedEvmWalletAddress`. */
   privyNormalizedWalletAddressLower?: string;
   /**

--- a/lib/spend/stellar-treasury-funding.ts
+++ b/lib/spend/stellar-treasury-funding.ts
@@ -15,7 +15,9 @@ import {
   spendRailErrorNetworkUnavailable,
   spendRailErrorStellarTreasuryCannotFundSpend,
   spendRailErrorTreasuryConfiguration,
+  spendRailDiagnosticKeySuffix,
   spendRailErrorWalletReadinessFailed,
+  spendRailErrorWithDiagnostics,
   type SpendRailError,
 } from '@/lib/spend/payment-rails/errors';
 import { parseStellarTreasuryFundingKeypair } from '@/lib/spend/stellar-treasury-funding-config';
@@ -33,11 +35,6 @@ const PRIOR_PAYMENT_MAX_PAGES = 5;
 
 function classifyHorizonException(): SpendRailError {
   return spendRailErrorNetworkUnavailable();
-}
-
-function suffix(value: string | null | undefined, length = 8): string | null {
-  const trimmed = value?.trim();
-  return trimmed ? trimmed.slice(-length) : null;
 }
 
 function resultCodesFromHorizonError(e: unknown): unknown {
@@ -69,17 +66,10 @@ function horizonDiagnostics(e: unknown): Record<string, unknown> {
   };
 }
 
-function railErrorWithDiagnostics(
-  error: SpendRailError,
-  internalDiagnostics: Record<string, unknown>
-): SpendRailError {
-  return { ...error, internalDiagnostics };
-}
-
 function classifySubmitException(e: unknown): SpendRailError {
   const raw = e instanceof Error ? e.message : String(e);
-  const resultCodes = JSON.stringify(resultCodesFromHorizonError(e) ?? {});
-  const s = `${raw} ${resultCodes}`.toLowerCase();
+  const codes = resultCodesFromHorizonError(e);
+  const s = `${raw} ${JSON.stringify(codes ?? {})}`.toLowerCase();
   if (
     s.includes('fetch') ||
     s.includes('econn') ||
@@ -348,11 +338,14 @@ export async function submitStellarTreasuryUsdcFunding(input: {
   if (!destOk.success) {
     return {
       kind: 'error',
-      error: railErrorWithDiagnostics(spendRailErrorWalletReadinessFailed(), {
-        phase: 'stellar_funding_destination_validation',
-        destination_public_key: input.destinationPublicKey.trim() || null,
-        destination_validation_result: 'invalid',
-      }),
+      error: spendRailErrorWithDiagnostics(
+        spendRailErrorWalletReadinessFailed(),
+        {
+          phase: 'stellar_funding_destination_validation',
+          destination_public_key: input.destinationPublicKey.trim() || null,
+          destination_validation_result: 'invalid',
+        }
+      ),
     };
   }
 
@@ -365,8 +358,10 @@ export async function submitStellarTreasuryUsdcFunding(input: {
   const commonDiagnostics = {
     destination_public_key: destOk.data,
     destination_validation_result: 'valid',
-    treasury_public_key_suffix: suffix(treasuryKp.publicKey()),
-    usdc_issuer_suffix: suffix(usdcIssuer),
+    treasury_public_key_suffix: spendRailDiagnosticKeySuffix(
+      treasuryKp.publicKey()
+    ),
+    usdc_issuer_suffix: spendRailDiagnosticKeySuffix(usdcIssuer),
   };
 
   const server = createStellarSpendHorizonServer();
@@ -385,7 +380,7 @@ export async function submitStellarTreasuryUsdcFunding(input: {
   } catch (e) {
     return {
       kind: 'error',
-      error: railErrorWithDiagnostics(classifyHorizonException(), {
+      error: spendRailErrorWithDiagnostics(classifyHorizonException(), {
         phase: 'stellar_funding_prior_lookup',
         ...commonDiagnostics,
         ...horizonDiagnostics(e),
@@ -452,7 +447,7 @@ export async function submitStellarTreasuryUsdcFunding(input: {
     console.error('submitStellarTreasuryUsdcFunding submit:', e);
     return {
       kind: 'error',
-      error: railErrorWithDiagnostics(classifySubmitException(e), {
+      error: spendRailErrorWithDiagnostics(classifySubmitException(e), {
         phase: 'stellar_funding_horizon_submit',
         ...commonDiagnostics,
         ...horizonDiagnostics(e),

--- a/lib/spend/stellar-treasury-funding.ts
+++ b/lib/spend/stellar-treasury-funding.ts
@@ -35,9 +35,51 @@ function classifyHorizonException(): SpendRailError {
   return spendRailErrorNetworkUnavailable();
 }
 
+function suffix(value: string | null | undefined, length = 8): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed.slice(-length) : null;
+}
+
+function resultCodesFromHorizonError(e: unknown): unknown {
+  const data = (e as { response?: { data?: unknown } })?.response?.data;
+  if (!data || typeof data !== 'object') return null;
+  const extras = (data as { extras?: unknown }).extras;
+  if (!extras || typeof extras !== 'object') return null;
+  return (extras as { result_codes?: unknown }).result_codes ?? null;
+}
+
+function horizonDiagnostics(e: unknown): Record<string, unknown> {
+  const response = (e as { response?: { status?: number; data?: unknown } })
+    ?.response;
+  const data =
+    response?.data && typeof response.data === 'object'
+      ? (response.data as Record<string, unknown>)
+      : null;
+  const resultCodes = resultCodesFromHorizonError(e);
+  return {
+    ...(response?.status ? { horizon_status: response.status } : {}),
+    ...(typeof data?.title === 'string' ? { horizon_title: data.title } : {}),
+    ...(typeof data?.detail === 'string'
+      ? { horizon_detail: data.detail.slice(0, 1000) }
+      : {}),
+    ...(data?.extras && typeof data.extras === 'object'
+      ? { horizon_extras: data.extras }
+      : {}),
+    ...(resultCodes ? { horizon_result_codes: resultCodes } : {}),
+  };
+}
+
+function railErrorWithDiagnostics(
+  error: SpendRailError,
+  internalDiagnostics: Record<string, unknown>
+): SpendRailError {
+  return { ...error, internalDiagnostics };
+}
+
 function classifySubmitException(e: unknown): SpendRailError {
   const raw = e instanceof Error ? e.message : String(e);
-  const s = raw.toLowerCase();
+  const resultCodes = JSON.stringify(resultCodesFromHorizonError(e) ?? {});
+  const s = `${raw} ${resultCodes}`.toLowerCase();
   if (
     s.includes('fetch') ||
     s.includes('econn') ||
@@ -207,7 +249,7 @@ export async function findSuccessfulStellarFundingTxByMemo(input: {
       .call();
   } catch (e) {
     console.error('findSuccessfulStellarFundingTxByMemo first page:', e);
-    throw classifyHorizonException();
+    throw e;
   }
 
   for (let pageIdx = 0; pageIdx < PRIOR_PAYMENT_MAX_PAGES; pageIdx += 1) {
@@ -259,7 +301,7 @@ export async function findSuccessfulStellarFundingTxByMemo(input: {
       page = await page.next();
     } catch (e) {
       console.error('findSuccessfulStellarFundingTxByMemo page.next:', e);
-      throw classifyHorizonException();
+      throw e;
     }
   }
 
@@ -304,7 +346,14 @@ export async function submitStellarTreasuryUsdcFunding(input: {
     input.destinationPublicKey.trim()
   );
   if (!destOk.success) {
-    return { kind: 'error', error: spendRailErrorWalletReadinessFailed() };
+    return {
+      kind: 'error',
+      error: railErrorWithDiagnostics(spendRailErrorWalletReadinessFailed(), {
+        phase: 'stellar_funding_destination_validation',
+        destination_public_key: input.destinationPublicKey.trim() || null,
+        destination_validation_result: 'invalid',
+      }),
+    };
   }
 
   const usdcIssuer = getStellarSpendUsdcIssuer();
@@ -313,18 +362,38 @@ export async function submitStellarTreasuryUsdcFunding(input: {
   }
   const code = getStellarSpendUsdcAssetCode();
   const asset = new Asset(code, usdcIssuer);
+  const commonDiagnostics = {
+    destination_public_key: destOk.data,
+    destination_validation_result: 'valid',
+    treasury_public_key_suffix: suffix(treasuryKp.publicKey()),
+    usdc_issuer_suffix: suffix(usdcIssuer),
+  };
 
   const server = createStellarSpendHorizonServer();
   const passphrase = getStellarSpendNetworkPassphrase();
 
-  const prior = await findSuccessfulStellarFundingTxByMemo({
-    treasuryPublicKey: treasuryKp.publicKey(),
-    destinationPublicKey: destOk.data,
-    fundingReferenceId: input.fundingReferenceId,
-    usdcAmount: input.usdcAmount,
-    usdcIssuer,
-    usdcCode: code,
-  });
+  let prior: string | null;
+  try {
+    prior = await findSuccessfulStellarFundingTxByMemo({
+      treasuryPublicKey: treasuryKp.publicKey(),
+      destinationPublicKey: destOk.data,
+      fundingReferenceId: input.fundingReferenceId,
+      usdcAmount: input.usdcAmount,
+      usdcIssuer,
+      usdcCode: code,
+    });
+  } catch (e) {
+    return {
+      kind: 'error',
+      error: railErrorWithDiagnostics(classifyHorizonException(), {
+        phase: 'stellar_funding_prior_lookup',
+        ...commonDiagnostics,
+        ...horizonDiagnostics(e),
+        error_message:
+          e instanceof Error ? e.message.slice(0, 1000) : String(e),
+      }),
+    };
+  }
   if (prior) {
     return { kind: 'confirmed', txHash: prior };
   }
@@ -381,7 +450,16 @@ export async function submitStellarTreasuryUsdcFunding(input: {
     txHash = res.hash;
   } catch (e) {
     console.error('submitStellarTreasuryUsdcFunding submit:', e);
-    return { kind: 'error', error: classifySubmitException(e) };
+    return {
+      kind: 'error',
+      error: railErrorWithDiagnostics(classifySubmitException(e), {
+        phase: 'stellar_funding_horizon_submit',
+        ...commonDiagnostics,
+        ...horizonDiagnostics(e),
+        error_message:
+          e instanceof Error ? e.message.slice(0, 1000) : String(e),
+      }),
+    };
   }
 
   const outcome = await waitForHorizonTxSuccess(server, txHash);

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -350,6 +350,7 @@ export type PointConversionLastFailure = {
   phase: 'readiness' | 'funding' | 'resume';
   category: string;
   reason_snippet: string;
+  internal_diagnostics?: Record<string, unknown>;
 };
 
 export type PointConversion = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Reload the spend session after Stellar readiness completes and rebuild the funding context with the fresh `rail_user_wallet_address`.
- Add an explicit `stellarFundingDestinationWalletAddress` context field so Stellar funding does not use the EVM auth wallet as the payment destination.
- Preserve internal funding diagnostics on rail errors and `conversion_last_failure` for destination validation, prior lookup, and Horizon submit failures.
- Enrich Stellar treasury submit classification with Horizon result codes such as `op_no_trust`, insufficient balance, and network/config failures.

## Testing
- `yarn test lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-conversion-confirm.test.ts lib/spend/stellar-wallet-readiness-orchestration.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

