### PR TITLE
fix: resolve Stellar wallet id from player metadata

### DIFF
--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -165,8 +165,8 @@ export const getPlayerByStellarWallet = async (
 export async function getPlayersByEvmWalletCaseInsensitive(
   walletAddress: string
 ): Promise<Player[]> {
-  // TODO: after existing duplicates are merged, add a partial unique index on
-  // `lower(trim(wallet_address))` so EVM casing cannot create parallel players.
+  // Note: once duplicate lowercased wallet groups are merged, a partial unique
+  // index on `lower(trim(wallet_address))` would prevent parallel EVM rows.
   const t = walletAddress.trim();
   if (!t) return [];
   const evm = tryNormalizeEvmAddress(t);
@@ -189,7 +189,12 @@ export async function updatePlayerStellarWalletMetadata(
     stellarWalletId?: string;
   }
 ): Promise<Player> {
-  const updates: Record<string, string> = {
+  type Patch = {
+    updated_at: string;
+    stellar_wallet_address?: string;
+    stellar_wallet_id?: string;
+  };
+  const updates: Patch = {
     updated_at: new Date().toISOString(),
   };
   const stellarWalletAddress = input.stellarWalletAddress?.trim();

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -156,8 +156,61 @@ export const getPlayerBySolanaWallet = async (solanaWalletAddress: string) => {
 export const getPlayerByStellarWallet = async (
   stellarWalletAddress: string
 ) => {
-  return getPlayerByField('stellar_wallet_address', stellarWalletAddress);
+  return getPlayerByField(
+    'stellar_wallet_address',
+    stellarWalletAddress.trim()
+  );
 };
+
+export async function getPlayersByEvmWalletCaseInsensitive(
+  walletAddress: string
+): Promise<Player[]> {
+  // TODO: after existing duplicates are merged, add a partial unique index on
+  // `lower(trim(wallet_address))` so EVM casing cannot create parallel players.
+  const t = walletAddress.trim();
+  if (!t) return [];
+  const evm = tryNormalizeEvmAddress(t);
+  if (!evm) return [];
+
+  const { data, error } = await supabase
+    .from('players')
+    .select(PLAYER_COLUMNS)
+    .ilike('wallet_address', evm)
+    .order('id', { ascending: true });
+
+  if (error) throw error;
+  return data ?? [];
+}
+
+export async function updatePlayerStellarWalletMetadata(
+  playerId: number,
+  input: {
+    stellarWalletAddress?: string;
+    stellarWalletId?: string;
+  }
+): Promise<Player> {
+  const updates: Record<string, string> = {
+    updated_at: new Date().toISOString(),
+  };
+  const stellarWalletAddress = input.stellarWalletAddress?.trim();
+  const stellarWalletId = input.stellarWalletId?.trim();
+  if (stellarWalletAddress) {
+    updates.stellar_wallet_address = stellarWalletAddress;
+  }
+  if (stellarWalletId) {
+    updates.stellar_wallet_id = stellarWalletId;
+  }
+
+  const { data, error } = await supabase
+    .from('players')
+    .update(updates)
+    .eq('id', playerId)
+    .select(PLAYER_COLUMNS)
+    .single();
+
+  if (error) throw error;
+  return data;
+}
 
 /**
  * Get player by Aptos wallet address

--- a/lib/privy/__tests__/stellar-rail-wallet.test.ts
+++ b/lib/privy/__tests__/stellar-rail-wallet.test.ts
@@ -3,7 +3,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 const mockGetUser = vi.fn();
 const mockWalletCreate = vi.fn();
 const mockGetPlayerByEmail = vi.fn();
+const mockGetPlayerByStellarWallet = vi.fn();
+const mockGetPlayersByEvmWalletCaseInsensitive = vi.fn();
 const mockCreateOrUpdatePlayerForStellar = vi.fn();
+const mockUpdatePlayerStellarWalletMetadata = vi.fn();
 
 vi.mock('@/lib/api/privy', () => ({
   getPrivyClient: () => ({
@@ -16,8 +19,14 @@ vi.mock('@/lib/api/privy', () => ({
 
 vi.mock('@/lib/db/players', () => ({
   getPlayerByEmail: (...a: unknown[]) => mockGetPlayerByEmail(...a),
+  getPlayerByStellarWallet: (...a: unknown[]) =>
+    mockGetPlayerByStellarWallet(...a),
+  getPlayersByEvmWalletCaseInsensitive: (...a: unknown[]) =>
+    mockGetPlayersByEvmWalletCaseInsensitive(...a),
   createOrUpdatePlayerForStellar: (...a: unknown[]) =>
     mockCreateOrUpdatePlayerForStellar(...a),
+  updatePlayerStellarWalletMetadata: (...a: unknown[]) =>
+    mockUpdatePlayerStellarWalletMetadata(...a),
 }));
 
 import {
@@ -106,9 +115,29 @@ describe('ensureStellarRailUserWallet', () => {
 describe('resolveStellarPrivyWalletIdForUser', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockGetPlayerByStellarWallet.mockResolvedValue(null);
+    mockGetPlayersByEvmWalletCaseInsensitive.mockResolvedValue([]);
   });
 
-  it('returns the linked Stellar wallet id matching the address', async () => {
+  it('returns DB wallet id without requiring Privy linked account match', async () => {
+    mockGetPlayerByStellarWallet.mockResolvedValue({
+      id: 2,
+      stellar_wallet_address: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      stellar_wallet_id: 'wid-db',
+    });
+    mockGetUser.mockResolvedValue({
+      linkedAccounts: [],
+    });
+    await expect(
+      resolveStellarPrivyWalletIdForUser(
+        'privy-u1',
+        'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+      )
+    ).resolves.toBe('wid-db');
+    expect(mockGetUser).not.toHaveBeenCalled();
+  });
+
+  it('falls back to linked Privy Stellar wallet id matching the address', async () => {
     mockGetUser.mockResolvedValue({
       linkedAccounts: [
         {
@@ -125,6 +154,75 @@ describe('resolveStellarPrivyWalletIdForUser', () => {
         'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
       )
     ).resolves.toBe('wid-99');
+  });
+
+  it('backfills missing DB wallet id when Privy fallback resolves it', async () => {
+    mockGetPlayerByStellarWallet.mockResolvedValue({
+      id: 2,
+      stellar_wallet_address: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      stellar_wallet_id: null,
+    });
+    mockGetUser.mockResolvedValue({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          id: 'wid-99',
+        },
+      ],
+    });
+
+    await expect(
+      resolveStellarPrivyWalletIdForUser(
+        'privy-u1',
+        'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+      )
+    ).resolves.toBe('wid-99');
+    expect(mockUpdatePlayerStellarWalletMetadata).toHaveBeenCalledWith(2, {
+      stellarWalletAddress: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      stellarWalletId: 'wid-99',
+    });
+  });
+
+  it('backfills an EVM-matched player case-insensitively when no Stellar row exists', async () => {
+    mockGetUser.mockResolvedValue({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'ethereum',
+          address: '0x4D418f71c531465337b65127B207aa849Fa5a9e3',
+        },
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+          id: 'wid-99',
+        },
+      ],
+    });
+    mockGetPlayersByEvmWalletCaseInsensitive.mockResolvedValue([
+      {
+        id: 1684,
+        wallet_address: '0x4d418f71c531465337b65127b207aa849fa5a9e3',
+        stellar_wallet_address: null,
+        stellar_wallet_id: null,
+      },
+    ]);
+
+    await expect(
+      resolveStellarPrivyWalletIdForUser(
+        'privy-u1',
+        'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB'
+      )
+    ).resolves.toBe('wid-99');
+    expect(mockGetPlayersByEvmWalletCaseInsensitive).toHaveBeenCalledWith(
+      '0x4D418f71c531465337b65127B207aa849Fa5a9e3'
+    );
+    expect(mockUpdatePlayerStellarWalletMetadata).toHaveBeenCalledWith(1684, {
+      stellarWalletAddress: 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB',
+      stellarWalletId: 'wid-99',
+    });
   });
 
   it('throws when no matching Stellar wallet is linked', async () => {

--- a/lib/privy/stellar-rail-wallet.ts
+++ b/lib/privy/stellar-rail-wallet.ts
@@ -111,9 +111,10 @@ export async function resolveStellarPrivyWalletIdForUser(
       wanted,
       user
     );
-    if (backfillPlayer?.id != null) {
+    const backfillPlayerId = backfillPlayer?.id;
+    if (backfillPlayerId != null) {
       try {
-        await updatePlayerStellarWalletMetadata(backfillPlayer.id, {
+        await updatePlayerStellarWalletMetadata(backfillPlayerId, {
           stellarWalletAddress: wanted,
           stellarWalletId: walletId,
         });
@@ -121,7 +122,7 @@ export async function resolveStellarPrivyWalletIdForUser(
         console.warn('resolveStellarPrivyWalletIdForUser backfill failed:', {
           privyUserId,
           stellar_address_suffix: stellarAddressSuffix,
-          player_id: backfillPlayer.id,
+          player_id: backfillPlayerId,
           error_name: e instanceof Error ? e.name : 'Unknown',
           error_message: e instanceof Error ? e.message : String(e),
         });
@@ -133,7 +134,7 @@ export async function resolveStellarPrivyWalletIdForUser(
       dbLookupFoundWalletId: false,
       privyLinkedAccountsFoundWalletId: true,
       outcome:
-        backfillPlayer?.id != null ? 'privy_match_backfilled' : 'privy_match',
+        backfillPlayerId != null ? 'privy_match_backfilled' : 'privy_match',
     });
     return walletId;
   }
@@ -147,12 +148,18 @@ export async function resolveStellarPrivyWalletIdForUser(
   throw new Error('stellar_privy_wallet_id_unresolved');
 }
 
+type StellarWalletIdResolutionOutcome =
+  | 'db_match'
+  | 'privy_match'
+  | 'privy_match_backfilled'
+  | 'unresolved';
+
 function logStellarWalletIdResolution(input: {
   privyUserId: string;
   stellarAddressSuffix: string;
   dbLookupFoundWalletId: boolean;
   privyLinkedAccountsFoundWalletId: boolean;
-  outcome: string;
+  outcome: StellarWalletIdResolutionOutcome;
 }) {
   console.info('resolveStellarPrivyWalletIdForUser:', {
     privyUserId: input.privyUserId,
@@ -165,7 +172,7 @@ function logStellarWalletIdResolution(input: {
 }
 
 function linkedEvmAddresses(user: { linkedAccounts?: unknown[] }): string[] {
-  const addresses: string[] = [];
+  const seen = new Set<string>();
   for (const account of user.linkedAccounts ?? []) {
     const record =
       account && typeof account === 'object'
@@ -180,11 +187,9 @@ function linkedEvmAddresses(user: { linkedAccounts?: unknown[] }): string[] {
       continue;
     }
     const trimmed = record.address.trim();
-    if (trimmed && !addresses.includes(trimmed)) {
-      addresses.push(trimmed);
-    }
+    if (trimmed) seen.add(trimmed);
   }
-  return addresses;
+  return Array.from(seen);
 }
 
 async function resolvePlayerForStellarWalletIdBackfill(
@@ -199,8 +204,15 @@ async function resolvePlayerForStellarWalletIdBackfill(
     return dbPlayer;
   }
 
-  for (const evmAddress of linkedEvmAddresses(user)) {
-    const matches = await getPlayersByEvmWalletCaseInsensitive(evmAddress);
+  const evmAddresses = linkedEvmAddresses(user);
+  if (evmAddresses.length === 0) return null;
+
+  const matchLists = await Promise.all(
+    evmAddresses.map((addr) => getPlayersByEvmWalletCaseInsensitive(addr))
+  );
+
+  for (let i = 0; i < evmAddresses.length; i++) {
+    const matches = matchLists[i] ?? [];
     const exactStellarMatch = matches.find(
       (player) => player.stellar_wallet_address?.trim() === wantedStellarAddress
     );

--- a/lib/privy/stellar-rail-wallet.ts
+++ b/lib/privy/stellar-rail-wallet.ts
@@ -2,7 +2,11 @@ import { getPrivyClient } from '@/lib/api/privy';
 import {
   createOrUpdatePlayerForStellar,
   getPlayerByEmail,
+  getPlayerByStellarWallet,
+  getPlayersByEvmWalletCaseInsensitive,
+  updatePlayerStellarWalletMetadata,
 } from '@/lib/db/players';
+import type { Player } from '@/lib/types';
 
 export type EnsureStellarRailUserWalletResult = {
   address: string;
@@ -77,9 +81,23 @@ export async function resolveStellarPrivyWalletIdForUser(
   privyUserId: string,
   canonicalAddress: string
 ): Promise<string> {
+  const wanted = canonicalAddress.trim();
+  const stellarAddressSuffix = wanted.slice(-8);
+  const dbPlayer = await getPlayerByStellarWallet(wanted);
+  const dbWalletId = dbPlayer?.stellar_wallet_id?.trim();
+  if (dbWalletId) {
+    logStellarWalletIdResolution({
+      privyUserId,
+      stellarAddressSuffix,
+      dbLookupFoundWalletId: true,
+      privyLinkedAccountsFoundWalletId: false,
+      outcome: 'db_match',
+    });
+    return dbWalletId;
+  }
+
   const privy = getPrivyClient();
   const user = await privy.getUser(privyUserId);
-  const wanted = canonicalAddress.trim();
   const linked = user.linkedAccounts?.find((a) => {
     if (a.type !== 'wallet' || !('chainType' in a)) return false;
     if (a.chainType !== 'stellar') return false;
@@ -87,7 +105,111 @@ export async function resolveStellarPrivyWalletIdForUser(
     return a.address.trim() === wanted;
   });
   if (linked && 'id' in linked && linked.id != null && linked.id !== '') {
-    return String(linked.id);
+    const walletId = String(linked.id);
+    const backfillPlayer = await resolvePlayerForStellarWalletIdBackfill(
+      dbPlayer,
+      wanted,
+      user
+    );
+    if (backfillPlayer?.id != null) {
+      try {
+        await updatePlayerStellarWalletMetadata(backfillPlayer.id, {
+          stellarWalletAddress: wanted,
+          stellarWalletId: walletId,
+        });
+      } catch (e) {
+        console.warn('resolveStellarPrivyWalletIdForUser backfill failed:', {
+          privyUserId,
+          stellar_address_suffix: stellarAddressSuffix,
+          player_id: backfillPlayer.id,
+          error_name: e instanceof Error ? e.name : 'Unknown',
+          error_message: e instanceof Error ? e.message : String(e),
+        });
+      }
+    }
+    logStellarWalletIdResolution({
+      privyUserId,
+      stellarAddressSuffix,
+      dbLookupFoundWalletId: false,
+      privyLinkedAccountsFoundWalletId: true,
+      outcome:
+        backfillPlayer?.id != null ? 'privy_match_backfilled' : 'privy_match',
+    });
+    return walletId;
   }
+  logStellarWalletIdResolution({
+    privyUserId,
+    stellarAddressSuffix,
+    dbLookupFoundWalletId: false,
+    privyLinkedAccountsFoundWalletId: false,
+    outcome: 'unresolved',
+  });
   throw new Error('stellar_privy_wallet_id_unresolved');
+}
+
+function logStellarWalletIdResolution(input: {
+  privyUserId: string;
+  stellarAddressSuffix: string;
+  dbLookupFoundWalletId: boolean;
+  privyLinkedAccountsFoundWalletId: boolean;
+  outcome: string;
+}) {
+  console.info('resolveStellarPrivyWalletIdForUser:', {
+    privyUserId: input.privyUserId,
+    stellar_address_suffix: input.stellarAddressSuffix,
+    db_lookup_found_wallet_id: input.dbLookupFoundWalletId,
+    privy_linked_accounts_found_wallet_id:
+      input.privyLinkedAccountsFoundWalletId,
+    outcome: input.outcome,
+  });
+}
+
+function linkedEvmAddresses(user: { linkedAccounts?: unknown[] }): string[] {
+  const addresses: string[] = [];
+  for (const account of user.linkedAccounts ?? []) {
+    const record =
+      account && typeof account === 'object'
+        ? (account as Record<string, unknown>)
+        : null;
+    if (!record) continue;
+    if (
+      record.type !== 'wallet' ||
+      typeof record.address !== 'string' ||
+      record.chainType === 'stellar'
+    ) {
+      continue;
+    }
+    const trimmed = record.address.trim();
+    if (trimmed && !addresses.includes(trimmed)) {
+      addresses.push(trimmed);
+    }
+  }
+  return addresses;
+}
+
+async function resolvePlayerForStellarWalletIdBackfill(
+  dbPlayer: Player | null,
+  wantedStellarAddress: string,
+  user: { linkedAccounts?: unknown[] }
+): Promise<Player | null> {
+  if (
+    dbPlayer?.stellar_wallet_address?.trim() === wantedStellarAddress &&
+    !dbPlayer.stellar_wallet_id?.trim()
+  ) {
+    return dbPlayer;
+  }
+
+  for (const evmAddress of linkedEvmAddresses(user)) {
+    const matches = await getPlayersByEvmWalletCaseInsensitive(evmAddress);
+    const exactStellarMatch = matches.find(
+      (player) => player.stellar_wallet_address?.trim() === wantedStellarAddress
+    );
+    if (exactStellarMatch) return exactStellarMatch;
+    const emptyStellarMatch = matches.find(
+      (player) => !player.stellar_wallet_address?.trim()
+    );
+    if (emptyStellarMatch) return emptyStellarMatch;
+  }
+
+  return null;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Resolve Stellar Privy wallet IDs from `players.stellar_wallet_address` / `stellar_wallet_id` before querying Privy linked accounts.
- Preserve Privy linked-account fallback and backfill missing `stellar_wallet_id` to the matched player row.
- Add case-insensitive EVM player matching for backfill when no exact Stellar row exists.
- Add non-secret resolver diagnostics with Privy user id, Stellar suffix, DB hit state, and Privy hit state.

## Testing
- `yarn test lib/privy/__tests__/stellar-rail-wallet.test.ts lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-payment-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.

## Follow-up
- Production has `players_wallet_address_key` on raw `wallet_address`, but no unique index on `lower(trim(wallet_address))`; duplicate lowercased wallet groups exist, including the reported wallet. Existing duplicates should be merged before adding a partial unique index on `lower(trim(wallet_address))`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

