### PR TITLE
fix: source Stellar payment sponsorship close from user

### DIFF
--- a/lib/spend/stellar-spend-payment-submit.test.ts
+++ b/lib/spend/stellar-spend-payment-submit.test.ts
@@ -1,0 +1,91 @@
+import { Account } from '@stellar/stellar-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const USER_PUBLIC_KEY =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const RECEIVER_PUBLIC_KEY =
+  'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+
+const hoisted = vi.hoisted(() => ({
+  mockRawSign: vi.fn(),
+  mockServer: {
+    loadAccount: vi.fn(),
+    fetchBaseFee: vi.fn(),
+    submitTransaction: vi.fn(),
+  },
+}));
+
+vi.mock('@/lib/privy-server-rest', () => ({
+  privyWalletRawSignTransactionHash: (...args: unknown[]) =>
+    hoisted.mockRawSign(...args),
+}));
+
+vi.mock('@/lib/spend/stellar-wallet-readiness-config', async () => {
+  const { Keypair, Networks } = await import('@stellar/stellar-sdk');
+  return {
+    createStellarSpendHorizonServer: () => hoisted.mockServer,
+    getStellarSpendNetworkPassphrase: () => Networks.TESTNET,
+    getStellarSpendUsdcAssetCode: () => 'USDC',
+    getStellarSpendUsdcIssuer: () =>
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+    parseStellarSpendSponsorKeypair: () =>
+      Keypair.fromSecret(
+        'SAPTCMRTYYW4H6ZU5YPH6LDJZYGEIECEPJYTBYPAX7KCFRRIVHJHGJFL'
+      ),
+  };
+});
+
+import { submitSponsoredStellarUsdcPaymentFromUser } from './stellar-spend-payment-submit';
+
+describe('submitSponsoredStellarUsdcPaymentFromUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    hoisted.mockRawSign.mockResolvedValue(Buffer.alloc(64));
+    hoisted.mockServer.loadAccount.mockResolvedValue(
+      new Account(USER_PUBLIC_KEY, '1')
+    );
+    hoisted.mockServer.fetchBaseFee.mockResolvedValue(100);
+  });
+
+  it('builds sponsored payment operations with the expected source accounts', async () => {
+    hoisted.mockServer.submitTransaction.mockRejectedValue(
+      Object.assign(new Error('Request failed with status code 400'), {
+        response: {
+          data: {
+            title: 'Transaction Failed',
+            extras: {
+              result_codes: {
+                transaction: 'tx_fee_bump_inner_failed',
+                inner_transaction: 'tx_failed',
+                operations: ['op_success', 'op_success', 'op_not_sponsored'],
+              },
+            },
+          },
+        },
+      })
+    );
+
+    const result = await submitSponsoredStellarUsdcPaymentFromUser({
+      userPublicKey: USER_PUBLIC_KEY,
+      privyStellarWalletId: 'stellar-wallet-id',
+      destinationPublicKey: RECEIVER_PUBLIC_KEY,
+      usdcAmount: 1,
+    });
+
+    expect(result.ok).toBe(false);
+    const feeBump = hoisted.mockServer.submitTransaction.mock.calls[0]?.[0];
+    const operations = feeBump.innerTransaction.operations;
+    expect(operations.map((op: { type: string }) => op.type)).toEqual([
+      'beginSponsoringFutureReserves',
+      'payment',
+      'endSponsoringFutureReserves',
+    ]);
+    expect(operations[0].source).toBe(feeBump.feeSource);
+    expect(operations[0].source).not.toBe(USER_PUBLIC_KEY);
+    expect(operations[1].source).toBeUndefined();
+    expect(operations[2].source).toBe(USER_PUBLIC_KEY);
+    expect(result.internalMessage).toContain('tx_fee_bump_inner_failed');
+    expect(result.internalMessage).toContain('tx_failed');
+    expect(result.internalMessage).toContain('op_not_sponsored');
+  });
+});

--- a/lib/spend/stellar-spend-payment-submit.test.ts
+++ b/lib/spend/stellar-spend-payment-submit.test.ts
@@ -22,16 +22,13 @@ vi.mock('@/lib/privy-server-rest', () => ({
 
 vi.mock('@/lib/spend/stellar-wallet-readiness-config', async () => {
   const { Keypair, Networks } = await import('@stellar/stellar-sdk');
+  const sponsor = Keypair.random();
   return {
     createStellarSpendHorizonServer: () => hoisted.mockServer,
     getStellarSpendNetworkPassphrase: () => Networks.TESTNET,
     getStellarSpendUsdcAssetCode: () => 'USDC',
-    getStellarSpendUsdcIssuer: () =>
-      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
-    parseStellarSpendSponsorKeypair: () =>
-      Keypair.fromSecret(
-        'SAPTCMRTYYW4H6ZU5YPH6LDJZYGEIECEPJYTBYPAX7KCFRRIVHJHGJFL'
-      ),
+    getStellarSpendUsdcIssuer: () => RECEIVER_PUBLIC_KEY,
+    parseStellarSpendSponsorKeypair: () => sponsor,
   };
 });
 

--- a/lib/spend/stellar-spend-payment-submit.ts
+++ b/lib/spend/stellar-spend-payment-submit.ts
@@ -20,8 +20,8 @@ function formatUsdcAmountForStellar(amount: number): string {
   return floored.toFixed(7);
 }
 
-function classifySubmitMessage(raw: string): string {
-  const s = raw.toLowerCase();
+function classifySubmitMessage(raw: string, resultCodes?: unknown): string {
+  const s = `${raw} ${JSON.stringify(resultCodes ?? {})}`.toLowerCase();
   if (
     s.includes('fetch') ||
     s.includes('econn') ||
@@ -42,6 +42,38 @@ function classifySubmitMessage(raw: string): string {
     return 'insufficient_usdc_or_reserve';
   }
   return 'stellar_submit_failed';
+}
+
+function horizonResultCodesFromError(e: unknown): unknown {
+  const data = (e as { response?: { data?: unknown } })?.response?.data;
+  if (!data || typeof data !== 'object') return null;
+  const extras = (data as { extras?: unknown }).extras;
+  if (!extras || typeof extras !== 'object') return null;
+  return (extras as { result_codes?: unknown }).result_codes ?? null;
+}
+
+function horizonSubmitInternalMessage(e: unknown): string {
+  const msg = e instanceof Error ? e.message : String(e);
+  const data = (e as { response?: { data?: unknown } })?.response?.data;
+  const resultCodes = horizonResultCodesFromError(e);
+  const title =
+    data &&
+    typeof data === 'object' &&
+    typeof (data as { title?: unknown }).title === 'string'
+      ? (data as { title: string }).title
+      : null;
+  const detail =
+    data &&
+    typeof data === 'object' &&
+    typeof (data as { detail?: unknown }).detail === 'string'
+      ? (data as { detail: string }).detail
+      : null;
+  return JSON.stringify({
+    message: msg.slice(0, 400),
+    ...(title ? { horizon_title: title } : {}),
+    ...(detail ? { horizon_detail: detail.slice(0, 800) } : {}),
+    ...(resultCodes ? { horizon_result_codes: resultCodes } : {}),
+  }).slice(0, 1200);
 }
 
 async function loadAccountOrThrow(
@@ -99,7 +131,7 @@ export async function submitSponsoredStellarUsdcPaymentFromUser(input: {
     const msg = e instanceof Error ? e.message : String(e);
     return {
       ok: false,
-      reason: classifySubmitMessage(msg),
+      reason: classifySubmitMessage(msg, horizonResultCodesFromError(e)),
       internalMessage: msg.slice(0, 500),
     };
   }
@@ -123,7 +155,7 @@ export async function submitSponsoredStellarUsdcPaymentFromUser(input: {
     )
     .addOperation(
       Operation.endSponsoringFutureReserves({
-        source: sponsor.publicKey(),
+        source: userPub,
       })
     )
     .setTimeout(180)
@@ -180,15 +212,10 @@ export async function submitSponsoredStellarUsdcPaymentFromUser(input: {
     return { ok: true, txHash: res.hash };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    const extras = (e as { response?: { data?: unknown } })?.response?.data;
-    const detail =
-      extras && typeof extras === 'object'
-        ? JSON.stringify(extras).slice(0, 800)
-        : '';
     return {
       ok: false,
-      reason: classifySubmitMessage(msg),
-      internalMessage: `${msg.slice(0, 400)} ${detail}`,
+      reason: classifySubmitMessage(msg, horizonResultCodesFromError(e)),
+      internalMessage: horizonSubmitInternalMessage(e),
     };
   }
 }

--- a/lib/spend/stellar-spend-payment-submit.ts
+++ b/lib/spend/stellar-spend-payment-submit.ts
@@ -44,30 +44,32 @@ function classifySubmitMessage(raw: string, resultCodes?: unknown): string {
   return 'stellar_submit_failed';
 }
 
-function horizonResultCodesFromError(e: unknown): unknown {
-  const data = (e as { response?: { data?: unknown } })?.response?.data;
-  if (!data || typeof data !== 'object') return null;
-  const extras = (data as { extras?: unknown }).extras;
-  if (!extras || typeof extras !== 'object') return null;
-  return (extras as { result_codes?: unknown }).result_codes ?? null;
+function readHorizonHttpErrorData(e: unknown): {
+  data: Record<string, unknown> | null;
+  resultCodes: unknown;
+} {
+  const raw = (e as { response?: { data?: unknown } })?.response?.data;
+  if (!raw || typeof raw !== 'object') {
+    return { data: null, resultCodes: null };
+  }
+  const data = raw as Record<string, unknown>;
+  const extras = data.extras;
+  if (!extras || typeof extras !== 'object') {
+    return { data, resultCodes: null };
+  }
+  return {
+    data,
+    resultCodes: (extras as { result_codes?: unknown }).result_codes ?? null,
+  };
 }
 
-function horizonSubmitInternalMessage(e: unknown): string {
-  const msg = e instanceof Error ? e.message : String(e);
-  const data = (e as { response?: { data?: unknown } })?.response?.data;
-  const resultCodes = horizonResultCodesFromError(e);
-  const title =
-    data &&
-    typeof data === 'object' &&
-    typeof (data as { title?: unknown }).title === 'string'
-      ? (data as { title: string }).title
-      : null;
-  const detail =
-    data &&
-    typeof data === 'object' &&
-    typeof (data as { detail?: unknown }).detail === 'string'
-      ? (data as { detail: string }).detail
-      : null;
+function formatHorizonSubmitInternalMessage(
+  msg: string,
+  data: Record<string, unknown> | null,
+  resultCodes: unknown
+): string {
+  const title = data && typeof data.title === 'string' ? data.title : null;
+  const detail = data && typeof data.detail === 'string' ? data.detail : null;
   return JSON.stringify({
     message: msg.slice(0, 400),
     ...(title ? { horizon_title: title } : {}),
@@ -129,9 +131,10 @@ export async function submitSponsoredStellarUsdcPaymentFromUser(input: {
     userAccount = await loadAccountOrThrow(server, userPub);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
+    const { resultCodes } = readHorizonHttpErrorData(e);
     return {
       ok: false,
-      reason: classifySubmitMessage(msg, horizonResultCodesFromError(e)),
+      reason: classifySubmitMessage(msg, resultCodes),
       internalMessage: msg.slice(0, 500),
     };
   }
@@ -212,10 +215,15 @@ export async function submitSponsoredStellarUsdcPaymentFromUser(input: {
     return { ok: true, txHash: res.hash };
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
+    const { data, resultCodes } = readHorizonHttpErrorData(e);
     return {
       ok: false,
-      reason: classifySubmitMessage(msg, horizonResultCodesFromError(e)),
-      internalMessage: horizonSubmitInternalMessage(e),
+      reason: classifySubmitMessage(msg, resultCodes),
+      internalMessage: formatHorizonSubmitInternalMessage(
+        msg,
+        data,
+        resultCodes
+      ),
     };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Source final payment `endSponsoringFutureReserves` from the user Stellar wallet instead of the sponsor.
- Preserve sponsor-sourced `beginSponsoringFutureReserves`, user/default-sourced USDC payment, and the existing fee-bump sponsorship flow.
- Include Horizon `extras.result_codes` in Stellar payment submit internal messages and submit reason classification.
- Add a direct payment submit test that inspects the fee-bump inner operation sources and result-code diagnostics.

## Testing
- `yarn test lib/spend/stellar-spend-payment-submit.test.ts lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend-payment-confirm.test.ts` passed.
- `yarn test lib/spend/stellar-wallet-readiness-orchestration.test.ts` passed.
- `yarn test lib/spend/stellar-spend-payment-submit.test.ts && yarn build` passed with existing lint warnings and dynamic route logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

