### PR TITLE
fix: show spend rail USDC balance in preview

### DIFF
--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -1,5 +1,38 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { buildSpendEligibilityPreview } from '@/lib/spend-conversion-preview';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+const hoisted = vi.hoisted(() => ({
+  fetchBaseBalance: vi.fn(),
+  fetchStellarBalance: vi.fn(),
+}));
+
+vi.mock('@/lib/walletconnect-poster-direct-usdc', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/walletconnect-poster-direct-usdc')
+    >();
+  return {
+    ...actual,
+    fetchUsdcBalanceOnBase: (...args: unknown[]) =>
+      hoisted.fetchBaseBalance(...args),
+  };
+});
+
+vi.mock('@/lib/spend/stellar-treasury-funding', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/spend/stellar-treasury-funding')
+    >();
+  return {
+    ...actual,
+    readStellarAccountConfirmedUsdcBalance: (...args: unknown[]) =>
+      hoisted.fetchStellarBalance(...args),
+  };
+});
+
+import {
+  buildSpendEligibilityPreview,
+  fetchUserSpendRailUsdcBalanceSafe,
+} from '@/lib/spend-conversion-preview';
 import type {
   SpendExperience,
   SpendSession,
@@ -58,6 +91,10 @@ const player = (pts: number): Player => ({
 
 describe('buildSpendEligibilityPreview', () => {
   const now = new Date('2026-06-01T15:00:00.000Z');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
 
   it('returns eligible when balances ok', () => {
     const r = buildSpendEligibilityPreview({
@@ -537,5 +574,52 @@ describe('buildSpendEligibilityPreview', () => {
       });
       expect(r.status).toBe('insufficient_points');
     });
+  });
+});
+
+describe('fetchUserSpendRailUsdcBalanceSafe', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('uses the EVM wallet Base balance for base_usdc', async () => {
+    hoisted.fetchBaseBalance.mockResolvedValue(0.97);
+
+    await expect(fetchUserSpendRailUsdcBalanceSafe(sess())).resolves.toBe(0.97);
+    expect(hoisted.fetchBaseBalance).toHaveBeenCalledWith(
+      '0x3333333333333333333333333333333333333333',
+      expect.any(Object)
+    );
+    expect(hoisted.fetchStellarBalance).not.toHaveBeenCalled();
+  });
+
+  it('uses the Stellar rail wallet balance for stellar_usdc', async () => {
+    hoisted.fetchStellarBalance.mockResolvedValue(1);
+    const stellarWallet =
+      'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+    await expect(
+      fetchUserSpendRailUsdcBalanceSafe(
+        sess({
+          spend_rail: 'stellar_usdc',
+          rail_user_wallet_address: stellarWallet,
+        })
+      )
+    ).resolves.toBe(1);
+    expect(hoisted.fetchStellarBalance).toHaveBeenCalledWith(stellarWallet);
+    expect(hoisted.fetchBaseBalance).not.toHaveBeenCalled();
+  });
+
+  it('does not query Base when Stellar rail wallet is missing', async () => {
+    await expect(
+      fetchUserSpendRailUsdcBalanceSafe(
+        sess({
+          spend_rail: 'stellar_usdc',
+          rail_user_wallet_address: null,
+        })
+      )
+    ).resolves.toBeNull();
+    expect(hoisted.fetchStellarBalance).not.toHaveBeenCalled();
+    expect(hoisted.fetchBaseBalance).not.toHaveBeenCalled();
   });
 });

--- a/lib/spend-conversion-preview.test.ts
+++ b/lib/spend-conversion-preview.test.ts
@@ -92,10 +92,6 @@ const player = (pts: number): Player => ({
 describe('buildSpendEligibilityPreview', () => {
   const now = new Date('2026-06-01T15:00:00.000Z');
 
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
-
   it('returns eligible when balances ok', () => {
     const r = buildSpendEligibilityPreview({
       session: sess(),

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -341,6 +341,28 @@ export async function fetchUserUsdcBalanceSafe(
   }
 }
 
+export async function fetchUserSpendRailUsdcBalanceSafe(
+  session: Pick<
+    SpendSession,
+    'spend_rail' | 'wallet_address' | 'rail_user_wallet_address'
+  >
+): Promise<number | null> {
+  if (session.spend_rail === 'stellar_usdc') {
+    const stellarWallet = session.rail_user_wallet_address?.trim();
+    if (!stellarWallet) return null;
+    try {
+      const { readStellarAccountConfirmedUsdcBalance } =
+        await import('@/lib/spend/stellar-treasury-funding');
+      return await readStellarAccountConfirmedUsdcBalance(stellarWallet);
+    } catch (e) {
+      console.error('fetchUserSpendRailUsdcBalanceSafe stellar:', e);
+      return null;
+    }
+  }
+
+  return fetchUserUsdcBalanceSafe(session.wallet_address);
+}
+
 export async function loadSpendEligibilityForSession(
   input: LoadEligibilityInput
 ): Promise<SpendEligibilityResult> {
@@ -370,7 +392,7 @@ export async function loadSpendEligibilityForSession(
         session.user_id
       ),
       getSpendTransactionBySessionId(session.id),
-      fetchUserUsdcBalanceSafe(session.wallet_address),
+      fetchUserSpendRailUsdcBalanceSafe(session),
     ]);
 
   return buildSpendEligibilityPreview({

--- a/lib/spend-conversion-preview.ts
+++ b/lib/spend-conversion-preview.ts
@@ -383,7 +383,7 @@ export async function loadSpendEligibilityForSession(
 
   const treasuryUsdcBalance = tb.ok ? tb.value : null;
 
-  const [player, pointConversion, fundedOther, spendTx, userUsdcBalance] =
+  const [player, pointConversion, fundedOther, spendTx, userSpendRailUsdc] =
     await Promise.all([
       getPlayerByWallet(session.wallet_address),
       getPointConversionBySessionId(session.id),
@@ -406,7 +406,7 @@ export async function loadSpendEligibilityForSession(
         ? fundedOther
         : null,
     treasuryUsdcBalance,
-    userUsdcBalance,
+    userUsdcBalance: userSpendRailUsdc,
     now,
   });
 }

--- a/lib/spend/stellar-treasury-funding.ts
+++ b/lib/spend/stellar-treasury-funding.ts
@@ -217,6 +217,24 @@ export async function readStellarTreasuryConfirmedUsdcBalance(): Promise<number>
   return balance;
 }
 
+export async function readStellarAccountConfirmedUsdcBalance(
+  publicKey: string
+): Promise<number | null> {
+  const parsed = stellarWalletAddressSchema.safeParse(publicKey.trim());
+  if (!parsed.success) return null;
+
+  const usdcIssuer = getStellarSpendUsdcIssuer();
+  if (!usdcIssuer) return null;
+
+  const server = createStellarSpendHorizonServer();
+  const account = await server.loadAccount(parsed.data);
+  return parseUsdcBalanceLine(
+    account,
+    getStellarSpendUsdcAssetCode(),
+    usdcIssuer
+  );
+}
+
 export async function findSuccessfulStellarFundingTxByMemo(input: {
   treasuryPublicKey: string;
   destinationPublicKey: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add rail-aware user USDC balance loading for spend conversion preview.
- Keep Base preview balances on the EVM wallet via the existing Base helper.
- Use `spend_sessions.rail_user_wallet_address` for Stellar preview balances and return `null` when the Stellar rail wallet is missing.
- Add a Stellar account USDC balance reader backed by Horizon.

## Testing
- `yarn test lib/spend-conversion-preview.test.ts` passed.
- `yarn test lib/spend/payment-rails/stellar-usdc-rail.test.ts lib/spend/stellar-treasury-funding.test.ts lib/spend-payment-confirm.test.ts` passed.
- `yarn build` passed with existing lint warnings and dynamic route logs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2fd3b459-e1c4-4539-ac03-2a97fbe61d47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

