### PR TITLE
chore: use Yarn for Vercel install and build

### DIFF
--- a/docs/v1-launch-config-and-runbook.md
+++ b/docs/v1-launch-config-and-runbook.md
@@ -137,4 +137,4 @@ Spend availability depends on env-backed **rail enablement** and validation in c
 - [`APP_OVERVIEW.md`](./APP_OVERVIEW.md) — product flows and data source rules
 - [`spend-rails-e2e-qa-matrix.md`](./spend-rails-e2e-qa-matrix.md) — spend rail QA
 - [`stellar-baselines-and-chain-architecture.md`](./stellar-baselines-and-chain-architecture.md) — Stellar architecture context
-- [`AGENTS.md`](../AGENTS.md) — contributor commands (local **Yarn** per `AGENTS.md`; production builds use `npm install` / `npm run build` from [`vercel.json`](../vercel.json))
+- [`AGENTS.md`](../AGENTS.md) — contributor commands (local **Yarn** per `AGENTS.md`; Vercel install and build commands are declared in [`vercel.json`](../vercel.json) and follow the same Yarn 1 workflow as the repo)

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
-  "buildCommand": "npm run build",
-  "installCommand": "npm install",
+  "buildCommand": "yarn build",
+  "installCommand": "yarn install --frozen-lockfile",
   "framework": "nextjs",
   "crons": [
     {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates `vercel.json` so Vercel installs and builds with Yarn v1, matching `yarn.lock` and `packageManager` in `package.json`.

## Changes

- **installCommand:** `yarn install --frozen-lockfile` (replaces `npm install`)
- **buildCommand:** `yarn build` (replaces `npm run build`)

`framework` and `crons` are unchanged.

## Validation

- `vercel.json` parses as valid JSON
- No `npm` install/build strings remain in `vercel.json`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-384afe00-8853-4296-9fb4-fd8c519ff1cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-384afe00-8853-4296-9fb4-fd8c519ff1cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

