### PR TITLE
fix: client-safe Stellar walletReadiness on conversion confirm

### DIFF
--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -7,6 +7,12 @@ const mockGetSpendContext = vi.fn();
 const mockRunConfirm = vi.fn();
 const mockResolve = vi.fn();
 const mockCaptureHandledException = vi.fn();
+const mockGetSpendWalletReadinessBySessionId = vi.fn();
+
+vi.mock('@/lib/db/spend-wallet-readiness', () => ({
+  getSpendWalletReadinessBySessionId: (...a: unknown[]) =>
+    mockGetSpendWalletReadinessBySessionId(...a),
+}));
 
 vi.mock('@/lib/api/privy', () => ({
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
@@ -194,6 +200,113 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
         statusCode: 400,
       })
     );
+  });
+
+  it('Stellar success returns client-safe walletReadiness without internal_diagnostics', async () => {
+    const stellarSession = {
+      ...session,
+      spend_rail: 'stellar_usdc' as const,
+    };
+    const stellarExperience = {
+      ...spendExperience,
+      spend_rail: 'stellar_usdc' as const,
+    };
+
+    mockVerifyWallet.mockResolvedValue({
+      authorized: true,
+      userId: 'privy-1',
+    });
+    mockGetPrivyUserId.mockResolvedValue('privy-1');
+    mockGetSpendContext.mockResolvedValue({
+      session: stellarSession,
+      spendExperience: stellarExperience,
+      usdcAmount: 5,
+      pointsRequired: 5000,
+    });
+    mockResolve.mockReturnValue('distinct-1');
+    mockRunConfirm.mockResolvedValue({
+      ok: true,
+      pointConversion: {
+        id: 'conv-1',
+        spend_experience_id: stellarExperience.id,
+        spend_session_id: stellarSession.id,
+        user_id: 'privy-1',
+        points_deducted: 5000,
+        usdc_amount: 5,
+        status: 'funded',
+        spend_rail: 'stellar_usdc',
+        network: 'Stellar',
+        asset_symbol: 'USDC',
+        treasury_wallet_address: stellarExperience.treasury_wallet_address,
+        user_wallet_address: stellarSession.wallet_address,
+        funding_tx_hash: 'abc',
+        explorer_tx_url: null,
+        idempotency_key: null,
+        conversion_attempt_count: 1,
+        conversion_last_failure: null,
+        created_at: '2026-01-01T00:00:00.000Z',
+        completed_at: '2026-01-01T00:00:01.000Z',
+        failed_reason: null,
+        updated_at: '2026-01-01T00:00:01.000Z',
+      },
+      session: { ...stellarSession, status: 'conversion_complete' as const },
+      resumed: false,
+      clientHint: 'funded',
+    });
+
+    mockGetSpendWalletReadinessBySessionId.mockResolvedValue({
+      id: 'wro-1',
+      spend_session_id: stellarSession.id,
+      user_id: 'privy-1',
+      spend_rail: 'stellar_usdc',
+      rail_user_wallet_address:
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      status: 'pending',
+      step_metadata: {
+        current_step: 'trustline_confirming',
+        server_only_field: 'must-not-leak',
+      },
+      sanitized_error_category: null,
+      sanitized_error_code: null,
+      internal_diagnostics: { horizon_body: 'secret' },
+      idempotency_key: `wallet_readiness:${stellarSession.id}`,
+      sponsor_treasury_transaction_id: 'sp-1',
+      trustline_treasury_transaction_id: 'tl-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+
+    const req = new NextRequest(
+      'http://localhost:3000/api/spend-sessions/sess-1/conversion/confirm',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          walletAddress: stellarSession.wallet_address,
+        }),
+      }
+    );
+    const res = await POST(req, { params: { sessionId: 'sess-1' } });
+    expect(res.status).toBe(200);
+
+    const json = (await res.json()) as {
+      success: boolean;
+      data: {
+        walletReadiness: Record<string, unknown>;
+      };
+    };
+    const raw = JSON.stringify(json);
+    expect(raw).not.toContain('internal_diagnostics');
+    expect(raw).not.toContain('horizon_body');
+    expect(raw).not.toContain('server_only_field');
+    expect(raw).not.toContain('step_metadata');
+
+    expect(json.success).toBe(true);
+    const wr = json.data.walletReadiness;
+    expect(wr).toBeDefined();
+    expect(wr).not.toHaveProperty('internal_diagnostics');
+    expect(wr).not.toHaveProperty('step_metadata');
+    expect(wr.current_step).toBe('trustline_confirming');
+    expect(wr.id).toBe('wro-1');
   });
 
   it('forwards retry_conversion intent to domain logic', async () => {

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { NextRequest } from 'next/server';
+import type { SpendWalletReadinessClientDto } from '@/lib/types';
 
 const mockVerifyWallet = vi.fn();
 const mockGetPrivyUserId = vi.fn();
@@ -290,23 +291,22 @@ describe('POST /api/spend-sessions/[sessionId]/conversion/confirm', () => {
 
     const json = (await res.json()) as {
       success: boolean;
-      data: {
-        walletReadiness: Record<string, unknown>;
-      };
+      data: { walletReadiness: SpendWalletReadinessClientDto };
     };
-    const raw = JSON.stringify(json);
-    expect(raw).not.toContain('internal_diagnostics');
-    expect(raw).not.toContain('horizon_body');
-    expect(raw).not.toContain('server_only_field');
-    expect(raw).not.toContain('step_metadata');
-
     expect(json.success).toBe(true);
-    const wr = json.data.walletReadiness;
-    expect(wr).toBeDefined();
-    expect(wr).not.toHaveProperty('internal_diagnostics');
-    expect(wr).not.toHaveProperty('step_metadata');
-    expect(wr.current_step).toBe('trustline_confirming');
-    expect(wr.id).toBe('wro-1');
+    expect(json.data.walletReadiness).toEqual({
+      id: 'wro-1',
+      status: 'pending',
+      rail_user_wallet_address:
+        'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+      sanitized_error_category: null,
+      sanitized_error_code: null,
+      current_step: 'trustline_confirming',
+      sponsor_treasury_transaction_id: 'sp-1',
+      trustline_treasury_transaction_id: 'tl-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    } satisfies SpendWalletReadinessClientDto);
   });
 
   it('forwards retry_conversion intent to domain logic', async () => {

--- a/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
+++ b/app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts
@@ -7,6 +7,7 @@ import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
 import { captureHandledException } from '@/lib/monitoring/capture-handled-exception';
 import { resolveServerIdentity } from '@/lib/analytics/server';
 import { getSpendWalletReadinessBySessionId } from '@/lib/db/spend-wallet-readiness';
+import { toSpendWalletReadinessClientDto } from '@/lib/spend/spend-wallet-readiness-client-dto';
 import {
   getSpendContextOr404,
   runSpendConversionConfirm,
@@ -105,10 +106,13 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
       return apiError(result.error, result.httpStatus);
     }
 
-    const walletReadiness =
+    const walletReadinessRow =
       spendExperience.spend_rail === 'stellar_usdc'
         ? await getSpendWalletReadinessBySessionId(session.id)
         : null;
+    const walletReadiness = walletReadinessRow
+      ? toSpendWalletReadinessClientDto(walletReadinessRow)
+      : null;
 
     return apiSuccess({
       pointConversion: result.pointConversion,

--- a/lib/spend/spend-wallet-readiness-client-dto.test.ts
+++ b/lib/spend/spend-wallet-readiness-client-dto.test.ts
@@ -57,4 +57,13 @@ describe('toSpendWalletReadinessClientDto', () => {
       }).current_step
     ).toBeNull();
   });
+
+  it('trims whitespace from current_step', () => {
+    expect(
+      toSpendWalletReadinessClientDto({
+        ...baseOp,
+        step_metadata: { current_step: '  trustline_confirming  ' },
+      }).current_step
+    ).toBe('trustline_confirming');
+  });
 });

--- a/lib/spend/spend-wallet-readiness-client-dto.test.ts
+++ b/lib/spend/spend-wallet-readiness-client-dto.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { toSpendWalletReadinessClientDto } from './spend-wallet-readiness-client-dto';
+import type { SpendWalletReadinessOperation } from '@/lib/types';
+
+const baseOp: SpendWalletReadinessOperation = {
+  id: 'wro-1',
+  spend_session_id: 'sess-1',
+  user_id: 'u1',
+  spend_rail: 'stellar_usdc',
+  rail_user_wallet_address:
+    'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+  status: 'pending',
+  step_metadata: {
+    current_step: 'trustline_confirming',
+    server_only_detail: { x: 1 },
+  },
+  sanitized_error_category: null,
+  sanitized_error_code: null,
+  internal_diagnostics: { raw_horizon: 'secret' },
+  idempotency_key: 'wallet_readiness:sess-1',
+  sponsor_treasury_transaction_id: 'sp-1',
+  trustline_treasury_transaction_id: 'tl-1',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:01:00.000Z',
+};
+
+describe('toSpendWalletReadinessClientDto', () => {
+  it('drops internal_diagnostics and raw step_metadata; exposes current_step', () => {
+    const dto = toSpendWalletReadinessClientDto(baseOp);
+    expect(dto).toEqual({
+      id: 'wro-1',
+      status: 'pending',
+      rail_user_wallet_address: baseOp.rail_user_wallet_address,
+      sanitized_error_category: null,
+      sanitized_error_code: null,
+      current_step: 'trustline_confirming',
+      sponsor_treasury_transaction_id: 'sp-1',
+      trustline_treasury_transaction_id: 'tl-1',
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:01:00.000Z',
+    });
+    expect(dto).not.toHaveProperty('internal_diagnostics');
+    expect(dto).not.toHaveProperty('step_metadata');
+  });
+
+  it('returns null current_step when missing or non-string', () => {
+    expect(
+      toSpendWalletReadinessClientDto({
+        ...baseOp,
+        step_metadata: {},
+      }).current_step
+    ).toBeNull();
+    expect(
+      toSpendWalletReadinessClientDto({
+        ...baseOp,
+        step_metadata: { current_step: 123 },
+      }).current_step
+    ).toBeNull();
+  });
+});

--- a/lib/spend/spend-wallet-readiness-client-dto.ts
+++ b/lib/spend/spend-wallet-readiness-client-dto.ts
@@ -3,27 +3,21 @@ import type {
   SpendWalletReadinessOperation,
 } from '@/lib/types';
 
-function currentStepFromStepMetadata(
-  stepMetadata: Record<string, unknown>
-): string | null {
-  const raw = stepMetadata.current_step;
-  if (typeof raw === 'string' && raw.trim().length > 0) {
-    return raw;
-  }
-  return null;
-}
-
 /** Maps a full readiness row to fields safe to return to HTTP clients. */
 export function toSpendWalletReadinessClientDto(
   op: SpendWalletReadinessOperation
 ): SpendWalletReadinessClientDto {
+  const raw = op.step_metadata.current_step;
+  const current_step =
+    typeof raw === 'string' && raw.trim().length > 0 ? raw.trim() : null;
+
   return {
     id: op.id,
     status: op.status,
     rail_user_wallet_address: op.rail_user_wallet_address,
     sanitized_error_category: op.sanitized_error_category,
     sanitized_error_code: op.sanitized_error_code,
-    current_step: currentStepFromStepMetadata(op.step_metadata),
+    current_step,
     sponsor_treasury_transaction_id: op.sponsor_treasury_transaction_id,
     trustline_treasury_transaction_id: op.trustline_treasury_transaction_id,
     created_at: op.created_at,

--- a/lib/spend/spend-wallet-readiness-client-dto.ts
+++ b/lib/spend/spend-wallet-readiness-client-dto.ts
@@ -1,0 +1,32 @@
+import type {
+  SpendWalletReadinessClientDto,
+  SpendWalletReadinessOperation,
+} from '@/lib/types';
+
+function currentStepFromStepMetadata(
+  stepMetadata: Record<string, unknown>
+): string | null {
+  const raw = stepMetadata.current_step;
+  if (typeof raw === 'string' && raw.trim().length > 0) {
+    return raw;
+  }
+  return null;
+}
+
+/** Maps a full readiness row to fields safe to return to HTTP clients. */
+export function toSpendWalletReadinessClientDto(
+  op: SpendWalletReadinessOperation
+): SpendWalletReadinessClientDto {
+  return {
+    id: op.id,
+    status: op.status,
+    rail_user_wallet_address: op.rail_user_wallet_address,
+    sanitized_error_category: op.sanitized_error_category,
+    sanitized_error_code: op.sanitized_error_code,
+    current_step: currentStepFromStepMetadata(op.step_metadata),
+    sponsor_treasury_transaction_id: op.sponsor_treasury_transaction_id,
+    trustline_treasury_transaction_id: op.trustline_treasury_transaction_id,
+    created_at: op.created_at,
+    updated_at: op.updated_at,
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -472,6 +472,21 @@ export type SpendWalletReadinessOperation = {
   updated_at: string;
 };
 
+/** Client-safe wallet readiness snapshot (conversion confirm / Stellar); excludes server diagnostics. */
+export type SpendWalletReadinessClientDto = {
+  id: string;
+  status: SpendWalletReadinessStatus;
+  rail_user_wallet_address: string | null;
+  sanitized_error_category: string | null;
+  sanitized_error_code: string | null;
+  /** From persisted `step_metadata.current_step` when it is a non-empty string. */
+  current_step: string | null;
+  sponsor_treasury_transaction_id: string | null;
+  trustline_treasury_transaction_id: string | null;
+  created_at: string;
+  updated_at: string;
+};
+
 /**
  * `spend_payment_prepare_operations.status` — aligned with `SpendRailPaymentOperationStatus`
  * (IRL-28).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The spend conversion confirm route was returning the full `SpendWalletReadinessOperation` for `stellar_usdc`, including `internal_diagnostics` and unfiltered `step_metadata`. This change maps the DB row through a dedicated client DTO before serializing the success response.

## Changes

- Added `SpendWalletReadinessClientDto` in `lib/types.ts` with only client-safe fields plus `current_step` (derived from `step_metadata.current_step` when it is a non-empty string).
- Added `toSpendWalletReadinessClientDto` in `lib/spend/spend-wallet-readiness-client-dto.ts`.
- Updated `app/api/spend-sessions/[sessionId]/conversion/confirm/route.ts` to use the formatter for Stellar wallet readiness.
- Tests: formatter unit tests and a route test that mocks a row containing `internal_diagnostics` and extra `step_metadata` keys and asserts they never appear in the JSON payload.

## Testing

- `yarn vitest run app/api/spend-sessions/[sessionId]/conversion/confirm/__tests__/route.test.ts lib/spend/spend-wallet-readiness-client-dto.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d2b6d21a-362a-4008-a5e4-c931048f1d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d2b6d21a-362a-4008-a5e4-c931048f1d36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

