### PR TITLE
fix: Stellar payment confirm atomic prepare lock before submit

### DIFF
--- a/database/add-spend-payment-prepare-submitting-status.sql
+++ b/database/add-spend-payment-prepare-submitting-status.sql
@@ -1,0 +1,20 @@
+-- Atomic Stellar backend payment submit guard: transient `submitting` between `prepared`
+-- and `submitted` so concurrent confirm requests cannot both call Privy/Horizon.
+
+ALTER TABLE spend_payment_prepare_operations
+  DROP CONSTRAINT IF EXISTS spend_payment_prepare_operations_status_check;
+
+ALTER TABLE spend_payment_prepare_operations
+  ADD CONSTRAINT spend_payment_prepare_operations_status_check
+  CHECK (status IN (
+    'prepared',
+    'submitting',
+    'submitted',
+    'confirmed',
+    'failed',
+    'needs_review'
+  ));
+
+COMMENT ON CONSTRAINT spend_payment_prepare_operations_status_check
+  ON spend_payment_prepare_operations IS
+  'Payment operation lifecycle (IRL-28 + submitting guard); submitting is transient during backend Stellar submit.';

--- a/lib/db/spend-payment-prepare.ts
+++ b/lib/db/spend-payment-prepare.ts
@@ -190,6 +190,31 @@ export type PatchSpendPaymentPrepareInput = {
   lastAmbiguityMetadata?: Record<string, unknown> | null;
 };
 
+/**
+ * Atomically claims a `prepared` row for Stellar backend submit (`prepared` → `submitting`).
+ * Returns the updated row when this request won the race; otherwise `null`.
+ */
+export async function tryClaimSpendPaymentPrepareForStellarSubmit(
+  prepareOperationId: string
+): Promise<SpendPaymentPrepareOperation | null> {
+  const { data, error } = await supabase
+    .from('spend_payment_prepare_operations')
+    .update({ status: 'submitting' })
+    .eq('id', prepareOperationId)
+    .eq('status', 'prepared')
+    .select(SPEND_PAYMENT_PREPARE_COLS)
+    .maybeSingle();
+
+  if (error) {
+    console.error('tryClaimSpendPaymentPrepareForStellarSubmit:', error);
+    throw new Error(
+      error.message || 'Failed to claim payment prepare for Stellar submit'
+    );
+  }
+  if (!data) return null;
+  return rowToSpendPaymentPrepareOperation(data as Record<string, unknown>);
+}
+
 export async function patchSpendPaymentPrepare(
   id: string,
   patch: PatchSpendPaymentPrepareInput
@@ -278,7 +303,7 @@ export async function listSpendSessionIdsForStalePaymentPrepareReconcile(input: 
   const { data, error } = await supabase
     .from('spend_payment_prepare_operations')
     .select('spend_session_id')
-    .in('status', ['submitted', 'prepared'])
+    .in('status', ['submitted', 'prepared', 'submitting'])
     .lt('updated_at', input.olderThanIso)
     .order('updated_at', { ascending: true })
     .limit(input.limit);

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -655,6 +655,8 @@ describe('runSpendPaymentConfirm', () => {
       return livePrepare;
     });
 
+    // Serialize tryClaim so concurrent confirms hit the mock like a single DB winner
+    // (only one call returns the claimed row; others see null then resume or 409).
     let tryClaimChain = Promise.resolve();
     const enqueueTryClaim = <T>(fn: () => Promise<T>): Promise<T> => {
       const next = tryClaimChain.then(fn);

--- a/lib/spend-payment-confirm.test.ts
+++ b/lib/spend-payment-confirm.test.ts
@@ -37,6 +37,10 @@ vi.mock('@/lib/db/spend-sessions', () => ({
 const mockGetPaymentPrepare = vi.fn();
 const mockPatchPrepare = vi.fn();
 
+const { mockTryClaim } = vi.hoisted(() => ({
+  mockTryClaim: vi.fn(),
+}));
+
 vi.mock('@/lib/db/spend-payment-prepare', async (importOriginal) => {
   const actual =
     await importOriginal<typeof import('@/lib/db/spend-payment-prepare')>();
@@ -45,6 +49,8 @@ vi.mock('@/lib/db/spend-payment-prepare', async (importOriginal) => {
     getSpendPaymentPrepareBySessionId: (...a: unknown[]) =>
       mockGetPaymentPrepare(...a),
     patchSpendPaymentPrepare: (...a: unknown[]) => mockPatchPrepare(...a),
+    tryClaimSpendPaymentPrepareForStellarSubmit: (...a: unknown[]) =>
+      mockTryClaim(...a),
   };
 });
 
@@ -64,6 +70,30 @@ vi.mock('@/lib/spend-conversion-preview', async (importOriginal) => {
 vi.mock('@/lib/spend-payment-verify', () => ({
   verifySpendUsdcPaymentTx: vi.fn(),
 }));
+
+vi.mock('@/lib/spend-payment-verify-stellar', () => ({
+  verifySpendStellarUsdcPaymentTx: vi.fn(),
+}));
+
+const { mockStellarConfirmPayment } = vi.hoisted(() => ({
+  mockStellarConfirmPayment: vi.fn(),
+}));
+
+vi.mock('@/lib/spend/payment-rails/registry', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@/lib/spend/payment-rails/registry')>();
+  return {
+    ...actual,
+    getSpendPaymentRail: (rail: string) => {
+      if (rail === 'stellar_usdc') {
+        return { confirmPayment: mockStellarConfirmPayment };
+      }
+      return actual.getSpendPaymentRail(
+        rail as import('@/lib/types').SpendRail
+      );
+    },
+  };
+});
 
 vi.mock('@/lib/spend-rail-config', () => ({
   getSpendReceivingWalletAddress: (spendRail: string) =>
@@ -93,15 +123,61 @@ import { runSpendPaymentConfirm } from '@/lib/spend-payment-confirm';
 import * as analytics from '@/lib/analytics/server';
 import * as spendSessions from '@/lib/db/spend-sessions';
 import * as spendPaymentVerify from '@/lib/spend-payment-verify';
+import * as stellarVerify from '@/lib/spend-payment-verify-stellar';
+import { spendRailErrorPaymentFailed } from '@/lib/spend/payment-rails/errors';
+import { getSpendReceivingWalletAddress } from '@/lib/spend-rail-config';
+import {
+  getStellarSpendUsdcAssetCode,
+  getStellarSpendUsdcIssuer,
+} from '@/lib/spend/stellar-wallet-readiness-config';
 import type {
   PointConversion,
   SpendExperience,
+  SpendPaymentPrepareOperation,
+  SpendPaymentPrepareOperationStatus,
   SpendSession,
   SpendTransaction,
 } from '@/lib/types';
 
 const validHash =
   '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+
+const STELLAR_RAIL_WALLET =
+  'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+const STELLAR_LEDGER_HASH = 'a'.repeat(64);
+
+function buildStellarPrepareRow(
+  status: SpendPaymentPrepareOperationStatus,
+  sessionId: string
+): SpendPaymentPrepareOperation {
+  const receivingWallet = getSpendReceivingWalletAddress('stellar_usdc').trim();
+  const usdcIssuer = getStellarSpendUsdcIssuer() ?? '';
+  const usdcCode = getStellarSpendUsdcAssetCode();
+  return {
+    id: 'prep-stellar',
+    spend_session_id: sessionId,
+    user_id: 'user-1',
+    spend_rail: 'stellar_usdc',
+    status,
+    prepared_action: {},
+    verification_snapshot: {
+      v: 1,
+      spend_rail: 'stellar_usdc',
+      from_wallet: STELLAR_RAIL_WALLET,
+      receiving_wallet: receivingWallet,
+      usdc_amount: 5,
+      usdc_asset_code: usdcCode,
+      usdc_issuer: usdcIssuer,
+    },
+    idempotency_key: `payment:${sessionId}`,
+    attempt_count: 0,
+    last_failure_reason: null,
+    last_failure_at: null,
+    last_ambiguity_metadata: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
 
 const baseSession: SpendSession = {
   id: 'sess-1',
@@ -141,6 +217,11 @@ const baseExperience: SpendExperience = {
   updated_at: '2026-01-01T00:00:00.000Z',
 };
 
+const stellarExperience: SpendExperience = {
+  ...baseExperience,
+  spend_rail: 'stellar_usdc',
+};
+
 function inProgressConversion(
   status: PointConversion['status']
 ): PointConversion {
@@ -173,6 +254,9 @@ describe('runSpendPaymentConfirm', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPatchPrepare.mockReset();
+    mockTryClaim.mockReset();
+    mockStellarConfirmPayment.mockReset();
+    vi.mocked(stellarVerify.verifySpendStellarUsdcPaymentTx).mockReset();
     mockFetchUserUsdc.mockResolvedValue(10);
     mockRailGate.mockReturnValue({ ok: true as const });
     mockGetSpendTransaction.mockResolvedValue(null);
@@ -493,5 +577,253 @@ describe('runSpendPaymentConfirm', () => {
     ).toBe(true);
     expect(spendSessions.updateSpendTransactionFields).not.toHaveBeenCalled();
     expect(analytics.trackSpendPaymentFailed).not.toHaveBeenCalled();
+  });
+
+  it('Stellar backend: two parallel confirms invoke confirmPayment at most once (prepare lock)', async () => {
+    const sessionId = 'sess-stellar-lock';
+    const stellarSession: SpendSession = {
+      ...baseSession,
+      id: sessionId,
+      spend_experience_id: 'exp-1',
+      spend_rail: 'stellar_usdc',
+      status: 'conversion_complete',
+      rail_user_wallet_address: STELLAR_RAIL_WALLET,
+    };
+
+    mockGetPointConversion.mockResolvedValue({
+      ...inProgressConversion('funded'),
+      spend_session_id: sessionId,
+      spend_rail: 'stellar_usdc',
+    });
+
+    mockStellarConfirmPayment.mockResolvedValue({
+      ok: true,
+      value: {
+        status: 'submitted',
+        ledgerTxReference: STELLAR_LEDGER_HASH,
+      },
+    });
+    vi.mocked(stellarVerify.verifySpendStellarUsdcPaymentTx).mockResolvedValue({
+      ok: true,
+    });
+    vi.mocked(
+      spendSessions.confirmSpendTransactionIfSubmitted
+    ).mockResolvedValue({
+      completed_at: '2026-01-02T00:00:00.000Z',
+    } as never);
+    vi.mocked(spendSessions.insertSpendTransactionSubmitted).mockResolvedValue({
+      id: 'tx-stellar',
+      spend_experience_id: 'exp-1',
+      spend_session_id: sessionId,
+      user_id: 'user-1',
+      usdc_amount: 5,
+      spend_rail: 'stellar_usdc',
+      network: 'Stellar',
+      asset_symbol: 'USDC',
+      from_wallet_address: STELLAR_RAIL_WALLET,
+      to_wallet_address: getSpendReceivingWalletAddress('stellar_usdc').trim(),
+      status: 'submitted',
+      payment_tx_hash: STELLAR_LEDGER_HASH,
+      explorer_tx_url: null,
+      idempotency_key: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: null,
+      failed_reason: null,
+      updated_at: '2026-01-01T00:00:00.000Z',
+    } satisfies SpendTransaction);
+
+    let livePrepare = buildStellarPrepareRow('prepared', sessionId);
+    mockPatchPrepare.mockImplementation(async (_id, patch) => {
+      livePrepare = {
+        ...livePrepare,
+        ...patch,
+        status: (patch.status ??
+          livePrepare.status) as SpendPaymentPrepareOperationStatus,
+        last_failure_reason:
+          patch.lastFailureReason !== undefined
+            ? patch.lastFailureReason
+            : livePrepare.last_failure_reason,
+        last_failure_at:
+          patch.lastFailureAt !== undefined
+            ? patch.lastFailureAt
+            : livePrepare.last_failure_at,
+        last_ambiguity_metadata:
+          patch.lastAmbiguityMetadata !== undefined
+            ? patch.lastAmbiguityMetadata
+            : livePrepare.last_ambiguity_metadata,
+      };
+      return livePrepare;
+    });
+
+    let tryClaimChain = Promise.resolve();
+    const enqueueTryClaim = <T>(fn: () => Promise<T>): Promise<T> => {
+      const next = tryClaimChain.then(fn);
+      tryClaimChain = next.then(
+        () => undefined,
+        () => undefined
+      );
+      return next;
+    };
+
+    let winnerChosen = false;
+    let lostRaceNextPrepareRead = false;
+    mockTryClaim.mockImplementation(async () =>
+      enqueueTryClaim(async () => {
+        if (!winnerChosen) {
+          winnerChosen = true;
+          return buildStellarPrepareRow('submitting', sessionId);
+        }
+        lostRaceNextPrepareRead = true;
+        return null;
+      })
+    );
+
+    mockGetPaymentPrepare.mockImplementation(async () => {
+      if (lostRaceNextPrepareRead) {
+        lostRaceNextPrepareRead = false;
+        return buildStellarPrepareRow('submitting', sessionId);
+      }
+      return { ...livePrepare };
+    });
+
+    mockGetSpendTransaction.mockResolvedValue(null);
+    vi.mocked(spendSessions.getSpendSessionById).mockResolvedValue({
+      ...stellarSession,
+      status: 'payment_complete',
+    });
+
+    const confirmArgs = {
+      session: stellarSession,
+      spendExperience: stellarExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      usdcAmount: 5,
+      stellarBackendConfirm: true as const,
+    };
+
+    const [first, second] = await Promise.all([
+      runSpendPaymentConfirm(confirmArgs),
+      runSpendPaymentConfirm(confirmArgs),
+    ]);
+
+    expect(mockStellarConfirmPayment).toHaveBeenCalledTimes(1);
+    const httpStatuses = [first, second].map((r) => r.httpStatus);
+    expect(httpStatuses).toContain(409);
+    expect([first, second].some((r) => r.ok)).toBe(true);
+  });
+
+  it('Stellar backend resume: submitted prepare + ledger hash skips confirmPayment', async () => {
+    const sessionId = 'sess-stellar-resume';
+    const stellarSession: SpendSession = {
+      ...baseSession,
+      id: sessionId,
+      spend_experience_id: 'exp-1',
+      spend_rail: 'stellar_usdc',
+      status: 'conversion_complete',
+      rail_user_wallet_address: STELLAR_RAIL_WALLET,
+    };
+
+    mockGetPointConversion.mockResolvedValue({
+      ...inProgressConversion('funded'),
+      spend_session_id: sessionId,
+      spend_rail: 'stellar_usdc',
+    });
+    mockGetPaymentPrepare.mockResolvedValue(
+      buildStellarPrepareRow('submitted', sessionId)
+    );
+    mockGetSpendTransaction.mockResolvedValue({
+      id: 'tx-resume',
+      spend_experience_id: 'exp-1',
+      spend_session_id: sessionId,
+      user_id: 'user-1',
+      usdc_amount: 5,
+      spend_rail: 'stellar_usdc',
+      network: 'Stellar',
+      asset_symbol: 'USDC',
+      from_wallet_address: STELLAR_RAIL_WALLET,
+      to_wallet_address: getSpendReceivingWalletAddress('stellar_usdc').trim(),
+      status: 'submitted',
+      payment_tx_hash: STELLAR_LEDGER_HASH,
+      explorer_tx_url: null,
+      idempotency_key: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      completed_at: null,
+      failed_reason: null,
+      updated_at: '2026-01-01T00:00:00.000Z',
+    } satisfies SpendTransaction);
+
+    vi.mocked(stellarVerify.verifySpendStellarUsdcPaymentTx).mockResolvedValue({
+      ok: true,
+    });
+    vi.mocked(
+      spendSessions.confirmSpendTransactionIfSubmitted
+    ).mockResolvedValue({
+      completed_at: '2026-01-02T00:00:00.000Z',
+    } as never);
+    vi.mocked(spendSessions.getSpendSessionById).mockResolvedValue({
+      ...stellarSession,
+      status: 'payment_complete',
+    });
+
+    await runSpendPaymentConfirm({
+      session: stellarSession,
+      spendExperience: stellarExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      usdcAmount: 5,
+      stellarBackendConfirm: true,
+    });
+
+    expect(mockStellarConfirmPayment).not.toHaveBeenCalled();
+    expect(mockTryClaim).not.toHaveBeenCalled();
+  });
+
+  it('Stellar backend: rail rejects submit after winning prepare lock marks prepare failed', async () => {
+    const sessionId = 'sess-stellar-reject';
+    const stellarSession: SpendSession = {
+      ...baseSession,
+      id: sessionId,
+      spend_experience_id: 'exp-1',
+      spend_rail: 'stellar_usdc',
+      status: 'conversion_complete',
+      rail_user_wallet_address: STELLAR_RAIL_WALLET,
+    };
+
+    mockGetPointConversion.mockResolvedValue({
+      ...inProgressConversion('funded'),
+      spend_session_id: sessionId,
+      spend_rail: 'stellar_usdc',
+    });
+    mockGetPaymentPrepare.mockResolvedValue(
+      buildStellarPrepareRow('prepared', sessionId)
+    );
+    mockTryClaim.mockResolvedValue(
+      buildStellarPrepareRow('submitting', sessionId)
+    );
+    mockStellarConfirmPayment.mockResolvedValue({
+      ok: false,
+      error: spendRailErrorPaymentFailed(),
+    });
+
+    const result = await runSpendPaymentConfirm({
+      session: stellarSession,
+      spendExperience: stellarExperience,
+      normalizedWallet: baseSession.wallet_address.toLowerCase(),
+      authUserId: 'user-1',
+      distinctId: 'd1',
+      usdcAmount: 5,
+      stellarBackendConfirm: true,
+    });
+
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected failure');
+    expect(mockStellarConfirmPayment).toHaveBeenCalledTimes(1);
+    expect(
+      mockPatchPrepare.mock.calls.some(
+        (args) => (args[1] as { status?: string })?.status === 'failed'
+      )
+    ).toBe(true);
   });
 });

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -11,6 +11,7 @@ import {
   getSpendPaymentPrepareBySessionId,
   patchSpendPaymentPrepare,
   spendPaymentOperationClientSummary,
+  tryClaimSpendPaymentPrepareForStellarSubmit,
 } from '@/lib/db/spend-payment-prepare';
 import { insertTreasuryReceivePaymentLedgerIfAbsent } from '@/lib/db/treasury-transactions';
 import {
@@ -189,12 +190,11 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
 
   const spendPaymentRail = getSpendPaymentRail('stellar_usdc');
 
-  const [preparedOp, spendTxInitial] = await Promise.all([
+  const [preparedOpInitial, spendTxInitial] = await Promise.all([
     getSpendPaymentPrepareBySessionId(session.id),
     getSpendTransactionBySessionId(session.id),
   ]);
-
-  if (!preparedOp) {
+  if (!preparedOpInitial) {
     return {
       ok: false,
       error:
@@ -202,6 +202,7 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
       httpStatus: 400,
     };
   }
+  let preparedOp: SpendPaymentPrepareOperation = preparedOpInitial;
 
   if (preparedOp.status === 'needs_review') {
     return {
@@ -481,27 +482,133 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
     };
   }
 
-  const railConfirm = await spendPaymentRail.confirmPayment({
-    spendSessionId: session.id,
-    spendExperienceId: spendExperience.id,
-    sessionOwnerPrivyUserId: authUserId,
-    railUserWalletAddress: session.rail_user_wallet_address,
-    usdcAmount: snap.usdc_amount,
-  });
+  const stellarSubmitInProgressMessage =
+    'Payment submission is already in progress for this session. Wait a moment and refresh, or try again shortly.';
+
+  const claimedPrepare = await tryClaimSpendPaymentPrepareForStellarSubmit(
+    preparedOp.id
+  );
+  if (!claimedPrepare) {
+    const [freshPrepare, freshSpendTx] = await Promise.all([
+      getSpendPaymentPrepareBySessionId(session.id),
+      getSpendTransactionBySessionId(session.id),
+    ]);
+    if (!freshPrepare) {
+      return {
+        ok: false,
+        error:
+          'Payment is not ready to confirm. Refresh this page to prepare your payment.',
+        httpStatus: 400,
+      };
+    }
+
+    if (
+      freshPrepare.status === 'submitted' &&
+      freshSpendTx?.status === 'submitted' &&
+      isStellarTransactionHash(freshSpendTx.payment_tx_hash)
+    ) {
+      const resumeSnap = freshPrepare.verification_snapshot;
+      if (!isSpendStellarUsdcVerificationSnapshotV1(resumeSnap)) {
+        return {
+          ok: false,
+          error: stellarSubmitInProgressMessage,
+          httpStatus: 409,
+          details: {
+            paymentOperation: spendPaymentOperationClientSummary(freshPrepare),
+          },
+        };
+      }
+      const ledgerHash = freshSpendTx.payment_tx_hash!.trim().toLowerCase();
+      const verify = await verifySpendStellarUsdcPaymentTx({
+        txHash: ledgerHash,
+        expectedFrom: resumeSnap.from_wallet,
+        expectedTo: resumeSnap.receiving_wallet,
+        expectedUsdcAmount: resumeSnap.usdc_amount,
+        usdcIssuer: issuerLive,
+        usdcCode: codeLive,
+      });
+      spendTx = freshSpendTx;
+      preparedOp = freshPrepare;
+      await updateSpendSessionStatus(session.id, 'payment_pending');
+      return handleVerifyOutcome(ledgerHash, verify);
+    }
+
+    return {
+      ok: false,
+      error: stellarSubmitInProgressMessage,
+      httpStatus: 409,
+      details: {
+        paymentOperation: spendPaymentOperationClientSummary(freshPrepare),
+      },
+    };
+  }
+
+  preparedOp = claimedPrepare;
+
+  let railConfirm: Awaited<
+    ReturnType<(typeof spendPaymentRail)['confirmPayment']>
+  >;
+  try {
+    railConfirm = await spendPaymentRail.confirmPayment({
+      spendSessionId: session.id,
+      spendExperienceId: spendExperience.id,
+      sessionOwnerPrivyUserId: authUserId,
+      railUserWalletAddress: session.rail_user_wallet_address,
+      usdcAmount: snap.usdc_amount,
+    });
+  } catch (err) {
+    const nowIso = new Date().toISOString();
+    const reason =
+      err instanceof Error
+        ? err.message.slice(0, 500)
+        : 'payment_submit_exception';
+    await patchSpendPaymentPrepare(preparedOp.id, {
+      status: 'failed',
+      lastFailureReason: `payment_submit_exception:${reason}`,
+      lastFailureAt: nowIso,
+      lastAmbiguityMetadata: null,
+    });
+    trackSpendPaymentFailed(distinctId, {
+      ...stellarAnalyticsBase,
+      status: 'failed',
+      error_reason: 'payment_submit_exception',
+      ...spendPilotSanitizedRailErrorFields(spendRailErrorPaymentFailed()),
+    });
+    const opAfter = await getSpendPaymentPrepareBySessionId(session.id);
+    return {
+      ok: false,
+      error:
+        'Payment submission failed unexpectedly. Refresh this page to prepare your payment again, then retry.',
+      httpStatus: 500,
+      details: opAfter
+        ? { paymentOperation: spendPaymentOperationClientSummary(opAfter) }
+        : undefined,
+    };
+  }
 
   if (!railConfirm.ok) {
+    const nowIso = new Date().toISOString();
+    await patchSpendPaymentPrepare(preparedOp.id, {
+      status: 'failed',
+      lastFailureReason: 'payment_submit_rejected',
+      lastFailureAt: nowIso,
+      lastAmbiguityMetadata: null,
+    });
     trackSpendPaymentFailed(distinctId, {
       ...stellarAnalyticsBase,
       status: 'failed',
       error_reason: 'payment_submit_rejected',
       ...spendPilotSanitizedRailErrorFields(railConfirm.error),
     });
+    const opAfter = await getSpendPaymentPrepareBySessionId(session.id);
     return {
       ok: false,
       error: railConfirm.error.userMessage,
       httpStatus: 400,
       details: {
-        paymentOperation: spendPaymentOperationClientSummary(preparedOp),
+        paymentOperation: opAfter
+          ? spendPaymentOperationClientSummary(opAfter)
+          : spendPaymentOperationClientSummary(preparedOp),
       },
     };
   }
@@ -509,6 +616,13 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   const outcome = railConfirm.value;
   const ledgerRef = outcome.ledgerTxReference?.trim() ?? '';
   if (!ledgerRef || !isStellarTransactionHash(ledgerRef)) {
+    const nowIso = new Date().toISOString();
+    await patchSpendPaymentPrepare(preparedOp.id, {
+      status: 'failed',
+      lastFailureReason: 'payment_submit_missing_ledger_ref',
+      lastFailureAt: nowIso,
+      lastAmbiguityMetadata: null,
+    });
     trackSpendPaymentFailed(distinctId, {
       ...stellarAnalyticsBase,
       ...(spendTx ? { spend_transaction_id: spendTx.id } : {}),
@@ -524,6 +638,13 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   }
 
   if (outcome.status !== 'submitted') {
+    const nowIso = new Date().toISOString();
+    await patchSpendPaymentPrepare(preparedOp.id, {
+      status: 'failed',
+      lastFailureReason: 'payment_submit_unexpected_state',
+      lastFailureAt: nowIso,
+      lastAmbiguityMetadata: null,
+    });
     trackSpendPaymentFailed(distinctId, {
       ...stellarAnalyticsBase,
       ...(spendTx ? { spend_transaction_id: spendTx.id } : {}),
@@ -1142,11 +1263,14 @@ export async function reconcileSubmittedSpendPaymentBackground(input: {
   distinctId: string;
 }): Promise<'advanced' | 'unchanged'> {
   const { session, spendExperience, distinctId } = input;
-  const [preparedOp, spendTx, fundedConversion] = await Promise.all([
+  const load = await Promise.all([
     getSpendPaymentPrepareBySessionId(session.id),
     getSpendTransactionBySessionId(session.id),
     getPointConversionBySessionId(session.id),
   ]);
+  let preparedOp = load[0];
+  const spendTx = load[1];
+  const fundedConversion = load[2];
 
   if (!preparedOp) {
     return 'unchanged';
@@ -1210,6 +1334,26 @@ export async function reconcileSubmittedSpendPaymentBackground(input: {
       point_conversion_id: fundedConversion?.id,
       payment_tx_hash: spendTx?.payment_tx_hash ?? '',
     };
+
+    if (preparedOp.status === 'submitting') {
+      if (
+        spendTx?.status === 'submitted' &&
+        spendTx.payment_tx_hash &&
+        isStellarTransactionHash(spendTx.payment_tx_hash)
+      ) {
+        await patchSpendPaymentPrepare(preparedOp.id, { status: 'submitted' });
+        preparedOp = { ...preparedOp, status: 'submitted' };
+      } else {
+        const staleNow = new Date().toISOString();
+        await patchSpendPaymentPrepare(preparedOp.id, {
+          status: 'prepared',
+          lastFailureReason: 'payment_submit_stale_interrupt',
+          lastFailureAt: staleNow,
+          lastAmbiguityMetadata: null,
+        });
+        return 'advanced';
+      }
+    }
 
     if (
       spendTx?.status === 'submitted' &&

--- a/lib/spend-payment-confirm.ts
+++ b/lib/spend-payment-confirm.ts
@@ -430,12 +430,14 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   };
 
   // Resume: already submitted on-chain; verify only (no second Privy submit).
+  const initialResumeLedger = spendTx?.payment_tx_hash?.trim();
   if (
     spendTx?.status === 'submitted' &&
     preparedOp.status === 'submitted' &&
-    isStellarTransactionHash(spendTx.payment_tx_hash)
+    initialResumeLedger &&
+    isStellarTransactionHash(initialResumeLedger)
   ) {
-    const ledgerHash = spendTx.payment_tx_hash!.trim().toLowerCase();
+    const ledgerHash = initialResumeLedger.toLowerCase();
     const verify = await verifySpendStellarUsdcPaymentTx({
       txHash: ledgerHash,
       expectedFrom: snap.from_wallet,
@@ -469,8 +471,10 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
   }
 
   if (spendTx?.status === 'confirmed') {
-    const fresh = await getSpendSessionById(session.id);
-    const prepOp = await getSpendPaymentPrepareBySessionId(session.id);
+    const [fresh, prepOp] = await Promise.all([
+      getSpendSessionById(session.id),
+      getSpendPaymentPrepareBySessionId(session.id),
+    ]);
     return {
       ok: true,
       spendTransaction: spendTx,
@@ -502,10 +506,12 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
       };
     }
 
+    const loserResumeLedger = freshSpendTx?.payment_tx_hash?.trim();
     if (
       freshPrepare.status === 'submitted' &&
       freshSpendTx?.status === 'submitted' &&
-      isStellarTransactionHash(freshSpendTx.payment_tx_hash)
+      loserResumeLedger &&
+      isStellarTransactionHash(loserResumeLedger)
     ) {
       const resumeSnap = freshPrepare.verification_snapshot;
       if (!isSpendStellarUsdcVerificationSnapshotV1(resumeSnap)) {
@@ -518,7 +524,7 @@ async function runSpendPaymentConfirmStellarUsdc(input: {
           },
         };
       }
-      const ledgerHash = freshSpendTx.payment_tx_hash!.trim().toLowerCase();
+      const ledgerHash = loserResumeLedger.toLowerCase();
       const verify = await verifySpendStellarUsdcPaymentTx({
         txHash: ledgerHash,
         expectedFrom: resumeSnap.from_wallet,
@@ -1029,8 +1035,10 @@ export async function runSpendPaymentConfirm(input: {
   }
 
   if (spendTx?.status === 'confirmed') {
-    const fresh = await getSpendSessionById(session.id);
-    const prepOp = await getSpendPaymentPrepareBySessionId(session.id);
+    const [fresh, prepOp] = await Promise.all([
+      getSpendSessionById(session.id),
+      getSpendPaymentPrepareBySessionId(session.id),
+    ]);
     return {
       ok: true,
       spendTransaction: spendTx,

--- a/lib/spend/payment-rails/types.ts
+++ b/lib/spend/payment-rails/types.ts
@@ -29,6 +29,7 @@ export type SpendRailFundingOperationStatus =
  */
 export type SpendRailPaymentOperationStatus =
   | 'prepared'
+  | 'submitting'
   | 'submitted'
   | 'confirmed'
   | 'failed'

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -478,6 +478,7 @@ export type SpendWalletReadinessOperation = {
  */
 export type SpendPaymentPrepareOperationStatus =
   | 'prepared'
+  | 'submitting'
   | 'submitted'
   | 'confirmed'
   | 'failed'


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stellar backend payment confirm could race: two requests might both call `confirmPayment` before either persisted a submitted `spend_transactions` row. This change adds an atomic DB guard on `spend_payment_prepare_operations` by transitioning `prepared` → `submitting` immediately before Privy/Horizon submit.

## Changes

- **Schema:** New migration `database/add-spend-payment-prepare-submitting-status.sql` extends the status CHECK constraint with transient `submitting`.
- **DB:** `tryClaimSpendPaymentPrepareForStellarSubmit` in `lib/db/spend-payment-prepare.ts` performs a conditional update (`prepared` → `submitting`) and returns the row only when this request won the race.
- **Flow:** `lib/spend-payment-confirm.ts` — after rail gate and before `confirmPayment`, the winner claims the lock; losers get **HTTP 409** with `details.paymentOperation` (submitting/submitted resume path still verifies without a second submit). Submit failures patch prepare to `failed` with clear `last_failure_reason` values; success path still moves to `submitted` then verification/terminal states as before.
- **Reconcile:** Stale `submitting` rows are included in `listSpendSessionIdsForStalePaymentPrepareReconcile`; `reconcileSubmittedSpendPaymentBackground` either aligns to `submitted` when a spend tx hash exists or resets to `prepared` with `payment_submit_stale_interrupt` when stuck without a hash.
- **Types:** `submitting` added to `SpendPaymentPrepareOperationStatus` and `SpendRailPaymentOperationStatus`.
- **Tests:** `lib/spend-payment-confirm.test.ts` — parallel confirm asserts `confirmPayment` runs at most once; resume path asserts no `confirmPayment`; rail reject asserts `failed` patch.

## Deploy notes

Apply the SQL migration to Supabase (or your migration runner) before deploying code that writes `submitting`, or inserts/updates will violate the old CHECK constraint.

## Verification

- `yarn test lib/spend-payment-confirm.test.ts`
- `yarn next build` (pre-commit)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6a724789-d245-425e-98c5-510a344dc7a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6a724789-d245-425e-98c5-510a344dc7a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

