### PR TITLE
docs: Public Records sponsored USDC activation PRD

### DIFF
--- a/docs/plans/public-records-sponsored-usdc-activation-prd.md
+++ b/docs/plans/public-records-sponsored-usdc-activation-prd.md
@@ -3,18 +3,24 @@
 **Status:** Draft (implementation not started)  
 **Pilot:** Public Records  
 **Last updated:** 2026-05-20  
-**Related docs:** `plans/irl-spend-pilot-technical-prd.md` (user-wallet USDC spend rail — explicitly different), `docs/APP_OVERVIEW.md`, `docs/stellar-baselines-and-chain-architecture.md`
+**Design:** [IRL Production — Sponsored activation UX (Figma)](https://www.figma.com/design/zIEzy0tYft7WdmNQkiLsTW/IRL-Production?node-id=2-106638&t=BWqUROj3XUIo7jHq-4)
+
+**Related documentation**
+
+- [IRL spend pilot technical PRD](../../plans/irl-spend-pilot-technical-prd.md) — user-wallet USDC spend rail (different custody model)
+- [APP_OVERVIEW](../APP_OVERVIEW.md)
+- [Stellar baselines and chain architecture](../stellar-baselines-and-chain-architecture.md)
 
 ---
 
 ## Summary
 
-IRL will run a **sponsor-funded cultural activation** at Public Records where a **campaign wallet** is prefunded with USDC. Attendees **earn and redeem real-world perks** (e.g. drink credit) through familiar IRL flows—check-in, QR, staff confirmation—**without receiving, holding, or withdrawing USDC**.
+IRL will run a **sponsor-funded cultural activation** at Public Records where a **campaign wallet** is prefunded with USDC. Attendees **earn and redeem real-world perks** (e.g. drink credit) through familiar IRL flows—check-in, QR, confirm purchase, in-venue swipe—**without receiving, holding, or withdrawing USDC**.
 
-On each confirmed redemption, the system records an **individual onchain USDC transfer** from the **campaign wallet** to a **venue settlement wallet** configured per event. Settlement may be **asynchronous**, but every transfer must remain **attributable to exactly one user redemption** so sponsor/investor dashboards can show **per-user transaction hashes** as proof of sponsor-funded spend.
+On each completed in-venue redemption, the system records an **individual onchain USDC transfer** from the **campaign wallet** to a **venue settlement wallet** configured per activation. Settlement runs on **Base or Stellar** per activation config. Settlement may be **asynchronous**, but every transfer must remain **attributable to exactly one user redemption** so the **admin dashboard** can show **per-user transaction hashes** as proof of sponsor-funded spend.
 
-**User-facing:** perk redemption.  
-**Backend:** sponsor USDC settlement to venue.
+**User-facing:** confirm purchase → success → swipe to redeem at venue (per Figma).  
+**Backend:** sponsor USDC settlement to venue (no user custody).
 
 ---
 
@@ -32,11 +38,11 @@ Partners and sponsors want **verifiable proof** that marketing dollars funded **
 | Spend pilot (`spend_experiences`) | Yes — embedded wallet | Treasury → user → receiving wallet            | **Out of scope** — opposite custody model |
 | **This activation**               | **No**                | **Campaign wallet → venue settlement wallet** | **In scope**                              |
 
-Privy remains the auth and identity layer (email/social, embedded wallet creation for future rails). For this pilot, **embedded wallets are not USDC payout destinations**.
+Privy remains the auth and identity layer (email/social; embedded wallet creation when needed for identity/rails). For this pilot, **embedded wallets are not USDC payout destinations**.
 
 ### Pilot sponsor narrative
 
-Public Records (venue) + sponsor/IRL campaign wallet demonstrate **sponsor-funded cultural spend onchain** while the attendee experience stays **IRL-native**: check in, redeem drink, staff confirms.
+Public Records + sponsor/IRL campaign wallet demonstrate **sponsor-funded cultural spend onchain** while the attendee experience stays **IRL-native**: check in, confirm perk, swipe to redeem at the bar.
 
 ### North star (explicitly deferred)
 
@@ -46,77 +52,83 @@ Long-term, user-controlled USDC wallets across many venues may be desirable. **T
 
 ## Goals
 
-1. **User experience:** Redemption feels like claiming a venue perk, not converting or spending crypto.
-2. **Sponsor proof:** Each confirmed redemption produces (or queues) **one distinct onchain USDC transaction** with a **public tx hash** tied to that redemption.
+1. **User experience:** Match authenticated Figma flow—confirm purchase, success, swipe to redeem, redeemed—without crypto conversion copy.
+2. **Sponsor proof:** Each completed redemption produces (or queues) **one distinct onchain USDC transaction** with a **public tx hash** tied to that redemption.
 3. **Custody:** Users **never** receive withdrawable USDC from the campaign wallet.
 4. **Settlement path:** USDC moves **campaign wallet → venue settlement wallet** only.
-5. **Operations:** Admin can configure activation, caps, wallets, rewards, and eligibility; staff can confirm redemptions; dashboard shows budget, settlements, and failures.
-6. **Attribution:** Async settlement is allowed; **redemption_id** (and user/event) must always link to at most one settlement attempt chain and one confirmed tx hash.
-7. **Auditability:** Backend can reconstruct eligibility → redemption → settlement for support and investor review.
+5. **Multi-rail v1:** Admin selects **Base** or **Stellar** per activation; settlement and wallet validation follow that rail.
+6. **Operations:** Admin configures activation, caps, wallets, rewards, eligibility; **admin-only** dashboard shows budget, settlements, and failures (**no CSV/export in v1**).
+7. **Attribution:** Async settlement allowed; `redemption_id` links to at most one confirmed settlement tx.
+8. **Auditability:** Backend reconstructs eligibility → redemption → settlement for support and reporting.
 
 ---
 
 ## Non-goals
 
 - Sending USDC to **user** embedded or external wallets.
-- User-visible “convert points to USDC” or “pay with USDC” flows.
-- **Batching** multiple redemptions into a single onchain transfer (breaks per-user proof requirement).
+- User-visible USDC amounts, wallet addresses, or “pay with crypto” flows.
+- **Batching** multiple redemptions into one onchain transfer.
+- **Staff-facing app**, staff login, staff confirmation queues, or **payment confirmation** flows (deferred).
+- **Admin CSV/export** of redemptions or settlements (deferred).
+- Dedicated **sponsor/investor** portal or role (admin dashboard only in v1).
 - Token-level spend restrictions, escrow contracts, or new smart contracts (unless separately approved).
-- Multi-venue marketplace settlement logic beyond one activation’s configured venue wallet.
-- Manual sponsor treasury top-up UI beyond documenting operator process (v1 may use existing wallet ops).
-- Geofencing as the sole eligibility mechanism (check-in/QR/staff/POS signals are in scope; geofence-only is not required).
-- Replacing or overloading `spend_items` / spend pilot tables without a dedicated activation schema.
-- Stellar or non-Base chains for v1 (default **Base USDC** unless admin explicitly configures another supported EVM rail later).
+- Multi-activation sponsor portfolios, automated invoicing, or tax reporting.
+- Chains other than **Base** and **Stellar** in v1.
 
 ---
 
 ## User stories
 
-| ID  | Story                                                                                                                                                                | Acceptance hint                                          |
-| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
-| U1  | As an attendee, I scan a checkpoint/activation QR and sign in so I can see my eligible perk.                                                                         | Eligibility evaluated server-side after Privy auth.      |
-| U2  | As an attendee, I complete check-in (or equivalent eligibility action) and see a simple reward (e.g. “Redeem drink”) with **no crypto amounts** in primary CTA copy. | UI shows perk title/status only; USDC not shown to user. |
-| U3  | As an attendee, I tap redeem and see “pending staff confirmation” until staff confirms.                                                                              | State `pending_staff_confirmation` visible to user.      |
-| U4  | As an attendee, after staff confirms, I see “Redeemed” and optional receipt id/time—not a wallet tx.                                                                 | No tx hash required in user UI for v1.                   |
-| U5  | As an attendee, I cannot redeem the same reward twice when campaign rules disallow it.                                                                               | Idempotent redemption rules enforced server-side.        |
-| U6  | As an attendee, if my redemption window expires, I see a clear expired/cancelled state.                                                                              | Terminal state `cancelled` or `expired` with reason.     |
+| ID  | Story                                                                                                                       | Acceptance hint                                              |
+| --- | --------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| U1  | As an attendee, I scan a checkpoint/activation QR and sign in so I can see my eligible perk.                                | Eligibility evaluated server-side after Privy auth.          |
+| U2  | As an attendee, I see a **Confirm Your Purchase** screen with points to send and perk received (Figma), not crypto amounts. | Copy uses PTS + perk title; no USDC/wallet.                  |
+| U3  | As an attendee, I tap **Confirm Purchase** and land on **Success** with balance/tier summary and swipe instructions.        | Points deducted (if configured) atomically with confirm.     |
+| U4  | As an attendee, I **swipe to redeem** at the venue when ready; the control shows progress then **Redeemed**.                | Swipe is idempotent; second swipe blocked after `redeemed`.  |
+| U5  | As an attendee, I cannot redeem twice when rules disallow it.                                                               | Server enforces per-user cap; UI shows prior redeemed state. |
+| U6  | As an attendee, if my window expires before swipe, I see **Expired** or **Cancelled**.                                      | Terminal state with clear copy.                              |
 
 ---
 
 ## Admin stories
 
-| ID  | Story                                                                                                                                      | Acceptance hint                                                          |
-| --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
-| A1  | As an admin, I create a **sponsored activation** tied to an event with sponsor name, campaign wallet, venue settlement wallet, and status. | All required fields validated; wallets checksum-validated.               |
-| A2  | As an admin, I configure **reward item(s)** with display name, USDC value per redemption, and optional points/eligibility rules.           | Reward USDC value sums into budget accounting.                           |
-| A3  | As an admin, I set **redemption cap** and/or **USDC budget cap** for the activation.                                                       | Redemptions blocked when cap exceeded; dashboard shows remaining budget. |
-| A4  | As an admin, I link **checkpoint / check-in / QR** eligibility rules to the activation.                                                    | Ineligible users cannot reach `available` redeem state.                  |
-| A5  | As an admin, I view activation dashboard metrics and exportable redemption/settlement list.                                                | See Dashboard requirements.                                              |
-| A6  | As an admin, I can disable an activation (no new redemptions; in-flight settlement continues or fails visibly).                            | `activation.status = paused/ended` enforced on new redemptions.          |
+| ID  | Story                                                                                                                                                                | Acceptance hint                                              |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
+| A1  | As an admin, I create a **sponsored activation** with sponsor name, **settlement rail** (`base` \| `stellar`), campaign wallet, venue settlement wallet, and status. | Rail-specific address validation.                            |
+| A2  | As an admin, I configure **reward item(s)** with display name, USDC settlement amount per redemption, and optional points cost.                                      | Points cost drives Confirm Purchase UI.                      |
+| A3  | As an admin, I set **redemption cap** and/or **USDC budget cap**.                                                                                                    | Block new confirms when exceeded; dashboard shows remaining. |
+| A4  | As an admin, I link **checkpoint / check-in / QR** eligibility rules.                                                                                                | Ineligible users cannot reach confirm purchase.              |
+| A5  | As an admin, I view activation metrics, tx hash feed, failed/pending settlements, and per-redemption drilldown **in-app only**.                                      | No export button or API in v1.                               |
+| A6  | As an admin, I can pause/end an activation (no new redemptions; in-flight settlement continues or fails visibly).                                                    | Status enforced on confirm/swipe APIs.                       |
 
 ---
 
-## Venue / staff stories
+## Authenticated user UX (Figma)
 
-| ID  | Story                                                                                                           | Acceptance hint                                                                     |
-| --- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| S1  | As staff, I open a staff-facing list of redemptions for this activation/event filtered by pending confirmation. | Shows user pseudonym/id, reward, time, status.                                      |
-| S2  | As staff, I confirm a pending redemption so the patron receives credit at the bar/POS.                          | Transition to `redeemed`; triggers settlement pipeline.                             |
-| S3  | As staff, I see whether a patron already redeemed so I do not double-serve.                                     | `redeemed` / `settlement_*` states visible.                                         |
-| S4  | As staff, I can mark a redemption cancelled before confirmation (wrong ticket, fraud suspicion) with reason.    | `cancelled` terminal; no settlement started.                                        |
-| S5  | As staff, optional POS/NFC/ticket scan event marks eligibility without exposing crypto.                         | Eligibility event recorded; same UX as existing checkpoint patterns where possible. |
+Reference: [Figma node 2-106638](https://www.figma.com/design/zIEzy0tYft7WdmNQkiLsTW/IRL-Production?node-id=2-106638&t=BWqUROj3XUIo7jHq-4).
 
----
+### Screen sequence (v1)
 
-## Sponsor / investor dashboard stories
+| Step | Figma label                           | Purpose                                                                                                               | Backend trigger                                  |
+| ---- | ------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------ |
+| 1    | Signed in — **Confirm Your Purchase** | Hero image, “You receive: {reward}”, YOU SEND {points} PTS, YOU RECEIVE {reward title}, account email, current points | Eligibility satisfied; redemption in `available` |
+| 2    | **Confirm Purchase** CTA              | User commits; points deducted if configured                                                                           | `purchase_confirmed` → `ready_to_redeem`         |
+| 3    | **Success!**                          | YOU SPENT, balance, tier; **How to collect** copy                                                                     | Read-only receipt state                          |
+| 4    | **Swipe to redeem**                   | Slider CTA; copy: show screen at event; swipe only when ready                                                         | Client gesture → `redeemed` API                  |
+| 5    | **Redeemed**                          | Green “REDEEMED” terminus; prior summary remains                                                                      | Triggers settlement queue                        |
 
-| ID  | Story                                                                                                                                                             | Acceptance hint                                                    |
-| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| D1  | As a sponsor viewer, I see total **check-ins verified**, **redemptions confirmed**, and **USDC settled** for the activation.                                      | Numbers reconcile with sum of confirmed settlement amounts.        |
-| D2  | As a sponsor viewer, I see **budget remaining** (configured cap minus settled minus queued).                                                                      | Formula documented in dashboard spec.                              |
-| D3  | As a sponsor viewer, I browse a **transaction hash feed** with one row per confirmed settlement linked to a redemption.                                           | No batched tx representing multiple users.                         |
-| D4  | As a sponsor viewer, I drill into a redemption and see user id (pseudonymous), event, reward, redemption status, settlement status, tx hash, block explorer link. | Drilldown matches onchain transfer amount to `reward.usdc_amount`. |
-| D5  | As a sponsor viewer, I see **failed/pending settlements** with retry status and age.                                                                              | Actionable ops list, not only aggregates.                          |
+### UX requirements
+
+- **FR-UX-1** Primary surfaces use **points and perk titles** only; never show USDC, chain, or tx hash to users.
+- **FR-UX-2** Swipe control must be **hard to complete accidentally** (slider, not single tap).
+- **FR-UX-3** Post-redeem screen is **read-only**; no second swipe path.
+- **FR-UX-4** Mobile-first layout per Figma (hero 4:5 asset, sticky bottom CTA).
+- **FR-UX-5** “How to collect” instructs patron to **show phone at venue**; no staff app implied.
+
+### Out of UX scope (v1)
+
+- Staff confirmation UI, staff PIN, or “confirm payment” modals.
+- Wallet connect or chain picker on user path (rail is activation-level).
 
 ---
 
@@ -124,187 +136,186 @@ Long-term, user-controlled USDC wallets across many venues may be desirable. **T
 
 ### FR-1 Activation lifecycle
 
-- **FR-1.1** Admin can create/update activation in `draft`; only `active` activations accept new eligibility/redemptions within window.
-- **FR-1.2** Activation stores: sponsor/campaign display name, `campaign_wallet_address`, `venue_settlement_wallet_address`, time window, caps, linked event/checkpoint ids, status.
-- **FR-1.3** Ending activation prevents **new** redemptions; existing `settlement_pending` items continue processing.
+- **FR-1.1** Admin creates/updates activation in `draft`; only `active` accepts eligibility, confirm, and swipe within window.
+- **FR-1.2** Activation stores: sponsor name, `settlement_rail` (`base` \| `stellar`), campaign wallet, venue settlement wallet, token/asset identifiers for rail, caps, eligibility config, status, window.
+- **FR-1.3** Ending activation blocks new confirms/swipes; existing `settlement_pending` continues.
 
-### FR-2 Eligibility
+### FR-2 Settlement rails (Base + Stellar)
 
-- **FR-2.1** User must authenticate via Privy before redemption UI.
-- **FR-2.2** System records an **eligibility event** (check-in, checkpoint scan, ticket scan, NFC, staff-granted, etc.) before redemption becomes `available`.
-- **FR-2.3** Eligibility rules are configurable per activation (e.g. one check-in per user per day, one reward per user per activation).
-- **FR-2.4** QR/checkpoint opens activation deep link; server validates activation id and signed/opaque token if used by existing checkpoint patterns.
+- **FR-2.1** Each activation has exactly one `settlement_rail` for v1.
+- **FR-2.2** **Base:** EVM addresses, Base USDC contract, Privy server wallet signing (reuse spend-rail Base patterns).
+- **FR-2.3** **Stellar:** Stellar G-addresses, USDC asset (issuer from env/config), Privy Stellar server wallet or documented signer (reuse `lib/privy/stellar-rail-wallet.ts` and treasury patterns where applicable).
+- **FR-2.4** Campaign and venue wallets must match the activation rail; cross-rail addresses rejected at config time.
+- **FR-2.5** Explorer links in admin dashboard are rail-aware (Base block explorer vs Stellar Expert).
 
-### FR-3 Redemption (user + staff)
+### FR-3 Eligibility
 
-- **FR-3.1** User initiates redeem → `pending_staff_confirmation` unless staff-less mode is explicitly configured (default: staff confirmation required for Public Records pilot).
-- **FR-3.2** Staff confirmation transitions to `redeemed` and consumes redemption cap / budget reservation.
-- **FR-3.3** User-facing copy must not reference USDC, wallets, or “crypto conversion.”
-- **FR-3.4** One logical redemption maps to at most one reward item instance and one settlement chain.
+- **FR-3.1** Privy auth required before confirm purchase.
+- **FR-3.2** Record **eligibility event** (checkpoint check-in, location check-in, QR scan, ticket scan, NFC—**not** staff grant in v1) before `available`.
+- **FR-3.3** Configurable rules: max per user per activation, daily limits, required checkpoint ids.
+- **FR-3.4** Deep link/QR validated server-side (signed token if aligned with checkpoint patterns).
 
-### FR-4 Settlement (backend)
+### FR-4 Redemption (user-only, no staff)
 
-- **FR-4.1** On `redeemed`, system creates a **settlement transaction** record in `not_started` → `queued`.
-- **FR-4.2** Settlement transfers **exactly** `reward.usdc_amount` (or configured amount at redemption time snapshot) from **campaign wallet** to **venue settlement wallet** on Base USDC.
-- **FR-4.3** **No** transfer to `user.wallet_address`.
-- **FR-4.4** One redemption → one onchain transfer (no batching). Retries reuse the same logical settlement id with new submission attempts tracked in metadata.
-- **FR-4.5** On chain confirmation, redemption moves to `settlement_confirmed` and stores `tx_hash`, `chain_id`, `amount`, `from`, `to`, `confirmed_at`.
-- **FR-4.6** Async settlement allowed: redemption may sit in `settlement_pending` while worker processes queue.
-- **FR-4.7** Campaign wallet balance check before submit; insufficient funds → `settlement_failed` with reason `campaign_insufficient_funds` and ops alert.
+- **FR-4.1** `available` → user opens Confirm Purchase.
+- **FR-4.2** **Confirm Purchase** atomically: validate points (if `points_cost > 0`), create/update redemption `purchase_confirmed`, deduct points, transition to `ready_to_redeem`.
+- **FR-4.3** **Swipe to redeem** transitions `ready_to_redeem` → `redeemed`; idempotent if already `redeemed`.
+- **FR-4.4** No `pending_staff_confirmation`, staff APIs, or payment-confirmation step in v1.
+- **FR-4.5** One redemption → one reward item → one settlement chain.
+- **FR-4.6** User copy excludes USDC, wallets, and conversion language.
 
-### FR-5 Budget and caps
+### FR-5 Settlement (backend)
 
-- **FR-5.1** Support `max_redemptions` (count) and/or `max_usdc_budget` (sum of settlement amounts).
-- **FR-5.2** Reserve budget on `redeemed`; release on `cancelled` before settlement submit; finalize decrement on `settlement_confirmed`.
-- **FR-5.3** Block new redemptions when cap exceeded (user message: “This perk is no longer available”).
+- **FR-5.1** On `redeemed`, create settlement `not_started` → `queued`.
+- **FR-5.2** Transfer `usdc_amount_snapshot` from campaign wallet → venue settlement wallet on activation rail.
+- **FR-5.3** **No** transfer to user wallet addresses (assert at build time).
+- **FR-5.4** One redemption → one onchain transfer (no batching).
+- **FR-5.5** On confirm: redemption `settlement_confirmed`, persist `tx_hash` / Stellar tx id, rail metadata.
+- **FR-5.6** Async worker allowed; redemption may show `settlement_pending` while user UI stays **Redeemed**.
+- **FR-5.7** Insufficient campaign balance → `settlement_failed`, admin alert; user UI unchanged.
 
-### FR-6 Wallets and signing
+### FR-6 Budget and caps
 
-- **FR-6.1** Campaign wallet is a **Privy server wallet** or otherwise IRL-controlled signer documented in runbook (same operational model as spend pilot treasury).
-- **FR-6.2** Venue settlement wallet is **admin-configured**, validated as an address on the activation chain.
-- **FR-6.3** Private keys never exposed to client; all transfers initiated server-side.
+- **FR-6.1** `max_redemptions` and/or `max_usdc_budget`.
+- **FR-6.2** Reserve budget on `redeemed`; release on `cancelled` before submit; finalize on `settlement_confirmed`.
+- **FR-6.3** Block new confirm when cap exceeded.
 
-### FR-7 Idempotency
+### FR-7 Wallets and signing
 
-- **FR-7.1** Idempotency key: `activation_id + user_id + reward_item_id + eligibility_event_id` (or stricter rule if one reward per user per activation).
-- **FR-7.2** Duplicate staff confirm or duplicate settlement worker invocations must not double-transfer USDC.
-- **FR-7.3** Unique DB constraint: one `confirmed` settlement per `redemption_id`.
+- **FR-7.1** Campaign wallet = IRL-controlled server wallet per rail.
+- **FR-7.2** Venue wallet = admin-configured receive address per rail.
+- **FR-7.3** Server-side signing only.
 
-### FR-8 Integration with existing app
+### FR-8 Idempotency
 
-- Reuse Privy auth (`lib/api/privy.ts`), player records, checkpoint/check-in flows, admin auth (`lib/auth.ts`), API response helpers (`lib/api/response.ts`), Mixpanel helpers (`lib/analytics/`), and Base USDC constants from existing wallet/spend code where applicable.
-- **New tables** preferred over overloading `spend_redemptions` to keep audit trails distinct.
+- **FR-8.1** Idempotency key: `activation_id + user_id + reward_item_id` (or include eligibility id if multiple rewards per activation).
+- **FR-8.2** Duplicate confirm/swipe/settlement worker calls must not double-deduct points or double-transfer.
+- **FR-8.3** Unique constraint: one `confirmed` settlement per `redemption_id`.
+
+### FR-9 Admin dashboard (no export)
+
+- **FR-9.1** In-app metrics, feeds, drilldowns only—**no** CSV download, bulk export API, or Metabase requirement in v1.
+- **FR-9.2** Manual settlement retry trigger allowed for admins (ops).
+
+### FR-10 Integration
+
+- Reuse Privy auth, players/points, checkpoints, admin auth, API response helpers, Mixpanel, Base USDC + Stellar spend-rail wallet utilities.
+- **New tables**; do not overload `spend_redemptions`.
 
 ---
 
 ## Data model / key entities
 
-Logical entities for implementation (SQL names illustrative).
+### `sponsored_activation`
 
-### `sponsored_activation` (activation / event)
+| Field                             | Type        | Notes                                          |
+| --------------------------------- | ----------- | ---------------------------------------------- |
+| `id`                              | uuid        | PK                                             |
+| `slug`                            | text        | e.g. `public-records-2026`                     |
+| `title`                           | text        | Display                                        |
+| `sponsor_name`                    | text        |                                                |
+| `event_id`                        | uuid?       |                                                |
+| `status`                          | enum        | `draft`, `active`, `paused`, `ended`           |
+| `settlement_rail`                 | enum        | **`base`**, **`stellar`** (required v1)        |
+| `campaign_wallet_address`         | text        | Rail-specific                                  |
+| `venue_settlement_wallet_address` | text        | Rail-specific                                  |
+| `usdc_asset_config`               | jsonb       | Base: contract address; Stellar: code + issuer |
+| `max_redemptions`                 | int?        |                                                |
+| `max_usdc_budget`                 | numeric?    |                                                |
+| `usdc_settled_total`              | numeric     |                                                |
+| `redemption_count_confirmed`      | int         |                                                |
+| `starts_at` / `ends_at`           | timestamptz |                                                |
+| `eligibility_config`              | jsonb       |                                                |
+| `created_by`                      | text        |                                                |
+| `created_at` / `updated_at`       | timestamptz |                                                |
 
-| Field                             | Type        | Notes                                     |
-| --------------------------------- | ----------- | ----------------------------------------- |
-| `id`                              | uuid        | PK                                        |
-| `slug`                            | text        | Public Records pilot slug                 |
-| `title`                           | text        | Display                                   |
-| `sponsor_name`                    | text        | Sponsor/campaign label                    |
-| `event_id`                        | uuid?       | FK to events if present                   |
-| `status`                          | enum        | `draft`, `active`, `paused`, `ended`      |
-| `campaign_wallet_address`         | text        | Source of USDC                            |
-| `venue_settlement_wallet_address` | text        | Destination                               |
-| `chain`                           | text        | Default `base`                            |
-| `usdc_token_address`              | text        | Base USDC contract                        |
-| `max_redemptions`                 | int?        | Count cap                                 |
-| `max_usdc_budget`                 | numeric?    | Budget cap                                |
-| `usdc_settled_total`              | numeric     | Running confirmed sum                     |
-| `redemption_count_confirmed`      | int         | Running count                             |
-| `starts_at` / `ends_at`           | timestamptz | Activation window                         |
-| `eligibility_config`              | jsonb       | Rules: checkpoint ids, max per user, etc. |
-| `created_by`                      | uuid/text   | Admin                                     |
-| `created_at` / `updated_at`       | timestamptz |                                           |
+### `activation_reward_item`
 
-### `activation_reward_item` (reward item)
+| Field            | Type    | Notes                               |
+| ---------------- | ------- | ----------------------------------- |
+| `id`             | uuid    | PK                                  |
+| `activation_id`  | uuid    | FK                                  |
+| `name`           | text    | Figma “Title of Item 1”             |
+| `hero_image_url` | text?   | Figma hero                          |
+| `description`    | text?   |                                     |
+| `points_cost`    | int     | Figma “YOU SEND” (0 = no deduction) |
+| `usdc_amount`    | numeric | Settlement amount (backend only)    |
+| `sort_order`     | int     |                                     |
+| `is_active`      | bool    |                                     |
+| `max_per_user`   | int?    | Default 1                           |
 
-| Field           | Type    | Notes                            |
-| --------------- | ------- | -------------------------------- |
-| `id`            | uuid    | PK                               |
-| `activation_id` | uuid    | FK                               |
-| `name`          | text    | e.g. “Drink credit”              |
-| `description`   | text?   | Staff/user helper                |
-| `usdc_amount`   | numeric | Settlement amount per redemption |
-| `sort_order`    | int     | UI ordering                      |
-| `is_active`     | bool    |                                  |
-| `max_per_user`  | int?    | Default 1 for pilot              |
+### `activation_eligibility_event`
 
-### `activation_eligibility_event` (user check-in / eligibility)
+| Field            | Type        | Notes                                                                                                  |
+| ---------------- | ----------- | ------------------------------------------------------------------------------------------------------ |
+| `id`             | uuid        | PK                                                                                                     |
+| `activation_id`  | uuid        | FK                                                                                                     |
+| `user_id`        | uuid        |                                                                                                        |
+| `wallet_address` | text?       | Identity only                                                                                          |
+| `source`         | enum        | `checkpoint_checkin`, `location_checkin`, `qr_scan`, `nfc`, `ticket_scan` (**no `staff_grant` in v1**) |
+| `source_ref_id`  | text?       |                                                                                                        |
+| `occurred_at`    | timestamptz |                                                                                                        |
+| `metadata`       | jsonb       |                                                                                                        |
 
-| Field            | Type        | Notes                                                                                           |
-| ---------------- | ----------- | ----------------------------------------------------------------------------------------------- |
-| `id`             | uuid        | PK                                                                                              |
-| `activation_id`  | uuid        | FK                                                                                              |
-| `user_id`        | uuid        | Player                                                                                          |
-| `wallet_address` | text?       | Identity reference, not payout target                                                           |
-| `source`         | enum        | `checkpoint_checkin`, `location_checkin`, `qr_scan`, `nfc`, `ticket_scan`, `staff_grant`, `pos` |
-| `source_ref_id`  | text?       | Checkpoint id, check-in id, etc.                                                                |
-| `occurred_at`    | timestamptz |                                                                                                 |
-| `metadata`       | jsonb       | Device, staff id, etc.                                                                          |
+### `activation_redemption`
 
-### `activation_redemption` (redemption)
+| Field                       | Type         | Notes               |
+| --------------------------- | ------------ | ------------------- |
+| `id`                        | uuid         | PK                  |
+| `activation_id`             | uuid         | FK                  |
+| `reward_item_id`            | uuid         | FK                  |
+| `user_id`                   | uuid         | FK                  |
+| `eligibility_event_id`      | uuid         | FK                  |
+| `status`                    | enum         | See state machine   |
+| `points_spent`              | int?         | Snapshot at confirm |
+| `usdc_amount_snapshot`      | numeric      | At confirm          |
+| `purchase_confirmed_at`     | timestamptz? |                     |
+| `redeemed_at`               | timestamptz? | Swipe completed     |
+| `cancelled_reason`          | text?        |                     |
+| `idempotency_key`           | text         | Unique              |
+| `created_at` / `updated_at` | timestamptz  |                     |
 
-| Field                       | Type         | Notes                        |
-| --------------------------- | ------------ | ---------------------------- |
-| `id`                        | uuid         | PK                           |
-| `activation_id`             | uuid         | FK                           |
-| `reward_item_id`            | uuid         | FK                           |
-| `user_id`                   | uuid         | FK                           |
-| `eligibility_event_id`      | uuid         | FK                           |
-| `status`                    | enum         | See redemption state machine |
-| `usdc_amount_snapshot`      | numeric      | Frozen at redeem time        |
-| `staff_confirmed_by`        | text?        | Staff operator id            |
-| `staff_confirmed_at`        | timestamptz? |                              |
-| `cancelled_reason`          | text?        |                              |
-| `idempotency_key`           | text         | Unique                       |
-| `created_at` / `updated_at` | timestamptz  |                              |
+**Removed from v1:** `staff_confirmed_by`, `staff_confirmed_at`.
 
-### `activation_settlement_transaction` (settlement)
+### `activation_settlement_transaction`
 
-| Field                                         | Type         | Notes                        |
-| --------------------------------------------- | ------------ | ---------------------------- |
-| `id`                                          | uuid         | PK                           |
-| `redemption_id`                               | uuid         | FK unique for confirmed      |
-| `activation_id`                               | uuid         | FK                           |
-| `status`                                      | enum         | See settlement state machine |
-| `amount`                                      | numeric      | USDC                         |
-| `from_wallet_address`                         | text         | Campaign                     |
-| `to_wallet_address`                           | text         | Venue                        |
-| `tx_hash`                                     | text?        | Set on confirm               |
-| `chain_id`                                    | int?         | Base                         |
-| `submission_attempt`                          | int          | Retry counter                |
-| `last_error_code`                             | text?        | Sanitized                    |
-| `last_error_message`                          | text?        | Ops only                     |
-| `queued_at` / `submitted_at` / `confirmed_at` | timestamptz? |                              |
-| `privy_transaction_id`                        | text?        | If applicable                |
-
-### `activation_dashboard_snapshot` (optional materialized metrics)
-
-May be computed view rather than table: check-ins count, redemptions by status, USDC settled, budget remaining, failed settlement count.
-
-### Entity relationships (ASCII)
-
-```
-sponsored_activation
-  ├── activation_reward_item (1:N)
-  ├── activation_eligibility_event (1:N)
-  └── activation_redemption (1:N)
-        └── activation_settlement_transaction (1:1)
-```
+| Field                                         | Type         | Notes                     |
+| --------------------------------------------- | ------------ | ------------------------- |
+| `id`                                          | uuid         | PK                        |
+| `redemption_id`                               | uuid         | FK                        |
+| `activation_id`                               | uuid         | FK                        |
+| `settlement_rail`                             | enum         | Copy from activation      |
+| `status`                                      | enum         | Settlement SM             |
+| `amount`                                      | numeric      |                           |
+| `from_wallet_address`                         | text         |                           |
+| `to_wallet_address`                           | text         |                           |
+| `tx_hash`                                     | text?        | EVM hash or Stellar tx id |
+| `submission_attempt`                          | int          |                           |
+| `last_error_code`                             | text?        |                           |
+| `queued_at` / `submitted_at` / `confirmed_at` | timestamptz? |                           |
+| `privy_transaction_id`                        | text?        | If applicable             |
 
 ---
 
 ## Event / admin configuration requirements
 
-Admin UI/API must support configuring at minimum:
+| Config                                    | Required       | Validation                               |
+| ----------------------------------------- | -------------- | ---------------------------------------- |
+| Sponsor / campaign name                   | Yes            | Non-empty                                |
+| **Settlement rail**                       | Yes            | `base` or `stellar`                      |
+| Campaign wallet                           | Yes            | EVM checksum (Base) or Stellar G-address |
+| Venue settlement wallet                   | Yes            | Same rail; ≠ campaign                    |
+| USDC asset config                         | Yes            | Rail-specific schema                     |
+| Reward name, `points_cost`, `usdc_amount` | Yes (≥1)       | `usdc_amount > 0`; `points_cost >= 0`    |
+| Redemption cap and/or USDC budget         | Yes (one+)     | Positive                                 |
+| Activation window                         | Yes            | `ends_at > starts_at`                    |
+| Checkpoint(s) / event id                  | Yes (PR pilot) | Exists in DB                             |
+| Eligibility rules JSON                    | Yes            | Zod                                      |
+| Status                                    | Yes            | `active` for user flows                  |
 
-| Config                                     | Required           | Validation                        |
-| ------------------------------------------ | ------------------ | --------------------------------- |
-| Sponsor / campaign name                    | Yes                | Non-empty                         |
-| Campaign wallet address                    | Yes                | EVM checksum, matches chain       |
-| Venue settlement wallet address            | Yes                | EVM checksum, ≠ campaign wallet   |
-| Reward item name + USDC amount             | Yes (≥1 item)      | `usdc_amount > 0`                 |
-| Redemption cap and/or USDC budget          | Yes (at least one) | Positive integers/decimals        |
-| Activation window (`starts_at`, `ends_at`) | Yes                | `ends_at > starts_at`             |
-| Linked checkpoint(s) or event id           | Yes for PR pilot   | Must exist in DB                  |
-| Eligibility rules JSON                     | Yes                | Schema-validated (Zod)            |
-| Staff confirmation required                | Yes (default true) | Boolean                           |
-| Status                                     | Yes                | Only `active` exposes user redeem |
+**Removed from v1 config:** `staff_confirmation_required`, payment confirmation toggles.
 
-**Public Records pilot defaults (configurable, not hardcoded in code):**
-
-- Reward: “Drink credit” — USDC amount TBD by sponsor (e.g. $8–$15 equivalent).
-- One redemption per user per activation unless ops overrides.
-- Staff confirmation required at bar.
-- Base USDC, campaign wallet prefunded before `active`.
+**Public Records defaults:** one drink reward, one redemption per user, prefunded campaign wallet before `active`, rail chosen per ops (Base or Stellar).
 
 ---
 
@@ -312,33 +323,37 @@ Admin UI/API must support configuring at minimum:
 
 ### States
 
-| State                        | Description                                  | User-visible                           | Staff-visible                       |
-| ---------------------------- | -------------------------------------------- | -------------------------------------- | ----------------------------------- |
-| `eligible`                   | User met eligibility; redeem not yet started | Optional “You unlocked a perk”         | —                                   |
-| `available`                  | Redeem CTA enabled                           | “Redeem drink”                         | —                                   |
-| `pending_staff_confirmation` | User requested redeem; awaiting staff        | “Waiting for staff”                    | “Confirm” action                    |
-| `redeemed`                   | Staff confirmed; perk consumed in product    | “Redeemed”                             | “Redeemed”                          |
-| `settlement_pending`         | Settlement queued or submitted               | “Redeemed” (no change)                 | Same                                |
-| `settlement_confirmed`       | Onchain tx confirmed                         | “Redeemed”                             | “Settled” + optional internal badge |
-| `settlement_failed`          | Settlement failed after redeem               | “Redeemed — processing” or ops message | Alert                               |
-| `cancelled`                  | Voided before/at staff confirm               | “Cancelled”                            | “Cancelled”                         |
-| `expired`                    | Window or hold expired                       | “Expired”                              | —                                   |
+| State                  | Description                  | User UI (Figma)                 |
+| ---------------------- | ---------------------------- | ------------------------------- |
+| `eligible`             | Eligibility recorded         | Pre-confirm or hidden           |
+| `available`            | Can open Confirm Purchase    | Confirm Your Purchase           |
+| `purchase_confirmed`   | Points committed (if any)    | Transitional (optional loading) |
+| `ready_to_redeem`      | Awaiting in-venue swipe      | Success + Swipe to redeem       |
+| `redeemed`             | Swipe completed              | Redeemed                        |
+| `settlement_pending`   | Onchain in flight            | Redeemed (unchanged)            |
+| `settlement_confirmed` | Tx confirmed                 | Redeemed                        |
+| `settlement_failed`    | Settlement exhausted retries | Redeemed (user); ops alert      |
+| `cancelled`            | Voided before swipe          | Cancelled message               |
+| `expired`              | Window/hold expired          | Expired message                 |
+
+**Not in v1:** `pending_staff_confirmation`.
 
 ### Transitions
 
 ```mermaid
 stateDiagram-v2
-  [*] --> eligible: eligibility_event recorded
+  [*] --> eligible: eligibility_event
   eligible --> available: rules pass
-  available --> pending_staff_confirmation: user taps Redeem
-  pending_staff_confirmation --> redeemed: staff confirms
-  pending_staff_confirmation --> cancelled: staff/user cancel
-  available --> expired: time window elapsed
-  pending_staff_confirmation --> expired: confirmation timeout
-  redeemed --> settlement_pending: settlement record created
+  available --> purchase_confirmed: confirm purchase API
+  purchase_confirmed --> ready_to_redeem: success
+  ready_to_redeem --> redeemed: swipe to redeem API
+  available --> expired: timeout
+  ready_to_redeem --> expired: swipe timeout
+  ready_to_redeem --> cancelled: user/admin cancel
+  redeemed --> settlement_pending: enqueue settlement
   settlement_pending --> settlement_confirmed: tx confirmed
-  settlement_pending --> settlement_failed: tx failed
-  settlement_failed --> settlement_pending: retry policy allows
+  settlement_pending --> settlement_failed: retries exhausted
+  settlement_failed --> settlement_pending: manual retry
   settlement_confirmed --> [*]
   cancelled --> [*]
   expired --> [*]
@@ -346,167 +361,155 @@ stateDiagram-v2
 
 ### Invariants
 
-- `settlement_*` states only occur after `redeemed`.
-- `settlement_confirmed` implies exactly one non-null `tx_hash` on the linked settlement row.
-- User never transitions to a state that implies user custody of USDC.
+- Settlement states only after `redeemed`.
+- `settlement_confirmed` ⇒ exactly one `tx_hash` on settlement row.
+- Swipe cannot occur before `ready_to_redeem`.
 
 ---
 
 ## Settlement state machine
 
-Independent settlement record states (linked 1:1 to redemption after `redeemed`).
+(Unchanged structure; rail-aware execution.)
 
-| State         | Description                                            |
-| ------------- | ------------------------------------------------------ |
-| `not_started` | Redemption just confirmed; worker not yet picked up    |
-| `queued`      | Eligible for worker; budget reserved                   |
-| `submitted`   | Tx broadcast; hash may be pending                      |
-| `confirmed`   | Tx confirmed onchain                                   |
-| `failed`      | Terminal failure for this attempt                      |
-| `retrying`    | Backoff retry in progress (subset of queued/submitted) |
-
-### Transitions
+| State         | Description                       |
+| ------------- | --------------------------------- |
+| `not_started` | Created at `redeemed`             |
+| `queued`      | Worker picked up; budget reserved |
+| `submitted`   | Broadcast                         |
+| `confirmed`   | Onchain success                   |
+| `failed`      | Attempt failed                    |
+| `retrying`    | Backoff                           |
 
 ```mermaid
 stateDiagram-v2
-  [*] --> not_started: redemption redeemed
-  not_started --> queued: worker enqueues
-  queued --> submitted: sign and broadcast
-  submitted --> confirmed: RPC receipt success
-  submitted --> failed: revert or timeout
-  failed --> retrying: retry budget remaining
-  retrying --> queued: backoff elapsed
+  [*] --> not_started: redeemed
+  not_started --> queued: enqueue
+  queued --> submitted: broadcast
+  submitted --> confirmed: receipt ok
+  submitted --> failed: error
+  failed --> retrying: policy allows
+  retrying --> queued: backoff done
   confirmed --> [*]
 ```
-
-### Mapping to redemption status
 
 | Settlement status                                | Redemption status      |
 | ------------------------------------------------ | ---------------------- |
 | `not_started`, `queued`, `submitted`, `retrying` | `settlement_pending`   |
 | `confirmed`                                      | `settlement_confirmed` |
-| `failed` (exhausted retries)                     | `settlement_failed`    |
+| `failed` (exhausted)                             | `settlement_failed`    |
 
 ---
 
-## Dashboard requirements
+## Dashboard requirements (admin only, no export)
 
-### Aggregate tiles (activation scope)
+### Aggregate tiles
 
-| Metric                | Definition                                                                             | Test                      |
-| --------------------- | -------------------------------------------------------------------------------------- | ------------------------- |
-| Check-ins verified    | Count of `activation_eligibility_event` for activation                                 | Matches eligibility table |
-| Redemptions created   | Count `activation_redemption` all statuses except `eligible`                           | Includes pending          |
-| Redemptions confirmed | Count in `redeemed`, `settlement_pending`, `settlement_confirmed`, `settlement_failed` |                           |
-| USDC settled          | Sum `amount` where settlement `confirmed`                                              | Equals onchain sum ±0     |
-| Budget remaining      | `max_usdc_budget - usdc_settled_total - reserved_pending`                              | Document reserved formula |
-| Redemptions remaining | `max_redemptions - redemption_count_confirmed` if count cap                            |                           |
+| Metric                | Definition                               |
+| --------------------- | ---------------------------------------- |
+| Check-ins verified    | Count `activation_eligibility_event`     |
+| Redemptions created   | Redemptions past `available`             |
+| Redemptions confirmed | `redeemed` + settlement states           |
+| USDC settled          | Sum confirmed settlement `amount`        |
+| Budget remaining      | `max_usdc_budget - settled - reserved`   |
+| Redemptions remaining | `max_redemptions - confirmed count`      |
+| Settlement rail       | Display `settlement_rail` for activation |
 
 ### Transaction hash feed
 
-- One row per **confirmed** settlement: `confirmed_at`, `tx_hash`, `amount`, `user_id` (pseudonym), `reward_item.name`, explorer link.
-- Sort: newest first.
-- **Must not** show batched multi-user transfers.
+- One row per **confirmed** settlement; explorer link per rail.
+- No batched multi-user txs.
 
-### Failed / pending settlement list
+### Failed / pending list
 
-- Filter: settlement in `queued`, `submitted`, `retrying`, or `failed`.
-- Columns: redemption id, user, reward, amount, status, attempt count, last error (sanitized), age.
-- Ops action: manual retry trigger (admin-only) if within policy.
+- Filter `queued`, `submitted`, `retrying`, `failed`.
+- Admin manual retry (no export).
 
 ### Per-redemption drilldown
 
-- User id / username / wallet (for support, not payout).
-- Event / activation title.
-- Reward item + snapshot amount.
-- Redemption status timeline timestamps.
-- Settlement status + `tx_hash` + explorer URL when confirmed.
-- Linked eligibility event source + timestamp.
+- User id/username, reward, points spent, redemption timeline, settlement status, `tx_hash`, eligibility source.
 
 ### Access control
 
-- Admin: full dashboard + config.
-- Sponsor/investor role: read-only aggregates and feed (no PII beyond pseudonym policy).
+- **Admin only** in v1 (no sponsor role, no export).
 
 ---
 
 ## Error and retry behavior
 
-| Error                       | User impact                         | System behavior                                           |
-| --------------------------- | ----------------------------------- | --------------------------------------------------------- |
-| Activation inactive / ended | Cannot start redeem                 | 4xx with clear message                                    |
-| Eligibility not met         | No redeem CTA                       | Stay `eligible` or hidden                                 |
-| Cap / budget exceeded       | “No longer available”               | Block at `available` → redeem                             |
-| Duplicate redeem            | “Already redeemed”                  | Idempotent return existing row                            |
-| Staff confirm race          | Single winner                       | DB transaction / unique constraint                        |
-| Campaign insufficient USDC  | User still sees redeemed; ops alert | `settlement_failed`, retry after fund                     |
-| RPC timeout                 | None                                | `submitted` → poll; then retry                            |
-| Tx reverted                 | None                                | `failed` → `retrying` with backoff                        |
-| Duplicate worker submit     | None                                | Idempotency on settlement id; no second tx if hash exists |
+| Error                      | User impact                    | System behavior            |
+| -------------------------- | ------------------------------ | -------------------------- |
+| Activation inactive        | Cannot confirm                 | 4xx                        |
+| Insufficient points        | Cannot confirm                 | 4xx on confirm             |
+| Cap / budget exceeded      | “No longer available”          | Block confirm              |
+| Duplicate confirm          | Show existing success/redeemed | Idempotent read            |
+| Duplicate swipe            | Stay redeemed                  | Idempotent                 |
+| Campaign insufficient USDC | None on user UI                | `settlement_failed`, retry |
+| RPC / Horizon timeout      | None                           | Poll + retry               |
+| Wrong rail signer          | None                           | Fail fast at config        |
 
-### Retry policy (v1 defaults)
+### Retry policy
 
-- Max **5** attempts per settlement over **24h** with exponential backoff (30s, 2m, 10m, 30m, 2h).
-- After exhaustion: `settlement_failed`, redemption `settlement_failed`, dashboard alert.
-- Retries must **not** create a second confirmed tx for the same `redemption_id`.
+- Max **5** attempts / **24h**, exponential backoff (30s → 2h).
+- No duplicate confirmed tx per `redemption_id`.
 
 ### User messaging
 
-- Never show raw RPC errors, wallet addresses, or “insufficient gas” to attendees.
-- Staff sees operational short codes (`SETTLEMENT_DELAYED`).
+- No raw chain errors or addresses in attendee UI.
 
 ---
 
 ## Security / abuse prevention
 
-- **Server-side authority:** All eligibility, redemption, and settlement transitions validated on API routes; never trust client-only state.
-- **Auth:** Privy token verification on all user endpoints; admin routes use existing admin auth.
-- **QR / deep links:** Use server-validatable activation/checkpoint ids; signed tokens if matching existing checkpoint security model.
-- **Rate limits:** Per-IP and per-user limits on redeem and eligibility endpoints.
-- **Staff actions:** Staff confirm requires staff auth or staff PIN/session scoped to activation (TBD in open questions).
-- **Wallet separation:** Campaign wallet keys only on server; venue wallet is receive-only from campaign perspective.
-- **No user payout:** Assert `to_wallet_address` ≠ any `players` embedded wallet at settlement build time.
-- **Audit:** Append-only or immutable settlement rows after `confirmed`; corrections via compensating admin notes, not silent deletes.
-- **Budget griefing:** Reserve USDC budget at `redeemed` to prevent over-subscription under concurrency.
+- Server-side validation for eligibility, confirm, swipe, settlement.
+- Privy auth on user endpoints; admin auth on admin routes.
+- Rate limits on confirm and swipe.
+- Swipe requires authenticated session + redemption in `ready_to_redeem` (optional: short-lived server nonce after confirm).
+- Settlement `to` ≠ user wallets on either rail.
+- Budget reserve at `redeemed`.
+- **Removed v1:** staff auth, staff PIN, payment confirmation gates.
 
 ---
 
 ## Analytics events
 
-Emit via existing Mixpanel helpers. Include `activation_id`, `event_id`, `user_id`, `reward_item_id`, `redemption_id`, `settlement_id`, `status`, `usdc_amount` (backend only properties where noted).
+Properties: `activation_id`, `settlement_rail`, `user_id`, `reward_item_id`, `redemption_id`, `settlement_id`, `status`, `points_spent`; `usdc_amount` **server-side only**.
 
-| Event                                       | When                          | Key properties                   |
-| ------------------------------------------- | ----------------------------- | -------------------------------- |
-| `sponsored_activation_viewed`               | User opens activation surface | `activation_id`, `source`        |
-| `sponsored_activation_eligibility_recorded` | Eligibility event persisted   | `source`, `eligibility_event_id` |
-| `sponsored_redemption_started`              | User taps redeem              | `reward_item_id`                 |
-| `sponsored_redemption_pending_staff`        | Entered pending staff         |                                  |
-| `sponsored_redemption_staff_confirmed`      | Staff confirms                | `staff_id`                       |
-| `sponsored_redemption_cancelled`            | Cancelled                     | `reason`                         |
-| `sponsored_redemption_expired`              | Expired                       |                                  |
-| `sponsored_settlement_queued`               | Settlement queued             | `usdc_amount`                    |
-| `sponsored_settlement_submitted`            | Tx broadcast                  | `tx_hash` if known               |
-| `sponsored_settlement_confirmed`            | Tx confirmed                  | `tx_hash`, `usdc_amount`         |
-| `sponsored_settlement_failed`               | Failed                        | `error_code`                     |
-| `sponsored_activation_cap_reached`          | Budget or count cap hit       | `cap_type`                       |
-| `sponsored_activation_dashboard_viewed`     | Sponsor/admin dashboard       | `viewer_role`                    |
+| Event                                         | When                         |
+| --------------------------------------------- | ---------------------------- |
+| `sponsored_activation_viewed`                 | Activation surface opened    |
+| `sponsored_activation_eligibility_recorded`   | Eligibility persisted        |
+| `sponsored_redemption_confirm_viewed`         | Confirm Purchase screen      |
+| `sponsored_redemption_purchase_confirmed`     | Confirm CTA success          |
+| `sponsored_redemption_swipe_started`          | Swipe gesture started        |
+| `sponsored_redemption_redeemed`               | Swipe completed → `redeemed` |
+| `sponsored_redemption_cancelled`              | Cancelled                    |
+| `sponsored_redemption_expired`                | Expired                      |
+| `sponsored_settlement_queued`                 | Settlement queued            |
+| `sponsored_settlement_submitted`              | Broadcast                    |
+| `sponsored_settlement_confirmed`              | Confirmed                    |
+| `sponsored_settlement_failed`                 | Failed                       |
+| `sponsored_activation_cap_reached`            | Cap hit                      |
+| `sponsored_activation_admin_dashboard_viewed` | Admin dashboard              |
+
+**Removed v1:** `sponsored_redemption_pending_staff`, `sponsored_redemption_staff_confirmed`, sponsor-viewer events.
 
 ---
 
 ## Open questions
 
-| #     | Question                                                                                    | Owner       | Blocks                  |
-| ----- | ------------------------------------------------------------------------------------------- | ----------- | ----------------------- |
-| OQ-1  | Exact USDC amount per drink credit for Public Records?                                      | Sponsor/Ops | Config only             |
-| OQ-2  | Staff auth model: dedicated staff login, admin impersonation, or shared PIN per event?      | Product/Eng | Staff UI                |
-| OQ-3  | Is staff confirmation timeout required (e.g. 15m) before `expired`?                         | Product     | State machine           |
-| OQ-4  | Campaign wallet: reuse spend-pilot Privy server wallet or dedicated PR wallet?              | Eng/Ops     | Runbook                 |
-| OQ-5  | On insufficient campaign funds mid-event: pause activation automatically vs manual top-up?  | Product     | Ops playbook            |
-| OQ-6  | Sponsor dashboard: in-app admin tab vs exported CSV vs Metabase?                            | Product     | Phase scope             |
-| OQ-7  | Points deduction: does this activation consume IRL points or only attendance gating?        | Product     | Eligibility rules       |
-| OQ-8  | Public Records eligibility: checkpoint id(s) and ticket vendor integration spec?            | Ops         | FR-2                    |
-| OQ-9  | Legal/copy review: any disclosure that sponsor funds venue onchain (in Terms only)?         | Legal       | None for implementation |
-| OQ-10 | Retry manual override: who can trigger and is a second tx id ever allowed after wrong hash? | Eng         | Support tooling         |
+| #    | Question                                                              | Owner       | Blocks         |
+| ---- | --------------------------------------------------------------------- | ----------- | -------------- |
+| OQ-1 | USDC amount per drink (Base vs Stellar same nominal?)                 | Sponsor/Ops | Config         |
+| OQ-2 | Points cost for Public Records confirm (99 PTS placeholder in Figma?) | Product     | Reward config  |
+| OQ-3 | Swipe timeout duration before `expired`                               | Product     | State machine  |
+| OQ-4 | Campaign wallet per rail: shared treasury vs dedicated PR wallets     | Eng/Ops     | Runbook        |
+| OQ-5 | Auto-pause activation on insufficient campaign USDC                   | Product     | Ops            |
+| OQ-6 | Public Records checkpoint id(s) and ticket integration                | Ops         | Eligibility    |
+| OQ-7 | Stellar USDC issuer for production settlement                         | Eng         | Stellar config |
+| OQ-8 | Legal copy for sponsor-funded venue settlement                        | Legal       | Terms only     |
+| OQ-9 | Manual settlement retry permissions                                   | Eng         | Admin UI       |
+
+**Closed for v1 (deferred):** staff auth, payment confirmation, CSV export, sponsor portal.
 
 ---
 
@@ -514,71 +517,63 @@ Emit via existing Mixpanel helpers. Include `activation_id`, `event_id`, `user_i
 
 ### Configuration
 
-- [ ] Admin can create Public Records activation with campaign + venue wallets, ≥1 reward, caps, and window.
-- [ ] Invalid wallet addresses and `ends_at < starts_at` are rejected with validation errors.
+- [ ] Admin creates activation with `settlement_rail` `base` or `stellar`, valid wallets, rewards, caps, window.
+- [ ] Cross-rail wallet addresses rejected.
 
-### User flow
+### User flow (Figma)
 
-- [ ] User can scan/open activation, authenticate, complete eligibility, and see perk copy without crypto terminology.
-- [ ] User can redeem and reach `pending_staff_confirmation` when staff confirmation enabled.
-- [ ] User cannot exceed per-user redemption rules.
-
-### Staff flow
-
-- [ ] Staff can list pending redemptions and confirm exactly one redemption per idempotent key.
-- [ ] Staff can cancel pending redemption without settlement record.
+- [ ] User sees Confirm Purchase with points + perk only (no USDC).
+- [ ] Confirm → Success → Swipe → Redeemed matches Figma states.
+- [ ] Second swipe blocked after redeemed.
+- [ ] Per-user redemption limits enforced.
 
 ### Settlement
 
-- [ ] Confirming redemption creates settlement in `queued` and eventually one **confirmed** onchain transfer.
-- [ ] Transfer is **campaign wallet → venue settlement wallet** only (automated test or staging wallet assertion).
-- [ ] **No** transfer to user wallet addresses in logs or DB.
-- [ ] Each confirmed settlement has unique `tx_hash` linked 1:1 to `redemption_id`.
-- [ ] Retries do not produce duplicate confirmed transfers for the same redemption.
+- [ ] `redeemed` enqueues settlement on correct rail.
+- [ ] Transfer is campaign → venue only; never to user wallet.
+- [ ] One confirmed `tx_hash` per redemption; no batching.
+- [ ] Retries do not duplicate confirmed transfers.
 
-### Dashboard
+### Admin dashboard
 
-- [ ] Tiles match database counts for check-ins, redemptions, USDC settled, budget remaining.
-- [ ] Tx hash feed lists only confirmed per-redemption settlements.
-- [ ] Drilldown shows full redemption + settlement timeline.
+- [ ] Tiles and feeds match DB; drilldown complete.
+- [ ] **No** export/download in UI or API.
 
 ### Non-functional
 
-- [ ] Mixpanel events fire for eligibility, redemption, settlement confirm/fail.
-- [ ] Failed settlements appear in ops list with sanitized errors.
+- [ ] Mixpanel events for confirm, swipe, settlement.
+- [ ] Failed settlements visible in admin pending/failed list.
 
 ---
 
 ## Out of scope / future work
 
-- User-controlled USDC wallets and user-initiated spends (see spend pilot PRD).
-- Batched settlement / merkle payout proofs.
-- Multi-activation sponsor portfolios in one dashboard.
-- Automated sponsor invoicing and tax reporting.
-- Onchain attribution to individual **user wallet** addresses.
-- Cross-chain settlement (Stellar, etc.) unless separately specified.
-- Smart contract escrows and programmable spend rules.
-- Public Records roll-out beyond configured activation window without new admin config.
+- **Staff app**, staff confirmation, payment confirmation at POS.
+- **Admin export** (CSV, bulk API).
+- **Sponsor/investor** read-only portal (admin dashboard suffices for v1).
+- User-controlled USDC wallets (spend pilot model).
+- Batched settlement.
+- Chains beyond Base and Stellar.
+- Smart contract escrows.
 
 ---
 
 ## Implementation notes (for engineers / agents)
 
-**Do not implement from this document alone without a technical design pass.** Expected next steps:
+1. Migrations for entities above; `settlement_rail` on activation + settlement rows.
+2. Zod schemas with discriminated wallet validation (`base` vs `stellar`).
+3. Atomic **confirm purchase** (points + redemption state) and **swipe redeem** (→ `redeemed` + enqueue).
+4. Rail-specific settlement workers (Base viem/Privy; Stellar Horizon/Privy).
+5. User routes + admin routes; UI from Figma node linked above.
+6. **Do not** implement staff or export surfaces in v1.
 
-1. Add Supabase migrations for entities above (names may be prefixed `sponsored_` or `activation_`).
-2. Add Zod schemas in `lib/schemas/`.
-3. Add `lib/db/` accessors and atomic transitions (confirm redeem + reserve budget + enqueue settlement).
-4. Add API routes under `app/api/` and admin pages under `app/admin/`.
-5. Add background worker or queue consumer for settlement (`queued` → `submitted` → `confirmed`).
-6. Reuse Base USDC + Privy server wallet patterns from spend rail code; **do not** reuse user-funding paths.
-
-**File naming suggestion:** `sponsored-activation` kebab-case routes and tables consistent with repo conventions.
+**Reuse:** `lib/privy/stellar-rail-wallet.ts`, Base spend-rail treasury code; **do not** reuse user USDC funding paths.
 
 ---
 
 ## Document history
 
-| Version | Date       | Author | Notes                          |
-| ------- | ---------- | ------ | ------------------------------ |
-| 0.1     | 2026-05-20 | Agent  | Initial PRD from product brief |
+| Version | Date       | Author | Notes                                                                         |
+| ------- | ---------- | ------ | ----------------------------------------------------------------------------- |
+| 0.1     | 2026-05-20 | Agent  | Initial PRD                                                                   |
+| 0.2     | 2026-05-20 | Agent  | Base+Stellar v1; Figma swipe UX; removed staff/sponsor/export/payment confirm |

--- a/docs/plans/public-records-sponsored-usdc-activation-prd.md
+++ b/docs/plans/public-records-sponsored-usdc-activation-prd.md
@@ -495,24 +495,6 @@ Properties: `activation_id`, `settlement_rail`, `user_id`, `reward_item_id`, `re
 
 ---
 
-## Open questions
-
-| #    | Question                                                              | Owner       | Blocks         |
-| ---- | --------------------------------------------------------------------- | ----------- | -------------- |
-| OQ-1 | USDC amount per drink (Base vs Stellar same nominal?)                 | Sponsor/Ops | Config         |
-| OQ-2 | Points cost for Public Records confirm (99 PTS placeholder in Figma?) | Product     | Reward config  |
-| OQ-3 | Swipe timeout duration before `expired`                               | Product     | State machine  |
-| OQ-4 | Campaign wallet per rail: shared treasury vs dedicated PR wallets     | Eng/Ops     | Runbook        |
-| OQ-5 | Auto-pause activation on insufficient campaign USDC                   | Product     | Ops            |
-| OQ-6 | Public Records checkpoint id(s) and ticket integration                | Ops         | Eligibility    |
-| OQ-7 | Stellar USDC issuer for production settlement                         | Eng         | Stellar config |
-| OQ-8 | Legal copy for sponsor-funded venue settlement                        | Legal       | Terms only     |
-| OQ-9 | Manual settlement retry permissions                                   | Eng         | Admin UI       |
-
-**Closed for v1 (deferred):** staff auth, payment confirmation, CSV export, sponsor portal.
-
----
-
 ## Acceptance criteria
 
 ### Configuration
@@ -568,12 +550,3 @@ Properties: `activation_id`, `settlement_rail`, `user_id`, `reward_item_id`, `re
 6. **Do not** implement staff or export surfaces in v1.
 
 **Reuse:** `lib/privy/stellar-rail-wallet.ts`, Base spend-rail treasury code; **do not** reuse user USDC funding paths.
-
----
-
-## Document history
-
-| Version | Date       | Author | Notes                                                                         |
-| ------- | ---------- | ------ | ----------------------------------------------------------------------------- |
-| 0.1     | 2026-05-20 | Agent  | Initial PRD                                                                   |
-| 0.2     | 2026-05-20 | Agent  | Base+Stellar v1; Figma swipe UX; removed staff/sponsor/export/payment confirm |

--- a/docs/plans/public-records-sponsored-usdc-activation-prd.md
+++ b/docs/plans/public-records-sponsored-usdc-activation-prd.md
@@ -1,0 +1,584 @@
+# Public Records Sponsored USDC Activation — Product Requirements Document
+
+**Status:** Draft (implementation not started)  
+**Pilot:** Public Records  
+**Last updated:** 2026-05-20  
+**Related docs:** `plans/irl-spend-pilot-technical-prd.md` (user-wallet USDC spend rail — explicitly different), `docs/APP_OVERVIEW.md`, `docs/stellar-baselines-and-chain-architecture.md`
+
+---
+
+## Summary
+
+IRL will run a **sponsor-funded cultural activation** at Public Records where a **campaign wallet** is prefunded with USDC. Attendees **earn and redeem real-world perks** (e.g. drink credit) through familiar IRL flows—check-in, QR, staff confirmation—**without receiving, holding, or withdrawing USDC**.
+
+On each confirmed redemption, the system records an **individual onchain USDC transfer** from the **campaign wallet** to a **venue settlement wallet** configured per event. Settlement may be **asynchronous**, but every transfer must remain **attributable to exactly one user redemption** so sponsor/investor dashboards can show **per-user transaction hashes** as proof of sponsor-funded spend.
+
+**User-facing:** perk redemption.  
+**Backend:** sponsor USDC settlement to venue.
+
+---
+
+## Background / context
+
+### Problem
+
+Partners and sponsors want **verifiable proof** that marketing dollars funded **real cultural attendance and venue spend**, not opaque off-chain redemptions. Users want **simple perks**, not crypto conversion UX.
+
+### Existing IRL rails (distinction)
+
+| Rail                              | User receives USDC?   | Onchain path                                  | Pilot relevance                           |
+| --------------------------------- | --------------------- | --------------------------------------------- | ----------------------------------------- |
+| Perks / rewards                   | No                    | None (codes/links)                            | UX reference for “redeem a perk”          |
+| Spend pilot (`spend_experiences`) | Yes — embedded wallet | Treasury → user → receiving wallet            | **Out of scope** — opposite custody model |
+| **This activation**               | **No**                | **Campaign wallet → venue settlement wallet** | **In scope**                              |
+
+Privy remains the auth and identity layer (email/social, embedded wallet creation for future rails). For this pilot, **embedded wallets are not USDC payout destinations**.
+
+### Pilot sponsor narrative
+
+Public Records (venue) + sponsor/IRL campaign wallet demonstrate **sponsor-funded cultural spend onchain** while the attendee experience stays **IRL-native**: check in, redeem drink, staff confirms.
+
+### North star (explicitly deferred)
+
+Long-term, user-controlled USDC wallets across many venues may be desirable. **This pilot does not send USDC to user wallets** and does not enable user withdrawal of campaign funds.
+
+---
+
+## Goals
+
+1. **User experience:** Redemption feels like claiming a venue perk, not converting or spending crypto.
+2. **Sponsor proof:** Each confirmed redemption produces (or queues) **one distinct onchain USDC transaction** with a **public tx hash** tied to that redemption.
+3. **Custody:** Users **never** receive withdrawable USDC from the campaign wallet.
+4. **Settlement path:** USDC moves **campaign wallet → venue settlement wallet** only.
+5. **Operations:** Admin can configure activation, caps, wallets, rewards, and eligibility; staff can confirm redemptions; dashboard shows budget, settlements, and failures.
+6. **Attribution:** Async settlement is allowed; **redemption_id** (and user/event) must always link to at most one settlement attempt chain and one confirmed tx hash.
+7. **Auditability:** Backend can reconstruct eligibility → redemption → settlement for support and investor review.
+
+---
+
+## Non-goals
+
+- Sending USDC to **user** embedded or external wallets.
+- User-visible “convert points to USDC” or “pay with USDC” flows.
+- **Batching** multiple redemptions into a single onchain transfer (breaks per-user proof requirement).
+- Token-level spend restrictions, escrow contracts, or new smart contracts (unless separately approved).
+- Multi-venue marketplace settlement logic beyond one activation’s configured venue wallet.
+- Manual sponsor treasury top-up UI beyond documenting operator process (v1 may use existing wallet ops).
+- Geofencing as the sole eligibility mechanism (check-in/QR/staff/POS signals are in scope; geofence-only is not required).
+- Replacing or overloading `spend_items` / spend pilot tables without a dedicated activation schema.
+- Stellar or non-Base chains for v1 (default **Base USDC** unless admin explicitly configures another supported EVM rail later).
+
+---
+
+## User stories
+
+| ID  | Story                                                                                                                                                                | Acceptance hint                                          |
+| --- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------- |
+| U1  | As an attendee, I scan a checkpoint/activation QR and sign in so I can see my eligible perk.                                                                         | Eligibility evaluated server-side after Privy auth.      |
+| U2  | As an attendee, I complete check-in (or equivalent eligibility action) and see a simple reward (e.g. “Redeem drink”) with **no crypto amounts** in primary CTA copy. | UI shows perk title/status only; USDC not shown to user. |
+| U3  | As an attendee, I tap redeem and see “pending staff confirmation” until staff confirms.                                                                              | State `pending_staff_confirmation` visible to user.      |
+| U4  | As an attendee, after staff confirms, I see “Redeemed” and optional receipt id/time—not a wallet tx.                                                                 | No tx hash required in user UI for v1.                   |
+| U5  | As an attendee, I cannot redeem the same reward twice when campaign rules disallow it.                                                                               | Idempotent redemption rules enforced server-side.        |
+| U6  | As an attendee, if my redemption window expires, I see a clear expired/cancelled state.                                                                              | Terminal state `cancelled` or `expired` with reason.     |
+
+---
+
+## Admin stories
+
+| ID  | Story                                                                                                                                      | Acceptance hint                                                          |
+| --- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ |
+| A1  | As an admin, I create a **sponsored activation** tied to an event with sponsor name, campaign wallet, venue settlement wallet, and status. | All required fields validated; wallets checksum-validated.               |
+| A2  | As an admin, I configure **reward item(s)** with display name, USDC value per redemption, and optional points/eligibility rules.           | Reward USDC value sums into budget accounting.                           |
+| A3  | As an admin, I set **redemption cap** and/or **USDC budget cap** for the activation.                                                       | Redemptions blocked when cap exceeded; dashboard shows remaining budget. |
+| A4  | As an admin, I link **checkpoint / check-in / QR** eligibility rules to the activation.                                                    | Ineligible users cannot reach `available` redeem state.                  |
+| A5  | As an admin, I view activation dashboard metrics and exportable redemption/settlement list.                                                | See Dashboard requirements.                                              |
+| A6  | As an admin, I can disable an activation (no new redemptions; in-flight settlement continues or fails visibly).                            | `activation.status = paused/ended` enforced on new redemptions.          |
+
+---
+
+## Venue / staff stories
+
+| ID  | Story                                                                                                           | Acceptance hint                                                                     |
+| --- | --------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| S1  | As staff, I open a staff-facing list of redemptions for this activation/event filtered by pending confirmation. | Shows user pseudonym/id, reward, time, status.                                      |
+| S2  | As staff, I confirm a pending redemption so the patron receives credit at the bar/POS.                          | Transition to `redeemed`; triggers settlement pipeline.                             |
+| S3  | As staff, I see whether a patron already redeemed so I do not double-serve.                                     | `redeemed` / `settlement_*` states visible.                                         |
+| S4  | As staff, I can mark a redemption cancelled before confirmation (wrong ticket, fraud suspicion) with reason.    | `cancelled` terminal; no settlement started.                                        |
+| S5  | As staff, optional POS/NFC/ticket scan event marks eligibility without exposing crypto.                         | Eligibility event recorded; same UX as existing checkpoint patterns where possible. |
+
+---
+
+## Sponsor / investor dashboard stories
+
+| ID  | Story                                                                                                                                                             | Acceptance hint                                                    |
+| --- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| D1  | As a sponsor viewer, I see total **check-ins verified**, **redemptions confirmed**, and **USDC settled** for the activation.                                      | Numbers reconcile with sum of confirmed settlement amounts.        |
+| D2  | As a sponsor viewer, I see **budget remaining** (configured cap minus settled minus queued).                                                                      | Formula documented in dashboard spec.                              |
+| D3  | As a sponsor viewer, I browse a **transaction hash feed** with one row per confirmed settlement linked to a redemption.                                           | No batched tx representing multiple users.                         |
+| D4  | As a sponsor viewer, I drill into a redemption and see user id (pseudonymous), event, reward, redemption status, settlement status, tx hash, block explorer link. | Drilldown matches onchain transfer amount to `reward.usdc_amount`. |
+| D5  | As a sponsor viewer, I see **failed/pending settlements** with retry status and age.                                                                              | Actionable ops list, not only aggregates.                          |
+
+---
+
+## Functional requirements
+
+### FR-1 Activation lifecycle
+
+- **FR-1.1** Admin can create/update activation in `draft`; only `active` activations accept new eligibility/redemptions within window.
+- **FR-1.2** Activation stores: sponsor/campaign display name, `campaign_wallet_address`, `venue_settlement_wallet_address`, time window, caps, linked event/checkpoint ids, status.
+- **FR-1.3** Ending activation prevents **new** redemptions; existing `settlement_pending` items continue processing.
+
+### FR-2 Eligibility
+
+- **FR-2.1** User must authenticate via Privy before redemption UI.
+- **FR-2.2** System records an **eligibility event** (check-in, checkpoint scan, ticket scan, NFC, staff-granted, etc.) before redemption becomes `available`.
+- **FR-2.3** Eligibility rules are configurable per activation (e.g. one check-in per user per day, one reward per user per activation).
+- **FR-2.4** QR/checkpoint opens activation deep link; server validates activation id and signed/opaque token if used by existing checkpoint patterns.
+
+### FR-3 Redemption (user + staff)
+
+- **FR-3.1** User initiates redeem → `pending_staff_confirmation` unless staff-less mode is explicitly configured (default: staff confirmation required for Public Records pilot).
+- **FR-3.2** Staff confirmation transitions to `redeemed` and consumes redemption cap / budget reservation.
+- **FR-3.3** User-facing copy must not reference USDC, wallets, or “crypto conversion.”
+- **FR-3.4** One logical redemption maps to at most one reward item instance and one settlement chain.
+
+### FR-4 Settlement (backend)
+
+- **FR-4.1** On `redeemed`, system creates a **settlement transaction** record in `not_started` → `queued`.
+- **FR-4.2** Settlement transfers **exactly** `reward.usdc_amount` (or configured amount at redemption time snapshot) from **campaign wallet** to **venue settlement wallet** on Base USDC.
+- **FR-4.3** **No** transfer to `user.wallet_address`.
+- **FR-4.4** One redemption → one onchain transfer (no batching). Retries reuse the same logical settlement id with new submission attempts tracked in metadata.
+- **FR-4.5** On chain confirmation, redemption moves to `settlement_confirmed` and stores `tx_hash`, `chain_id`, `amount`, `from`, `to`, `confirmed_at`.
+- **FR-4.6** Async settlement allowed: redemption may sit in `settlement_pending` while worker processes queue.
+- **FR-4.7** Campaign wallet balance check before submit; insufficient funds → `settlement_failed` with reason `campaign_insufficient_funds` and ops alert.
+
+### FR-5 Budget and caps
+
+- **FR-5.1** Support `max_redemptions` (count) and/or `max_usdc_budget` (sum of settlement amounts).
+- **FR-5.2** Reserve budget on `redeemed`; release on `cancelled` before settlement submit; finalize decrement on `settlement_confirmed`.
+- **FR-5.3** Block new redemptions when cap exceeded (user message: “This perk is no longer available”).
+
+### FR-6 Wallets and signing
+
+- **FR-6.1** Campaign wallet is a **Privy server wallet** or otherwise IRL-controlled signer documented in runbook (same operational model as spend pilot treasury).
+- **FR-6.2** Venue settlement wallet is **admin-configured**, validated as an address on the activation chain.
+- **FR-6.3** Private keys never exposed to client; all transfers initiated server-side.
+
+### FR-7 Idempotency
+
+- **FR-7.1** Idempotency key: `activation_id + user_id + reward_item_id + eligibility_event_id` (or stricter rule if one reward per user per activation).
+- **FR-7.2** Duplicate staff confirm or duplicate settlement worker invocations must not double-transfer USDC.
+- **FR-7.3** Unique DB constraint: one `confirmed` settlement per `redemption_id`.
+
+### FR-8 Integration with existing app
+
+- Reuse Privy auth (`lib/api/privy.ts`), player records, checkpoint/check-in flows, admin auth (`lib/auth.ts`), API response helpers (`lib/api/response.ts`), Mixpanel helpers (`lib/analytics/`), and Base USDC constants from existing wallet/spend code where applicable.
+- **New tables** preferred over overloading `spend_redemptions` to keep audit trails distinct.
+
+---
+
+## Data model / key entities
+
+Logical entities for implementation (SQL names illustrative).
+
+### `sponsored_activation` (activation / event)
+
+| Field                             | Type        | Notes                                     |
+| --------------------------------- | ----------- | ----------------------------------------- |
+| `id`                              | uuid        | PK                                        |
+| `slug`                            | text        | Public Records pilot slug                 |
+| `title`                           | text        | Display                                   |
+| `sponsor_name`                    | text        | Sponsor/campaign label                    |
+| `event_id`                        | uuid?       | FK to events if present                   |
+| `status`                          | enum        | `draft`, `active`, `paused`, `ended`      |
+| `campaign_wallet_address`         | text        | Source of USDC                            |
+| `venue_settlement_wallet_address` | text        | Destination                               |
+| `chain`                           | text        | Default `base`                            |
+| `usdc_token_address`              | text        | Base USDC contract                        |
+| `max_redemptions`                 | int?        | Count cap                                 |
+| `max_usdc_budget`                 | numeric?    | Budget cap                                |
+| `usdc_settled_total`              | numeric     | Running confirmed sum                     |
+| `redemption_count_confirmed`      | int         | Running count                             |
+| `starts_at` / `ends_at`           | timestamptz | Activation window                         |
+| `eligibility_config`              | jsonb       | Rules: checkpoint ids, max per user, etc. |
+| `created_by`                      | uuid/text   | Admin                                     |
+| `created_at` / `updated_at`       | timestamptz |                                           |
+
+### `activation_reward_item` (reward item)
+
+| Field           | Type    | Notes                            |
+| --------------- | ------- | -------------------------------- |
+| `id`            | uuid    | PK                               |
+| `activation_id` | uuid    | FK                               |
+| `name`          | text    | e.g. “Drink credit”              |
+| `description`   | text?   | Staff/user helper                |
+| `usdc_amount`   | numeric | Settlement amount per redemption |
+| `sort_order`    | int     | UI ordering                      |
+| `is_active`     | bool    |                                  |
+| `max_per_user`  | int?    | Default 1 for pilot              |
+
+### `activation_eligibility_event` (user check-in / eligibility)
+
+| Field            | Type        | Notes                                                                                           |
+| ---------------- | ----------- | ----------------------------------------------------------------------------------------------- |
+| `id`             | uuid        | PK                                                                                              |
+| `activation_id`  | uuid        | FK                                                                                              |
+| `user_id`        | uuid        | Player                                                                                          |
+| `wallet_address` | text?       | Identity reference, not payout target                                                           |
+| `source`         | enum        | `checkpoint_checkin`, `location_checkin`, `qr_scan`, `nfc`, `ticket_scan`, `staff_grant`, `pos` |
+| `source_ref_id`  | text?       | Checkpoint id, check-in id, etc.                                                                |
+| `occurred_at`    | timestamptz |                                                                                                 |
+| `metadata`       | jsonb       | Device, staff id, etc.                                                                          |
+
+### `activation_redemption` (redemption)
+
+| Field                       | Type         | Notes                        |
+| --------------------------- | ------------ | ---------------------------- |
+| `id`                        | uuid         | PK                           |
+| `activation_id`             | uuid         | FK                           |
+| `reward_item_id`            | uuid         | FK                           |
+| `user_id`                   | uuid         | FK                           |
+| `eligibility_event_id`      | uuid         | FK                           |
+| `status`                    | enum         | See redemption state machine |
+| `usdc_amount_snapshot`      | numeric      | Frozen at redeem time        |
+| `staff_confirmed_by`        | text?        | Staff operator id            |
+| `staff_confirmed_at`        | timestamptz? |                              |
+| `cancelled_reason`          | text?        |                              |
+| `idempotency_key`           | text         | Unique                       |
+| `created_at` / `updated_at` | timestamptz  |                              |
+
+### `activation_settlement_transaction` (settlement)
+
+| Field                                         | Type         | Notes                        |
+| --------------------------------------------- | ------------ | ---------------------------- |
+| `id`                                          | uuid         | PK                           |
+| `redemption_id`                               | uuid         | FK unique for confirmed      |
+| `activation_id`                               | uuid         | FK                           |
+| `status`                                      | enum         | See settlement state machine |
+| `amount`                                      | numeric      | USDC                         |
+| `from_wallet_address`                         | text         | Campaign                     |
+| `to_wallet_address`                           | text         | Venue                        |
+| `tx_hash`                                     | text?        | Set on confirm               |
+| `chain_id`                                    | int?         | Base                         |
+| `submission_attempt`                          | int          | Retry counter                |
+| `last_error_code`                             | text?        | Sanitized                    |
+| `last_error_message`                          | text?        | Ops only                     |
+| `queued_at` / `submitted_at` / `confirmed_at` | timestamptz? |                              |
+| `privy_transaction_id`                        | text?        | If applicable                |
+
+### `activation_dashboard_snapshot` (optional materialized metrics)
+
+May be computed view rather than table: check-ins count, redemptions by status, USDC settled, budget remaining, failed settlement count.
+
+### Entity relationships (ASCII)
+
+```
+sponsored_activation
+  ├── activation_reward_item (1:N)
+  ├── activation_eligibility_event (1:N)
+  └── activation_redemption (1:N)
+        └── activation_settlement_transaction (1:1)
+```
+
+---
+
+## Event / admin configuration requirements
+
+Admin UI/API must support configuring at minimum:
+
+| Config                                     | Required           | Validation                        |
+| ------------------------------------------ | ------------------ | --------------------------------- |
+| Sponsor / campaign name                    | Yes                | Non-empty                         |
+| Campaign wallet address                    | Yes                | EVM checksum, matches chain       |
+| Venue settlement wallet address            | Yes                | EVM checksum, ≠ campaign wallet   |
+| Reward item name + USDC amount             | Yes (≥1 item)      | `usdc_amount > 0`                 |
+| Redemption cap and/or USDC budget          | Yes (at least one) | Positive integers/decimals        |
+| Activation window (`starts_at`, `ends_at`) | Yes                | `ends_at > starts_at`             |
+| Linked checkpoint(s) or event id           | Yes for PR pilot   | Must exist in DB                  |
+| Eligibility rules JSON                     | Yes                | Schema-validated (Zod)            |
+| Staff confirmation required                | Yes (default true) | Boolean                           |
+| Status                                     | Yes                | Only `active` exposes user redeem |
+
+**Public Records pilot defaults (configurable, not hardcoded in code):**
+
+- Reward: “Drink credit” — USDC amount TBD by sponsor (e.g. $8–$15 equivalent).
+- One redemption per user per activation unless ops overrides.
+- Staff confirmation required at bar.
+- Base USDC, campaign wallet prefunded before `active`.
+
+---
+
+## Redemption state machine
+
+### States
+
+| State                        | Description                                  | User-visible                           | Staff-visible                       |
+| ---------------------------- | -------------------------------------------- | -------------------------------------- | ----------------------------------- |
+| `eligible`                   | User met eligibility; redeem not yet started | Optional “You unlocked a perk”         | —                                   |
+| `available`                  | Redeem CTA enabled                           | “Redeem drink”                         | —                                   |
+| `pending_staff_confirmation` | User requested redeem; awaiting staff        | “Waiting for staff”                    | “Confirm” action                    |
+| `redeemed`                   | Staff confirmed; perk consumed in product    | “Redeemed”                             | “Redeemed”                          |
+| `settlement_pending`         | Settlement queued or submitted               | “Redeemed” (no change)                 | Same                                |
+| `settlement_confirmed`       | Onchain tx confirmed                         | “Redeemed”                             | “Settled” + optional internal badge |
+| `settlement_failed`          | Settlement failed after redeem               | “Redeemed — processing” or ops message | Alert                               |
+| `cancelled`                  | Voided before/at staff confirm               | “Cancelled”                            | “Cancelled”                         |
+| `expired`                    | Window or hold expired                       | “Expired”                              | —                                   |
+
+### Transitions
+
+```mermaid
+stateDiagram-v2
+  [*] --> eligible: eligibility_event recorded
+  eligible --> available: rules pass
+  available --> pending_staff_confirmation: user taps Redeem
+  pending_staff_confirmation --> redeemed: staff confirms
+  pending_staff_confirmation --> cancelled: staff/user cancel
+  available --> expired: time window elapsed
+  pending_staff_confirmation --> expired: confirmation timeout
+  redeemed --> settlement_pending: settlement record created
+  settlement_pending --> settlement_confirmed: tx confirmed
+  settlement_pending --> settlement_failed: tx failed
+  settlement_failed --> settlement_pending: retry policy allows
+  settlement_confirmed --> [*]
+  cancelled --> [*]
+  expired --> [*]
+```
+
+### Invariants
+
+- `settlement_*` states only occur after `redeemed`.
+- `settlement_confirmed` implies exactly one non-null `tx_hash` on the linked settlement row.
+- User never transitions to a state that implies user custody of USDC.
+
+---
+
+## Settlement state machine
+
+Independent settlement record states (linked 1:1 to redemption after `redeemed`).
+
+| State         | Description                                            |
+| ------------- | ------------------------------------------------------ |
+| `not_started` | Redemption just confirmed; worker not yet picked up    |
+| `queued`      | Eligible for worker; budget reserved                   |
+| `submitted`   | Tx broadcast; hash may be pending                      |
+| `confirmed`   | Tx confirmed onchain                                   |
+| `failed`      | Terminal failure for this attempt                      |
+| `retrying`    | Backoff retry in progress (subset of queued/submitted) |
+
+### Transitions
+
+```mermaid
+stateDiagram-v2
+  [*] --> not_started: redemption redeemed
+  not_started --> queued: worker enqueues
+  queued --> submitted: sign and broadcast
+  submitted --> confirmed: RPC receipt success
+  submitted --> failed: revert or timeout
+  failed --> retrying: retry budget remaining
+  retrying --> queued: backoff elapsed
+  confirmed --> [*]
+```
+
+### Mapping to redemption status
+
+| Settlement status                                | Redemption status      |
+| ------------------------------------------------ | ---------------------- |
+| `not_started`, `queued`, `submitted`, `retrying` | `settlement_pending`   |
+| `confirmed`                                      | `settlement_confirmed` |
+| `failed` (exhausted retries)                     | `settlement_failed`    |
+
+---
+
+## Dashboard requirements
+
+### Aggregate tiles (activation scope)
+
+| Metric                | Definition                                                                             | Test                      |
+| --------------------- | -------------------------------------------------------------------------------------- | ------------------------- |
+| Check-ins verified    | Count of `activation_eligibility_event` for activation                                 | Matches eligibility table |
+| Redemptions created   | Count `activation_redemption` all statuses except `eligible`                           | Includes pending          |
+| Redemptions confirmed | Count in `redeemed`, `settlement_pending`, `settlement_confirmed`, `settlement_failed` |                           |
+| USDC settled          | Sum `amount` where settlement `confirmed`                                              | Equals onchain sum ±0     |
+| Budget remaining      | `max_usdc_budget - usdc_settled_total - reserved_pending`                              | Document reserved formula |
+| Redemptions remaining | `max_redemptions - redemption_count_confirmed` if count cap                            |                           |
+
+### Transaction hash feed
+
+- One row per **confirmed** settlement: `confirmed_at`, `tx_hash`, `amount`, `user_id` (pseudonym), `reward_item.name`, explorer link.
+- Sort: newest first.
+- **Must not** show batched multi-user transfers.
+
+### Failed / pending settlement list
+
+- Filter: settlement in `queued`, `submitted`, `retrying`, or `failed`.
+- Columns: redemption id, user, reward, amount, status, attempt count, last error (sanitized), age.
+- Ops action: manual retry trigger (admin-only) if within policy.
+
+### Per-redemption drilldown
+
+- User id / username / wallet (for support, not payout).
+- Event / activation title.
+- Reward item + snapshot amount.
+- Redemption status timeline timestamps.
+- Settlement status + `tx_hash` + explorer URL when confirmed.
+- Linked eligibility event source + timestamp.
+
+### Access control
+
+- Admin: full dashboard + config.
+- Sponsor/investor role: read-only aggregates and feed (no PII beyond pseudonym policy).
+
+---
+
+## Error and retry behavior
+
+| Error                       | User impact                         | System behavior                                           |
+| --------------------------- | ----------------------------------- | --------------------------------------------------------- |
+| Activation inactive / ended | Cannot start redeem                 | 4xx with clear message                                    |
+| Eligibility not met         | No redeem CTA                       | Stay `eligible` or hidden                                 |
+| Cap / budget exceeded       | “No longer available”               | Block at `available` → redeem                             |
+| Duplicate redeem            | “Already redeemed”                  | Idempotent return existing row                            |
+| Staff confirm race          | Single winner                       | DB transaction / unique constraint                        |
+| Campaign insufficient USDC  | User still sees redeemed; ops alert | `settlement_failed`, retry after fund                     |
+| RPC timeout                 | None                                | `submitted` → poll; then retry                            |
+| Tx reverted                 | None                                | `failed` → `retrying` with backoff                        |
+| Duplicate worker submit     | None                                | Idempotency on settlement id; no second tx if hash exists |
+
+### Retry policy (v1 defaults)
+
+- Max **5** attempts per settlement over **24h** with exponential backoff (30s, 2m, 10m, 30m, 2h).
+- After exhaustion: `settlement_failed`, redemption `settlement_failed`, dashboard alert.
+- Retries must **not** create a second confirmed tx for the same `redemption_id`.
+
+### User messaging
+
+- Never show raw RPC errors, wallet addresses, or “insufficient gas” to attendees.
+- Staff sees operational short codes (`SETTLEMENT_DELAYED`).
+
+---
+
+## Security / abuse prevention
+
+- **Server-side authority:** All eligibility, redemption, and settlement transitions validated on API routes; never trust client-only state.
+- **Auth:** Privy token verification on all user endpoints; admin routes use existing admin auth.
+- **QR / deep links:** Use server-validatable activation/checkpoint ids; signed tokens if matching existing checkpoint security model.
+- **Rate limits:** Per-IP and per-user limits on redeem and eligibility endpoints.
+- **Staff actions:** Staff confirm requires staff auth or staff PIN/session scoped to activation (TBD in open questions).
+- **Wallet separation:** Campaign wallet keys only on server; venue wallet is receive-only from campaign perspective.
+- **No user payout:** Assert `to_wallet_address` ≠ any `players` embedded wallet at settlement build time.
+- **Audit:** Append-only or immutable settlement rows after `confirmed`; corrections via compensating admin notes, not silent deletes.
+- **Budget griefing:** Reserve USDC budget at `redeemed` to prevent over-subscription under concurrency.
+
+---
+
+## Analytics events
+
+Emit via existing Mixpanel helpers. Include `activation_id`, `event_id`, `user_id`, `reward_item_id`, `redemption_id`, `settlement_id`, `status`, `usdc_amount` (backend only properties where noted).
+
+| Event                                       | When                          | Key properties                   |
+| ------------------------------------------- | ----------------------------- | -------------------------------- |
+| `sponsored_activation_viewed`               | User opens activation surface | `activation_id`, `source`        |
+| `sponsored_activation_eligibility_recorded` | Eligibility event persisted   | `source`, `eligibility_event_id` |
+| `sponsored_redemption_started`              | User taps redeem              | `reward_item_id`                 |
+| `sponsored_redemption_pending_staff`        | Entered pending staff         |                                  |
+| `sponsored_redemption_staff_confirmed`      | Staff confirms                | `staff_id`                       |
+| `sponsored_redemption_cancelled`            | Cancelled                     | `reason`                         |
+| `sponsored_redemption_expired`              | Expired                       |                                  |
+| `sponsored_settlement_queued`               | Settlement queued             | `usdc_amount`                    |
+| `sponsored_settlement_submitted`            | Tx broadcast                  | `tx_hash` if known               |
+| `sponsored_settlement_confirmed`            | Tx confirmed                  | `tx_hash`, `usdc_amount`         |
+| `sponsored_settlement_failed`               | Failed                        | `error_code`                     |
+| `sponsored_activation_cap_reached`          | Budget or count cap hit       | `cap_type`                       |
+| `sponsored_activation_dashboard_viewed`     | Sponsor/admin dashboard       | `viewer_role`                    |
+
+---
+
+## Open questions
+
+| #     | Question                                                                                    | Owner       | Blocks                  |
+| ----- | ------------------------------------------------------------------------------------------- | ----------- | ----------------------- |
+| OQ-1  | Exact USDC amount per drink credit for Public Records?                                      | Sponsor/Ops | Config only             |
+| OQ-2  | Staff auth model: dedicated staff login, admin impersonation, or shared PIN per event?      | Product/Eng | Staff UI                |
+| OQ-3  | Is staff confirmation timeout required (e.g. 15m) before `expired`?                         | Product     | State machine           |
+| OQ-4  | Campaign wallet: reuse spend-pilot Privy server wallet or dedicated PR wallet?              | Eng/Ops     | Runbook                 |
+| OQ-5  | On insufficient campaign funds mid-event: pause activation automatically vs manual top-up?  | Product     | Ops playbook            |
+| OQ-6  | Sponsor dashboard: in-app admin tab vs exported CSV vs Metabase?                            | Product     | Phase scope             |
+| OQ-7  | Points deduction: does this activation consume IRL points or only attendance gating?        | Product     | Eligibility rules       |
+| OQ-8  | Public Records eligibility: checkpoint id(s) and ticket vendor integration spec?            | Ops         | FR-2                    |
+| OQ-9  | Legal/copy review: any disclosure that sponsor funds venue onchain (in Terms only)?         | Legal       | None for implementation |
+| OQ-10 | Retry manual override: who can trigger and is a second tx id ever allowed after wrong hash? | Eng         | Support tooling         |
+
+---
+
+## Acceptance criteria
+
+### Configuration
+
+- [ ] Admin can create Public Records activation with campaign + venue wallets, ≥1 reward, caps, and window.
+- [ ] Invalid wallet addresses and `ends_at < starts_at` are rejected with validation errors.
+
+### User flow
+
+- [ ] User can scan/open activation, authenticate, complete eligibility, and see perk copy without crypto terminology.
+- [ ] User can redeem and reach `pending_staff_confirmation` when staff confirmation enabled.
+- [ ] User cannot exceed per-user redemption rules.
+
+### Staff flow
+
+- [ ] Staff can list pending redemptions and confirm exactly one redemption per idempotent key.
+- [ ] Staff can cancel pending redemption without settlement record.
+
+### Settlement
+
+- [ ] Confirming redemption creates settlement in `queued` and eventually one **confirmed** onchain transfer.
+- [ ] Transfer is **campaign wallet → venue settlement wallet** only (automated test or staging wallet assertion).
+- [ ] **No** transfer to user wallet addresses in logs or DB.
+- [ ] Each confirmed settlement has unique `tx_hash` linked 1:1 to `redemption_id`.
+- [ ] Retries do not produce duplicate confirmed transfers for the same redemption.
+
+### Dashboard
+
+- [ ] Tiles match database counts for check-ins, redemptions, USDC settled, budget remaining.
+- [ ] Tx hash feed lists only confirmed per-redemption settlements.
+- [ ] Drilldown shows full redemption + settlement timeline.
+
+### Non-functional
+
+- [ ] Mixpanel events fire for eligibility, redemption, settlement confirm/fail.
+- [ ] Failed settlements appear in ops list with sanitized errors.
+
+---
+
+## Out of scope / future work
+
+- User-controlled USDC wallets and user-initiated spends (see spend pilot PRD).
+- Batched settlement / merkle payout proofs.
+- Multi-activation sponsor portfolios in one dashboard.
+- Automated sponsor invoicing and tax reporting.
+- Onchain attribution to individual **user wallet** addresses.
+- Cross-chain settlement (Stellar, etc.) unless separately specified.
+- Smart contract escrows and programmable spend rules.
+- Public Records roll-out beyond configured activation window without new admin config.
+
+---
+
+## Implementation notes (for engineers / agents)
+
+**Do not implement from this document alone without a technical design pass.** Expected next steps:
+
+1. Add Supabase migrations for entities above (names may be prefixed `sponsored_` or `activation_`).
+2. Add Zod schemas in `lib/schemas/`.
+3. Add `lib/db/` accessors and atomic transitions (confirm redeem + reserve budget + enqueue settlement).
+4. Add API routes under `app/api/` and admin pages under `app/admin/`.
+5. Add background worker or queue consumer for settlement (`queued` → `submitted` → `confirmed`).
+6. Reuse Base USDC + Privy server wallet patterns from spend rail code; **do not** reuse user-funding paths.
+
+**File naming suggestion:** `sponsored-activation` kebab-case routes and tables consistent with repo conventions.
+
+---
+
+## Document history
+
+| Version | Date       | Author | Notes                          |
+| ------- | ---------- | ------ | ------------------------------ |
+| 0.1     | 2026-05-20 | Agent  | Initial PRD from product brief |


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the Public Records sponsored USDC activation PRD per product review:

- **v1 rails:** Base and Stellar (per-activation `settlement_rail`)
- **User UX:** Figma-linked flow — Confirm Purchase → Success → Swipe to redeem → Redeemed (no staff app)
- **Removed from v1:** staff stories/features, sponsor portal stories, payment/staff confirmation, admin CSV/export
- **State machine:** `ready_to_redeem` + swipe instead of `pending_staff_confirmation`

Still documentation only — no feature implementation.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ca10c23d-affd-415d-9efd-1903840e01e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ca10c23d-affd-415d-9efd-1903840e01e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

