### PR TITLE
feat(schemas): sponsored activation Zod validation (IRL-52)

### DIFF
--- a/lib/schemas/__tests__/sponsored-activation.test.ts
+++ b/lib/schemas/__tests__/sponsored-activation.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { getAddress } from 'viem';
+import {
+  createSponsoredActivationSchema,
+  updateSponsoredActivationSchema,
+} from '../sponsored-activation';
+
+/** Valid EVM-format address for schema tests (avoids repo allowlisted production contract literals). */
+const SAMPLE_EVM_CONTRACT = '0x2222222222222222222222222222222222222222';
+const STELLAR_A = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+const STELLAR_B = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
+
+const validTime = {
+  starts_at: '2026-06-01T12:00:00.000Z',
+  ends_at: '2026-06-30T12:00:00.000Z',
+};
+
+describe('createSponsoredActivationSchema', () => {
+  it('accepts a valid Base rail config with EIP-55-normalized wallets', () => {
+    const campaign = '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266';
+    const venue = '0x70997970c51812dc3a010c7d01b50e0d17dc79c8';
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'pr-summer',
+      title: 'Public Records',
+      sponsor_name: 'Acme',
+      max_redemptions: 500,
+      ...validTime,
+      eligibility_config: { min_tier: 1 },
+      campaign_wallet_address: campaign,
+      venue_settlement_wallet_address: venue,
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.campaign_wallet_address).toBe(
+        getAddress(campaign as `0x${string}`)
+      );
+      expect(r.data.venue_settlement_wallet_address).toBe(
+        getAddress(venue as `0x${string}`)
+      );
+      expect(r.data.usdc_asset_config.contract_address).toBe(
+        getAddress(SAMPLE_EVM_CONTRACT as `0x${string}`)
+      );
+    }
+  });
+
+  it('accepts a valid Stellar rail config', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'stellar',
+      slug: 'pr-stellar',
+      title: 'Stellar pilot',
+      sponsor_name: 'Acme',
+      max_usdc_budget: 1000,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: STELLAR_A,
+      venue_settlement_wallet_address: STELLAR_B,
+      usdc_asset_config: {
+        asset_code: 'USDC',
+        issuer: STELLAR_B,
+      },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.settlement_rail).toBe('stellar');
+      expect(r.data.campaign_wallet_address).toBe(STELLAR_A);
+    }
+  });
+
+  it('rejects Stellar G-address on base rail', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: STELLAR_A,
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects EVM 0x address on stellar rail', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'stellar',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      venue_settlement_wallet_address: STELLAR_B,
+      usdc_asset_config: {
+        asset_code: 'USDC',
+        issuer: STELLAR_B,
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects equal campaign and venue Stellar wallets', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'stellar',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: STELLAR_A,
+      venue_settlement_wallet_address: STELLAR_A,
+      usdc_asset_config: {
+        asset_code: 'USDC',
+        issuer: STELLAR_B,
+      },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects equal campaign and venue wallets (EVM-aware)', () => {
+    const addr = '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266';
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: addr,
+      venue_settlement_wallet_address: addr.toLowerCase(),
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('requires at least one of max_redemptions or max_usdc_budget on create', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects time window when ends_at is not after starts_at', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      starts_at: '2026-06-30T12:00:00.000Z',
+      ends_at: '2026-06-01T12:00:00.000Z',
+      eligibility_config: {},
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('rejects nested reward_items on create', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+      reward_items: [],
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it('allows optional event_id on create', () => {
+    const r = createSponsoredActivationSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      event_id: 'evt_123',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(true);
+    if (r.success) expect(r.data.event_id).toBe('evt_123');
+  });
+});
+
+describe('updateSponsoredActivationSchema', () => {
+  it('does not require caps on update', () => {
+    const r = updateSponsoredActivationSchema.safeParse({
+      title: 'Only title',
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts clearing both caps on update', () => {
+    const r = updateSponsoredActivationSchema.safeParse({
+      max_redemptions: null,
+      max_usdc_budget: null,
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('requires settlement_rail when updating wallet fields', () => {
+    const r = updateSponsoredActivationSchema.safeParse({
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    });
+    expect(r.success).toBe(false);
+  });
+});

--- a/lib/schemas/activation-eligibility.ts
+++ b/lib/schemas/activation-eligibility.ts
@@ -1,0 +1,27 @@
+import { z } from 'zod';
+
+/**
+ * `activation_eligibility_event.source` — matches
+ * `database/irl-51-sponsored-activation-schema.sql` CHECK constraint.
+ */
+export const activationEligibilitySourceSchema = z.enum([
+  'checkpoint_checkin',
+  'location_checkin',
+  'qr_scan',
+  'nfc',
+  'ticket_scan',
+]);
+
+export type ActivationEligibilitySource = z.infer<
+  typeof activationEligibilitySourceSchema
+>;
+
+/**
+ * v1 activation-side eligibility rules: permissive object (not a strict rules engine).
+ */
+export const eligibilityConfigValueSchema = z.object({}).catchall(z.unknown());
+
+/** JSON object with optional loose keys; defaults to `{}` for create payloads. */
+export const eligibilityConfigSchema = eligibilityConfigValueSchema.default({});
+
+export type EligibilityConfig = z.infer<typeof eligibilityConfigValueSchema>;

--- a/lib/schemas/activation-redemption.ts
+++ b/lib/schemas/activation-redemption.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+/**
+ * `activation_redemption.status` — matches
+ * `database/irl-51-sponsored-activation-schema.sql` CHECK constraint.
+ */
+export const activationRedemptionStatusSchema = z.enum([
+  'eligible',
+  'available',
+  'purchase_confirmed',
+  'ready_to_redeem',
+  'redeemed',
+  'settlement_pending',
+  'settlement_confirmed',
+  'settlement_failed',
+  'cancelled',
+  'expired',
+]);
+
+export type ActivationRedemptionStatus = z.infer<
+  typeof activationRedemptionStatusSchema
+>;

--- a/lib/schemas/activation-reward-item.ts
+++ b/lib/schemas/activation-reward-item.ts
@@ -1,0 +1,40 @@
+import { z } from 'zod';
+
+/**
+ * Admin body for `activation_reward_item` create (parent `activation_id` typically from route).
+ */
+export const createActivationRewardItemSchema = z
+  .object({
+    name: z.string().min(1).max(512),
+    hero_image_url: z.string().max(2048).optional().nullable(),
+    description: z.string().max(10000).optional().nullable(),
+    points_cost: z.coerce.number().int().min(0).default(0),
+    usdc_amount: z.coerce.number().positive().max(1e15),
+    sort_order: z.coerce.number().int().min(0).default(0),
+    is_active: z.boolean().default(true),
+    max_per_user: z.coerce.number().int().min(1).default(1),
+  })
+  .strict();
+
+export const updateActivationRewardItemSchema = z
+  .object({
+    name: z.string().min(1).max(512).optional(),
+    hero_image_url: z.string().max(2048).optional().nullable(),
+    description: z.string().max(10000).optional().nullable(),
+    points_cost: z.coerce.number().int().min(0).optional(),
+    usdc_amount: z.coerce.number().positive().max(1e15).optional(),
+    sort_order: z.coerce.number().int().min(0).optional(),
+    is_active: z.boolean().optional(),
+    max_per_user: z.coerce.number().int().min(1).optional(),
+  })
+  .strict()
+  .refine((data) => Object.keys(data).length > 0, {
+    message: 'At least one field is required',
+  });
+
+export type CreateActivationRewardItemInput = z.infer<
+  typeof createActivationRewardItemSchema
+>;
+export type UpdateActivationRewardItemInput = z.infer<
+  typeof updateActivationRewardItemSchema
+>;

--- a/lib/schemas/activation-settlement.ts
+++ b/lib/schemas/activation-settlement.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+
+/**
+ * `activation_settlement_transaction.status` — matches
+ * `database/irl-51-sponsored-activation-schema.sql` CHECK constraint.
+ */
+export const activationSettlementStatusSchema = z.enum([
+  'not_started',
+  'queued',
+  'submitted',
+  'confirmed',
+  'failed',
+  'retrying',
+]);
+
+export type ActivationSettlementStatus = z.infer<
+  typeof activationSettlementStatusSchema
+>;

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -1,0 +1,351 @@
+import { z } from 'zod';
+import { getAddress, isAddress } from 'viem';
+import {
+  eligibilityConfigSchema,
+  eligibilityConfigValueSchema,
+} from '@/lib/schemas/activation-eligibility';
+import { stellarWalletAddressSchema } from '@/lib/schemas/player';
+import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+/**
+ * `sponsored_activation.settlement_rail` — matches DB CHECK
+ * (`database/irl-51-sponsored-activation-schema.sql`).
+ */
+export const settlementRailSchema = z.enum(['base', 'stellar']);
+
+/**
+ * `sponsored_activation.status` — matches DB CHECK.
+ */
+export const sponsoredActivationStatusSchema = z.enum([
+  'draft',
+  'active',
+  'paused',
+  'ended',
+]);
+
+/** EIP-55–normalized EVM address after successful parse. */
+export const normalizedEvmAddressSchema = z
+  .string()
+  .transform((s) => s.trim())
+  .refine((s) => isAddress(s), { message: 'Invalid EVM wallet address' })
+  .transform((s) => getAddress(s as `0x${string}`));
+
+const stellarGAddressSchema = z
+  .string()
+  .transform((s) => s.trim().toUpperCase())
+  .pipe(stellarWalletAddressSchema);
+
+const stellarAssetCodeSchema = z
+  .string()
+  .min(1)
+  .max(12)
+  .regex(/^[a-zA-Z0-9]+$/, 'Invalid Stellar asset code');
+
+export const baseUsdcAssetConfigSchema = z
+  .object({
+    contract_address: normalizedEvmAddressSchema,
+  })
+  .strict();
+
+export const stellarUsdcAssetConfigSchema = z
+  .object({
+    asset_code: stellarAssetCodeSchema,
+    issuer: stellarGAddressSchema,
+  })
+  .strict();
+
+const positiveIntOrNullSchema = z.union([
+  z.null(),
+  z.number().int().positive(),
+]);
+
+const positiveDecimalOrNullSchema = z.union([
+  z.null(),
+  z.number().positive().max(1e15),
+]);
+
+const sponsoredActivationCommonCreateFields = {
+  slug: z.string().min(1).max(256),
+  title: z.string().min(1).max(512),
+  sponsor_name: z.string().min(1).max(512),
+  event_id: z.string().min(1).max(512).optional().nullable(),
+  status: sponsoredActivationStatusSchema.default('draft'),
+  max_redemptions: positiveIntOrNullSchema.optional(),
+  max_usdc_budget: positiveDecimalOrNullSchema.optional(),
+  starts_at: z.string().datetime({ offset: true }),
+  ends_at: z.string().datetime({ offset: true }),
+  eligibility_config: eligibilityConfigSchema,
+  created_by: z.string().max(255).optional().nullable(),
+};
+
+const createSponsoredActivationBaseObject = z
+  .object({
+    ...sponsoredActivationCommonCreateFields,
+    settlement_rail: z.literal('base'),
+    campaign_wallet_address: normalizedEvmAddressSchema,
+    venue_settlement_wallet_address: normalizedEvmAddressSchema,
+    usdc_asset_config: baseUsdcAssetConfigSchema,
+  })
+  .strict();
+
+const createSponsoredActivationStellarObject = z
+  .object({
+    ...sponsoredActivationCommonCreateFields,
+    settlement_rail: z.literal('stellar'),
+    campaign_wallet_address: stellarGAddressSchema,
+    venue_settlement_wallet_address: stellarGAddressSchema,
+    usdc_asset_config: stellarUsdcAssetConfigSchema,
+  })
+  .strict();
+
+/**
+ * Rail-discriminated create payload (plain objects only — required for `discriminatedUnion`).
+ * Prefer `createSponsoredActivationSchema` for full validation including caps and window.
+ */
+export const sponsoredActivationCreateDiscriminatedSchema =
+  z.discriminatedUnion('settlement_rail', [
+    createSponsoredActivationBaseObject,
+    createSponsoredActivationStellarObject,
+  ]);
+
+export const createSponsoredActivationSchema =
+  sponsoredActivationCreateDiscriminatedSchema.superRefine((data, ctx) => {
+    if (
+      sameWalletAddress(
+        data.campaign_wallet_address,
+        data.venue_settlement_wallet_address
+      )
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'campaign_wallet_address must differ from venue_settlement_wallet_address',
+        path: ['venue_settlement_wallet_address'],
+      });
+    }
+    if (new Date(data.ends_at) <= new Date(data.starts_at)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'ends_at must be after starts_at',
+        path: ['ends_at'],
+      });
+    }
+    const hasRedemptions =
+      data.max_redemptions != null && data.max_redemptions > 0;
+    const hasBudget = data.max_usdc_budget != null && data.max_usdc_budget > 0;
+    if (!hasRedemptions && !hasBudget) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'At least one of max_redemptions or max_usdc_budget is required on create',
+        path: ['max_redemptions'],
+      });
+    }
+  });
+
+function mergeConfigParseIssues(
+  result: z.SafeParseReturnType<unknown, unknown>,
+  ctx: z.RefinementCtx,
+  path: (string | number)[]
+) {
+  if (result.success) return;
+  for (const issue of result.error.issues) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: issue.message,
+      path: [...path, ...issue.path],
+    });
+  }
+}
+
+const updateSponsoredActivationBaseObject = z
+  .object({
+    slug: z.string().min(1).max(256).optional(),
+    title: z.string().min(1).max(512).optional(),
+    sponsor_name: z.string().min(1).max(512).optional(),
+    event_id: z.string().min(1).max(512).optional().nullable(),
+    status: sponsoredActivationStatusSchema.optional(),
+    max_redemptions: positiveIntOrNullSchema.optional(),
+    max_usdc_budget: positiveDecimalOrNullSchema.optional(),
+    starts_at: z.string().datetime({ offset: true }).optional(),
+    ends_at: z.string().datetime({ offset: true }).optional(),
+    eligibility_config: eligibilityConfigValueSchema.optional(),
+    created_by: z.string().max(255).optional().nullable(),
+    settlement_rail: settlementRailSchema.optional(),
+    campaign_wallet_address: z.string().optional(),
+    venue_settlement_wallet_address: z.string().optional(),
+    usdc_asset_config: z.unknown().optional(),
+  })
+  .strict();
+
+function normalizeUpdatePayload(
+  data: z.infer<typeof updateSponsoredActivationBaseObject>
+): z.infer<typeof updateSponsoredActivationBaseObject> {
+  const next = { ...data };
+  if (next.settlement_rail === 'base') {
+    if (next.campaign_wallet_address !== undefined) {
+      const n = tryNormalizeEvmAddress(next.campaign_wallet_address);
+      if (n) next.campaign_wallet_address = n;
+    }
+    if (next.venue_settlement_wallet_address !== undefined) {
+      const n = tryNormalizeEvmAddress(next.venue_settlement_wallet_address);
+      if (n) next.venue_settlement_wallet_address = n;
+    }
+    if (next.usdc_asset_config && typeof next.usdc_asset_config === 'object') {
+      const cfg = next.usdc_asset_config as { contract_address?: string };
+      if (typeof cfg.contract_address === 'string') {
+        const n = tryNormalizeEvmAddress(cfg.contract_address);
+        if (n) {
+          next.usdc_asset_config = { ...cfg, contract_address: n };
+        }
+      }
+    }
+  }
+  if (next.settlement_rail === 'stellar') {
+    if (next.campaign_wallet_address !== undefined) {
+      next.campaign_wallet_address = next.campaign_wallet_address
+        .trim()
+        .toUpperCase();
+    }
+    if (next.venue_settlement_wallet_address !== undefined) {
+      next.venue_settlement_wallet_address =
+        next.venue_settlement_wallet_address.trim().toUpperCase();
+    }
+    if (next.usdc_asset_config && typeof next.usdc_asset_config === 'object') {
+      const cfg = next.usdc_asset_config as {
+        issuer?: string;
+        asset_code?: string;
+      };
+      next.usdc_asset_config = {
+        ...cfg,
+        ...(typeof cfg.issuer === 'string'
+          ? { issuer: cfg.issuer.trim().toUpperCase() }
+          : {}),
+        ...(typeof cfg.asset_code === 'string'
+          ? { asset_code: cfg.asset_code.trim() }
+          : {}),
+      };
+    }
+  }
+  return next;
+}
+
+export const updateSponsoredActivationSchema =
+  updateSponsoredActivationBaseObject
+    .refine((data) => Object.keys(data).length > 0, {
+      message: 'At least one field is required',
+    })
+    .superRefine((data, ctx) => {
+      const hasCampaign = data.campaign_wallet_address !== undefined;
+      const hasVenue = data.venue_settlement_wallet_address !== undefined;
+      const hasConfig = data.usdc_asset_config !== undefined;
+      const rail = data.settlement_rail;
+
+      if ((hasCampaign || hasVenue || hasConfig) && rail === undefined) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message:
+            'settlement_rail is required when updating wallet addresses or USDC asset config',
+          path: ['settlement_rail'],
+        });
+        return;
+      }
+
+      if (data.starts_at !== undefined && data.ends_at !== undefined) {
+        if (new Date(data.ends_at) <= new Date(data.starts_at)) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'ends_at must be after starts_at',
+            path: ['ends_at'],
+          });
+        }
+      }
+
+      if (rail === 'base' && (hasCampaign || hasVenue || hasConfig)) {
+        if (hasCampaign) {
+          const n = tryNormalizeEvmAddress(data.campaign_wallet_address!);
+          if (!n) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Invalid EVM wallet address',
+              path: ['campaign_wallet_address'],
+            });
+          }
+        }
+        if (hasVenue) {
+          const n = tryNormalizeEvmAddress(
+            data.venue_settlement_wallet_address!
+          );
+          if (!n) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              message: 'Invalid EVM wallet address',
+              path: ['venue_settlement_wallet_address'],
+            });
+          }
+        }
+        if (hasConfig) {
+          mergeConfigParseIssues(
+            baseUsdcAssetConfigSchema.safeParse(data.usdc_asset_config),
+            ctx,
+            ['usdc_asset_config']
+          );
+        }
+      }
+
+      if (rail === 'stellar' && (hasCampaign || hasVenue || hasConfig)) {
+        if (hasCampaign) {
+          const r = stellarGAddressSchema.safeParse(
+            data.campaign_wallet_address
+          );
+          if (!r.success) {
+            mergeConfigParseIssues(r, ctx, ['campaign_wallet_address']);
+          }
+        }
+        if (hasVenue) {
+          const r = stellarGAddressSchema.safeParse(
+            data.venue_settlement_wallet_address
+          );
+          if (!r.success) {
+            mergeConfigParseIssues(r, ctx, ['venue_settlement_wallet_address']);
+          }
+        }
+        if (hasConfig) {
+          mergeConfigParseIssues(
+            stellarUsdcAssetConfigSchema.safeParse(data.usdc_asset_config),
+            ctx,
+            ['usdc_asset_config']
+          );
+        }
+      }
+
+      if (
+        rail !== undefined &&
+        hasCampaign &&
+        hasVenue &&
+        data.campaign_wallet_address !== undefined &&
+        data.venue_settlement_wallet_address !== undefined
+      ) {
+        if (
+          sameWalletAddress(
+            data.campaign_wallet_address,
+            data.venue_settlement_wallet_address
+          )
+        ) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message:
+              'campaign_wallet_address must differ from venue_settlement_wallet_address',
+            path: ['venue_settlement_wallet_address'],
+          });
+        }
+      }
+    })
+    .transform((data) => normalizeUpdatePayload(data));
+
+export type CreateSponsoredActivationInput = z.infer<
+  typeof createSponsoredActivationSchema
+>;
+export type UpdateSponsoredActivationInput = z.infer<
+  typeof updateSponsoredActivationSchema
+>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-52: Zod schemas for admin sponsored USDC activation payloads, aligned with `database/irl-51-sponsored-activation-schema.sql`.

## Changes

- **`lib/schemas/sponsored-activation.ts`**: `z.discriminatedUnion('settlement_rail', …)` for Base vs Stellar (EVM EIP-55 normalization via viem; Stellar G-addresses via `stellarWalletAddressSchema` with trim/uppercase). `createSponsoredActivationSchema` enforces wallet inequality (`sameWalletAddress`), `ends_at > starts_at`, create-only cap rule (at least one of `max_redemptions` / `max_usdc_budget`), optional `event_id`, `.strict()` (no nested `reward_items`). `updateSponsoredActivationSchema` is a partial patch with `settlement_rail` required when wallet or USDC asset config fields are present; EVM addresses normalized on successful parse when rail is Base.
- **`lib/schemas/activation-eligibility.ts`**: `activationEligibilitySourceSchema`, permissive `eligibilityConfigSchema` / `eligibilityConfigValueSchema`.
- **`lib/schemas/activation-redemption.ts`** and **`lib/schemas/activation-settlement.ts`**: status enums matching DB CHECK values.
- **`lib/schemas/activation-reward-item.ts`**: create/update reward item body schemas.
- **`lib/schemas/__tests__/sponsored-activation.test.ts`**: Base/Stellar happy paths, cross-rail rejection, cap rule on create, wallet inequality (EVM and Stellar), time window, strict create, update cap behavior.

## Verification

- `yarn test lib/schemas/__tests__/sponsored-activation.test.ts`
- `yarn build` (pre-commit)

## Notes

- Tests use a generic valid EVM-format contract literal (`0x2222…`) so the repository secret scanner does not block on a production Base USDC contract constant.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-52](https://linear.app/irlenergy/issue/IRL-52/add-zod-schemas-with-rail-discriminated-wallet-validation)

<div><a href="https://cursor.com/agents/bc-907a851c-be70-42cb-b1b3-b2efbb97004d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-907a851c-be70-42cb-b1b3-b2efbb97004d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

