### PR TITLE
feat(admin): sponsored activation CRUD APIs (IRL-53)

### DIFF
--- a/app/api/admin/spend-experiences/route.ts
+++ b/app/api/admin/spend-experiences/route.ts
@@ -19,14 +19,7 @@ import {
 } from '@/lib/spend-rail-config';
 import { trackSpendPilotRailMutationBlocked } from '@/lib/analytics/server';
 import { spendPilotRailMixpanelFields } from '@/lib/analytics/spend-pilot-rail-context';
-
-function createIdempotencyKey(request: NextRequest): string {
-  return (
-    request.headers.get('idempotency-key') ??
-    request.headers.get('x-idempotency-key') ??
-    crypto.randomUUID()
-  ).trim();
-}
+import { adminCreateIdempotencyKey } from '@/lib/api/idempotency';
 
 /** GET /api/admin/spend-experiences */
 export async function GET(request: NextRequest) {
@@ -58,7 +51,7 @@ export async function POST(request: NextRequest) {
       return apiValidationError(validation.error);
     }
 
-    const idempotencyKey = createIdempotencyKey(request);
+    const idempotencyKey = adminCreateIdempotencyKey(request);
     if (!idempotencyKey) {
       return apiError('Missing idempotency key', 400);
     }

--- a/app/api/admin/sponsored-activations/[activationId]/reward-items/[itemId]/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/reward-items/[itemId]/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest } from 'next/server';
+import {
+  getActivationRewardItemById,
+  updateActivationRewardItem,
+} from '@/lib/db/activation-reward-items';
+import { getSponsoredActivationById } from '@/lib/db/sponsored-activations';
+import { updateActivationRewardItemSchema } from '@/lib/schemas/activation-reward-item';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+interface RouteParams {
+  params: { activationId: string; itemId: string };
+}
+
+/** GET /api/admin/sponsored-activations/{activationId}/reward-items/{itemId} */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const activation = await getSponsoredActivationById(params.activationId);
+    if (!activation) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    const item = await getActivationRewardItemById(
+      params.activationId,
+      params.itemId
+    );
+    if (!item) {
+      return apiError('Reward item not found', 404);
+    }
+
+    return apiSuccess({ rewardItem: item });
+  } catch (error) {
+    console.error(
+      'GET /api/admin/sponsored-activations/[activationId]/reward-items/[itemId]:',
+      error
+    );
+    return apiError('Failed to load reward item', 500);
+  }
+}
+
+/** PATCH /api/admin/sponsored-activations/{activationId}/reward-items/{itemId} */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const activation = await getSponsoredActivationById(params.activationId);
+    if (!activation) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    const existing = await getActivationRewardItemById(
+      params.activationId,
+      params.itemId
+    );
+    if (!existing) {
+      return apiError('Reward item not found', 404);
+    }
+
+    const raw = await request.json();
+    const validation = updateActivationRewardItemSchema.safeParse(raw);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+    const v = validation.data;
+
+    const patch: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(v)) {
+      if (val !== undefined) {
+        patch[key] = val;
+      }
+    }
+
+    const updated = await updateActivationRewardItem(
+      params.activationId,
+      params.itemId,
+      patch
+    );
+    if (!updated) {
+      return apiError('Reward item not found', 404);
+    }
+
+    return apiSuccess({ rewardItem: updated });
+  } catch (error) {
+    console.error(
+      'PATCH /api/admin/sponsored-activations/[activationId]/reward-items/[itemId]:',
+      error
+    );
+    return apiError('Failed to update reward item', 500);
+  }
+}

--- a/app/api/admin/sponsored-activations/[activationId]/reward-items/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/reward-items/route.ts
@@ -1,0 +1,79 @@
+import { NextRequest } from 'next/server';
+import {
+  createActivationRewardItem,
+  listActivationRewardItems,
+} from '@/lib/db/activation-reward-items';
+import { getSponsoredActivationById } from '@/lib/db/sponsored-activations';
+import { createActivationRewardItemSchema } from '@/lib/schemas/activation-reward-item';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+interface RouteParams {
+  params: { activationId: string };
+}
+
+/** GET /api/admin/sponsored-activations/{activationId}/reward-items */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const activation = await getSponsoredActivationById(params.activationId);
+    if (!activation) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    const items = await listActivationRewardItems(params.activationId);
+    return apiSuccess({ rewardItems: items });
+  } catch (error) {
+    console.error(
+      'GET /api/admin/sponsored-activations/[activationId]/reward-items:',
+      error
+    );
+    return apiError('Failed to list reward items', 500);
+  }
+}
+
+/** POST /api/admin/sponsored-activations/{activationId}/reward-items */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const activation = await getSponsoredActivationById(params.activationId);
+    if (!activation) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    const body = await request.json();
+    const validation = createActivationRewardItemSchema.safeParse(body);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+    const data = validation.data;
+
+    const row = await createActivationRewardItem({
+      activation_id: activation.id,
+      name: data.name,
+      hero_image_url: data.hero_image_url,
+      description: data.description,
+      points_cost: data.points_cost,
+      usdc_amount: data.usdc_amount,
+      sort_order: data.sort_order,
+      is_active: data.is_active,
+      max_per_user: data.max_per_user,
+    });
+
+    return apiSuccess({ rewardItem: row }, 'Reward item created successfully');
+  } catch (error) {
+    console.error(
+      'POST /api/admin/sponsored-activations/[activationId]/reward-items:',
+      error
+    );
+    return apiError('Failed to create reward item', 500);
+  }
+}

--- a/app/api/admin/sponsored-activations/[activationId]/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/route.ts
@@ -6,7 +6,10 @@ import {
   getSponsoredActivationById,
   updateSponsoredActivation,
 } from '@/lib/db/sponsored-activations';
-import { updateSponsoredActivationSchema } from '@/lib/schemas/sponsored-activation';
+import {
+  sponsoredActivationSettlementBundleSchema,
+  updateSponsoredActivationSchema,
+} from '@/lib/schemas/sponsored-activation';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
 import { sponsoredActivationAdminEnvelope } from '@/lib/activation/explorer-url';
@@ -94,6 +97,26 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
 
     if (locked && patchTouchesImmutableWalletFields(v)) {
       return immutabilityViolationError();
+    }
+
+    if (!locked && patchTouchesImmutableWalletFields(v)) {
+      const merged = {
+        settlement_rail: v.settlement_rail ?? existing.settlement_rail,
+        campaign_wallet_address:
+          v.campaign_wallet_address ?? existing.campaign_wallet_address,
+        venue_settlement_wallet_address:
+          v.venue_settlement_wallet_address ??
+          existing.venue_settlement_wallet_address,
+        usdc_asset_config:
+          v.usdc_asset_config !== undefined
+            ? v.usdc_asset_config
+            : existing.usdc_asset_config,
+      };
+      const bundle =
+        sponsoredActivationSettlementBundleSchema.safeParse(merged);
+      if (!bundle.success) {
+        return apiValidationError(bundle.error);
+      }
     }
 
     if (v.status === 'active' && existing.status !== 'active') {

--- a/app/api/admin/sponsored-activations/[activationId]/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/route.ts
@@ -15,6 +15,13 @@ interface RouteParams {
   params: { activationId: string };
 }
 
+const IMMUTABLE_WALLET_PATCH_KEYS = [
+  'settlement_rail',
+  'campaign_wallet_address',
+  'venue_settlement_wallet_address',
+  'usdc_asset_config',
+] as const;
+
 function immutabilityViolationError() {
   return apiValidationError(
     new z.ZodError([
@@ -26,6 +33,12 @@ function immutabilityViolationError() {
       },
     ])
   );
+}
+
+function patchTouchesImmutableWalletFields(
+  v: z.infer<typeof updateSponsoredActivationSchema>
+): boolean {
+  return IMMUTABLE_WALLET_PATCH_KEYS.some((key) => v[key] !== undefined);
 }
 
 /** GET /api/admin/sponsored-activations/{activationId} */
@@ -73,18 +86,14 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
     }
     const v = validation.data;
 
-    const redemptionCount = await countActivationRedemptions(existing.id);
+    const redemptionCount =
+      existing.status === 'draft'
+        ? await countActivationRedemptions(existing.id)
+        : 0;
     const locked = existing.status !== 'draft' || redemptionCount > 0;
 
-    if (locked) {
-      if (
-        v.settlement_rail !== undefined ||
-        v.campaign_wallet_address !== undefined ||
-        v.venue_settlement_wallet_address !== undefined ||
-        v.usdc_asset_config !== undefined
-      ) {
-        return immutabilityViolationError();
-      }
+    if (locked && patchTouchesImmutableWalletFields(v)) {
+      return immutabilityViolationError();
     }
 
     if (v.status === 'active' && existing.status !== 'active') {
@@ -110,18 +119,6 @@ export async function PATCH(request: NextRequest, { params }: RouteParams) {
       if (val !== undefined) {
         patch[key] = val;
       }
-    }
-
-    if (Object.keys(patch).length === 0) {
-      return apiValidationError(
-        new z.ZodError([
-          {
-            code: z.ZodIssueCode.custom,
-            message: 'No fields to update',
-            path: [],
-          },
-        ])
-      );
     }
 
     const nextStarts = (v.starts_at ?? existing.starts_at) as string;

--- a/app/api/admin/sponsored-activations/[activationId]/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/route.ts
@@ -1,0 +1,156 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import {
+  countActivationRedemptions,
+  countActiveRewardItemsForActivation,
+  getSponsoredActivationById,
+  updateSponsoredActivation,
+} from '@/lib/db/sponsored-activations';
+import { updateSponsoredActivationSchema } from '@/lib/schemas/sponsored-activation';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+import { sponsoredActivationAdminEnvelope } from '@/lib/activation/explorer-url';
+
+interface RouteParams {
+  params: { activationId: string };
+}
+
+function immutabilityViolationError() {
+  return apiValidationError(
+    new z.ZodError([
+      {
+        code: z.ZodIssueCode.custom,
+        message:
+          'settlement_rail, campaign_wallet_address, venue_settlement_wallet_address, and usdc_asset_config are immutable unless status is draft with no activation_redemption rows',
+        path: [],
+      },
+    ])
+  );
+}
+
+/** GET /api/admin/sponsored-activations/{activationId} */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const row = await getSponsoredActivationById(params.activationId);
+    if (!row) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    return apiSuccess({
+      activation: sponsoredActivationAdminEnvelope(row),
+    });
+  } catch (error) {
+    console.error(
+      'GET /api/admin/sponsored-activations/[activationId]:',
+      error
+    );
+    return apiError('Failed to load sponsored activation', 500);
+  }
+}
+
+/** PATCH /api/admin/sponsored-activations/{activationId} */
+export async function PATCH(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const existing = await getSponsoredActivationById(params.activationId);
+    if (!existing) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    const raw = await request.json();
+    const validation = updateSponsoredActivationSchema.safeParse(raw);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+    const v = validation.data;
+
+    const redemptionCount = await countActivationRedemptions(existing.id);
+    const locked = existing.status !== 'draft' || redemptionCount > 0;
+
+    if (locked) {
+      if (
+        v.settlement_rail !== undefined ||
+        v.campaign_wallet_address !== undefined ||
+        v.venue_settlement_wallet_address !== undefined ||
+        v.usdc_asset_config !== undefined
+      ) {
+        return immutabilityViolationError();
+      }
+    }
+
+    if (v.status === 'active' && existing.status !== 'active') {
+      const activeItems = await countActiveRewardItemsForActivation(
+        existing.id
+      );
+      if (activeItems < 1) {
+        return apiValidationError(
+          new z.ZodError([
+            {
+              code: z.ZodIssueCode.custom,
+              message:
+                'At least one active reward item is required before status can be active',
+              path: ['status'],
+            },
+          ])
+        );
+      }
+    }
+
+    const patch: Record<string, unknown> = {};
+    for (const [key, val] of Object.entries(v)) {
+      if (val !== undefined) {
+        patch[key] = val;
+      }
+    }
+
+    if (Object.keys(patch).length === 0) {
+      return apiValidationError(
+        new z.ZodError([
+          {
+            code: z.ZodIssueCode.custom,
+            message: 'No fields to update',
+            path: [],
+          },
+        ])
+      );
+    }
+
+    const nextStarts = (v.starts_at ?? existing.starts_at) as string;
+    const nextEnds = (v.ends_at ?? existing.ends_at) as string;
+    if (new Date(nextEnds) <= new Date(nextStarts)) {
+      return apiValidationError(
+        new z.ZodError([
+          {
+            code: z.ZodIssueCode.custom,
+            message: 'ends_at must be after starts_at',
+            path: ['ends_at'],
+          },
+        ])
+      );
+    }
+
+    const updated = await updateSponsoredActivation(existing.id, patch);
+    if (!updated) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    return apiSuccess({
+      activation: sponsoredActivationAdminEnvelope(updated),
+    });
+  } catch (error) {
+    console.error(
+      'PATCH /api/admin/sponsored-activations/[activationId]:',
+      error
+    );
+    return apiError('Failed to update sponsored activation', 500);
+  }
+}

--- a/app/api/admin/sponsored-activations/__tests__/admin-sponsored-activations.routes.test.ts
+++ b/app/api/admin/sponsored-activations/__tests__/admin-sponsored-activations.routes.test.ts
@@ -1,0 +1,411 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockList = vi.fn();
+const mockGetById = vi.fn();
+const mockGetByIdempotency = vi.fn();
+const mockCreate = vi.fn();
+const mockUpdate = vi.fn();
+const mockCountRedemptions = vi.fn();
+const mockCountActiveItems = vi.fn();
+const mockCreatePrivy = vi.fn();
+const mockListItems = vi.fn();
+const mockGetItem = vi.fn();
+const mockCreateItem = vi.fn();
+const mockUpdateItem = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  listSponsoredActivations: () => mockList(),
+  getSponsoredActivationById: (id: string) => mockGetById(id),
+  getSponsoredActivationByCreateIdempotencyKey: (k: string) =>
+    mockGetByIdempotency(k),
+  createSponsoredActivation: (input: unknown) => mockCreate(input),
+  updateSponsoredActivation: (id: string, patch: unknown) =>
+    mockUpdate(id, patch),
+  countActivationRedemptions: (id: string) => mockCountRedemptions(id),
+  countActiveRewardItemsForActivation: (id: string) => mockCountActiveItems(id),
+}));
+
+vi.mock('@/lib/api/privy', () => ({
+  createSponsoredActivationPrivyCampaignWallet: (...args: unknown[]) =>
+    mockCreatePrivy(...args),
+}));
+
+vi.mock('@/lib/db/activation-reward-items', () => ({
+  listActivationRewardItems: (activationId: string) =>
+    mockListItems(activationId),
+  createActivationRewardItem: (input: unknown) => mockCreateItem(input),
+  getActivationRewardItemById: (activationId: string, itemId: string) =>
+    mockGetItem(activationId, itemId),
+  updateActivationRewardItem: (
+    activationId: string,
+    itemId: string,
+    patch: unknown
+  ) => mockUpdateItem(activationId, itemId, patch),
+}));
+
+vi.mock('@/lib/activation/explorer-url', () => ({
+  sponsoredActivationAdminEnvelope: (row: Record<string, unknown>) => ({
+    ...row,
+    campaign_wallet_explorer_url: 'https://ex/c',
+    venue_settlement_wallet_explorer_url: 'https://ex/v',
+    settlement_explorer_tx_url_template: 'https://ex/tx/{txHash}',
+  }),
+}));
+
+import { GET as listGET, POST as listPOST } from '../route';
+import { GET as oneGET, PATCH as onePATCH } from '../[activationId]/route';
+import {
+  GET as itemsGET,
+  POST as itemsPOST,
+} from '../[activationId]/reward-items/route';
+import {
+  GET as itemGET,
+  PATCH as itemPATCH,
+} from '../[activationId]/reward-items/[itemId]/route';
+
+const SAMPLE_CONTRACT = '0x2222222222222222222222222222222222222222';
+const STELLAR = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+const validWindow = {
+  starts_at: '2026-06-01T12:00:00.000Z',
+  ends_at: '2026-06-30T12:00:00.000Z',
+};
+
+const baseFixture = {
+  id: 'act-1',
+  slug: 's1',
+  title: 'T',
+  sponsor_name: 'S',
+  event_id: null,
+  status: 'draft' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  venue_settlement_wallet_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
+  max_redemptions: 10,
+  max_usdc_budget: null,
+  usdc_settled_total: 0,
+  redemption_count_confirmed: 0,
+  ...validWindow,
+  eligibility_config: {},
+  created_by: 'a@b.com',
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: 'k1',
+  privy_campaign_wallet_id: 'pw1',
+};
+
+function jsonReq(
+  method: 'GET' | 'POST' | 'PATCH',
+  url: string,
+  body?: Record<string, unknown>,
+  idem?: string
+): NextRequest {
+  const h = new Headers();
+  h.set('x-user-email', 'admin@example.com');
+  if (body) h.set('Content-Type', 'application/json');
+  if (idem) h.set('idempotency-key', idem);
+  return new NextRequest(url, {
+    method,
+    headers: h,
+    body: body != null ? JSON.stringify(body) : undefined,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRequireAdmin.mockResolvedValue({
+    isValid: true,
+    user: { email: 'admin@example.com' },
+  });
+  mockGetByIdempotency.mockResolvedValue(null);
+  mockCountRedemptions.mockResolvedValue(0);
+  mockCountActiveItems.mockResolvedValue(1);
+  mockCreatePrivy.mockResolvedValue({
+    privy_campaign_wallet_id: 'pw-new',
+    campaign_wallet_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+    campaign_wallet_chain: 'base-mainnet',
+    campaign_wallet_created_at: '2026-04-28T00:00:00.000Z',
+  });
+});
+
+describe('GET /api/admin/sponsored-activations', () => {
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await listGET(
+      jsonReq('GET', 'http://localhost/api/admin/sponsored-activations')
+    );
+    expect(res.status).toBe(403);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it('returns activations for admin', async () => {
+    mockList.mockResolvedValue([baseFixture]);
+    const res = await listGET(
+      jsonReq('GET', 'http://localhost/api/admin/sponsored-activations')
+    );
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.success).toBe(true);
+    expect(j.data.activations).toHaveLength(1);
+  });
+});
+
+describe('POST /api/admin/sponsored-activations', () => {
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await listPOST(
+      jsonReq('POST', 'http://localhost/api/admin/sponsored-activations', {
+        settlement_rail: 'base',
+        slug: 'x',
+        title: 't',
+        sponsor_name: 's',
+        max_redemptions: 1,
+        ...validWindow,
+        eligibility_config: {},
+        venue_settlement_wallet_address:
+          '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+        usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
+      })
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 400 on cross-rail venue address', async () => {
+    const res = await listPOST(
+      jsonReq('POST', 'http://localhost/api/admin/sponsored-activations', {
+        settlement_rail: 'base',
+        slug: 'x',
+        title: 't',
+        sponsor_name: 's',
+        max_redemptions: 1,
+        ...validWindow,
+        eligibility_config: {},
+        venue_settlement_wallet_address: STELLAR,
+        usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(mockCreatePrivy).not.toHaveBeenCalled();
+  });
+
+  it('provisions Privy wallet and persists activation', async () => {
+    mockCreate.mockResolvedValue(baseFixture);
+    const res = await listPOST(
+      jsonReq(
+        'POST',
+        'http://localhost/api/admin/sponsored-activations',
+        {
+          settlement_rail: 'base',
+          slug: 'new-slug',
+          title: 't',
+          sponsor_name: 's',
+          max_redemptions: 1,
+          ...validWindow,
+          eligibility_config: {},
+          venue_settlement_wallet_address:
+            '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+          usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
+        },
+        'idem-xyz'
+      )
+    );
+    expect(res.status).toBe(200);
+    expect(mockCreatePrivy).toHaveBeenCalledWith({
+      idempotencyKey: 'idem-xyz',
+      settlementRail: 'base',
+    });
+    expect(mockCreate).toHaveBeenCalled();
+    const createArg = mockCreate.mock.calls[0][0] as { status: string };
+    expect(createArg.status).toBe('draft');
+  });
+});
+
+describe('PATCH /api/admin/sponsored-activations/[activationId]', () => {
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await onePATCH(
+      jsonReq('PATCH', 'http://localhost/api/admin/sponsored-activations/a', {
+        title: 'x',
+      }),
+      { params: { activationId: 'a' } }
+    );
+    expect(res.status).toBe(403);
+  });
+
+  it('blocks immutable wallet fields when status is active', async () => {
+    mockGetById.mockResolvedValue({
+      ...baseFixture,
+      status: 'active',
+    });
+    const res = await onePATCH(
+      jsonReq(
+        'PATCH',
+        'http://localhost/api/admin/sponsored-activations/act-1',
+        {
+          settlement_rail: 'base',
+          venue_settlement_wallet_address:
+            '0x3C44CdDdB6a900fa2b585dd299e03d12FA4293BC',
+        }
+      ),
+      { params: { activationId: 'act-1' } }
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('blocks wallet edits when draft but redemptions exist', async () => {
+    mockGetById.mockResolvedValue({ ...baseFixture, status: 'draft' });
+    mockCountRedemptions.mockResolvedValue(1);
+    const res = await onePATCH(
+      jsonReq(
+        'PATCH',
+        'http://localhost/api/admin/sponsored-activations/act-1',
+        {
+          settlement_rail: 'base',
+          usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
+        }
+      ),
+      { params: { activationId: 'act-1' } }
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+
+  it('allows activating when reward items exist', async () => {
+    mockGetById.mockResolvedValue({ ...baseFixture, status: 'draft' });
+    mockCountActiveItems.mockResolvedValue(1);
+    mockUpdate.mockResolvedValue({ ...baseFixture, status: 'active' });
+    const res = await onePATCH(
+      jsonReq(
+        'PATCH',
+        'http://localhost/api/admin/sponsored-activations/act-1',
+        {
+          status: 'active',
+        }
+      ),
+      { params: { activationId: 'act-1' } }
+    );
+    expect(res.status).toBe(200);
+    expect(mockUpdate).toHaveBeenCalled();
+  });
+
+  it('rejects active without active reward items', async () => {
+    mockGetById.mockResolvedValue({ ...baseFixture, status: 'draft' });
+    mockCountActiveItems.mockResolvedValue(0);
+    const res = await onePATCH(
+      jsonReq(
+        'PATCH',
+        'http://localhost/api/admin/sponsored-activations/act-1',
+        {
+          status: 'active',
+        }
+      ),
+      { params: { activationId: 'act-1' } }
+    );
+    expect(res.status).toBe(400);
+    expect(mockUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe('GET /api/admin/sponsored-activations/[activationId]', () => {
+  it('returns 404 when missing', async () => {
+    mockGetById.mockResolvedValue(null);
+    const res = await oneGET(
+      jsonReq(
+        'GET',
+        'http://localhost/api/admin/sponsored-activations/missing'
+      ),
+      { params: { activationId: 'missing' } }
+    );
+    expect(res.status).toBe(404);
+  });
+});
+
+describe('reward item routes', () => {
+  it('lists reward items', async () => {
+    mockGetById.mockResolvedValue(baseFixture);
+    mockListItems.mockResolvedValue([]);
+    const res = await itemsGET(
+      jsonReq(
+        'GET',
+        'http://localhost/api/admin/sponsored-activations/act-1/reward-items'
+      ),
+      { params: { activationId: 'act-1' } }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('creates reward item', async () => {
+    mockGetById.mockResolvedValue(baseFixture);
+    mockCreateItem.mockResolvedValue({
+      id: 'ri-1',
+      activation_id: 'act-1',
+      name: 'Drink',
+      hero_image_url: null,
+      description: null,
+      points_cost: 0,
+      usdc_amount: 5,
+      sort_order: 0,
+      is_active: true,
+      max_per_user: 1,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
+    const res = await itemsPOST(
+      jsonReq(
+        'POST',
+        'http://localhost/api/admin/sponsored-activations/act-1/reward-items',
+        {
+          name: 'Drink',
+          usdc_amount: 5,
+        }
+      ),
+      { params: { activationId: 'act-1' } }
+    );
+    expect(res.status).toBe(200);
+  });
+
+  it('gets and patches a reward item', async () => {
+    mockGetById.mockResolvedValue(baseFixture);
+    const item = {
+      id: 'ri-1',
+      activation_id: 'act-1',
+      name: 'Drink',
+      hero_image_url: null,
+      description: null,
+      points_cost: 0,
+      usdc_amount: 5,
+      sort_order: 0,
+      is_active: true,
+      max_per_user: 1,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    };
+    mockGetItem.mockResolvedValue(item);
+    const g = await itemGET(
+      jsonReq(
+        'GET',
+        'http://localhost/api/admin/sponsored-activations/act-1/reward-items/ri-1'
+      ),
+      { params: { activationId: 'act-1', itemId: 'ri-1' } }
+    );
+    expect(g.status).toBe(200);
+
+    mockUpdateItem.mockResolvedValue({ ...item, is_active: false });
+    const p = await itemPATCH(
+      jsonReq(
+        'PATCH',
+        'http://localhost/api/admin/sponsored-activations/act-1/reward-items/ri-1',
+        { is_active: false }
+      ),
+      { params: { activationId: 'act-1', itemId: 'ri-1' } }
+    );
+    expect(p.status).toBe(200);
+  });
+});

--- a/app/api/admin/sponsored-activations/route.ts
+++ b/app/api/admin/sponsored-activations/route.ts
@@ -11,14 +11,7 @@ import { requireAdmin } from '@/lib/auth';
 import { createSponsoredActivationPrivyCampaignWallet } from '@/lib/api/privy';
 import { sameWalletAddress } from '@/lib/utils/wallets';
 import { sponsoredActivationAdminEnvelope } from '@/lib/activation/explorer-url';
-
-function createIdempotencyKey(request: NextRequest): string {
-  return (
-    request.headers.get('idempotency-key') ??
-    request.headers.get('x-idempotency-key') ??
-    crypto.randomUUID()
-  ).trim();
-}
+import { adminCreateIdempotencyKey } from '@/lib/api/idempotency';
 
 /** GET /api/admin/sponsored-activations */
 export async function GET(request: NextRequest) {
@@ -46,7 +39,7 @@ export async function POST(request: NextRequest) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 
-    const idempotencyKey = createIdempotencyKey(request);
+    const idempotencyKey = adminCreateIdempotencyKey(request);
     if (!idempotencyKey) {
       return apiError('Missing idempotency key', 400);
     }
@@ -93,8 +86,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const adminEmail = adminCheck.user?.email ?? undefined;
-
     const row = await createSponsoredActivation({
       slug: data.slug,
       title: data.title,
@@ -113,7 +104,7 @@ export async function POST(request: NextRequest) {
       starts_at: data.starts_at,
       ends_at: data.ends_at,
       eligibility_config: data.eligibility_config as Record<string, unknown>,
-      created_by: data.created_by ?? adminEmail ?? null,
+      created_by: data.created_by ?? adminCheck.user?.email ?? null,
       activation_create_idempotency_key: idempotencyKey,
       privy_campaign_wallet_id: wallet.privy_campaign_wallet_id,
     });

--- a/app/api/admin/sponsored-activations/route.ts
+++ b/app/api/admin/sponsored-activations/route.ts
@@ -1,0 +1,135 @@
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+import {
+  createSponsoredActivation,
+  getSponsoredActivationByCreateIdempotencyKey,
+  listSponsoredActivations,
+} from '@/lib/db/sponsored-activations';
+import { adminCreateSponsoredActivationRequestSchema } from '@/lib/schemas/sponsored-activation';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+import { createSponsoredActivationPrivyCampaignWallet } from '@/lib/api/privy';
+import { sameWalletAddress } from '@/lib/utils/wallets';
+import { sponsoredActivationAdminEnvelope } from '@/lib/activation/explorer-url';
+
+function createIdempotencyKey(request: NextRequest): string {
+  return (
+    request.headers.get('idempotency-key') ??
+    request.headers.get('x-idempotency-key') ??
+    crypto.randomUUID()
+  ).trim();
+}
+
+/** GET /api/admin/sponsored-activations */
+export async function GET(request: NextRequest) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const rows = await listSponsoredActivations();
+    return apiSuccess({
+      activations: rows.map((r) => sponsoredActivationAdminEnvelope(r)),
+    });
+  } catch (error) {
+    console.error('GET /api/admin/sponsored-activations:', error);
+    return apiError('Failed to list sponsored activations', 500);
+  }
+}
+
+/** POST /api/admin/sponsored-activations */
+export async function POST(request: NextRequest) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const idempotencyKey = createIdempotencyKey(request);
+    if (!idempotencyKey) {
+      return apiError('Missing idempotency key', 400);
+    }
+
+    const existing =
+      await getSponsoredActivationByCreateIdempotencyKey(idempotencyKey);
+    if (existing) {
+      return apiSuccess(
+        {
+          activation: sponsoredActivationAdminEnvelope(existing),
+        },
+        'Sponsored activation already created'
+      );
+    }
+
+    const body = await request.json();
+    const validation =
+      adminCreateSponsoredActivationRequestSchema.safeParse(body);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+    const data = validation.data;
+
+    const wallet = await createSponsoredActivationPrivyCampaignWallet({
+      idempotencyKey,
+      settlementRail: data.settlement_rail,
+    });
+
+    if (
+      sameWalletAddress(
+        wallet.campaign_wallet_address,
+        data.venue_settlement_wallet_address
+      )
+    ) {
+      return apiValidationError(
+        new z.ZodError([
+          {
+            code: z.ZodIssueCode.custom,
+            message:
+              'Provisioned campaign wallet must differ from venue_settlement_wallet_address',
+            path: ['venue_settlement_wallet_address'],
+          },
+        ])
+      );
+    }
+
+    const adminEmail = adminCheck.user?.email ?? undefined;
+
+    const row = await createSponsoredActivation({
+      slug: data.slug,
+      title: data.title,
+      sponsor_name: data.sponsor_name,
+      event_id: data.event_id ?? null,
+      status: 'draft',
+      settlement_rail: data.settlement_rail,
+      campaign_wallet_address: wallet.campaign_wallet_address,
+      venue_settlement_wallet_address: data.venue_settlement_wallet_address,
+      usdc_asset_config: data.usdc_asset_config as unknown as Record<
+        string,
+        unknown
+      >,
+      max_redemptions: data.max_redemptions ?? null,
+      max_usdc_budget: data.max_usdc_budget ?? null,
+      starts_at: data.starts_at,
+      ends_at: data.ends_at,
+      eligibility_config: data.eligibility_config as Record<string, unknown>,
+      created_by: data.created_by ?? adminEmail ?? null,
+      activation_create_idempotency_key: idempotencyKey,
+      privy_campaign_wallet_id: wallet.privy_campaign_wallet_id,
+    });
+
+    return apiSuccess(
+      {
+        activation: sponsoredActivationAdminEnvelope(row),
+      },
+      'Sponsored activation created successfully'
+    );
+  } catch (error) {
+    console.error('POST /api/admin/sponsored-activations:', error);
+    const message =
+      error instanceof Error && error.message.toLowerCase().includes('privy')
+        ? error.message
+        : 'Failed to create sponsored activation';
+    return apiError(message, 500);
+  }
+}

--- a/database/irl-53-sponsored-activation-admin-columns.sql
+++ b/database/irl-53-sponsored-activation-admin-columns.sql
@@ -1,0 +1,15 @@
+-- IRL-53: Admin activation create idempotency + Privy campaign wallet id (optional audit).
+ALTER TABLE sponsored_activation
+    ADD COLUMN IF NOT EXISTS activation_create_idempotency_key TEXT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sponsored_activation_create_idempotency_key
+    ON sponsored_activation (activation_create_idempotency_key)
+    WHERE activation_create_idempotency_key IS NOT NULL;
+
+ALTER TABLE sponsored_activation
+    ADD COLUMN IF NOT EXISTS privy_campaign_wallet_id TEXT;
+
+COMMENT ON COLUMN sponsored_activation.activation_create_idempotency_key IS
+    'Optional client idempotency key for POST /api/admin/sponsored-activations (mirrors spend_experiences).';
+COMMENT ON COLUMN sponsored_activation.privy_campaign_wallet_id IS
+    'Privy server wallet id for campaign_wallet_address (Base: ethereum; Stellar: stellar chain).';

--- a/lib/activation/explorer-url.ts
+++ b/lib/activation/explorer-url.ts
@@ -5,24 +5,17 @@ import {
   getSettlementExplorerTxUrlTemplate,
 } from '@/lib/spend-rail-config';
 
-export { formatSettlementExplorerTxUrl } from '@/lib/spend-rail-config';
-
 export type SponsoredActivationExplorerPack = {
   campaign_wallet_explorer_url: string | null;
   venue_settlement_wallet_explorer_url: string | null;
   settlement_explorer_tx_url_template: string;
 };
 
-export function sponsoredActivationExplorerPack(
-  row: Pick<
-    SponsoredActivationRow,
-    | 'settlement_rail'
-    | 'campaign_wallet_address'
-    | 'venue_settlement_wallet_address'
-  >
-): SponsoredActivationExplorerPack {
+export function sponsoredActivationAdminEnvelope(
+  row: SponsoredActivationRow
+): SponsoredActivationRow & SponsoredActivationExplorerPack {
   const rail = row.settlement_rail as SettlementExplorerRail;
-  return {
+  const explorer: SponsoredActivationExplorerPack = {
     campaign_wallet_explorer_url: formatSettlementWalletExplorerUrl(
       rail,
       row.campaign_wallet_address
@@ -34,10 +27,5 @@ export function sponsoredActivationExplorerPack(
     settlement_explorer_tx_url_template:
       getSettlementExplorerTxUrlTemplate(rail),
   };
-}
-
-export function sponsoredActivationAdminEnvelope(
-  row: SponsoredActivationRow
-): SponsoredActivationRow & SponsoredActivationExplorerPack {
-  return { ...row, ...sponsoredActivationExplorerPack(row) };
+  return { ...row, ...explorer };
 }

--- a/lib/activation/explorer-url.ts
+++ b/lib/activation/explorer-url.ts
@@ -1,0 +1,43 @@
+import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
+import type { SettlementExplorerRail } from '@/lib/spend-rail-config';
+import {
+  formatSettlementWalletExplorerUrl,
+  getSettlementExplorerTxUrlTemplate,
+} from '@/lib/spend-rail-config';
+
+export { formatSettlementExplorerTxUrl } from '@/lib/spend-rail-config';
+
+export type SponsoredActivationExplorerPack = {
+  campaign_wallet_explorer_url: string | null;
+  venue_settlement_wallet_explorer_url: string | null;
+  settlement_explorer_tx_url_template: string;
+};
+
+export function sponsoredActivationExplorerPack(
+  row: Pick<
+    SponsoredActivationRow,
+    | 'settlement_rail'
+    | 'campaign_wallet_address'
+    | 'venue_settlement_wallet_address'
+  >
+): SponsoredActivationExplorerPack {
+  const rail = row.settlement_rail as SettlementExplorerRail;
+  return {
+    campaign_wallet_explorer_url: formatSettlementWalletExplorerUrl(
+      rail,
+      row.campaign_wallet_address
+    ),
+    venue_settlement_wallet_explorer_url: formatSettlementWalletExplorerUrl(
+      rail,
+      row.venue_settlement_wallet_address
+    ),
+    settlement_explorer_tx_url_template:
+      getSettlementExplorerTxUrlTemplate(rail),
+  };
+}
+
+export function sponsoredActivationAdminEnvelope(
+  row: SponsoredActivationRow
+): SponsoredActivationRow & SponsoredActivationExplorerPack {
+  return { ...row, ...sponsoredActivationExplorerPack(row) };
+}

--- a/lib/activation/lifecycle.test.ts
+++ b/lib/activation/lifecycle.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { canActivationAcceptUserRedemptionFlow } from '@/lib/activation/lifecycle';
+
+const window = {
+  starts_at: '2026-06-01T12:00:00.000Z',
+  ends_at: '2026-06-30T12:00:00.000Z',
+};
+
+describe('canActivationAcceptUserRedemptionFlow', () => {
+  it('returns true only for active status inside the window', () => {
+    const now = new Date('2026-06-15T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow(
+        { status: 'active', ...window },
+        now
+      )
+    ).toBe(true);
+  });
+
+  it('returns false for draft', () => {
+    const now = new Date('2026-06-15T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow({ status: 'draft', ...window }, now)
+    ).toBe(false);
+  });
+
+  it('returns false for paused', () => {
+    const now = new Date('2026-06-15T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow(
+        { status: 'paused', ...window },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it('returns false for ended', () => {
+    const now = new Date('2026-06-15T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow({ status: 'ended', ...window }, now)
+    ).toBe(false);
+  });
+
+  it('returns false before starts_at', () => {
+    const now = new Date('2026-05-01T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow(
+        { status: 'active', ...window },
+        now
+      )
+    ).toBe(false);
+  });
+
+  it('returns false at or after ends_at', () => {
+    const atEnd = new Date('2026-06-30T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow(
+        { status: 'active', ...window },
+        atEnd
+      )
+    ).toBe(false);
+    const after = new Date('2026-07-01T00:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow(
+        { status: 'active', ...window },
+        after
+      )
+    ).toBe(false);
+  });
+
+  it('returns true at starts_at boundary', () => {
+    const now = new Date('2026-06-01T12:00:00.000Z');
+    expect(
+      canActivationAcceptUserRedemptionFlow(
+        { status: 'active', ...window },
+        now
+      )
+    ).toBe(true);
+  });
+});

--- a/lib/activation/lifecycle.ts
+++ b/lib/activation/lifecycle.ts
@@ -1,0 +1,25 @@
+/**
+ * Shared activation lifecycle rules for user redemption flows (IRL-57+).
+ */
+
+export type ActivationLifecycleSnapshot = {
+  status: string;
+  starts_at: string;
+  ends_at: string;
+};
+
+/**
+ * True when the activation is live for user eligibility / confirm / swipe flows.
+ * Requires `active` status and `starts_at <= now < ends_at`.
+ */
+export function canActivationAcceptUserRedemptionFlow(
+  activation: ActivationLifecycleSnapshot,
+  now: Date = new Date()
+): boolean {
+  if (activation.status !== 'active') return false;
+  const t = now.getTime();
+  const startMs = new Date(activation.starts_at).getTime();
+  const endMs = new Date(activation.ends_at).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs)) return false;
+  return startMs <= t && t < endMs;
+}

--- a/lib/api/idempotency.ts
+++ b/lib/api/idempotency.ts
@@ -1,0 +1,13 @@
+import type { NextRequest } from 'next/server';
+
+/**
+ * Reads `idempotency-key` / `x-idempotency-key` for admin POST creates, or generates a UUID.
+ * Matches spend experience admin create behavior.
+ */
+export function adminCreateIdempotencyKey(request: NextRequest): string {
+  return (
+    request.headers.get('idempotency-key') ??
+    request.headers.get('x-idempotency-key') ??
+    crypto.randomUUID()
+  ).trim();
+}

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -381,3 +381,48 @@ export async function createSpendPrivyServerWallet(params: {
     throw new Error('Privy server wallet could not be created');
   }
 }
+
+export type SponsoredActivationCampaignWalletMetadata = {
+  privy_campaign_wallet_id: string;
+  campaign_wallet_address: string;
+  campaign_wallet_chain: string;
+  campaign_wallet_created_at: string;
+};
+
+/**
+ * Provisions a Privy server wallet for a sponsored activation campaign.
+ * Base rail uses an Ethereum-format address on Base; Stellar rail uses a Stellar account.
+ */
+export async function createSponsoredActivationPrivyCampaignWallet(params: {
+  idempotencyKey: string;
+  settlementRail: 'base' | 'stellar';
+}): Promise<SponsoredActivationCampaignWalletMetadata> {
+  try {
+    const client = getPrivyClient();
+    if (params.settlementRail === 'base') {
+      const wallet = await client.walletApi.createWallet({
+        chainType: 'ethereum',
+        idempotencyKey: params.idempotencyKey,
+      });
+      return {
+        privy_campaign_wallet_id: wallet.id,
+        campaign_wallet_address: wallet.address,
+        campaign_wallet_chain: 'base-mainnet',
+        campaign_wallet_created_at: wallet.createdAt.toISOString(),
+      };
+    }
+    const wallet = await client.walletApi.createWallet({
+      chainType: 'stellar',
+      idempotencyKey: params.idempotencyKey,
+    });
+    return {
+      privy_campaign_wallet_id: wallet.id,
+      campaign_wallet_address: wallet.address,
+      campaign_wallet_chain: 'stellar',
+      campaign_wallet_created_at: wallet.createdAt.toISOString(),
+    };
+  } catch (error) {
+    console.error('createSponsoredActivationPrivyCampaignWallet:', error);
+    throw new Error('Privy campaign wallet could not be created');
+  }
+}

--- a/lib/db/activation-reward-items.ts
+++ b/lib/db/activation-reward-items.ts
@@ -1,0 +1,136 @@
+import { supabase } from '@/lib/db/client';
+
+export type ActivationRewardItemRow = {
+  id: string;
+  activation_id: string;
+  name: string;
+  hero_image_url: string | null;
+  description: string | null;
+  points_cost: number;
+  usdc_amount: number;
+  sort_order: number;
+  is_active: boolean;
+  max_per_user: number;
+  created_at: string;
+  updated_at: string;
+};
+
+const TABLE = 'activation_reward_item';
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+}
+
+function normalizeRow(row: Record<string, unknown>): ActivationRewardItemRow {
+  return {
+    id: String(row.id),
+    activation_id: String(row.activation_id),
+    name: String(row.name),
+    hero_image_url:
+      row.hero_image_url == null ? null : String(row.hero_image_url),
+    description: row.description == null ? null : String(row.description),
+    points_cost: Math.trunc(toNumber(row.points_cost)),
+    usdc_amount: toNumber(row.usdc_amount),
+    sort_order: Math.trunc(toNumber(row.sort_order)),
+    is_active: Boolean(row.is_active),
+    max_per_user: Math.trunc(toNumber(row.max_per_user)),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+  };
+}
+
+export async function listActivationRewardItems(
+  activationId: string
+): Promise<ActivationRewardItemRow[]> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('activation_id', activationId)
+    .order('sort_order', { ascending: true })
+    .order('created_at', { ascending: true });
+  if (error) {
+    console.error('listActivationRewardItems:', error);
+    throw new Error(error.message || 'Failed to list reward items');
+  }
+  return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+}
+
+export async function getActivationRewardItemById(
+  activationId: string,
+  itemId: string
+): Promise<ActivationRewardItemRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('activation_id', activationId)
+    .eq('id', itemId)
+    .maybeSingle();
+  if (error) {
+    console.error('getActivationRewardItemById:', error);
+    throw new Error(error.message || 'Failed to load reward item');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export type CreateActivationRewardItemDbInput = {
+  activation_id: string;
+  name: string;
+  hero_image_url?: string | null;
+  description?: string | null;
+  points_cost: number;
+  usdc_amount: number;
+  sort_order: number;
+  is_active: boolean;
+  max_per_user: number;
+};
+
+export async function createActivationRewardItem(
+  input: CreateActivationRewardItemDbInput
+): Promise<ActivationRewardItemRow> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert({
+      activation_id: input.activation_id,
+      name: input.name,
+      hero_image_url: input.hero_image_url ?? null,
+      description: input.description ?? null,
+      points_cost: input.points_cost,
+      usdc_amount: input.usdc_amount,
+      sort_order: input.sort_order,
+      is_active: input.is_active,
+      max_per_user: input.max_per_user,
+    })
+    .select('*')
+    .single();
+  if (error) {
+    console.error('createActivationRewardItem:', error);
+    throw new Error(error.message || 'Failed to create reward item');
+  }
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function updateActivationRewardItem(
+  activationId: string,
+  itemId: string,
+  patch: Record<string, unknown>
+): Promise<ActivationRewardItemRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(patch)
+    .eq('activation_id', activationId)
+    .eq('id', itemId)
+    .select('*')
+    .maybeSingle();
+  if (error) {
+    console.error('updateActivationRewardItem:', error);
+    throw new Error(error.message || 'Failed to update reward item');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}

--- a/lib/db/sponsored-activations.ts
+++ b/lib/db/sponsored-activations.ts
@@ -218,6 +218,15 @@ export async function createSponsoredActivation(
     .select('*')
     .single();
   if (error) {
+    if (
+      (error as { code?: string }).code === '23505' &&
+      input.activation_create_idempotency_key
+    ) {
+      const existing = await getSponsoredActivationByCreateIdempotencyKey(
+        input.activation_create_idempotency_key
+      );
+      if (existing) return existing;
+    }
     console.error('createSponsoredActivation:', error);
     throw new Error(error.message || 'Failed to create sponsored activation');
   }

--- a/lib/db/sponsored-activations.ts
+++ b/lib/db/sponsored-activations.ts
@@ -1,0 +1,247 @@
+import { supabase } from '@/lib/db/client';
+
+export type SponsoredActivationStatus = 'draft' | 'active' | 'paused' | 'ended';
+
+export type SettlementRail = 'base' | 'stellar';
+
+export type SponsoredActivationRow = {
+  id: string;
+  slug: string;
+  title: string;
+  sponsor_name: string;
+  event_id: string | null;
+  status: SponsoredActivationStatus;
+  settlement_rail: SettlementRail;
+  campaign_wallet_address: string;
+  venue_settlement_wallet_address: string;
+  usdc_asset_config: Record<string, unknown>;
+  max_redemptions: number | null;
+  max_usdc_budget: number | null;
+  usdc_settled_total: number;
+  redemption_count_confirmed: number;
+  starts_at: string;
+  ends_at: string;
+  eligibility_config: Record<string, unknown>;
+  created_by: string | null;
+  created_at: string;
+  updated_at: string;
+  activation_create_idempotency_key: string | null;
+  privy_campaign_wallet_id: string | null;
+};
+
+const TABLE = 'sponsored_activation';
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+}
+
+function toIntOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = toNumber(value);
+  return Number.isNaN(n) ? null : Math.trunc(n);
+}
+
+function normalizeRow(row: Record<string, unknown>): SponsoredActivationRow {
+  return {
+    id: String(row.id),
+    slug: String(row.slug),
+    title: String(row.title),
+    sponsor_name: String(row.sponsor_name),
+    event_id: row.event_id == null ? null : String(row.event_id),
+    status: row.status as SponsoredActivationStatus,
+    settlement_rail: row.settlement_rail as SettlementRail,
+    campaign_wallet_address: String(row.campaign_wallet_address),
+    venue_settlement_wallet_address: String(
+      row.venue_settlement_wallet_address
+    ),
+    usdc_asset_config:
+      row.usdc_asset_config != null && typeof row.usdc_asset_config === 'object'
+        ? (row.usdc_asset_config as Record<string, unknown>)
+        : {},
+    max_redemptions: toIntOrNull(row.max_redemptions),
+    max_usdc_budget:
+      row.max_usdc_budget === null || row.max_usdc_budget === undefined
+        ? null
+        : toNumber(row.max_usdc_budget),
+    usdc_settled_total: toNumber(row.usdc_settled_total),
+    redemption_count_confirmed: Math.trunc(
+      toNumber(row.redemption_count_confirmed)
+    ),
+    starts_at: String(row.starts_at),
+    ends_at: String(row.ends_at),
+    eligibility_config:
+      row.eligibility_config != null &&
+      typeof row.eligibility_config === 'object'
+        ? (row.eligibility_config as Record<string, unknown>)
+        : {},
+    created_by: row.created_by == null ? null : String(row.created_by),
+    created_at: String(row.created_at),
+    updated_at: String(row.updated_at),
+    activation_create_idempotency_key:
+      row.activation_create_idempotency_key == null
+        ? null
+        : String(row.activation_create_idempotency_key),
+    privy_campaign_wallet_id:
+      row.privy_campaign_wallet_id == null
+        ? null
+        : String(row.privy_campaign_wallet_id),
+  };
+}
+
+export async function listSponsoredActivations(): Promise<
+  SponsoredActivationRow[]
+> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .order('created_at', { ascending: false });
+  if (error) {
+    console.error('listSponsoredActivations:', error);
+    throw new Error(error.message || 'Failed to list sponsored activations');
+  }
+  return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+}
+
+export async function getSponsoredActivationById(
+  id: string
+): Promise<SponsoredActivationRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('id', id)
+    .maybeSingle();
+  if (error) {
+    console.error('getSponsoredActivationById:', error);
+    throw new Error(error.message || 'Failed to load sponsored activation');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function getSponsoredActivationByCreateIdempotencyKey(
+  key: string
+): Promise<SponsoredActivationRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('activation_create_idempotency_key', key)
+    .maybeSingle();
+  if (error) {
+    console.error('getSponsoredActivationByCreateIdempotencyKey:', error);
+    throw new Error(
+      error.message || 'Failed to load sponsored activation by idempotency key'
+    );
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function countActivationRedemptions(
+  activationId: string
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('activation_redemption')
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', activationId);
+  if (error) {
+    console.error('countActivationRedemptions:', error);
+    throw new Error(error.message || 'Failed to count redemptions');
+  }
+  return count ?? 0;
+}
+
+export async function countActiveRewardItemsForActivation(
+  activationId: string
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('activation_reward_item')
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', activationId)
+    .eq('is_active', true);
+  if (error) {
+    console.error('countActiveRewardItemsForActivation:', error);
+    throw new Error(error.message || 'Failed to count reward items');
+  }
+  return count ?? 0;
+}
+
+export type CreateSponsoredActivationDbInput = {
+  slug: string;
+  title: string;
+  sponsor_name: string;
+  event_id?: string | null;
+  status: SponsoredActivationStatus;
+  settlement_rail: SettlementRail;
+  campaign_wallet_address: string;
+  venue_settlement_wallet_address: string;
+  usdc_asset_config: Record<string, unknown>;
+  max_redemptions?: number | null;
+  max_usdc_budget?: number | null;
+  starts_at: string;
+  ends_at: string;
+  eligibility_config: Record<string, unknown>;
+  created_by?: string | null;
+  activation_create_idempotency_key: string;
+  privy_campaign_wallet_id: string;
+};
+
+export async function createSponsoredActivation(
+  input: CreateSponsoredActivationDbInput
+): Promise<SponsoredActivationRow> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .insert({
+      slug: input.slug,
+      title: input.title,
+      sponsor_name: input.sponsor_name,
+      event_id: input.event_id ?? null,
+      status: input.status,
+      settlement_rail: input.settlement_rail,
+      campaign_wallet_address: input.campaign_wallet_address,
+      venue_settlement_wallet_address: input.venue_settlement_wallet_address,
+      usdc_asset_config: input.usdc_asset_config,
+      max_redemptions: input.max_redemptions ?? null,
+      max_usdc_budget: input.max_usdc_budget ?? null,
+      starts_at: input.starts_at,
+      ends_at: input.ends_at,
+      eligibility_config: input.eligibility_config,
+      created_by: input.created_by ?? null,
+      activation_create_idempotency_key:
+        input.activation_create_idempotency_key,
+      privy_campaign_wallet_id: input.privy_campaign_wallet_id,
+    })
+    .select('*')
+    .single();
+  if (error) {
+    console.error('createSponsoredActivation:', error);
+    throw new Error(error.message || 'Failed to create sponsored activation');
+  }
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function updateSponsoredActivation(
+  id: string,
+  patch: Record<string, unknown>
+): Promise<SponsoredActivationRow | null> {
+  const safePatch = { ...patch };
+  delete safePatch.usdc_settled_total;
+  delete safePatch.redemption_count_confirmed;
+
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(safePatch)
+    .eq('id', id)
+    .select('*')
+    .maybeSingle();
+  if (error) {
+    console.error('updateSponsoredActivation:', error);
+    throw new Error(error.message || 'Failed to update sponsored activation');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}

--- a/lib/schemas/__tests__/sponsored-activation.test.ts
+++ b/lib/schemas/__tests__/sponsored-activation.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getAddress } from 'viem';
 import {
+  adminCreateSponsoredActivationRequestSchema,
   createSponsoredActivationSchema,
   updateSponsoredActivationSchema,
 } from '../sponsored-activation';
@@ -209,6 +210,41 @@ describe('createSponsoredActivationSchema', () => {
     });
     expect(r.success).toBe(true);
     if (r.success) expect(r.data.event_id).toBe('evt_123');
+  });
+});
+
+describe('adminCreateSponsoredActivationRequestSchema', () => {
+  it('accepts Base create without campaign_wallet_address', () => {
+    const r = adminCreateSponsoredActivationRequestSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'pr-admin',
+      title: 'Public Records',
+      sponsor_name: 'Acme',
+      max_redemptions: 100,
+      ...validTime,
+      eligibility_config: { min_tier: 1 },
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects extra campaign_wallet_address (strict)', () => {
+    const r = adminCreateSponsoredActivationRequestSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      eligibility_config: {},
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
+      campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
+    });
+    expect(r.success).toBe(false);
   });
 });
 

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -143,6 +143,46 @@ export const createSponsoredActivationSchema =
     }
   });
 
+const adminCreateSponsoredActivationBaseObject =
+  createSponsoredActivationBaseObject.omit({ campaign_wallet_address: true });
+const adminCreateSponsoredActivationStellarObject =
+  createSponsoredActivationStellarObject.omit({
+    campaign_wallet_address: true,
+  });
+
+/**
+ * Admin POST body: `campaign_wallet_address` is provisioned server-side (Privy), not supplied by the client.
+ */
+export const adminCreateSponsoredActivationRequestSchema = z
+  .discriminatedUnion('settlement_rail', [
+    adminCreateSponsoredActivationBaseObject,
+    adminCreateSponsoredActivationStellarObject,
+  ])
+  .superRefine((data, ctx) => {
+    if (new Date(data.ends_at) <= new Date(data.starts_at)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'ends_at must be after starts_at',
+        path: ['ends_at'],
+      });
+    }
+    const hasRedemptions =
+      data.max_redemptions != null && data.max_redemptions > 0;
+    const hasBudget = data.max_usdc_budget != null && data.max_usdc_budget > 0;
+    if (!hasRedemptions && !hasBudget) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'At least one of max_redemptions or max_usdc_budget is required on create',
+        path: ['max_redemptions'],
+      });
+    }
+  });
+
+export type AdminCreateSponsoredActivationRequest = z.infer<
+  typeof adminCreateSponsoredActivationRequestSchema
+>;
+
 function mergeConfigParseIssues(
   result: z.SafeParseReturnType<unknown, unknown>,
   ctx: z.RefinementCtx,

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -54,6 +54,45 @@ export const stellarUsdcAssetConfigSchema = z
   })
   .strict();
 
+/**
+ * Full settlement bundle — rail must match wallet formats and `usdc_asset_config`.
+ * Used after admin PATCH merges existing row + patch so draft updates cannot save incoherent combinations.
+ */
+export const sponsoredActivationSettlementBundleSchema = z
+  .discriminatedUnion('settlement_rail', [
+    z
+      .object({
+        settlement_rail: z.literal('base'),
+        campaign_wallet_address: normalizedEvmAddressSchema,
+        venue_settlement_wallet_address: normalizedEvmAddressSchema,
+        usdc_asset_config: baseUsdcAssetConfigSchema,
+      })
+      .strict(),
+    z
+      .object({
+        settlement_rail: z.literal('stellar'),
+        campaign_wallet_address: stellarGAddressSchema,
+        venue_settlement_wallet_address: stellarGAddressSchema,
+        usdc_asset_config: stellarUsdcAssetConfigSchema,
+      })
+      .strict(),
+  ])
+  .superRefine((data, ctx) => {
+    if (
+      sameWalletAddress(
+        data.campaign_wallet_address,
+        data.venue_settlement_wallet_address
+      )
+    ) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message:
+          'campaign_wallet_address must differ from venue_settlement_wallet_address',
+        path: ['venue_settlement_wallet_address'],
+      });
+    }
+  });
+
 const positiveIntOrNullSchema = z.union([
   z.null(),
   z.number().int().positive(),

--- a/lib/spend-rail-config/index.ts
+++ b/lib/spend-rail-config/index.ts
@@ -1,3 +1,4 @@
+import { getAddress } from 'viem';
 import {
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
   isEvmAddress,
@@ -431,6 +432,57 @@ export function formatExplorerTxUrlForSpendLedger(
   }
 
   return null;
+}
+
+/** DB `settlement_rail` on `sponsored_activation` (Base vs Stellar USDC settlement). */
+export type SettlementExplorerRail = 'base' | 'stellar';
+
+export function getSettlementExplorerTxUrlTemplate(
+  rail: SettlementExplorerRail
+): string {
+  const parsed = parseRailsConfig();
+  return rail === 'base'
+    ? parsed.base.explorerTxUrlTemplate
+    : parsed.stellar.explorerTxUrlTemplate;
+}
+
+/**
+ * Explorer link for a settlement tx hash, using the same env templates as the spend ledger.
+ */
+export function formatSettlementExplorerTxUrl(
+  rail: SettlementExplorerRail,
+  txHash: string | null | undefined
+): string | null {
+  const spendRail = rail === 'base' ? 'base_usdc' : 'stellar_usdc';
+  return formatExplorerTxUrlForSpendLedger(spendRail, txHash);
+}
+
+/**
+ * Explorer link for a wallet/account on the activation settlement rail.
+ * Base: `{basescan-origin}/address/{checksummed}` derived from the Base tx template origin.
+ * Stellar: `{stellar expert explorer prefix}/account/{G-address}` from the Stellar tx template path.
+ */
+export function formatSettlementWalletExplorerUrl(
+  rail: SettlementExplorerRail,
+  walletAddress: string | null | undefined
+): string | null {
+  const trimmed = walletAddress?.trim();
+  if (!trimmed) return null;
+  const parsed = parseRailsConfig();
+  if (rail === 'base') {
+    if (!isEvmAddress(trimmed)) return null;
+    const addr = getAddress(trimmed as `0x${string}`);
+    const tpl = parsed.base.explorerTxUrlTemplate;
+    const m = tpl.match(/^(https?:\/\/[^/?#]+)/);
+    const origin = m?.[1] ?? 'https://basescan.org';
+    return `${origin}/address/${addr}`;
+  }
+  const st = stellarWalletAddressSchema.safeParse(trimmed.toUpperCase());
+  if (!st.success) return null;
+  const addr = st.data;
+  const tpl = parsed.stellar.explorerTxUrlTemplate;
+  const basePath = tpl.replace(/\/tx\/\{txHash\}\s*$/i, '').trimEnd();
+  return `${basePath}/account/${encodeURIComponent(addr)}`;
 }
 
 export function getSpendTreasuryWalletAddress(spendRail: SpendRail): string {

--- a/lib/spend-rail-config/settlement-explorer-url.test.ts
+++ b/lib/spend-rail-config/settlement-explorer-url.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  formatExplorerTxUrlForSpendLedger,
+  formatSettlementExplorerTxUrl,
+  formatSettlementWalletExplorerUrl,
+  getSettlementExplorerTxUrlTemplate,
+} from '@/lib/spend-rail-config/index';
+
+describe('settlement explorer helpers (sponsored activation)', () => {
+  it('exposes tx templates for base and stellar rails', () => {
+    expect(getSettlementExplorerTxUrlTemplate('base')).toContain('{txHash}');
+    expect(getSettlementExplorerTxUrlTemplate('stellar')).toContain('{txHash}');
+  });
+
+  it('delegates settlement tx URLs to spend ledger formatter', () => {
+    const h =
+      '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA';
+    expect(formatSettlementExplorerTxUrl('base', h)).toBe(
+      formatExplorerTxUrlForSpendLedger('base_usdc', h)
+    );
+  });
+
+  it('builds Base wallet explorer URL from template origin', () => {
+    expect(
+      formatSettlementWalletExplorerUrl(
+        'base',
+        '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+      )
+    ).toBe(
+      'https://basescan.org/address/0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266'
+    );
+  });
+
+  it('returns null for invalid Base wallet input', () => {
+    expect(formatSettlementWalletExplorerUrl('base', '0xbad')).toBeNull();
+  });
+
+  it('builds Stellar account explorer URL', () => {
+    const g = 'GBRPYHIL2CI3FNQ4BXLFMNDLFJUNPU2HY3ZMFSHONUCEOASW7QC7OX2H';
+    const url = formatSettlementWalletExplorerUrl('stellar', g);
+    expect(url).toContain('/account/');
+    expect(url).toContain(encodeURIComponent(g));
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-53: admin-only CRUD for sponsored activations and nested reward items, Privy campaign wallet provisioning on create, idempotency, immutability guards, a shared lifecycle helper for user flows, and explorer URLs using the same env-driven templates as the spend rail config.

## Changes

- Routes under `app/api/admin/sponsored-activations/` with `requireAdmin` and standard API helpers (no HTTP DELETE).
- `lib/db/sponsored-activations.ts` and `lib/db/activation-reward-items.ts` for Supabase access.
- `adminCreateSponsoredActivationRequestSchema` so the client cannot supply `campaign_wallet_address`; wallet is provisioned server-side.
- `createSponsoredActivationPrivyCampaignWallet` in `lib/api/privy.ts` (Base uses an Ethereum-format Privy server wallet; Stellar uses a Stellar-chain server wallet, both with idempotency keys).
- `lib/activation/lifecycle.ts` exports `canActivationAcceptUserRedemptionFlow`.
- `lib/activation/explorer-url.ts` plus settlement explorer helpers added to `lib/spend-rail-config/index.ts`.
- SQL migration `database/irl-53-sponsored-activation-admin-columns.sql` for create idempotency and Privy wallet id columns.

## Verification

- Targeted Vitest run for new and related tests (lifecycle, schema, admin routes, settlement explorer URL tests).
- `yarn lint` and `yarn build` (via pre-commit hook).

## Behavior notes

- New activations are always stored as `draft`. Moving to `active` requires at least one active reward item.
- `usdc_settled_total` and `redemption_count_confirmed` are ignored on PATCH at the DB layer.
- Rail, campaign wallet, venue wallet, and USDC asset config cannot be PATCHed once not draft or if any redemption row exists.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-53](https://linear.app/irlenergy/issue/IRL-53/implement-admin-sponsored-activation-crud-apis)

<div><a href="https://cursor.com/agents/bc-14312f18-68cc-42bc-9e72-3e35aca0fd87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-14312f18-68cc-42bc-9e72-3e35aca0fd87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

