### PR TITLE
Implement confirm purchase API for sponsored activations (IRL-54)

### DIFF
--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
@@ -6,8 +6,6 @@ const mockGetPrivyUserId = vi.fn();
 const mockGetActivation = vi.fn();
 const mockGetRedemptionById = vi.fn();
 const mockGetRewardItem = vi.fn();
-const mockCountLifetime = vi.fn();
-const mockCountDaily = vi.fn();
 const mockConfirmRpc = vi.fn();
 const mockGetPlayerByWallet = vi.fn();
 const mockCreateOrUpdatePlayer = vi.fn();
@@ -24,11 +22,6 @@ vi.mock('@/lib/db/sponsored-activations', () => ({
 
 vi.mock('@/lib/db/activation-redemptions', () => ({
   getActivationRedemptionById: (...a: unknown[]) => mockGetRedemptionById(...a),
-  countActivationPurchaseConfirmsForUserActivation: (...a: unknown[]) =>
-    mockCountLifetime(...a),
-  countActivationPurchaseConfirmsForUserActivationInUtcWindow: (
-    ...a: unknown[]
-  ) => mockCountDaily(...a),
   confirmActivationPurchaseAtomic: (...a: unknown[]) => mockConfirmRpc(...a),
 }));
 
@@ -139,8 +132,6 @@ beforeEach(() => {
     total_points: 100,
   });
   mockGetRewardItem.mockResolvedValue(rewardItem);
-  mockCountLifetime.mockResolvedValue(0);
-  mockCountDaily.mockResolvedValue(0);
   mockConfirmRpc.mockResolvedValue({
     outcome: 'created',
     playerTotalPoints: 90,
@@ -168,8 +159,10 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
       redemptionId,
       playerId: 1,
       walletAddress: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
+      maxPurchaseConfirmsPerUser: eligibilityConfig.max_events_per_user,
+      maxPurchaseConfirmsPerUserPerDay:
+        eligibilityConfig.max_events_per_user_per_day,
     });
-    expect(mockCountLifetime).toHaveBeenCalled();
   });
 
   it('returns 400 when points are insufficient', async () => {
@@ -229,8 +222,25 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     const j = await res.json();
     expect(j.data.redemption.status).toBe('ready_to_redeem');
     expect(j.data.player.total_points).toBe(90);
-    expect(mockCountLifetime).not.toHaveBeenCalled();
-    expect(mockCountDaily).not.toHaveBeenCalled();
+    expect(mockGetRewardItem).not.toHaveBeenCalled();
+  });
+
+  it('allows idempotent confirm when activation is paused (replay)', async () => {
+    mockGetActivation.mockResolvedValue({
+      ...activeActivation,
+      status: 'paused',
+    });
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
+    mockConfirmRpc.mockResolvedValue({
+      outcome: 'already_confirmed',
+      playerTotalPoints: 90,
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    expect(mockConfirmRpc).toHaveBeenCalled();
   });
 
   it('returns 400 when max_per_user is exceeded (RPC)', async () => {
@@ -273,9 +283,11 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     expect(res.status).toBe(401);
   });
 
-  it('returns 429 when daily confirm rate limit is exceeded', async () => {
+  it('returns 429 when daily confirm rate limit is exceeded (RPC)', async () => {
     mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
-    mockCountDaily.mockResolvedValue(2);
+    mockConfirmRpc.mockRejectedValue(
+      new Error('ACTIVATION_PURCHASE_DAILY_USER_LIMIT_EXCEEDED')
+    );
 
     const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
       params: { activationId: activeActivation.id },

--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
@@ -152,9 +152,8 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     let load = 0;
     mockGetRedemptionById.mockImplementation(async () => {
       load += 1;
-      return load === 1
-        ? redemptionRow('available')
-        : redemptionRow('ready_to_redeem');
+      if (load === 1) return redemptionRow('available');
+      return redemptionRow('ready_to_redeem');
     });
 
     const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {

--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
@@ -1,0 +1,300 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyWallet = vi.fn();
+const mockGetPrivyUserId = vi.fn();
+const mockGetActivation = vi.fn();
+const mockGetRedemptionById = vi.fn();
+const mockGetRewardItem = vi.fn();
+const mockCountLifetime = vi.fn();
+const mockCountDaily = vi.fn();
+const mockConfirmRpc = vi.fn();
+const mockGetPlayerByWallet = vi.fn();
+const mockCreateOrUpdatePlayer = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
+  getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+}));
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  getSponsoredActivationByIdOrSlug: (...a: unknown[]) =>
+    mockGetActivation(...a),
+}));
+
+vi.mock('@/lib/db/activation-redemptions', () => ({
+  getActivationRedemptionById: (...a: unknown[]) => mockGetRedemptionById(...a),
+  countActivationPurchaseConfirmsForUserActivation: (...a: unknown[]) =>
+    mockCountLifetime(...a),
+  countActivationPurchaseConfirmsForUserActivationInUtcWindow: (
+    ...a: unknown[]
+  ) => mockCountDaily(...a),
+  confirmActivationPurchaseAtomic: (...a: unknown[]) => mockConfirmRpc(...a),
+}));
+
+vi.mock('@/lib/db/activation-reward-items', () => ({
+  getActivationRewardItemById: (...a: unknown[]) => mockGetRewardItem(...a),
+}));
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerByWallet: (...a: unknown[]) => mockGetPlayerByWallet(...a),
+  createOrUpdatePlayer: (...a: unknown[]) => mockCreateOrUpdatePlayer(...a),
+}));
+
+import { POST } from '../route';
+
+const wallet = '0x1234567890123456789012345678901234567890';
+const redemptionId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const eligibilityConfig = {
+  max_events_per_user: 5,
+  max_events_per_user_per_day: 2,
+  required_checkpoint_ids: ['cp-1'],
+};
+
+const activeActivation = {
+  id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  slug: 'slug-1',
+  title: 'T',
+  sponsor_name: 'S',
+  event_id: null,
+  status: 'active' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  venue_settlement_wallet_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  usdc_asset_config: {},
+  max_redemptions: 10,
+  max_usdc_budget: null,
+  usdc_settled_total: 0,
+  redemption_count_confirmed: 0,
+  starts_at: '2026-01-01T00:00:00.000Z',
+  ends_at: '2027-01-01T00:00:00.000Z',
+  eligibility_config: eligibilityConfig,
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: null,
+  privy_campaign_wallet_id: null,
+};
+
+const rewardItem = {
+  id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  activation_id: activeActivation.id,
+  name: 'Drink',
+  hero_image_url: null,
+  description: null,
+  points_cost: 10,
+  usdc_amount: 5,
+  sort_order: 0,
+  is_active: true,
+  max_per_user: 1,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+function redemptionRow(
+  status: 'available' | 'ready_to_redeem'
+): Record<string, unknown> {
+  return {
+    id: redemptionId,
+    activation_id: activeActivation.id,
+    reward_item_id: rewardItem.id,
+    user_id: 1,
+    eligibility_event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+    status,
+    idempotency_key: `${activeActivation.id}:1:${rewardItem.id}`,
+    points_spent: status === 'ready_to_redeem' ? 10 : null,
+    usdc_amount_snapshot: status === 'ready_to_redeem' ? 5 : null,
+    purchase_confirmed_at:
+      status === 'ready_to_redeem' ? '2026-05-25T12:00:00.000Z' : null,
+    redeemed_at: null,
+    cancelled_reason: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function postReq(body: unknown, activationSegment = activeActivation.id) {
+  return new NextRequest(
+    `http://localhost/api/sponsored-activations/${activationSegment}/confirm-purchase`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockVerifyWallet.mockResolvedValue({
+    authorized: true,
+    userId: 'privy-user-1',
+  });
+  mockGetPrivyUserId.mockResolvedValue('privy-user-1');
+  mockGetActivation.mockResolvedValue(activeActivation);
+  mockGetPlayerByWallet.mockResolvedValue({
+    id: 1,
+    wallet_address: wallet,
+    total_points: 100,
+  });
+  mockGetRewardItem.mockResolvedValue(rewardItem);
+  mockCountLifetime.mockResolvedValue(0);
+  mockCountDaily.mockResolvedValue(0);
+  mockConfirmRpc.mockResolvedValue({
+    outcome: 'created',
+    playerTotalPoints: 90,
+  });
+});
+
+describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () => {
+  it('returns 200 with redemption and player points on success', async () => {
+    let load = 0;
+    mockGetRedemptionById.mockImplementation(async () => {
+      load += 1;
+      return load === 1
+        ? redemptionRow('available')
+        : redemptionRow('ready_to_redeem');
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.success).toBe(true);
+    expect(j.data.redemption.status).toBe('ready_to_redeem');
+    expect(j.data.player.total_points).toBe(90);
+    expect(mockConfirmRpc).toHaveBeenCalledWith({
+      redemptionId,
+      playerId: 1,
+      walletAddress: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
+    });
+    expect(mockCountLifetime).toHaveBeenCalled();
+  });
+
+  it('returns 400 when points are insufficient', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockConfirmRpc.mockRejectedValue(
+      new Error('ACTIVATION_PURCHASE_INSUFFICIENT_POINTS')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.success).toBe(false);
+    expect(j.error).toContain('enough points');
+  });
+
+  it('returns 400 when activation is not in a live user redemption window', async () => {
+    mockGetActivation.mockResolvedValue({
+      ...activeActivation,
+      status: 'paused',
+    });
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    expect(mockConfirmRpc).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when activation redemption cap is exceeded (RPC)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockConfirmRpc.mockRejectedValue(
+      new Error('ACTIVATION_PURCHASE_CAP_EXCEEDED')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('This reward is no longer available');
+  });
+
+  it('is idempotent when redemption is already ready_to_redeem', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
+    mockConfirmRpc.mockResolvedValue({
+      outcome: 'already_confirmed',
+      playerTotalPoints: 90,
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.data.redemption.status).toBe('ready_to_redeem');
+    expect(j.data.player.total_points).toBe(90);
+    expect(mockCountLifetime).not.toHaveBeenCalled();
+    expect(mockCountDaily).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when max_per_user is exceeded (RPC)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockConfirmRpc.mockRejectedValue(
+      new Error('ACTIVATION_PURCHASE_MAX_PER_USER')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('This reward is no longer available');
+  });
+
+  it('returns 401 when Privy wallet auth fails', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: false,
+      error: 'Unauthorized',
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(401);
+    expect(mockGetRedemptionById).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 when token userId does not match wallet ownership', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: true,
+      userId: 'privy-user-1',
+    });
+    mockGetPrivyUserId.mockResolvedValue('other-user');
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 429 when daily confirm rate limit is exceeded', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockCountDaily.mockResolvedValue(2);
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(429);
+    const j = await res.json();
+    expect(j.error).toBe('Too many eligibility requests today');
+  });
+
+  it('rejects non-strict JSON bodies via Zod', async () => {
+    const res = await POST(
+      postReq({
+        walletAddress: wallet,
+        redemptionId,
+        extra: true,
+      } as Record<string, unknown>),
+      { params: { activationId: activeActivation.id } }
+    );
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/route.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/route.ts
@@ -6,9 +6,6 @@ export const dynamic = 'force-dynamic';
 
 type RouteParams = { params: { activationId: string } };
 
-/**
- * POST /api/sponsored-activations/{activationIdOrSlug}/confirm-purchase
- */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   const activationKey = params.activationId?.trim() ?? '';
 

--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/route.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { runConfirmActivationPurchase } from '@/lib/activation/confirm-purchase';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { activationId: string } };
+
+/**
+ * POST /api/sponsored-activations/{activationIdOrSlug}/confirm-purchase
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const activationKey = params.activationId?.trim() ?? '';
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  const result = await runConfirmActivationPurchase({
+    request,
+    activationKey,
+    body,
+  });
+  if (!result.ok) return result.response;
+  return apiSuccess(result.body);
+}

--- a/database/confirm-activation-purchase-atomic.sql
+++ b/database/confirm-activation-purchase-atomic.sql
@@ -1,0 +1,162 @@
+-- IRL-54: Atomic confirm purchase for sponsored activations (points + redemption + cap increment).
+-- Idempotent when redemption is already past `available` (no second deduct, no cap bump).
+
+CREATE OR REPLACE FUNCTION confirm_activation_purchase_atomic(
+  p_redemption_id UUID,
+  p_player_id BIGINT,
+  p_wallet_address TEXT
+) RETURNS TABLE (
+  outcome TEXT,
+  player_total_points INTEGER
+) AS $$
+DECLARE
+  v_red activation_redemption%ROWTYPE;
+  v_act sponsored_activation%ROWTYPE;
+  v_item activation_reward_item%ROWTYPE;
+  v_player_total INTEGER;
+  v_player_row_id BIGINT;
+  v_points INTEGER;
+  v_nt INTEGER;
+BEGIN
+  IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_WALLET_REQUIRED';
+  END IF;
+
+  SELECT *
+  INTO v_red
+  FROM activation_redemption
+  WHERE id = p_redemption_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_NOT_FOUND';
+  END IF;
+
+  IF v_red.user_id IS DISTINCT FROM p_player_id THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_MISMATCH';
+  END IF;
+
+  -- Idempotent: already confirmed or later success path (no mutation).
+  IF v_red.status IN (
+    'ready_to_redeem',
+    'redeemed',
+    'settlement_pending',
+    'settlement_confirmed',
+    'settlement_failed',
+    'purchase_confirmed'
+  ) THEN
+    SELECT COALESCE(total_points, 0)::INTEGER
+    INTO v_player_total
+    FROM players
+    WHERE id = p_player_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_NOT_FOUND';
+    END IF;
+
+    RETURN QUERY SELECT 'already_confirmed'::TEXT, v_player_total;
+    RETURN;
+  END IF;
+
+  IF v_red.status IS DISTINCT FROM 'available' THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_INVALID_STATUS';
+  END IF;
+
+  SELECT *
+  INTO v_act
+  FROM sponsored_activation
+  WHERE id = v_red.activation_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_ACTIVATION_NOT_FOUND';
+  END IF;
+
+  SELECT *
+  INTO v_item
+  FROM activation_reward_item
+  WHERE id = v_red.reward_item_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_item.activation_id IS DISTINCT FROM v_act.id THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_REWARD_ITEM_MISMATCH';
+  END IF;
+
+  IF NOT v_item.is_active THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_REWARD_INACTIVE';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_nt
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_red.activation_id
+    AND ar.user_id = v_red.user_id
+    AND ar.reward_item_id = v_red.reward_item_id
+    AND ar.status NOT IN (
+      'redeemed',
+      'settlement_confirmed',
+      'cancelled',
+      'expired',
+      'settlement_failed'
+    );
+
+  IF v_nt > v_item.max_per_user THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_MAX_PER_USER';
+  END IF;
+
+  IF v_act.max_redemptions IS NOT NULL
+     AND v_act.redemption_count_confirmed >= v_act.max_redemptions THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_CAP_EXCEEDED';
+  END IF;
+
+  v_points := v_item.points_cost::INTEGER;
+  IF v_points IS NULL OR v_points < 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_INVALID_POINTS_COST';
+  END IF;
+
+  SELECT id, COALESCE(total_points, 0)::INTEGER
+  INTO v_player_row_id, v_player_total
+  FROM players
+  WHERE id = p_player_id
+    AND lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_MISMATCH';
+  END IF;
+
+  IF v_points > 0 THEN
+    IF v_player_total < v_points THEN
+      RAISE EXCEPTION 'ACTIVATION_PURCHASE_INSUFFICIENT_POINTS';
+    END IF;
+
+    UPDATE players
+    SET
+      total_points = COALESCE(total_points, 0) - v_points,
+      updated_at = NOW()
+    WHERE id = v_player_row_id
+    RETURNING total_points::INTEGER INTO v_player_total;
+  END IF;
+
+  UPDATE sponsored_activation
+  SET
+    redemption_count_confirmed = redemption_count_confirmed + 1,
+    updated_at = NOW()
+  WHERE id = v_act.id;
+
+  UPDATE activation_redemption
+  SET
+    status = 'ready_to_redeem',
+    points_spent = v_points,
+    usdc_amount_snapshot = v_item.usdc_amount,
+    purchase_confirmed_at = COALESCE(purchase_confirmed_at, NOW()),
+    updated_at = NOW()
+  WHERE id = v_red.id;
+
+  RETURN QUERY SELECT 'created'::TEXT, v_player_total;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION confirm_activation_purchase_atomic IS
+  'IRL-54: Atomically deduct points (when points_cost > 0), bump activation redemption_count_confirmed, '
+  'and move activation_redemption from available to ready_to_redeem. Idempotent for later statuses.';

--- a/database/confirm-activation-purchase-atomic.sql
+++ b/database/confirm-activation-purchase-atomic.sql
@@ -4,7 +4,9 @@
 CREATE OR REPLACE FUNCTION confirm_activation_purchase_atomic(
   p_redemption_id UUID,
   p_player_id BIGINT,
-  p_wallet_address TEXT
+  p_wallet_address TEXT,
+  p_max_purchase_confirms_per_user INTEGER,
+  p_max_purchase_confirms_per_user_per_day INTEGER
 ) RETURNS TABLE (
   outcome TEXT,
   player_total_points INTEGER
@@ -17,6 +19,8 @@ DECLARE
   v_player_row_id BIGINT;
   v_points INTEGER;
   v_nt INTEGER;
+  v_lifetime_confirms INTEGER;
+  v_daily_confirms INTEGER;
 BEGIN
   IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
     RAISE EXCEPTION 'ACTIVATION_PURCHASE_WALLET_REQUIRED';
@@ -70,6 +74,32 @@ BEGIN
 
   IF NOT FOUND THEN
     RAISE EXCEPTION 'ACTIVATION_PURCHASE_ACTIVATION_NOT_FOUND';
+  END IF;
+
+  -- Per-user purchase caps (activation eligibility config), evaluated after activation row lock
+  -- so concurrent confirms for the same user cannot race past limits (IRL-54).
+  SELECT COUNT(*)::INTEGER
+  INTO v_lifetime_confirms
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_act.id
+    AND ar.user_id = v_red.user_id
+    AND ar.purchase_confirmed_at IS NOT NULL;
+
+  IF v_lifetime_confirms >= p_max_purchase_confirms_per_user THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_LIFETIME_USER_LIMIT_EXCEEDED';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_daily_confirms
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_act.id
+    AND ar.user_id = v_red.user_id
+    AND ar.purchase_confirmed_at IS NOT NULL
+    AND (ar.purchase_confirmed_at AT TIME ZONE 'UTC')::date =
+        (now() AT TIME ZONE 'UTC')::date;
+
+  IF v_daily_confirms >= p_max_purchase_confirms_per_user_per_day THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_DAILY_USER_LIMIT_EXCEEDED';
   END IF;
 
   SELECT *
@@ -159,4 +189,5 @@ $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION confirm_activation_purchase_atomic IS
   'IRL-54: Atomically deduct points (when points_cost > 0), bump activation redemption_count_confirmed, '
-  'and move activation_redemption from available to ready_to_redeem. Idempotent for later statuses.';
+  'and move activation_redemption from available to ready_to_redeem. Idempotent for later statuses. '
+  'Enforces per-user lifetime and UTC-daily purchase caps after locking the activation row.';

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -19,6 +19,7 @@ import {
   countActivationPurchaseConfirmsForUserActivationInUtcWindow,
   getActivationRedemptionById,
   type ActivationRedemptionRow,
+  type ConfirmActivationPurchaseRpcResult,
 } from '@/lib/db/activation-redemptions';
 import { getActivationRewardItemById } from '@/lib/db/activation-reward-items';
 import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
@@ -51,14 +52,12 @@ async function assertPrivyWalletAuth(
 }
 
 async function resolvePlayerForWallet(
-  walletAddress: string
+  normalizedWalletAddress: string
 ): Promise<{ playerId: number }> {
-  const trimmed = walletAddress.trim();
-  const normalized = tryNormalizeEvmAddress(trimmed) ?? trimmed;
-  let player = await getPlayerByWallet(normalized);
+  let player = await getPlayerByWallet(normalizedWalletAddress);
   if (!player?.id) {
     player = await createOrUpdatePlayer({
-      wallet_address: normalized,
+      wallet_address: normalizedWalletAddress,
       total_points: 0,
     });
   }
@@ -104,9 +103,6 @@ function mapRpcOrUnexpectedError(message: string): {
   return { status: 500, error: 'Something went wrong' };
 }
 
-/**
- * POST handler body for sponsored activation confirm purchase (IRL-54).
- */
 export async function runConfirmActivationPurchase(input: {
   request: NextRequest;
   activationKey: string;
@@ -132,8 +128,10 @@ export async function runConfirmActivationPurchase(input: {
   }
 
   const { walletAddress, redemptionId } = parsed.data;
+  const walletKey =
+    tryNormalizeEvmAddress(walletAddress.trim()) ?? walletAddress.trim();
 
-  const gate = await assertPrivyWalletAuth(input.request, walletAddress);
+  const gate = await assertPrivyWalletAuth(input.request, walletKey);
   if (!gate.ok) return { ok: false, response: gate.response };
 
   const activation = await getSponsoredActivationByIdOrSlug(activationSegment);
@@ -176,7 +174,7 @@ export async function runConfirmActivationPurchase(input: {
 
   let playerId: number;
   try {
-    const resolved = await resolvePlayerForWallet(walletAddress);
+    const resolved = await resolvePlayerForWallet(walletKey);
     playerId = resolved.playerId;
   } catch (e) {
     console.error('confirm purchase (resolve player):', e);
@@ -229,25 +227,24 @@ export async function runConfirmActivationPurchase(input: {
     };
   }
 
-  const walletForRpc =
-    tryNormalizeEvmAddress(walletAddress.trim()) ?? walletAddress.trim();
-
   if (redemption.status === 'available') {
     let lifetimeCount: number;
     let dailyCount: number;
     try {
-      lifetimeCount = await countActivationPurchaseConfirmsForUserActivation({
-        activationId: activation.id,
-        userId: playerId,
-      });
       const { startIso, endIso } = getUtcDayBounds();
-      dailyCount =
-        await countActivationPurchaseConfirmsForUserActivationInUtcWindow({
+      const results = await Promise.all([
+        countActivationPurchaseConfirmsForUserActivation({
+          activationId: activation.id,
+          userId: playerId,
+        }),
+        countActivationPurchaseConfirmsForUserActivationInUtcWindow({
           activationId: activation.id,
           userId: playerId,
           purchaseConfirmedAtGte: startIso,
           purchaseConfirmedAtLt: endIso,
-        });
+        }),
+      ]);
+      [lifetimeCount, dailyCount] = results;
     } catch (e) {
       console.error('confirm purchase (rate limit counts):', e);
       return {
@@ -278,12 +275,12 @@ export async function runConfirmActivationPurchase(input: {
     }
   }
 
-  let rpc: { outcome: string; playerTotalPoints: number };
+  let rpc: ConfirmActivationPurchaseRpcResult;
   try {
     rpc = await confirmActivationPurchaseAtomic({
       redemptionId,
       playerId,
-      walletAddress: walletForRpc,
+      walletAddress: walletKey,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : '';

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -1,0 +1,321 @@
+import { NextRequest, type NextResponse } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import {
+  apiError,
+  apiValidationError,
+  type ApiResponse,
+} from '@/lib/api/response';
+import {
+  buildActivationRedemptionIdempotencyKey,
+  checkEligibilityEventRateLimits,
+} from '@/lib/activation/eligibility';
+import { canActivationAcceptUserRedemptionFlow } from '@/lib/activation/lifecycle';
+import {
+  confirmActivationPurchaseAtomic,
+  countActivationPurchaseConfirmsForUserActivation,
+  countActivationPurchaseConfirmsForUserActivationInUtcWindow,
+  getActivationRedemptionById,
+  type ActivationRedemptionRow,
+} from '@/lib/db/activation-redemptions';
+import { getActivationRewardItemById } from '@/lib/db/activation-reward-items';
+import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
+import { safeParseActivationEligibilityRulesConfig } from '@/lib/schemas/activation-eligibility-config';
+import { activationConfirmPurchaseBodySchema } from '@/lib/schemas/activation-confirm-purchase';
+import { getUtcDayBounds } from '@/lib/utils/date';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+export type ConfirmPurchaseSuccessBody = {
+  redemption: ActivationRedemptionRow;
+  player: { total_points: number };
+};
+
+async function assertPrivyWalletAuth(
+  request: NextRequest,
+  walletAddress: string
+): Promise<
+  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
+  }
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return { ok: false, response: apiError('Unauthorized', 401) };
+  }
+  return { ok: true };
+}
+
+async function resolvePlayerForWallet(
+  walletAddress: string
+): Promise<{ playerId: number }> {
+  const trimmed = walletAddress.trim();
+  const normalized = tryNormalizeEvmAddress(trimmed) ?? trimmed;
+  let player = await getPlayerByWallet(normalized);
+  if (!player?.id) {
+    player = await createOrUpdatePlayer({
+      wallet_address: normalized,
+      total_points: 0,
+    });
+  }
+  if (!player?.id) {
+    throw new Error('Failed to resolve player for wallet');
+  }
+  return { playerId: player.id };
+}
+
+function mapRpcOrUnexpectedError(message: string): {
+  status: 400 | 404 | 500;
+  error: string;
+} {
+  if (message.includes('ACTIVATION_PURCHASE_INSUFFICIENT_POINTS')) {
+    return {
+      status: 400,
+      error: 'You do not have enough points for this reward',
+    };
+  }
+  if (
+    message.includes('ACTIVATION_PURCHASE_CAP_EXCEEDED') ||
+    message.includes('ACTIVATION_PURCHASE_MAX_PER_USER') ||
+    message.includes('ACTIVATION_PURCHASE_REWARD_INACTIVE')
+  ) {
+    return { status: 400, error: 'This reward is no longer available' };
+  }
+  if (message.includes('ACTIVATION_PURCHASE_INVALID_STATUS')) {
+    return { status: 400, error: 'Unable to confirm this purchase' };
+  }
+  if (
+    message.includes('ACTIVATION_PURCHASE_NOT_FOUND') ||
+    message.includes('ACTIVATION_PURCHASE_ACTIVATION_NOT_FOUND') ||
+    message.includes('ACTIVATION_PURCHASE_REWARD_ITEM_MISMATCH')
+  ) {
+    return { status: 404, error: 'Unable to confirm this purchase' };
+  }
+  if (
+    message.includes('ACTIVATION_PURCHASE_PLAYER_MISMATCH') ||
+    message.includes('ACTIVATION_PURCHASE_PLAYER_NOT_FOUND')
+  ) {
+    return { status: 400, error: 'Unable to confirm this purchase' };
+  }
+  return { status: 500, error: 'Something went wrong' };
+}
+
+/**
+ * POST handler body for sponsored activation confirm purchase (IRL-54).
+ */
+export async function runConfirmActivationPurchase(input: {
+  request: NextRequest;
+  activationKey: string;
+  body: unknown;
+}): Promise<
+  | {
+      ok: true;
+      body: ConfirmPurchaseSuccessBody;
+    }
+  | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const activationSegment = input.activationKey.trim();
+  if (!activationSegment) {
+    return {
+      ok: false,
+      response: apiError('Missing activation id or slug', 400),
+    };
+  }
+
+  const parsed = activationConfirmPurchaseBodySchema.safeParse(input.body);
+  if (!parsed.success) {
+    return { ok: false, response: apiValidationError(parsed.error) };
+  }
+
+  const { walletAddress, redemptionId } = parsed.data;
+
+  const gate = await assertPrivyWalletAuth(input.request, walletAddress);
+  if (!gate.ok) return { ok: false, response: gate.response };
+
+  const activation = await getSponsoredActivationByIdOrSlug(activationSegment);
+  if (!activation) {
+    return {
+      ok: false,
+      response: apiError('Sponsored activation not found', 404),
+    };
+  }
+
+  const configParse = safeParseActivationEligibilityRulesConfig(
+    activation.eligibility_config
+  );
+  if (!configParse.success) {
+    return {
+      ok: false,
+      response: apiError(
+        'Activation eligibility configuration is invalid',
+        400
+      ),
+    };
+  }
+  const rulesConfig = configParse.data;
+
+  if (
+    !canActivationAcceptUserRedemptionFlow({
+      status: activation.status,
+      starts_at: activation.starts_at,
+      ends_at: activation.ends_at,
+    })
+  ) {
+    return {
+      ok: false,
+      response: apiError(
+        'Activation is not accepting redemptions right now',
+        400
+      ),
+    };
+  }
+
+  let playerId: number;
+  try {
+    const resolved = await resolvePlayerForWallet(walletAddress);
+    playerId = resolved.playerId;
+  } catch (e) {
+    console.error('confirm purchase (resolve player):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  const redemption = await getActivationRedemptionById(redemptionId);
+  if (!redemption || redemption.activation_id !== activation.id) {
+    return {
+      ok: false,
+      response: apiError('Unable to confirm this purchase', 404),
+    };
+  }
+  if (redemption.user_id !== playerId) {
+    return {
+      ok: false,
+      response: apiError('Unable to confirm this purchase', 404),
+    };
+  }
+
+  const expectedKey = buildActivationRedemptionIdempotencyKey({
+    activationId: activation.id,
+    playerId,
+    rewardItemId: redemption.reward_item_id,
+  });
+  if (redemption.idempotency_key !== expectedKey) {
+    return {
+      ok: false,
+      response: apiError('Unable to confirm this purchase', 400),
+    };
+  }
+
+  const rewardItem = await getActivationRewardItemById(
+    activation.id,
+    redemption.reward_item_id
+  );
+  if (!rewardItem) {
+    return {
+      ok: false,
+      response: apiError('Unable to confirm this purchase', 404),
+    };
+  }
+  if (!rewardItem.is_active) {
+    return {
+      ok: false,
+      response: apiError('This reward is no longer available', 400),
+    };
+  }
+
+  const walletForRpc =
+    tryNormalizeEvmAddress(walletAddress.trim()) ?? walletAddress.trim();
+
+  if (redemption.status === 'available') {
+    let lifetimeCount: number;
+    let dailyCount: number;
+    try {
+      lifetimeCount = await countActivationPurchaseConfirmsForUserActivation({
+        activationId: activation.id,
+        userId: playerId,
+      });
+      const { startIso, endIso } = getUtcDayBounds();
+      dailyCount =
+        await countActivationPurchaseConfirmsForUserActivationInUtcWindow({
+          activationId: activation.id,
+          userId: playerId,
+          purchaseConfirmedAtGte: startIso,
+          purchaseConfirmedAtLt: endIso,
+        });
+    } catch (e) {
+      console.error('confirm purchase (rate limit counts):', e);
+      return {
+        ok: false,
+        response: apiError('Something went wrong', 500),
+      };
+    }
+
+    const rate = checkEligibilityEventRateLimits({
+      config: rulesConfig,
+      lifetimeCountBeforeInsert: lifetimeCount,
+      dailyCountBeforeInsert: dailyCount,
+    });
+    if (rate === 'daily_exceeded') {
+      return {
+        ok: false,
+        response: apiError('Too many eligibility requests today', 429),
+      };
+    }
+    if (rate === 'lifetime_exceeded') {
+      return {
+        ok: false,
+        response: apiError(
+          'Eligibility limit reached for this activation',
+          400
+        ),
+      };
+    }
+  }
+
+  let rpc: { outcome: string; playerTotalPoints: number };
+  try {
+    rpc = await confirmActivationPurchaseAtomic({
+      redemptionId,
+      playerId,
+      walletAddress: walletForRpc,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : '';
+    const mapped = mapRpcOrUnexpectedError(msg);
+    return {
+      ok: false,
+      response: apiError(mapped.error, mapped.status),
+    };
+  }
+
+  let fresh: ActivationRedemptionRow | null;
+  try {
+    fresh = await getActivationRedemptionById(redemptionId);
+  } catch (e) {
+    console.error('confirm purchase (reload redemption):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+  if (!fresh) {
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  return {
+    ok: true,
+    body: {
+      redemption: fresh,
+      player: { total_points: rpc.playerTotalPoints },
+    },
+  };
+}

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -8,15 +8,10 @@ import {
   apiValidationError,
   type ApiResponse,
 } from '@/lib/api/response';
-import {
-  buildActivationRedemptionIdempotencyKey,
-  checkEligibilityEventRateLimits,
-} from '@/lib/activation/eligibility';
+import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import { canActivationAcceptUserRedemptionFlow } from '@/lib/activation/lifecycle';
 import {
   confirmActivationPurchaseAtomic,
-  countActivationPurchaseConfirmsForUserActivation,
-  countActivationPurchaseConfirmsForUserActivationInUtcWindow,
   getActivationRedemptionById,
   type ActivationRedemptionRow,
   type ConfirmActivationPurchaseRpcResult,
@@ -26,13 +21,30 @@ import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { safeParseActivationEligibilityRulesConfig } from '@/lib/schemas/activation-eligibility-config';
 import { activationConfirmPurchaseBodySchema } from '@/lib/schemas/activation-confirm-purchase';
-import { getUtcDayBounds } from '@/lib/utils/date';
+import type { ActivationRedemptionStatus } from '@/lib/schemas/activation-redemption';
 import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 
 export type ConfirmPurchaseSuccessBody = {
   redemption: ActivationRedemptionRow;
   player: { total_points: number };
 };
+
+/** Matches `confirm_activation_purchase_atomic` idempotent early-return statuses. */
+const PURCHASE_CONFIRM_IDEMPOTENT_STATUSES =
+  new Set<ActivationRedemptionStatus>([
+    'ready_to_redeem',
+    'redeemed',
+    'settlement_pending',
+    'settlement_confirmed',
+    'settlement_failed',
+    'purchase_confirmed',
+  ]);
+
+function isActivationPurchaseConfirmIdempotentReplay(
+  status: ActivationRedemptionStatus
+): boolean {
+  return PURCHASE_CONFIRM_IDEMPOTENT_STATUSES.has(status);
+}
 
 async function assertPrivyWalletAuth(
   request: NextRequest,
@@ -68,7 +80,7 @@ async function resolvePlayerForWallet(
 }
 
 function mapRpcOrUnexpectedError(message: string): {
-  status: 400 | 404 | 500;
+  status: 400 | 404 | 429 | 500;
   error: string;
 } {
   if (message.includes('ACTIVATION_PURCHASE_INSUFFICIENT_POINTS')) {
@@ -83,6 +95,18 @@ function mapRpcOrUnexpectedError(message: string): {
     message.includes('ACTIVATION_PURCHASE_REWARD_INACTIVE')
   ) {
     return { status: 400, error: 'This reward is no longer available' };
+  }
+  if (message.includes('ACTIVATION_PURCHASE_DAILY_USER_LIMIT_EXCEEDED')) {
+    return {
+      status: 429,
+      error: 'Too many eligibility requests today',
+    };
+  }
+  if (message.includes('ACTIVATION_PURCHASE_LIFETIME_USER_LIMIT_EXCEEDED')) {
+    return {
+      status: 400,
+      error: 'Eligibility limit reached for this activation',
+    };
   }
   if (message.includes('ACTIVATION_PURCHASE_INVALID_STATUS')) {
     return { status: 400, error: 'Unable to confirm this purchase' };
@@ -156,22 +180,6 @@ export async function runConfirmActivationPurchase(input: {
   }
   const rulesConfig = configParse.data;
 
-  if (
-    !canActivationAcceptUserRedemptionFlow({
-      status: activation.status,
-      starts_at: activation.starts_at,
-      ends_at: activation.ends_at,
-    })
-  ) {
-    return {
-      ok: false,
-      response: apiError(
-        'Activation is not accepting redemptions right now',
-        400
-      ),
-    };
-  }
-
   let playerId: number;
   try {
     const resolved = await resolvePlayerForWallet(walletKey);
@@ -210,67 +218,37 @@ export async function runConfirmActivationPurchase(input: {
     };
   }
 
-  const rewardItem = await getActivationRewardItemById(
-    activation.id,
-    redemption.reward_item_id
-  );
-  if (!rewardItem) {
-    return {
-      ok: false,
-      response: apiError('Unable to confirm this purchase', 404),
-    };
-  }
-  if (!rewardItem.is_active) {
-    return {
-      ok: false,
-      response: apiError('This reward is no longer available', 400),
-    };
-  }
-
-  if (redemption.status === 'available') {
-    let lifetimeCount: number;
-    let dailyCount: number;
-    try {
-      const { startIso, endIso } = getUtcDayBounds();
-      const results = await Promise.all([
-        countActivationPurchaseConfirmsForUserActivation({
-          activationId: activation.id,
-          userId: playerId,
-        }),
-        countActivationPurchaseConfirmsForUserActivationInUtcWindow({
-          activationId: activation.id,
-          userId: playerId,
-          purchaseConfirmedAtGte: startIso,
-          purchaseConfirmedAtLt: endIso,
-        }),
-      ]);
-      [lifetimeCount, dailyCount] = results;
-    } catch (e) {
-      console.error('confirm purchase (rate limit counts):', e);
-      return {
-        ok: false,
-        response: apiError('Something went wrong', 500),
-      };
-    }
-
-    const rate = checkEligibilityEventRateLimits({
-      config: rulesConfig,
-      lifetimeCountBeforeInsert: lifetimeCount,
-      dailyCountBeforeInsert: dailyCount,
-    });
-    if (rate === 'daily_exceeded') {
-      return {
-        ok: false,
-        response: apiError('Too many eligibility requests today', 429),
-      };
-    }
-    if (rate === 'lifetime_exceeded') {
+  if (!isActivationPurchaseConfirmIdempotentReplay(redemption.status)) {
+    if (
+      !canActivationAcceptUserRedemptionFlow({
+        status: activation.status,
+        starts_at: activation.starts_at,
+        ends_at: activation.ends_at,
+      })
+    ) {
       return {
         ok: false,
         response: apiError(
-          'Eligibility limit reached for this activation',
+          'Activation is not accepting redemptions right now',
           400
         ),
+      };
+    }
+
+    const rewardItem = await getActivationRewardItemById(
+      activation.id,
+      redemption.reward_item_id
+    );
+    if (!rewardItem) {
+      return {
+        ok: false,
+        response: apiError('Unable to confirm this purchase', 404),
+      };
+    }
+    if (!rewardItem.is_active) {
+      return {
+        ok: false,
+        response: apiError('This reward is no longer available', 400),
       };
     }
   }
@@ -281,6 +259,8 @@ export async function runConfirmActivationPurchase(input: {
       redemptionId,
       playerId,
       walletAddress: walletKey,
+      maxPurchaseConfirmsPerUser: rulesConfig.max_events_per_user,
+      maxPurchaseConfirmsPerUserPerDay: rulesConfig.max_events_per_user_per_day,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : '';

--- a/lib/db/activation-redemptions.ts
+++ b/lib/db/activation-redemptions.ts
@@ -9,11 +9,31 @@ export type ActivationRedemptionRow = {
   eligibility_event_id: string;
   status: ActivationRedemptionStatus;
   idempotency_key: string;
+  points_spent: number | null;
+  usdc_amount_snapshot: number | null;
+  purchase_confirmed_at: string | null;
+  redeemed_at: string | null;
+  cancelled_reason: string | null;
   created_at: string;
   updated_at: string;
 };
 
 const TABLE = 'activation_redemption';
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+}
+
+function toIntOrNull(value: unknown): number | null {
+  if (value === null || value === undefined) return null;
+  const n = toNumber(value);
+  return Number.isNaN(n) ? null : Math.trunc(n);
+}
 
 function normalizeRow(row: Record<string, unknown>): ActivationRedemptionRow {
   return {
@@ -24,6 +44,19 @@ function normalizeRow(row: Record<string, unknown>): ActivationRedemptionRow {
     eligibility_event_id: String(row.eligibility_event_id),
     status: row.status as ActivationRedemptionStatus,
     idempotency_key: String(row.idempotency_key),
+    points_spent: toIntOrNull(row.points_spent),
+    usdc_amount_snapshot:
+      row.usdc_amount_snapshot === null ||
+      row.usdc_amount_snapshot === undefined
+        ? null
+        : toNumber(row.usdc_amount_snapshot),
+    purchase_confirmed_at:
+      row.purchase_confirmed_at == null
+        ? null
+        : String(row.purchase_confirmed_at),
+    redeemed_at: row.redeemed_at == null ? null : String(row.redeemed_at),
+    cancelled_reason:
+      row.cancelled_reason == null ? null : String(row.cancelled_reason),
     created_at: String(row.created_at),
     updated_at: String(row.updated_at),
   };
@@ -98,6 +131,125 @@ export async function insertActivationRedemption(
     throw new Error(error.message || 'Failed to create redemption');
   }
   return normalizeRow(data as Record<string, unknown>);
+}
+
+export async function getActivationRedemptionById(
+  redemptionId: string
+): Promise<ActivationRedemptionRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('id', redemptionId)
+    .maybeSingle();
+  if (error) {
+    console.error('getActivationRedemptionById:', error);
+    throw new Error(error.message || 'Failed to load redemption');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+/** Counts completed confirm-purchase outcomes for rate limits (IRL-54). */
+export async function countActivationPurchaseConfirmsForUserActivation(input: {
+  activationId: string;
+  userId: number;
+}): Promise<number> {
+  const { count, error } = await supabase
+    .from(TABLE)
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', input.activationId)
+    .eq('user_id', input.userId)
+    .not('purchase_confirmed_at', 'is', null);
+  if (error) {
+    console.error('countActivationPurchaseConfirmsForUserActivation:', error);
+    throw new Error(error.message || 'Failed to count purchase confirms');
+  }
+  return count ?? 0;
+}
+
+export async function countActivationPurchaseConfirmsForUserActivationInUtcWindow(input: {
+  activationId: string;
+  userId: number;
+  purchaseConfirmedAtGte: string;
+  purchaseConfirmedAtLt: string;
+}): Promise<number> {
+  const { count, error } = await supabase
+    .from(TABLE)
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', input.activationId)
+    .eq('user_id', input.userId)
+    .not('purchase_confirmed_at', 'is', null)
+    .gte('purchase_confirmed_at', input.purchaseConfirmedAtGte)
+    .lt('purchase_confirmed_at', input.purchaseConfirmedAtLt);
+  if (error) {
+    console.error(
+      'countActivationPurchaseConfirmsForUserActivationInUtcWindow:',
+      error
+    );
+    throw new Error(error.message || 'Failed to count daily purchase confirms');
+  }
+  return count ?? 0;
+}
+
+export type ConfirmActivationPurchaseRpcResult = {
+  outcome: 'created' | 'already_confirmed';
+  playerTotalPoints: number;
+};
+
+function readConfirmActivationPurchaseRpcRow(
+  data: unknown
+): ConfirmActivationPurchaseRpcResult | null {
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const outcome = r.outcome;
+  const ptsRaw = r.player_total_points ?? r.playerTotalPoints;
+  const pts =
+    typeof ptsRaw === 'number' && Number.isFinite(ptsRaw)
+      ? ptsRaw
+      : typeof ptsRaw === 'string'
+        ? parseInt(ptsRaw, 10)
+        : NaN;
+  if (
+    (outcome !== 'created' && outcome !== 'already_confirmed') ||
+    !Number.isFinite(pts)
+  ) {
+    return null;
+  }
+  return { outcome, playerTotalPoints: pts };
+}
+
+/**
+ * Atomically deduct points (when configured), bump activation cap counter, and move redemption
+ * to `ready_to_redeem`. Requires `confirm_activation_purchase_atomic` in the database (IRL-54).
+ */
+export async function confirmActivationPurchaseAtomic(input: {
+  redemptionId: string;
+  playerId: number;
+  walletAddress: string;
+}): Promise<ConfirmActivationPurchaseRpcResult> {
+  const { data, error } = await supabase.rpc(
+    'confirm_activation_purchase_atomic',
+    {
+      p_redemption_id: input.redemptionId,
+      p_player_id: input.playerId,
+      p_wallet_address: input.walletAddress,
+    }
+  );
+
+  if (error) {
+    throw new Error(
+      error.message || 'confirm_activation_purchase_atomic failed'
+    );
+  }
+
+  const parsed = readConfirmActivationPurchaseRpcRow(data);
+  if (!parsed) {
+    throw new Error(
+      'Unexpected RPC response from confirm_activation_purchase_atomic'
+    );
+  }
+  return parsed;
 }
 
 export async function getActivationRedemptionByIdempotencyKey(

--- a/lib/db/activation-redemptions.ts
+++ b/lib/db/activation-redemptions.ts
@@ -223,11 +223,14 @@ function readConfirmActivationPurchaseRpcRow(
 /**
  * Atomically deduct points (when configured), bump activation cap counter, and move redemption
  * to `ready_to_redeem`. Requires `confirm_activation_purchase_atomic` in the database (IRL-54).
+ * Passes eligibility per-user caps so limits are enforced inside the RPC after locking the activation.
  */
 export async function confirmActivationPurchaseAtomic(input: {
   redemptionId: string;
   playerId: number;
   walletAddress: string;
+  maxPurchaseConfirmsPerUser: number;
+  maxPurchaseConfirmsPerUserPerDay: number;
 }): Promise<ConfirmActivationPurchaseRpcResult> {
   const { data, error } = await supabase.rpc(
     'confirm_activation_purchase_atomic',
@@ -235,6 +238,9 @@ export async function confirmActivationPurchaseAtomic(input: {
       p_redemption_id: input.redemptionId,
       p_player_id: input.playerId,
       p_wallet_address: input.walletAddress,
+      p_max_purchase_confirms_per_user: input.maxPurchaseConfirmsPerUser,
+      p_max_purchase_confirms_per_user_per_day:
+        input.maxPurchaseConfirmsPerUserPerDay,
     }
   );
 

--- a/lib/db/activation-redemptions.ts
+++ b/lib/db/activation-redemptions.ts
@@ -204,12 +204,13 @@ function readConfirmActivationPurchaseRpcRow(
   const r = row as Record<string, unknown>;
   const outcome = r.outcome;
   const ptsRaw = r.player_total_points ?? r.playerTotalPoints;
-  const pts =
-    typeof ptsRaw === 'number' && Number.isFinite(ptsRaw)
-      ? ptsRaw
-      : typeof ptsRaw === 'string'
-        ? parseInt(ptsRaw, 10)
-        : NaN;
+  let pts = NaN;
+  if (typeof ptsRaw === 'number' && Number.isFinite(ptsRaw)) {
+    pts = ptsRaw;
+  } else if (typeof ptsRaw === 'string') {
+    const parsedPts = parseInt(ptsRaw, 10);
+    pts = Number.isNaN(parsedPts) ? NaN : parsedPts;
+  }
   if (
     (outcome !== 'created' && outcome !== 'already_confirmed') ||
     !Number.isFinite(pts)

--- a/lib/schemas/activation-confirm-purchase.ts
+++ b/lib/schemas/activation-confirm-purchase.ts
@@ -7,7 +7,6 @@ const confirmPurchaseWalletAddressSchema = z
     message: 'walletAddress must be a valid EVM address',
   });
 
-/** POST /api/sponsored-activations/{activationIdOrSlug}/confirm-purchase (IRL-54). */
 export const activationConfirmPurchaseBodySchema = z
   .object({
     walletAddress: confirmPurchaseWalletAddressSchema,

--- a/lib/schemas/activation-confirm-purchase.ts
+++ b/lib/schemas/activation-confirm-purchase.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+const confirmPurchaseWalletAddressSchema = z
+  .string()
+  .min(1, 'walletAddress is required')
+  .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
+    message: 'walletAddress must be a valid EVM address',
+  });
+
+/** POST /api/sponsored-activations/{activationIdOrSlug}/confirm-purchase (IRL-54). */
+export const activationConfirmPurchaseBodySchema = z
+  .object({
+    walletAddress: confirmPurchaseWalletAddressSchema,
+    redemptionId: z.string().uuid('redemptionId must be a valid UUID'),
+  })
+  .strict();
+
+export type ActivationConfirmPurchaseBody = z.infer<
+  typeof activationConfirmPurchaseBodySchema
+>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-54: `POST /api/sponsored-activations/{activationIdOrSlug}/confirm-purchase` so authenticated users can move an `available` redemption to `ready_to_redeem` with optional points deduction, activation redemption cap enforcement, `max_per_user`, and idempotent replays.

## Changes

- **API:** New route with strict Zod body `{ walletAddress, redemptionId }`, same Privy gate as eligibility (`verifyWalletOwnership` plus token `userId` match), `canActivationAcceptUserRedemptionFlow`, reward `is_active`, idempotency key `${activation_id}:${player_id}:${reward_item_id}`, and `eligibility_config` rate limits (`checkEligibilityEventRateLimits` on counts of rows with `purchase_confirmed_at` set) applied only for new confirms from `available`.
- **DB:** New migration `database/confirm-activation-purchase-atomic.sql` defining `confirm_activation_purchase_atomic`, which locks redemption, activation, reward item, and player when deducting; validates cap, max per user, and points; increments `redemption_count_confirmed` once per new confirm; sets `points_spent`, `usdc_amount_snapshot`, `purchase_confirmed_at`, and `ready_to_redeem`; idempotent `already_confirmed` path without a second deduct or cap bump.
- **Client:** `confirmActivationPurchaseAtomic` and purchase-confirm count helpers in `lib/db/activation-redemptions.ts`; orchestration and error mapping in `lib/activation/confirm-purchase.ts` using generic user-facing copy (no chain or wallet details in errors).
- **Tests:** Vitest route suite for happy path, insufficient points, inactive window, cap, idempotency, max per user, 401, 429, and strict body validation.

## Deploy notes

Apply `database/confirm-activation-purchase-atomic.sql` to the database before relying on this route in production.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-54](https://linear.app/irlenergy/issue/IRL-54/implement-confirm-purchase-api-atomic-points-redemption-state)

<div><a href="https://cursor.com/agents/bc-02fcd496-1e48-4005-b0de-3e2d4d2ed1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-02fcd496-1e48-4005-b0de-3e2d4d2ed1d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

