### PR TITLE
feat(IRL-55): swipe-to-redeem and cancel-redemption APIs with atomic RPCs

### DIFF
--- a/app/api/sponsored-activations/[activationId]/cancel-redemption/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/cancel-redemption/__tests__/route.test.ts
@@ -7,7 +7,6 @@ const mockGetActivation = vi.fn();
 const mockGetRedemptionById = vi.fn();
 const mockCancelRpc = vi.fn();
 const mockGetPlayerByWallet = vi.fn();
-const mockCreateOrUpdatePlayer = vi.fn();
 
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
@@ -26,7 +25,7 @@ vi.mock('@/lib/db/activation-redemptions', () => ({
 
 vi.mock('@/lib/db/players', () => ({
   getPlayerByWallet: (...a: unknown[]) => mockGetPlayerByWallet(...a),
-  createOrUpdatePlayer: (...a: unknown[]) => mockCreateOrUpdatePlayer(...a),
+  createOrUpdatePlayer: vi.fn(),
 }));
 
 import { POST } from '../route';

--- a/app/api/sponsored-activations/[activationId]/cancel-redemption/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/cancel-redemption/__tests__/route.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyWallet = vi.fn();
+const mockGetPrivyUserId = vi.fn();
+const mockGetActivation = vi.fn();
+const mockGetRedemptionById = vi.fn();
+const mockCancelRpc = vi.fn();
+const mockGetPlayerByWallet = vi.fn();
+const mockCreateOrUpdatePlayer = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
+  getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+}));
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  getSponsoredActivationByIdOrSlug: (...a: unknown[]) =>
+    mockGetActivation(...a),
+}));
+
+vi.mock('@/lib/db/activation-redemptions', () => ({
+  getActivationRedemptionById: (...a: unknown[]) => mockGetRedemptionById(...a),
+  cancelActivationRedemptionAtomic: (...a: unknown[]) => mockCancelRpc(...a),
+}));
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerByWallet: (...a: unknown[]) => mockGetPlayerByWallet(...a),
+  createOrUpdatePlayer: (...a: unknown[]) => mockCreateOrUpdatePlayer(...a),
+}));
+
+import { POST } from '../route';
+
+const wallet = '0x1234567890123456789012345678901234567890';
+const redemptionId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const activeActivation = {
+  id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  slug: 'slug-1',
+  title: 'T',
+  sponsor_name: 'S',
+  event_id: null,
+  status: 'active' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  venue_settlement_wallet_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  usdc_asset_config: {},
+  max_redemptions: 10,
+  max_usdc_budget: null,
+  usdc_settled_total: 0,
+  redemption_count_confirmed: 0,
+  starts_at: '2026-01-01T00:00:00.000Z',
+  ends_at: '2027-01-01T00:00:00.000Z',
+  eligibility_config: {
+    max_events_per_user: 5,
+    max_events_per_user_per_day: 2,
+    required_checkpoint_ids: ['cp-1'],
+  },
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: null,
+  privy_campaign_wallet_id: null,
+};
+
+function redemptionRow(
+  status: 'ready_to_redeem' | 'cancelled' | 'available'
+): Record<string, unknown> {
+  return {
+    id: redemptionId,
+    activation_id: activeActivation.id,
+    reward_item_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    user_id: 1,
+    eligibility_event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+    status,
+    idempotency_key: `${activeActivation.id}:1:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb`,
+    points_spent: 10,
+    usdc_amount_snapshot: 5,
+    purchase_confirmed_at: '2026-05-25T12:00:00.000Z',
+    redeemed_at: null,
+    cancelled_reason: status === 'cancelled' ? 'user_cancelled' : null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function postReq(body: unknown, activationSegment = activeActivation.id) {
+  return new NextRequest(
+    `http://localhost/api/sponsored-activations/${activationSegment}/cancel-redemption`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockVerifyWallet.mockResolvedValue({
+    authorized: true,
+    userId: 'privy-user-1',
+  });
+  mockGetPrivyUserId.mockResolvedValue('privy-user-1');
+  mockGetActivation.mockResolvedValue(activeActivation);
+  mockGetPlayerByWallet.mockResolvedValue({
+    id: 1,
+    wallet_address: wallet,
+    total_points: 100,
+  });
+  mockCancelRpc.mockResolvedValue({ outcome: 'cancelled' });
+});
+
+describe('POST /api/sponsored-activations/[activationId]/cancel-redemption', () => {
+  it('returns 200 with cancelled redemption', async () => {
+    let loads = 0;
+    mockGetRedemptionById.mockImplementation(async () => {
+      loads += 1;
+      if (loads === 1) return redemptionRow('ready_to_redeem');
+      return redemptionRow('cancelled');
+    });
+
+    const res = await POST(
+      postReq({ walletAddress: wallet, redemptionId, reason: 'changed mind' }),
+      { params: { activationId: activeActivation.id } }
+    );
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.success).toBe(true);
+    expect(j.data.redemption.status).toBe('cancelled');
+    expect(mockCancelRpc).toHaveBeenCalledWith({
+      redemptionId,
+      playerId: 1,
+      walletAddress: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
+      reason: 'changed mind',
+    });
+  });
+
+  it('is idempotent when redemption is already cancelled', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('cancelled'));
+    mockCancelRpc.mockResolvedValue({ outcome: 'already_cancelled' });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.data.redemption.status).toBe('cancelled');
+  });
+
+  it('returns 400 when redemption is not ready_to_redeem', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockCancelRpc.mockRejectedValue(
+      new Error('ACTIVATION_CANCEL_INVALID_STATUS')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('Unable to cancel this redemption');
+  });
+
+  it('returns 401 when Privy wallet auth fails', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: false,
+      error: 'Unauthorized',
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(401);
+    expect(mockGetRedemptionById).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/sponsored-activations/[activationId]/cancel-redemption/route.ts
+++ b/app/api/sponsored-activations/[activationId]/cancel-redemption/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { runCancelActivationRedemption } from '@/lib/activation/cancel-redemption';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { activationId: string } };
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const activationKey = params.activationId?.trim() ?? '';
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  const result = await runCancelActivationRedemption({
+    request,
+    activationKey,
+    body,
+  });
+  if (!result.ok) return result.response;
+  return apiSuccess(result.body);
+}

--- a/app/api/sponsored-activations/[activationId]/cancel-redemption/route.ts
+++ b/app/api/sponsored-activations/[activationId]/cancel-redemption/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 type RouteParams = { params: { activationId: string } };
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
-  const activationKey = params.activationId?.trim() ?? '';
+  const activationKey = params.activationId ?? '';
 
   let body: unknown;
   try {

--- a/app/api/sponsored-activations/[activationId]/swipe-redeem/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/swipe-redeem/__tests__/route.test.ts
@@ -1,0 +1,318 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockVerifyWallet = vi.fn();
+const mockGetPrivyUserId = vi.fn();
+const mockGetActivation = vi.fn();
+const mockGetRedemptionById = vi.fn();
+const mockSwipeRpc = vi.fn();
+const mockGetPlayerByWallet = vi.fn();
+const mockCreateOrUpdatePlayer = vi.fn();
+const mockGetSettlementByRedemptionId = vi.fn();
+
+vi.mock('@/lib/api/privy', () => ({
+  verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
+  getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+}));
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  getSponsoredActivationByIdOrSlug: (...a: unknown[]) =>
+    mockGetActivation(...a),
+}));
+
+vi.mock('@/lib/db/activation-redemptions', () => ({
+  getActivationRedemptionById: (...a: unknown[]) => mockGetRedemptionById(...a),
+  swipeActivationRedeemAtomic: (...a: unknown[]) => mockSwipeRpc(...a),
+}));
+
+vi.mock('@/lib/db/activation-settlement-transactions', () => ({
+  getActivationSettlementTransactionByRedemptionId: (...a: unknown[]) =>
+    mockGetSettlementByRedemptionId(...a),
+}));
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerByWallet: (...a: unknown[]) => mockGetPlayerByWallet(...a),
+  createOrUpdatePlayer: (...a: unknown[]) => mockCreateOrUpdatePlayer(...a),
+}));
+
+import { POST } from '../route';
+
+const wallet = '0x1234567890123456789012345678901234567890';
+const redemptionId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+
+const eligibilityConfig = {
+  max_events_per_user: 5,
+  max_events_per_user_per_day: 2,
+  required_checkpoint_ids: ['cp-1'],
+};
+
+const activeActivation = {
+  id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  slug: 'slug-1',
+  title: 'T',
+  sponsor_name: 'S',
+  event_id: null,
+  status: 'active' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266',
+  venue_settlement_wallet_address: '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+  usdc_asset_config: {},
+  max_redemptions: 10,
+  max_usdc_budget: 100,
+  usdc_settled_total: 0,
+  redemption_count_confirmed: 0,
+  starts_at: '2026-01-01T00:00:00.000Z',
+  ends_at: '2027-01-01T00:00:00.000Z',
+  eligibility_config: eligibilityConfig,
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: null,
+  privy_campaign_wallet_id: null,
+};
+
+const settlementRow = {
+  id: 'dddddddd-dddd-dddd-dddd-dddddddddddd',
+  redemption_id: redemptionId,
+  activation_id: activeActivation.id,
+  settlement_rail: 'base' as const,
+  status: 'queued' as const,
+  amount: 5,
+  from_wallet_address: activeActivation.campaign_wallet_address,
+  to_wallet_address: activeActivation.venue_settlement_wallet_address,
+  tx_hash: null,
+  submission_attempt: 0,
+  last_error_code: null,
+  queued_at: '2026-05-25T12:00:00.000Z',
+  submitted_at: null,
+  confirmed_at: null,
+  privy_transaction_id: null,
+};
+
+function redemptionRow(
+  status: 'available' | 'ready_to_redeem' | 'settlement_pending' | 'expired'
+): Record<string, unknown> {
+  return {
+    id: redemptionId,
+    activation_id: activeActivation.id,
+    reward_item_id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+    user_id: 1,
+    eligibility_event_id: 'eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee',
+    status,
+    idempotency_key: `${activeActivation.id}:1:bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb`,
+    points_spent: 10,
+    usdc_amount_snapshot: 5,
+    purchase_confirmed_at: '2026-05-25T12:00:00.000Z',
+    redeemed_at:
+      status === 'settlement_pending' || status === 'expired'
+        ? '2026-05-25T12:05:00.000Z'
+        : null,
+    cancelled_reason: status === 'expired' ? 'activation_window_ended' : null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+function postReq(body: unknown, activationSegment = activeActivation.id) {
+  return new NextRequest(
+    `http://localhost/api/sponsored-activations/${activationSegment}/swipe-redeem`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockVerifyWallet.mockResolvedValue({
+    authorized: true,
+    userId: 'privy-user-1',
+  });
+  mockGetPrivyUserId.mockResolvedValue('privy-user-1');
+  mockGetActivation.mockResolvedValue(activeActivation);
+  mockGetPlayerByWallet.mockResolvedValue({
+    id: 1,
+    wallet_address: wallet,
+    total_points: 100,
+  });
+  mockSwipeRpc.mockResolvedValue({ outcome: 'created' });
+  mockGetSettlementByRedemptionId.mockResolvedValue(settlementRow);
+});
+
+describe('POST /api/sponsored-activations/[activationId]/swipe-redeem', () => {
+  it('returns 200 with redemption and settlement on success', async () => {
+    let loads = 0;
+    mockGetRedemptionById.mockImplementation(async () => {
+      loads += 1;
+      if (loads === 1) return redemptionRow('ready_to_redeem');
+      return redemptionRow('settlement_pending');
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.success).toBe(true);
+    expect(j.data.redemption.status).toBe('settlement_pending');
+    expect(j.data.settlement.status).toBe('queued');
+    expect(j.data.settlement.redemption_id).toBe(redemptionId);
+    expect(mockSwipeRpc).toHaveBeenCalledWith({
+      redemptionId,
+      playerId: 1,
+      walletAddress: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
+      maxSwipeRedeemsPerUser: eligibilityConfig.max_events_per_user,
+      maxSwipeRedeemsPerUserPerDay:
+        eligibilityConfig.max_events_per_user_per_day,
+    });
+  });
+
+  it('returns 400 when redemption is not ready_to_redeem (wrong status)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockSwipeRpc.mockRejectedValue(
+      new Error('ACTIVATION_SWIPE_INVALID_STATUS')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.success).toBe(false);
+    expect(j.error).toBe('Unable to complete this redemption');
+  });
+
+  it('is idempotent when redemption is already settlement_pending', async () => {
+    mockGetRedemptionById.mockResolvedValue(
+      redemptionRow('settlement_pending')
+    );
+    mockSwipeRpc.mockResolvedValue({ outcome: 'already_redeemed' });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    const j = await res.json();
+    expect(j.data.redemption.status).toBe('settlement_pending');
+    expect(j.data.settlement.id).toBe(settlementRow.id);
+  });
+
+  it('returns idempotent 200 when activation is paused but redemption already swiped', async () => {
+    mockGetActivation.mockResolvedValue({
+      ...activeActivation,
+      status: 'paused',
+    });
+    mockGetRedemptionById.mockResolvedValue(
+      redemptionRow('settlement_pending')
+    );
+    mockSwipeRpc.mockResolvedValue({ outcome: 'already_redeemed' });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(200);
+    expect(mockSwipeRpc).toHaveBeenCalled();
+  });
+
+  it('returns 400 when USDC budget is exceeded (RPC)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
+    mockSwipeRpc.mockRejectedValue(
+      new Error('ACTIVATION_SWIPE_BUDGET_EXCEEDED')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('This reward is no longer available');
+  });
+
+  it('returns 400 when max_per_user is exceeded at swipe (RPC)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
+    mockSwipeRpc.mockRejectedValue(new Error('ACTIVATION_SWIPE_MAX_PER_USER'));
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('This reward is no longer available');
+  });
+
+  it('returns 400 with terminal redemption when swipe is after activation window (expired)', async () => {
+    let loads = 0;
+    mockGetRedemptionById.mockImplementation(async (id: string) => {
+      expect(id).toBe(redemptionId);
+      loads += 1;
+      if (loads === 1) return redemptionRow('ready_to_redeem');
+      return redemptionRow('expired');
+    });
+    mockSwipeRpc.mockResolvedValue({ outcome: 'expired' });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('This redemption is no longer valid');
+    expect(j.details?.redemption?.status).toBe('expired');
+  });
+
+  it('returns 400 when activation is paused on a new swipe (not idempotent)', async () => {
+    mockGetActivation.mockResolvedValue({
+      ...activeActivation,
+      status: 'paused',
+    });
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
+    mockSwipeRpc.mockRejectedValue(new Error('ACTIVATION_SWIPE_NOT_LIVE'));
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('Activation is not accepting redemptions right now');
+  });
+
+  it('returns 429 when daily swipe rate limit is exceeded (RPC)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
+    mockSwipeRpc.mockRejectedValue(
+      new Error('ACTIVATION_SWIPE_DAILY_USER_LIMIT_EXCEEDED')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(429);
+    const j = await res.json();
+    expect(j.error).toBe('Too many eligibility requests today');
+  });
+
+  it('rejects non-strict JSON bodies via Zod', async () => {
+    const res = await POST(
+      postReq({
+        walletAddress: wallet,
+        redemptionId,
+        extra: true,
+      } as Record<string, unknown>),
+      { params: { activationId: activeActivation.id } }
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('returns 401 when Privy wallet auth fails', async () => {
+    mockVerifyWallet.mockResolvedValue({
+      authorized: false,
+      error: 'Unauthorized',
+    });
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(401);
+    expect(mockGetRedemptionById).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/sponsored-activations/[activationId]/swipe-redeem/route.ts
+++ b/app/api/sponsored-activations/[activationId]/swipe-redeem/route.ts
@@ -7,7 +7,7 @@ export const dynamic = 'force-dynamic';
 type RouteParams = { params: { activationId: string } };
 
 export async function POST(request: NextRequest, { params }: RouteParams) {
-  const activationKey = params.activationId?.trim() ?? '';
+  const activationKey = params.activationId ?? '';
 
   let body: unknown;
   try {

--- a/app/api/sponsored-activations/[activationId]/swipe-redeem/route.ts
+++ b/app/api/sponsored-activations/[activationId]/swipe-redeem/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { runSwipeActivationRedeem } from '@/lib/activation/swipe-redeem';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { activationId: string } };
+
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  const activationKey = params.activationId?.trim() ?? '';
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return apiError('Invalid JSON body', 400);
+  }
+
+  const result = await runSwipeActivationRedeem({
+    request,
+    activationKey,
+    body,
+  });
+  if (!result.ok) return result.response;
+  return apiSuccess(result.body);
+}

--- a/database/cancel-activation-redemption-atomic.sql
+++ b/database/cancel-activation-redemption-atomic.sql
@@ -1,0 +1,71 @@
+-- IRL-55: User-initiated cancel from ready_to_redeem only (no settlement row yet).
+
+CREATE OR REPLACE FUNCTION cancel_activation_redemption_atomic(
+  p_redemption_id UUID,
+  p_player_id BIGINT,
+  p_wallet_address TEXT,
+  p_reason TEXT
+) RETURNS TABLE (
+  outcome TEXT
+) AS $$
+DECLARE
+  v_red activation_redemption%ROWTYPE;
+  v_player_row_id BIGINT;
+  v_reason TEXT;
+BEGIN
+  IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_CANCEL_WALLET_REQUIRED';
+  END IF;
+
+  SELECT *
+  INTO v_red
+  FROM activation_redemption
+  WHERE id = p_redemption_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_CANCEL_NOT_FOUND';
+  END IF;
+
+  IF v_red.user_id IS DISTINCT FROM p_player_id THEN
+    RAISE EXCEPTION 'ACTIVATION_CANCEL_PLAYER_MISMATCH';
+  END IF;
+
+  IF v_red.status = 'cancelled' THEN
+    RETURN QUERY SELECT 'already_cancelled'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_red.status IS DISTINCT FROM 'ready_to_redeem' THEN
+    RAISE EXCEPTION 'ACTIVATION_CANCEL_INVALID_STATUS';
+  END IF;
+
+  SELECT id
+  INTO v_player_row_id
+  FROM players
+  WHERE id = p_player_id
+    AND lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_CANCEL_PLAYER_WALLET_MISMATCH';
+  END IF;
+
+  v_reason := NULLIF(trim(COALESCE(p_reason, '')), '');
+  IF v_reason IS NULL THEN
+    v_reason := 'user_cancelled';
+  END IF;
+
+  UPDATE activation_redemption
+  SET
+    status = 'cancelled',
+    cancelled_reason = v_reason,
+    updated_at = NOW()
+  WHERE id = v_red.id;
+
+  RETURN QUERY SELECT 'cancelled'::TEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION cancel_activation_redemption_atomic IS
+  'IRL-55: Cancels activation_redemption from ready_to_redeem to cancelled. Idempotent when already cancelled.';

--- a/database/cancel-activation-redemption-atomic.sql
+++ b/database/cancel-activation-redemption-atomic.sql
@@ -10,7 +10,6 @@ CREATE OR REPLACE FUNCTION cancel_activation_redemption_atomic(
 ) AS $$
 DECLARE
   v_red activation_redemption%ROWTYPE;
-  v_player_row_id BIGINT;
   v_reason TEXT;
 BEGIN
   IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
@@ -40,8 +39,7 @@ BEGIN
     RAISE EXCEPTION 'ACTIVATION_CANCEL_INVALID_STATUS';
   END IF;
 
-  SELECT id
-  INTO v_player_row_id
+  PERFORM 1
   FROM players
   WHERE id = p_player_id
     AND lower(trim(wallet_address)) = lower(trim(p_wallet_address))

--- a/database/irl-55-swipe-settlement-unique-redemption.sql
+++ b/database/irl-55-swipe-settlement-unique-redemption.sql
@@ -1,0 +1,7 @@
+-- IRL-55: At most one settlement queue row per redemption (idempotent swipe / worker model).
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_activation_settlement_one_row_per_redemption
+    ON activation_settlement_transaction (redemption_id);
+
+COMMENT ON INDEX idx_activation_settlement_one_row_per_redemption IS
+    'IRL-55: Guarantees swipe-to-redeem cannot enqueue duplicate settlement rows for the same redemption.';

--- a/database/swipe-activation-redeem-atomic.sql
+++ b/database/swipe-activation-redeem-atomic.sql
@@ -53,6 +53,8 @@ BEGIN
     RAISE EXCEPTION 'ACTIVATION_SWIPE_MISSING_USDC_SNAPSHOT';
   END IF;
 
+  v_snapshot := v_red.usdc_amount_snapshot;
+
   SELECT *
   INTO v_act
   FROM sponsored_activation
@@ -139,7 +141,6 @@ BEGIN
     WHERE st.activation_id = v_act.id
       AND st.status IN ('not_started', 'queued', 'submitted', 'retrying');
 
-    v_snapshot := v_red.usdc_amount_snapshot;
     v_budget_cap := v_act.max_usdc_budget;
 
     IF (v_settled + v_inflight + v_snapshot) > v_budget_cap THEN

--- a/database/swipe-activation-redeem-atomic.sql
+++ b/database/swipe-activation-redeem-atomic.sql
@@ -1,0 +1,197 @@
+-- IRL-55: Atomic swipe-to-redeem — ready_to_redeem → settlement_pending, enqueue one settlement row.
+-- Idempotent when redemption is already in a post-swipe settlement state.
+
+CREATE OR REPLACE FUNCTION swipe_activation_redeem_atomic(
+  p_redemption_id UUID,
+  p_player_id BIGINT,
+  p_wallet_address TEXT,
+  p_max_swipe_redeems_per_user INTEGER,
+  p_max_swipe_redeems_per_user_per_day INTEGER
+) RETURNS TABLE (
+  outcome TEXT
+) AS $$
+DECLARE
+  v_red activation_redemption%ROWTYPE;
+  v_act sponsored_activation%ROWTYPE;
+  v_item activation_reward_item%ROWTYPE;
+  v_player_row_id BIGINT;
+  v_lifetime_swipes INTEGER;
+  v_daily_swipes INTEGER;
+  v_nt INTEGER;
+  v_inflight NUMERIC(24, 8);
+  v_budget_cap NUMERIC(24, 8);
+  v_settled NUMERIC(24, 8);
+  v_snapshot NUMERIC(24, 8);
+BEGIN
+  IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_WALLET_REQUIRED';
+  END IF;
+
+  SELECT *
+  INTO v_red
+  FROM activation_redemption
+  WHERE id = p_redemption_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_NOT_FOUND';
+  END IF;
+
+  IF v_red.user_id IS DISTINCT FROM p_player_id THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_PLAYER_MISMATCH';
+  END IF;
+
+  IF v_red.status IN ('settlement_pending', 'settlement_confirmed', 'settlement_failed') THEN
+    RETURN QUERY SELECT 'already_redeemed'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_red.status IS DISTINCT FROM 'ready_to_redeem' THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_INVALID_STATUS';
+  END IF;
+
+  IF v_red.usdc_amount_snapshot IS NULL OR v_red.usdc_amount_snapshot <= 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_MISSING_USDC_SNAPSHOT';
+  END IF;
+
+  SELECT *
+  INTO v_act
+  FROM sponsored_activation
+  WHERE id = v_red.activation_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_ACTIVATION_NOT_FOUND';
+  END IF;
+
+  IF NOW() < v_act.starts_at OR NOW() >= v_act.ends_at THEN
+    UPDATE activation_redemption
+    SET
+      status = 'expired',
+      cancelled_reason = 'activation_window_ended',
+      updated_at = NOW()
+    WHERE id = v_red.id;
+
+    RETURN QUERY SELECT 'expired'::TEXT;
+    RETURN;
+  END IF;
+
+  IF v_act.status IS DISTINCT FROM 'active' THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_NOT_LIVE';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_lifetime_swipes
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_act.id
+    AND ar.user_id = v_red.user_id
+    AND ar.redeemed_at IS NOT NULL;
+
+  IF v_lifetime_swipes >= p_max_swipe_redeems_per_user THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_LIFETIME_USER_LIMIT_EXCEEDED';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_daily_swipes
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_act.id
+    AND ar.user_id = v_red.user_id
+    AND ar.redeemed_at IS NOT NULL
+    AND (ar.redeemed_at AT TIME ZONE 'UTC')::date =
+        (NOW() AT TIME ZONE 'UTC')::date;
+
+  IF v_daily_swipes >= p_max_swipe_redeems_per_user_per_day THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_DAILY_USER_LIMIT_EXCEEDED';
+  END IF;
+
+  SELECT *
+  INTO v_item
+  FROM activation_reward_item
+  WHERE id = v_red.reward_item_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_item.activation_id IS DISTINCT FROM v_act.id THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_REWARD_ITEM_MISMATCH';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_nt
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_red.activation_id
+    AND ar.user_id = v_red.user_id
+    AND ar.reward_item_id = v_red.reward_item_id
+    AND ar.status NOT IN (
+      'redeemed',
+      'settlement_confirmed',
+      'cancelled',
+      'expired',
+      'settlement_failed'
+    );
+
+  IF v_nt > v_item.max_per_user THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_MAX_PER_USER';
+  END IF;
+
+  IF v_act.max_usdc_budget IS NOT NULL THEN
+    v_settled := v_act.usdc_settled_total;
+    SELECT COALESCE(SUM(amount), 0)
+    INTO v_inflight
+    FROM activation_settlement_transaction st
+    WHERE st.activation_id = v_act.id
+      AND st.status IN ('not_started', 'queued', 'submitted', 'retrying');
+
+    v_snapshot := v_red.usdc_amount_snapshot;
+    v_budget_cap := v_act.max_usdc_budget;
+
+    IF (v_settled + v_inflight + v_snapshot) > v_budget_cap THEN
+      RAISE EXCEPTION 'ACTIVATION_SWIPE_BUDGET_EXCEEDED';
+    END IF;
+  END IF;
+
+  SELECT id
+  INTO v_player_row_id
+  FROM players
+  WHERE id = p_player_id
+    AND lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_SWIPE_PLAYER_WALLET_MISMATCH';
+  END IF;
+
+  UPDATE activation_redemption
+  SET
+    status = 'settlement_pending',
+    redeemed_at = COALESCE(redeemed_at, NOW()),
+    updated_at = NOW()
+  WHERE id = v_red.id;
+
+  INSERT INTO activation_settlement_transaction (
+    redemption_id,
+    activation_id,
+    settlement_rail,
+    status,
+    amount,
+    from_wallet_address,
+    to_wallet_address,
+    queued_at
+  ) VALUES (
+    v_red.id,
+    v_act.id,
+    v_act.settlement_rail,
+    'queued',
+    v_snapshot,
+    v_act.campaign_wallet_address,
+    v_act.venue_settlement_wallet_address,
+    NOW()
+  );
+
+  RETURN QUERY SELECT 'created'::TEXT;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION swipe_activation_redeem_atomic IS
+  'IRL-55: Moves activation_redemption from ready_to_redeem to settlement_pending, inserts one queued '
+  'activation_settlement_transaction. Idempotent for settlement_pending and later settlement outcomes. '
+  'Lazy-expires to expired when activation time window is invalid. Enforces swipe rate limits (redeemed_at), '
+  'max_per_user, and optional USDC budget reservation via in-flight settlement sums.';

--- a/database/swipe-activation-redeem-atomic.sql
+++ b/database/swipe-activation-redeem-atomic.sql
@@ -14,7 +14,6 @@ DECLARE
   v_red activation_redemption%ROWTYPE;
   v_act sponsored_activation%ROWTYPE;
   v_item activation_reward_item%ROWTYPE;
-  v_player_row_id BIGINT;
   v_lifetime_swipes INTEGER;
   v_daily_swipes INTEGER;
   v_nt INTEGER;
@@ -148,8 +147,7 @@ BEGIN
     END IF;
   END IF;
 
-  SELECT id
-  INTO v_player_row_id
+  PERFORM 1
   FROM players
   WHERE id = p_player_id
     AND lower(trim(wallet_address)) = lower(trim(p_wallet_address))

--- a/lib/activation/activation-wallet-gate.ts
+++ b/lib/activation/activation-wallet-gate.ts
@@ -1,0 +1,44 @@
+import { NextRequest, type NextResponse } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import { apiError, type ApiResponse } from '@/lib/api/response';
+import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+
+/**
+ * Ensures the request has a valid Privy Bearer token and the token user matches
+ * the wallet owner returned by Privy (same pattern as confirm-purchase).
+ */
+export async function assertPrivyWalletAuth(
+  request: NextRequest,
+  walletAddress: string
+): Promise<
+  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
+  }
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return { ok: false, response: apiError('Unauthorized', 401) };
+  }
+  return { ok: true };
+}
+
+export async function resolvePlayerForWallet(
+  normalizedWalletAddress: string
+): Promise<{ playerId: number }> {
+  let player = await getPlayerByWallet(normalizedWalletAddress);
+  if (!player?.id) {
+    player = await createOrUpdatePlayer({
+      wallet_address: normalizedWalletAddress,
+      total_points: 0,
+    });
+  }
+  if (!player?.id) {
+    throw new Error('Failed to resolve player for wallet');
+  }
+  return { playerId: player.id };
+}

--- a/lib/activation/cancel-redemption.ts
+++ b/lib/activation/cancel-redemption.ts
@@ -1,20 +1,19 @@
 import { NextRequest, type NextResponse } from 'next/server';
 import {
-  getPrivyUserIdFromRequest,
-  verifyWalletOwnership,
-} from '@/lib/api/privy';
+  assertPrivyWalletAuth,
+  resolvePlayerForWallet,
+} from '@/lib/activation/activation-wallet-gate';
+import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import {
   apiError,
   apiValidationError,
   type ApiResponse,
 } from '@/lib/api/response';
-import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import {
   cancelActivationRedemptionAtomic,
   getActivationRedemptionById,
   type ActivationRedemptionRow,
 } from '@/lib/db/activation-redemptions';
-import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { activationCancelRedemptionBodySchema } from '@/lib/schemas/activation-cancel-redemption';
 import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
@@ -22,39 +21,6 @@ import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 export type CancelRedemptionSuccessBody = {
   redemption: ActivationRedemptionRow;
 };
-
-async function assertPrivyWalletAuth(
-  request: NextRequest,
-  walletAddress: string
-): Promise<
-  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
-> {
-  const auth = await verifyWalletOwnership(request, walletAddress);
-  if (!auth.authorized || !auth.userId) {
-    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
-  }
-  const tokenUser = await getPrivyUserIdFromRequest(request);
-  if (!tokenUser || tokenUser !== auth.userId) {
-    return { ok: false, response: apiError('Unauthorized', 401) };
-  }
-  return { ok: true };
-}
-
-async function resolvePlayerForWallet(
-  normalizedWalletAddress: string
-): Promise<{ playerId: number }> {
-  let player = await getPlayerByWallet(normalizedWalletAddress);
-  if (!player?.id) {
-    player = await createOrUpdatePlayer({
-      wallet_address: normalizedWalletAddress,
-      total_points: 0,
-    });
-  }
-  if (!player?.id) {
-    throw new Error('Failed to resolve player for wallet');
-  }
-  return { playerId: player.id };
-}
 
 function mapCancelRpcOrUnexpectedError(message: string): {
   status: 400 | 404 | 500;
@@ -154,7 +120,7 @@ export async function runCancelActivationRedemption(input: {
       redemptionId,
       playerId,
       walletAddress: walletKey,
-      reason: reason?.trim() ? reason.trim() : null,
+      reason: reason ?? null,
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : '';

--- a/lib/activation/cancel-redemption.ts
+++ b/lib/activation/cancel-redemption.ts
@@ -1,0 +1,186 @@
+import { NextRequest, type NextResponse } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import {
+  apiError,
+  apiValidationError,
+  type ApiResponse,
+} from '@/lib/api/response';
+import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
+import {
+  cancelActivationRedemptionAtomic,
+  getActivationRedemptionById,
+  type ActivationRedemptionRow,
+} from '@/lib/db/activation-redemptions';
+import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
+import { activationCancelRedemptionBodySchema } from '@/lib/schemas/activation-cancel-redemption';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+export type CancelRedemptionSuccessBody = {
+  redemption: ActivationRedemptionRow;
+};
+
+async function assertPrivyWalletAuth(
+  request: NextRequest,
+  walletAddress: string
+): Promise<
+  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
+  }
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return { ok: false, response: apiError('Unauthorized', 401) };
+  }
+  return { ok: true };
+}
+
+async function resolvePlayerForWallet(
+  normalizedWalletAddress: string
+): Promise<{ playerId: number }> {
+  let player = await getPlayerByWallet(normalizedWalletAddress);
+  if (!player?.id) {
+    player = await createOrUpdatePlayer({
+      wallet_address: normalizedWalletAddress,
+      total_points: 0,
+    });
+  }
+  if (!player?.id) {
+    throw new Error('Failed to resolve player for wallet');
+  }
+  return { playerId: player.id };
+}
+
+function mapCancelRpcOrUnexpectedError(message: string): {
+  status: 400 | 404 | 500;
+  error: string;
+} {
+  if (message.includes('ACTIVATION_CANCEL_INVALID_STATUS')) {
+    return { status: 400, error: 'Unable to cancel this redemption' };
+  }
+  if (
+    message.includes('ACTIVATION_CANCEL_NOT_FOUND') ||
+    message.includes('ACTIVATION_CANCEL_PLAYER_MISMATCH')
+  ) {
+    return { status: 404, error: 'Unable to cancel this redemption' };
+  }
+  if (message.includes('ACTIVATION_CANCEL_PLAYER_WALLET_MISMATCH')) {
+    return { status: 400, error: 'Unable to cancel this redemption' };
+  }
+  return { status: 500, error: 'Something went wrong' };
+}
+
+export async function runCancelActivationRedemption(input: {
+  request: NextRequest;
+  activationKey: string;
+  body: unknown;
+}): Promise<
+  | { ok: true; body: CancelRedemptionSuccessBody }
+  | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const activationSegment = input.activationKey.trim();
+  if (!activationSegment) {
+    return {
+      ok: false,
+      response: apiError('Missing activation id or slug', 400),
+    };
+  }
+
+  const parsed = activationCancelRedemptionBodySchema.safeParse(input.body);
+  if (!parsed.success) {
+    return { ok: false, response: apiValidationError(parsed.error) };
+  }
+
+  const { walletAddress, redemptionId, reason } = parsed.data;
+  const walletKey =
+    tryNormalizeEvmAddress(walletAddress.trim()) ?? walletAddress.trim();
+
+  const gate = await assertPrivyWalletAuth(input.request, walletKey);
+  if (!gate.ok) return { ok: false, response: gate.response };
+
+  const activation = await getSponsoredActivationByIdOrSlug(activationSegment);
+  if (!activation) {
+    return {
+      ok: false,
+      response: apiError('Sponsored activation not found', 404),
+    };
+  }
+
+  let playerId: number;
+  try {
+    const resolved = await resolvePlayerForWallet(walletKey);
+    playerId = resolved.playerId;
+  } catch (e) {
+    console.error('cancel redemption (resolve player):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  const redemption = await getActivationRedemptionById(redemptionId);
+  if (!redemption || redemption.activation_id !== activation.id) {
+    return {
+      ok: false,
+      response: apiError('Unable to cancel this redemption', 404),
+    };
+  }
+  if (redemption.user_id !== playerId) {
+    return {
+      ok: false,
+      response: apiError('Unable to cancel this redemption', 404),
+    };
+  }
+
+  const expectedKey = buildActivationRedemptionIdempotencyKey({
+    activationId: activation.id,
+    playerId,
+    rewardItemId: redemption.reward_item_id,
+  });
+  if (redemption.idempotency_key !== expectedKey) {
+    return {
+      ok: false,
+      response: apiError('Unable to cancel this redemption', 400),
+    };
+  }
+
+  try {
+    await cancelActivationRedemptionAtomic({
+      redemptionId,
+      playerId,
+      walletAddress: walletKey,
+      reason: reason?.trim() ? reason.trim() : null,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : '';
+    const mapped = mapCancelRpcOrUnexpectedError(msg);
+    return {
+      ok: false,
+      response: apiError(mapped.error, mapped.status),
+    };
+  }
+
+  let fresh: ActivationRedemptionRow | null;
+  try {
+    fresh = await getActivationRedemptionById(redemptionId);
+  } catch (e) {
+    console.error('cancel redemption (reload redemption):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+  if (!fresh) {
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  return { ok: true, body: { redemption: fresh } };
+}

--- a/lib/activation/swipe-redeem.ts
+++ b/lib/activation/swipe-redeem.ts
@@ -1,0 +1,276 @@
+import { NextRequest, type NextResponse } from 'next/server';
+import {
+  getPrivyUserIdFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import {
+  apiError,
+  apiValidationError,
+  type ApiResponse,
+} from '@/lib/api/response';
+import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
+import {
+  getActivationRedemptionById,
+  swipeActivationRedeemAtomic,
+  type ActivationRedemptionRow,
+  type SwipeActivationRedeemRpcResult,
+} from '@/lib/db/activation-redemptions';
+import { getActivationSettlementTransactionByRedemptionId } from '@/lib/db/activation-settlement-transactions';
+import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
+import { safeParseActivationEligibilityRulesConfig } from '@/lib/schemas/activation-eligibility-config';
+import { activationSwipeRedeemBodySchema } from '@/lib/schemas/activation-swipe-redeem';
+import type { ActivationSettlementTransactionRow } from '@/lib/db/activation-settlement-transactions';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+export type SwipeRedeemSuccessBody = {
+  redemption: ActivationRedemptionRow;
+  settlement: ActivationSettlementTransactionRow;
+};
+
+async function assertPrivyWalletAuth(
+  request: NextRequest,
+  walletAddress: string
+): Promise<
+  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const auth = await verifyWalletOwnership(request, walletAddress);
+  if (!auth.authorized || !auth.userId) {
+    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
+  }
+  const tokenUser = await getPrivyUserIdFromRequest(request);
+  if (!tokenUser || tokenUser !== auth.userId) {
+    return { ok: false, response: apiError('Unauthorized', 401) };
+  }
+  return { ok: true };
+}
+
+async function resolvePlayerForWallet(
+  normalizedWalletAddress: string
+): Promise<{ playerId: number }> {
+  let player = await getPlayerByWallet(normalizedWalletAddress);
+  if (!player?.id) {
+    player = await createOrUpdatePlayer({
+      wallet_address: normalizedWalletAddress,
+      total_points: 0,
+    });
+  }
+  if (!player?.id) {
+    throw new Error('Failed to resolve player for wallet');
+  }
+  return { playerId: player.id };
+}
+
+function mapSwipeRpcOrUnexpectedError(message: string): {
+  status: 400 | 404 | 429 | 500;
+  error: string;
+} {
+  if (
+    message.includes('ACTIVATION_SWIPE_BUDGET_EXCEEDED') ||
+    message.includes('ACTIVATION_SWIPE_MAX_PER_USER')
+  ) {
+    return { status: 400, error: 'This reward is no longer available' };
+  }
+  if (message.includes('ACTIVATION_SWIPE_DAILY_USER_LIMIT_EXCEEDED')) {
+    return {
+      status: 429,
+      error: 'Too many eligibility requests today',
+    };
+  }
+  if (message.includes('ACTIVATION_SWIPE_LIFETIME_USER_LIMIT_EXCEEDED')) {
+    return {
+      status: 400,
+      error: 'Eligibility limit reached for this activation',
+    };
+  }
+  if (message.includes('ACTIVATION_SWIPE_INVALID_STATUS')) {
+    return { status: 400, error: 'Unable to complete this redemption' };
+  }
+  if (message.includes('ACTIVATION_SWIPE_NOT_LIVE')) {
+    return {
+      status: 400,
+      error: 'Activation is not accepting redemptions right now',
+    };
+  }
+  if (
+    message.includes('ACTIVATION_SWIPE_NOT_FOUND') ||
+    message.includes('ACTIVATION_SWIPE_ACTIVATION_NOT_FOUND') ||
+    message.includes('ACTIVATION_SWIPE_REWARD_ITEM_MISMATCH')
+  ) {
+    return { status: 404, error: 'Unable to complete this redemption' };
+  }
+  if (
+    message.includes('ACTIVATION_SWIPE_PLAYER_MISMATCH') ||
+    message.includes('ACTIVATION_SWIPE_PLAYER_WALLET_MISMATCH')
+  ) {
+    return { status: 400, error: 'Unable to complete this redemption' };
+  }
+  return { status: 500, error: 'Something went wrong' };
+}
+
+async function loadSettlementOrThrow(
+  redemptionId: string
+): Promise<ActivationSettlementTransactionRow> {
+  const settlement =
+    await getActivationSettlementTransactionByRedemptionId(redemptionId);
+  if (!settlement) {
+    throw new Error('ACTIVATION_SWIPE_SETTLEMENT_ROW_MISSING');
+  }
+  return settlement;
+}
+
+export async function runSwipeActivationRedeem(input: {
+  request: NextRequest;
+  activationKey: string;
+  body: unknown;
+}): Promise<
+  | { ok: true; body: SwipeRedeemSuccessBody }
+  | { ok: false; response: NextResponse<ApiResponse<unknown>> }
+> {
+  const activationSegment = input.activationKey.trim();
+  if (!activationSegment) {
+    return {
+      ok: false,
+      response: apiError('Missing activation id or slug', 400),
+    };
+  }
+
+  const parsed = activationSwipeRedeemBodySchema.safeParse(input.body);
+  if (!parsed.success) {
+    return { ok: false, response: apiValidationError(parsed.error) };
+  }
+
+  const { walletAddress, redemptionId } = parsed.data;
+  const walletKey =
+    tryNormalizeEvmAddress(walletAddress.trim()) ?? walletAddress.trim();
+
+  const gate = await assertPrivyWalletAuth(input.request, walletKey);
+  if (!gate.ok) return { ok: false, response: gate.response };
+
+  const activation = await getSponsoredActivationByIdOrSlug(activationSegment);
+  if (!activation) {
+    return {
+      ok: false,
+      response: apiError('Sponsored activation not found', 404),
+    };
+  }
+
+  const configParse = safeParseActivationEligibilityRulesConfig(
+    activation.eligibility_config
+  );
+  if (!configParse.success) {
+    return {
+      ok: false,
+      response: apiError(
+        'Activation eligibility configuration is invalid',
+        400
+      ),
+    };
+  }
+  const rulesConfig = configParse.data;
+
+  let playerId: number;
+  try {
+    const resolved = await resolvePlayerForWallet(walletKey);
+    playerId = resolved.playerId;
+  } catch (e) {
+    console.error('swipe redeem (resolve player):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  const redemption = await getActivationRedemptionById(redemptionId);
+  if (!redemption || redemption.activation_id !== activation.id) {
+    return {
+      ok: false,
+      response: apiError('Unable to complete this redemption', 404),
+    };
+  }
+  if (redemption.user_id !== playerId) {
+    return {
+      ok: false,
+      response: apiError('Unable to complete this redemption', 404),
+    };
+  }
+
+  const expectedKey = buildActivationRedemptionIdempotencyKey({
+    activationId: activation.id,
+    playerId,
+    rewardItemId: redemption.reward_item_id,
+  });
+  if (redemption.idempotency_key !== expectedKey) {
+    return {
+      ok: false,
+      response: apiError('Unable to complete this redemption', 400),
+    };
+  }
+
+  let rpc: SwipeActivationRedeemRpcResult;
+  try {
+    rpc = await swipeActivationRedeemAtomic({
+      redemptionId,
+      playerId,
+      walletAddress: walletKey,
+      maxSwipeRedeemsPerUser: rulesConfig.max_events_per_user,
+      maxSwipeRedeemsPerUserPerDay: rulesConfig.max_events_per_user_per_day,
+    });
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : '';
+    const mapped = mapSwipeRpcOrUnexpectedError(msg);
+    return {
+      ok: false,
+      response: apiError(mapped.error, mapped.status),
+    };
+  }
+
+  if (rpc.outcome === 'expired') {
+    let fresh: ActivationRedemptionRow | null;
+    try {
+      fresh = await getActivationRedemptionById(redemptionId);
+    } catch (err) {
+      console.error('swipe redeem (reload redemption after expire):', err);
+      return {
+        ok: false,
+        response: apiError('Something went wrong', 500),
+      };
+    }
+    if (!fresh) {
+      return {
+        ok: false,
+        response: apiError('Something went wrong', 500),
+      };
+    }
+    return {
+      ok: false,
+      response: apiError('This redemption is no longer valid', 400, {
+        redemption: fresh,
+      }),
+    };
+  }
+
+  let freshRedemption: ActivationRedemptionRow | null;
+  let settlement: ActivationSettlementTransactionRow;
+  try {
+    freshRedemption = await getActivationRedemptionById(redemptionId);
+    settlement = await loadSettlementOrThrow(redemptionId);
+  } catch (e) {
+    console.error('swipe redeem (reload redemption/settlement):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+  if (!freshRedemption) {
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  return {
+    ok: true,
+    body: { redemption: freshRedemption, settlement },
+  };
+}

--- a/lib/activation/swipe-redeem.ts
+++ b/lib/activation/swipe-redeem.ts
@@ -1,65 +1,33 @@
 import { NextRequest, type NextResponse } from 'next/server';
 import {
-  getPrivyUserIdFromRequest,
-  verifyWalletOwnership,
-} from '@/lib/api/privy';
+  assertPrivyWalletAuth,
+  resolvePlayerForWallet,
+} from '@/lib/activation/activation-wallet-gate';
+import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import {
   apiError,
   apiValidationError,
   type ApiResponse,
 } from '@/lib/api/response';
-import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import {
   getActivationRedemptionById,
   swipeActivationRedeemAtomic,
   type ActivationRedemptionRow,
   type SwipeActivationRedeemRpcResult,
 } from '@/lib/db/activation-redemptions';
-import { getActivationSettlementTransactionByRedemptionId } from '@/lib/db/activation-settlement-transactions';
-import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+import {
+  getActivationSettlementTransactionByRedemptionId,
+  type ActivationSettlementTransactionRow,
+} from '@/lib/db/activation-settlement-transactions';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { safeParseActivationEligibilityRulesConfig } from '@/lib/schemas/activation-eligibility-config';
 import { activationSwipeRedeemBodySchema } from '@/lib/schemas/activation-swipe-redeem';
-import type { ActivationSettlementTransactionRow } from '@/lib/db/activation-settlement-transactions';
 import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 
 export type SwipeRedeemSuccessBody = {
   redemption: ActivationRedemptionRow;
   settlement: ActivationSettlementTransactionRow;
 };
-
-async function assertPrivyWalletAuth(
-  request: NextRequest,
-  walletAddress: string
-): Promise<
-  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
-> {
-  const auth = await verifyWalletOwnership(request, walletAddress);
-  if (!auth.authorized || !auth.userId) {
-    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
-  }
-  const tokenUser = await getPrivyUserIdFromRequest(request);
-  if (!tokenUser || tokenUser !== auth.userId) {
-    return { ok: false, response: apiError('Unauthorized', 401) };
-  }
-  return { ok: true };
-}
-
-async function resolvePlayerForWallet(
-  normalizedWalletAddress: string
-): Promise<{ playerId: number }> {
-  let player = await getPlayerByWallet(normalizedWalletAddress);
-  if (!player?.id) {
-    player = await createOrUpdatePlayer({
-      wallet_address: normalizedWalletAddress,
-      total_points: 0,
-    });
-  }
-  if (!player?.id) {
-    throw new Error('Failed to resolve player for wallet');
-  }
-  return { playerId: player.id };
-}
 
 function mapSwipeRpcOrUnexpectedError(message: string): {
   status: 400 | 404 | 429 | 500;
@@ -106,17 +74,6 @@ function mapSwipeRpcOrUnexpectedError(message: string): {
     return { status: 400, error: 'Unable to complete this redemption' };
   }
   return { status: 500, error: 'Something went wrong' };
-}
-
-async function loadSettlementOrThrow(
-  redemptionId: string
-): Promise<ActivationSettlementTransactionRow> {
-  const settlement =
-    await getActivationSettlementTransactionByRedemptionId(redemptionId);
-  if (!settlement) {
-    throw new Error('ACTIVATION_SWIPE_SETTLEMENT_ROW_MISSING');
-  }
-  return settlement;
 }
 
 export async function runSwipeActivationRedeem(input: {
@@ -225,44 +182,48 @@ export async function runSwipeActivationRedeem(input: {
     };
   }
 
-  if (rpc.outcome === 'expired') {
-    let fresh: ActivationRedemptionRow | null;
-    try {
-      fresh = await getActivationRedemptionById(redemptionId);
-    } catch (err) {
-      console.error('swipe redeem (reload redemption after expire):', err);
-      return {
-        ok: false,
-        response: apiError('Something went wrong', 500),
-      };
-    }
-    if (!fresh) {
-      return {
-        ok: false,
-        response: apiError('Something went wrong', 500),
-      };
-    }
-    return {
-      ok: false,
-      response: apiError('This redemption is no longer valid', 400, {
-        redemption: fresh,
-      }),
-    };
-  }
-
   let freshRedemption: ActivationRedemptionRow | null;
-  let settlement: ActivationSettlementTransactionRow;
   try {
     freshRedemption = await getActivationRedemptionById(redemptionId);
-    settlement = await loadSettlementOrThrow(redemptionId);
-  } catch (e) {
-    console.error('swipe redeem (reload redemption/settlement):', e);
+  } catch (err) {
+    console.error('swipe redeem (reload redemption after RPC):', err);
     return {
       ok: false,
       response: apiError('Something went wrong', 500),
     };
   }
   if (!freshRedemption) {
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+
+  if (rpc.outcome === 'expired') {
+    return {
+      ok: false,
+      response: apiError('This redemption is no longer valid', 400, {
+        redemption: freshRedemption,
+      }),
+    };
+  }
+
+  let settlement: ActivationSettlementTransactionRow | null;
+  try {
+    settlement =
+      await getActivationSettlementTransactionByRedemptionId(redemptionId);
+  } catch (e) {
+    console.error('swipe redeem (load settlement):', e);
+    return {
+      ok: false,
+      response: apiError('Something went wrong', 500),
+    };
+  }
+  if (!settlement) {
+    console.error(
+      'swipe redeem: settlement row missing after successful swipe RPC',
+      { redemptionId }
+    );
     return {
       ok: false,
       response: apiError('Something went wrong', 500),

--- a/lib/db/activation-redemptions.ts
+++ b/lib/db/activation-redemptions.ts
@@ -259,6 +259,119 @@ export async function confirmActivationPurchaseAtomic(input: {
   return parsed;
 }
 
+export type SwipeActivationRedeemRpcOutcome =
+  | 'created'
+  | 'already_redeemed'
+  | 'expired';
+
+export type SwipeActivationRedeemRpcResult = {
+  outcome: SwipeActivationRedeemRpcOutcome;
+};
+
+function readSwipeActivationRedeemRpcRow(
+  data: unknown
+): SwipeActivationRedeemRpcResult | null {
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const outcome = r.outcome;
+  if (
+    outcome !== 'created' &&
+    outcome !== 'already_redeemed' &&
+    outcome !== 'expired'
+  ) {
+    return null;
+  }
+  return { outcome };
+}
+
+/**
+ * Atomically completes in-venue swipe: `ready_to_redeem` → `settlement_pending`, one queued settlement row.
+ * Requires `swipe_activation_redeem_atomic` in the database (IRL-55).
+ */
+export async function swipeActivationRedeemAtomic(input: {
+  redemptionId: string;
+  playerId: number;
+  walletAddress: string;
+  maxSwipeRedeemsPerUser: number;
+  maxSwipeRedeemsPerUserPerDay: number;
+}): Promise<SwipeActivationRedeemRpcResult> {
+  const { data, error } = await supabase.rpc('swipe_activation_redeem_atomic', {
+    p_redemption_id: input.redemptionId,
+    p_player_id: input.playerId,
+    p_wallet_address: input.walletAddress,
+    p_max_swipe_redeems_per_user: input.maxSwipeRedeemsPerUser,
+    p_max_swipe_redeems_per_user_per_day: input.maxSwipeRedeemsPerUserPerDay,
+  });
+
+  if (error) {
+    throw new Error(error.message || 'swipe_activation_redeem_atomic failed');
+  }
+
+  const parsed = readSwipeActivationRedeemRpcRow(data);
+  if (!parsed) {
+    throw new Error(
+      'Unexpected RPC response from swipe_activation_redeem_atomic'
+    );
+  }
+  return parsed;
+}
+
+export type CancelActivationRedemptionRpcOutcome =
+  | 'cancelled'
+  | 'already_cancelled';
+
+export type CancelActivationRedemptionRpcResult = {
+  outcome: CancelActivationRedemptionRpcOutcome;
+};
+
+function readCancelActivationRedemptionRpcRow(
+  data: unknown
+): CancelActivationRedemptionRpcResult | null {
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || typeof row !== 'object') return null;
+  const r = row as Record<string, unknown>;
+  const outcome = r.outcome;
+  if (outcome !== 'cancelled' && outcome !== 'already_cancelled') {
+    return null;
+  }
+  return { outcome };
+}
+
+/**
+ * User cancel from `ready_to_redeem` only. Requires `cancel_activation_redemption_atomic` (IRL-55).
+ */
+export async function cancelActivationRedemptionAtomic(input: {
+  redemptionId: string;
+  playerId: number;
+  walletAddress: string;
+  reason: string | null;
+}): Promise<CancelActivationRedemptionRpcResult> {
+  const { data, error } = await supabase.rpc(
+    'cancel_activation_redemption_atomic',
+    {
+      p_redemption_id: input.redemptionId,
+      p_player_id: input.playerId,
+      p_wallet_address: input.walletAddress,
+      p_reason: input.reason,
+    }
+  );
+
+  if (error) {
+    throw new Error(
+      error.message || 'cancel_activation_redemption_atomic failed'
+    );
+  }
+
+  const parsed = readCancelActivationRedemptionRpcRow(data);
+  if (!parsed) {
+    throw new Error(
+      'Unexpected RPC response from cancel_activation_redemption_atomic'
+    );
+  }
+  return parsed;
+}
+
 export async function getActivationRedemptionByIdempotencyKey(
   idempotencyKey: string
 ): Promise<ActivationRedemptionRow | null> {

--- a/lib/db/activation-settlement-transactions.ts
+++ b/lib/db/activation-settlement-transactions.ts
@@ -1,0 +1,80 @@
+import { supabase } from '@/lib/db/client';
+import type { ActivationSettlementStatus } from '@/lib/schemas/activation-settlement';
+import type { SettlementRail } from '@/lib/db/sponsored-activations';
+
+const TABLE = 'activation_settlement_transaction';
+
+export type ActivationSettlementTransactionRow = {
+  id: string;
+  redemption_id: string;
+  activation_id: string;
+  settlement_rail: SettlementRail;
+  status: ActivationSettlementStatus;
+  amount: number;
+  from_wallet_address: string;
+  to_wallet_address: string;
+  tx_hash: string | null;
+  submission_attempt: number;
+  last_error_code: string | null;
+  queued_at: string | null;
+  submitted_at: string | null;
+  confirmed_at: string | null;
+  privy_transaction_id: string | null;
+};
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+}
+
+function toInt(value: unknown): number {
+  const n = toNumber(value);
+  return Number.isNaN(n) ? 0 : Math.trunc(n);
+}
+
+function normalizeRow(
+  row: Record<string, unknown>
+): ActivationSettlementTransactionRow {
+  return {
+    id: String(row.id),
+    redemption_id: String(row.redemption_id),
+    activation_id: String(row.activation_id),
+    settlement_rail: row.settlement_rail as SettlementRail,
+    status: row.status as ActivationSettlementStatus,
+    amount: toNumber(row.amount),
+    from_wallet_address: String(row.from_wallet_address),
+    to_wallet_address: String(row.to_wallet_address),
+    tx_hash: row.tx_hash == null ? null : String(row.tx_hash),
+    submission_attempt: toInt(row.submission_attempt),
+    last_error_code:
+      row.last_error_code == null ? null : String(row.last_error_code),
+    queued_at: row.queued_at == null ? null : String(row.queued_at),
+    submitted_at: row.submitted_at == null ? null : String(row.submitted_at),
+    confirmed_at: row.confirmed_at == null ? null : String(row.confirmed_at),
+    privy_transaction_id:
+      row.privy_transaction_id == null
+        ? null
+        : String(row.privy_transaction_id),
+  };
+}
+
+export async function getActivationSettlementTransactionByRedemptionId(
+  redemptionId: string
+): Promise<ActivationSettlementTransactionRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('redemption_id', redemptionId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getActivationSettlementTransactionByRedemptionId:', error);
+    throw new Error(error.message || 'Failed to load settlement transaction');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}

--- a/lib/schemas/activation-cancel-redemption.ts
+++ b/lib/schemas/activation-cancel-redemption.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+const cancelRedemptionWalletAddressSchema = z
+  .string()
+  .min(1, 'walletAddress is required')
+  .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
+    message: 'walletAddress must be a valid EVM address',
+  });
+
+export const activationCancelRedemptionBodySchema = z
+  .object({
+    walletAddress: cancelRedemptionWalletAddressSchema,
+    redemptionId: z.string().uuid('redemptionId must be a valid UUID'),
+    reason: z
+      .string()
+      .max(500, 'reason must be at most 500 characters')
+      .optional(),
+  })
+  .strict();
+
+export type ActivationCancelRedemptionBody = z.infer<
+  typeof activationCancelRedemptionBodySchema
+>;

--- a/lib/schemas/activation-swipe-redeem.ts
+++ b/lib/schemas/activation-swipe-redeem.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod';
+
+const swipeRedeemWalletAddressSchema = z
+  .string()
+  .min(1, 'walletAddress is required')
+  .refine((s) => /^0x[a-fA-F0-9]{40}$/.test(s.trim()), {
+    message: 'walletAddress must be a valid EVM address',
+  });
+
+export const activationSwipeRedeemBodySchema = z
+  .object({
+    walletAddress: swipeRedeemWalletAddressSchema,
+    redemptionId: z.string().uuid('redemptionId must be a valid UUID'),
+  })
+  .strict();
+
+export type ActivationSwipeRedeemBody = z.infer<
+  typeof activationSwipeRedeemBodySchema
+>;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-55: authenticated swipe from `ready_to_redeem` to `settlement_pending` with one queued `activation_settlement_transaction`, optional user cancel from `ready_to_redeem`, caps/budget/rate limits in Postgres, and idempotent replays.

## Changes

- **POST** `/api/sponsored-activations/{activationIdOrSlug}/swipe-redeem` — body `{ walletAddress, redemptionId }` (strict Zod, same shape as confirm-purchase). Returns `{ redemption, settlement }`.
- **POST** `/api/sponsored-activations/{activationIdOrSlug}/cancel-redemption` — body `{ walletAddress, redemptionId, reason? }`. Returns `{ redemption }`.
- **Privy:** `verifyWalletOwnership` plus JWT `userId` match (same pattern as confirm-purchase).
- **SQL:** `swipe_activation_redeem_atomic`, `cancel_activation_redemption_atomic`, and unique index on `activation_settlement_transaction(redemption_id)` so duplicate swipes cannot double-enqueue.
- **Vitest** route tests for happy path, wrong status, idempotency, budget, max per user, paused activation + idempotent replay, expiry outcome, cancel, 401, 429, and strict JSON.

## Deploy notes

Apply SQL in order: `database/irl-55-swipe-settlement-unique-redemption.sql`, then `database/swipe-activation-redeem-atomic.sql`, then `database/cancel-activation-redemption-atomic.sql` (or via your migration workflow).

## Out of scope (per brief)

Settlement workers, UI, Mixpanel, staff confirmation, post-confirm nonce.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-55](https://linear.app/irlenergy/issue/IRL-55/implement-swipe-to-redeem-api-with-caps-and-idempotency)

<div><a href="https://cursor.com/agents/bc-8e3d8b2e-b8ff-4d07-a4ca-4fe03a9f772a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8e3d8b2e-b8ff-4d07-a4ca-4fe03a9f772a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

