### PR TITLE
feat(IRL-56): Base campaign-to-venue activation settlement worker

### DIFF
--- a/lib/activation/base-settlement-worker.test.ts
+++ b/lib/activation/base-settlement-worker.test.ts
@@ -1,0 +1,398 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockGetSettlementById = vi.fn();
+const mockUpdateSettlement = vi.fn();
+const mockUpdateSettlementIfStatus = vi.fn();
+const mockGetActivationById = vi.fn();
+const mockGetRedemptionById = vi.fn();
+const mockSyncRedemption = vi.fn();
+const mockGetPlayerWallet = vi.fn();
+const mockSubmitTreasury = vi.fn();
+const mockFindRecent = vi.fn();
+const mockGetReceiptStatus = vi.fn();
+const mockWaitForTransaction = vi.fn();
+
+vi.mock('@/lib/db/activation-settlement-transactions', () => ({
+  getActivationSettlementTransactionById: (...a: unknown[]) =>
+    mockGetSettlementById(...a),
+  updateActivationSettlementTransaction: (...a: unknown[]) =>
+    mockUpdateSettlement(...a),
+  updateActivationSettlementIfStatus: (...a: unknown[]) =>
+    mockUpdateSettlementIfStatus(...a),
+}));
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  getSponsoredActivationById: (...a: unknown[]) => mockGetActivationById(...a),
+}));
+
+vi.mock('@/lib/db/activation-redemptions', () => ({
+  getActivationRedemptionById: (...a: unknown[]) => mockGetRedemptionById(...a),
+  syncActivationRedemptionSettlementOutcome: (...a: unknown[]) =>
+    mockSyncRedemption(...a),
+}));
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerEvmWalletAddressById: (...a: unknown[]) => mockGetPlayerWallet(...a),
+}));
+
+vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
+  submitTreasuryUsdcTransfer: (...a: unknown[]) => mockSubmitTreasury(...a),
+  findRecentTreasuryUsdcTransfer: (...a: unknown[]) => mockFindRecent(...a),
+  getTreasuryTxReceiptStatus: (...a: unknown[]) => mockGetReceiptStatus(...a),
+}));
+
+vi.mock('@/lib/privy-server-rest', () => {
+  class PrivyRestNotConfiguredError extends Error {
+    name = 'PrivyRestNotConfiguredError';
+  }
+  class PrivyRestTransactionFailedError extends Error {
+    name = 'PrivyRestTransactionFailedError';
+  }
+  class PrivyRestTransactionTimeoutError extends Error {
+    name = 'PrivyRestTransactionTimeoutError';
+    constructor(public transactionId: string) {
+      super('timeout');
+    }
+  }
+  return {
+    PrivyRestNotConfiguredError,
+    PrivyRestTransactionFailedError,
+    PrivyRestTransactionTimeoutError,
+    waitForTransaction: (...a: unknown[]) => mockWaitForTransaction(...a),
+  };
+});
+
+import {
+  BASE_ACTIVATION_SETTLEMENT_ERROR_CODES,
+  processBaseActivationSettlement,
+} from '@/lib/activation/base-settlement-worker';
+import { PrivyRestTransactionTimeoutError } from '@/lib/privy-server-rest';
+
+const campaign = '0x1111111111111111111111111111111111111111';
+const venue = '0x2222222222222222222222222222222222222222';
+const usdc = '0x1234567890123456789012345678901234567890';
+const txHash =
+  '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function baseActivation(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'act-1',
+    settlement_rail: 'base',
+    campaign_wallet_address: campaign,
+    venue_settlement_wallet_address: venue,
+    usdc_asset_config: { contract_address: usdc },
+    privy_campaign_wallet_id: 'privy-wallet-1',
+    ...overrides,
+  };
+}
+
+function baseSettlement(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'settle-1',
+    redemption_id: 'red-1',
+    activation_id: 'act-1',
+    settlement_rail: 'base',
+    status: 'queued',
+    amount: 1.5,
+    from_wallet_address: campaign,
+    to_wallet_address: venue,
+    tx_hash: null,
+    submission_attempt: 0,
+    last_error_code: null,
+    queued_at: '2026-01-01T00:00:00.000Z',
+    submitted_at: null,
+    confirmed_at: null,
+    privy_transaction_id: null,
+    ...overrides,
+  };
+}
+
+function baseRedemption(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'red-1',
+    activation_id: 'act-1',
+    reward_item_id: 'item-1',
+    user_id: 42,
+    eligibility_event_id: 'elig-1',
+    status: 'settlement_pending',
+    idempotency_key: 'key',
+    points_spent: null,
+    usdc_amount_snapshot: 1.5,
+    purchase_confirmed_at: null,
+    redeemed_at: '2026-01-01T00:00:00.000Z',
+    cancelled_reason: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('processBaseActivationSettlement', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateSettlement.mockImplementation(
+      async (_id: string, patch: object) => ({
+        ...baseSettlement(),
+        ...patch,
+      })
+    );
+    mockUpdateSettlementIfStatus.mockImplementation(
+      async (_input: { patch: object }) => ({
+        ...baseSettlement({ status: 'submitted' }),
+        ...(_input as { patch: object }).patch,
+      })
+    );
+    mockGetReceiptStatus.mockResolvedValue('success');
+    mockGetPlayerWallet.mockResolvedValue(null);
+  });
+
+  it('skips when settlement rail is not base', async () => {
+    mockGetSettlementById.mockResolvedValue(
+      baseSettlement({ settlement_rail: 'stellar' })
+    );
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+    expect(r).toEqual({
+      outcome: 'skipped',
+      reason: 'settlement_rail_not_base',
+    });
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+  });
+
+  it('skips when activation rail is not base', async () => {
+    mockGetSettlementById.mockResolvedValue(baseSettlement());
+    mockGetActivationById.mockResolvedValue(
+      baseActivation({ settlement_rail: 'stellar' })
+    );
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+    expect(r).toEqual({
+      outcome: 'skipped',
+      reason: 'activation_rail_not_base',
+    });
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+  });
+
+  it('happy path: submits with activation USDC contract, confirms, syncs redemption', async () => {
+    mockGetSettlementById
+      .mockResolvedValueOnce(baseSettlement())
+      .mockResolvedValue({
+        ...baseSettlement({
+          status: 'confirmed',
+          tx_hash: txHash,
+          privy_transaction_id: 'privy-tx-1',
+          submission_attempt: 1,
+        }),
+      });
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockSubmitTreasury.mockResolvedValue({
+      ok: true,
+      txHash: txHash as `0x${string}`,
+      privyTransactionId: 'privy-tx-1',
+      privyStatus: 'finalized',
+    });
+    mockUpdateSettlementIfStatus.mockResolvedValue({
+      ...baseSettlement({
+        status: 'submitted',
+        privy_transaction_id: 'privy-tx-1',
+      }),
+    });
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(mockSubmitTreasury).toHaveBeenCalledWith(
+      expect.objectContaining({
+        serverWalletId: 'privy-wallet-1',
+        serverWalletAddress: campaign,
+        recipientAddress: venue,
+        usdcAmount: 1.5,
+        usdcContractAddress: usdc,
+        referenceId: 'activation-settlement:settle-1',
+      })
+    );
+    expect(r.outcome).toBe('confirmed');
+    if (r.outcome === 'confirmed') {
+      expect(r.txHash).toBe(txHash);
+    }
+    expect(mockSyncRedemption).toHaveBeenCalledWith({
+      redemptionId: 'red-1',
+      nextStatus: 'settlement_confirmed',
+    });
+  });
+
+  it('fails venue guard when to_wallet_address does not match activation venue', async () => {
+    mockGetSettlementById.mockResolvedValue(
+      baseSettlement({
+        to_wallet_address: '0x3333333333333333333333333333333333333333',
+      })
+    );
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+    expect(mockUpdateSettlement).toHaveBeenCalledWith(
+      'settle-1',
+      expect.objectContaining({
+        status: 'failed',
+        last_error_code:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
+      })
+    );
+  });
+
+  it('fails when recipient would be user embedded wallet', async () => {
+    mockGetSettlementById.mockResolvedValue(baseSettlement());
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockGetPlayerWallet.mockResolvedValue(venue);
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+    expect(mockUpdateSettlement).toHaveBeenCalledWith(
+      'settle-1',
+      expect.objectContaining({
+        last_error_code:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
+      })
+    );
+  });
+
+  it('idempotent when already confirmed', async () => {
+    mockGetSettlementById.mockResolvedValue(
+      baseSettlement({
+        status: 'confirmed',
+        tx_hash: txHash,
+      })
+    );
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(
+      baseRedemption({ status: 'settlement_confirmed' })
+    );
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+    expect(r).toMatchObject({
+      outcome: 'idempotent_confirmed',
+      txHash,
+    });
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+  });
+
+  it('idempotent replay on submitted: resolves hash via chain scan without second submit', async () => {
+    mockGetSettlementById
+      .mockResolvedValueOnce(
+        baseSettlement({
+          status: 'submitted',
+          privy_transaction_id: 'privy-tx-old',
+          submission_attempt: 1,
+        })
+      )
+      .mockResolvedValue({
+        ...baseSettlement({
+          status: 'confirmed',
+          tx_hash: txHash,
+          privy_transaction_id: 'privy-tx-old',
+          submission_attempt: 1,
+        }),
+      });
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockWaitForTransaction.mockRejectedValue(
+      new PrivyRestTransactionTimeoutError('privy-tx-old')
+    );
+    mockFindRecent.mockResolvedValue(txHash as `0x${string}`);
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+    expect(mockFindRecent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        erc20ContractAddress: usdc,
+        usdcAmount: 1.5,
+      })
+    );
+    expect(r.outcome).toBe('confirmed');
+  });
+
+  it('insufficient campaign USDC → settlement_failed + error code', async () => {
+    mockGetSettlementById.mockResolvedValue(baseSettlement());
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockSubmitTreasury.mockResolvedValue({
+      ok: false,
+      error: 'ERC20: transfer amount exceeds balance',
+    });
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(r.outcome).toBe('terminal_failed');
+    if (r.outcome === 'terminal_failed') {
+      expect(r.lastErrorCode).toBe(
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.insufficient_campaign_usdc
+      );
+    }
+    expect(mockUpdateSettlement).toHaveBeenCalledWith(
+      'settle-1',
+      expect.objectContaining({
+        status: 'failed',
+      })
+    );
+  });
+
+  it('missing privy_campaign_wallet_id → failed without submit', async () => {
+    mockGetSettlementById.mockResolvedValue(baseSettlement());
+    mockGetActivationById.mockResolvedValue(
+      baseActivation({ privy_campaign_wallet_id: null })
+    );
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(mockSubmitTreasury).not.toHaveBeenCalled();
+    expect(mockUpdateSettlement).toHaveBeenCalledWith(
+      'settle-1',
+      expect.objectContaining({
+        last_error_code:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
+      })
+    );
+  });
+
+  it('Privy REST not configured → config failure after submit attempt', async () => {
+    const { PrivyRestNotConfiguredError } =
+      await import('@/lib/privy-server-rest');
+    mockGetSettlementById.mockResolvedValue(baseSettlement());
+    mockGetActivationById.mockResolvedValue(baseActivation());
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockSubmitTreasury.mockRejectedValue(new PrivyRestNotConfiguredError());
+
+    const r = await processBaseActivationSettlement({
+      settlementId: 'settle-1',
+    });
+
+    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(mockSubmitTreasury).toHaveBeenCalled();
+  });
+});

--- a/lib/activation/base-settlement-worker.ts
+++ b/lib/activation/base-settlement-worker.ts
@@ -1,0 +1,610 @@
+import { getAddress, isAddress } from 'viem';
+import {
+  getActivationRedemptionById,
+  syncActivationRedemptionSettlementOutcome,
+} from '@/lib/db/activation-redemptions';
+import {
+  getActivationSettlementTransactionById,
+  updateActivationSettlementIfStatus,
+  updateActivationSettlementTransaction,
+  type ActivationSettlementTransactionRow,
+} from '@/lib/db/activation-settlement-transactions';
+import { getPlayerEvmWalletAddressById } from '@/lib/db/players';
+import { getSponsoredActivationById } from '@/lib/db/sponsored-activations';
+import {
+  PrivyRestNotConfiguredError,
+  PrivyRestTransactionFailedError,
+  PrivyRestTransactionTimeoutError,
+  waitForTransaction,
+} from '@/lib/privy-server-rest';
+import { baseUsdcAssetConfigSchema } from '@/lib/schemas/sponsored-activation';
+import {
+  findRecentTreasuryUsdcTransfer,
+  getTreasuryTxReceiptStatus,
+  submitTreasuryUsdcTransfer,
+} from '@/lib/spend-treasury-usdc-transfer';
+import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+/** Stable `last_error_code` values for settlement rows (IRL-56). */
+export const BASE_ACTIVATION_SETTLEMENT_ERROR_CODES = {
+  campaign_wallet_not_configured: 'campaign_wallet_not_configured',
+  venue_wallet_mismatch: 'venue_wallet_mismatch',
+  recipient_is_user_wallet: 'recipient_is_user_wallet',
+  invalid_usdc_contract: 'invalid_usdc_contract',
+  settlement_wallet_invalid: 'settlement_wallet_invalid',
+  campaign_wallet_mismatch: 'campaign_wallet_mismatch',
+  insufficient_campaign_usdc: 'insufficient_campaign_usdc',
+  privy_submit_failed: 'privy_submit_failed',
+  privy_transaction_failed: 'privy_transaction_failed',
+  onchain_reverted: 'onchain_reverted',
+  settlement_not_found: 'settlement_not_found',
+  redemption_not_found: 'redemption_not_found',
+  redemption_status_invalid: 'redemption_status_invalid',
+  privy_not_configured: 'privy_not_configured',
+} as const;
+
+export type BaseActivationSettlementErrorCode =
+  (typeof BASE_ACTIVATION_SETTLEMENT_ERROR_CODES)[keyof typeof BASE_ACTIVATION_SETTLEMENT_ERROR_CODES];
+
+export type ProcessBaseActivationSettlementResult =
+  | {
+      outcome: 'skipped';
+      reason: 'settlement_rail_not_base' | 'activation_rail_not_base';
+    }
+  | {
+      outcome: 'idempotent_confirmed';
+      settlement: ActivationSettlementTransactionRow;
+      txHash: string;
+    }
+  | {
+      outcome: 'terminal_failed';
+      settlement: ActivationSettlementTransactionRow;
+      lastErrorCode: string | null;
+    }
+  | {
+      outcome: 'confirmed';
+      settlement: ActivationSettlementTransactionRow;
+      txHash: string;
+    }
+  | {
+      outcome: 'submitted_pending';
+      settlement: ActivationSettlementTransactionRow;
+      privyTransactionId: string;
+    }
+  | {
+      outcome: 'config_or_validation_failed';
+      settlement: ActivationSettlementTransactionRow;
+      lastErrorCode: BaseActivationSettlementErrorCode;
+    };
+
+const INSUFFICIENT_ERC20_RE =
+  /exceeds\s+balance|insufficient\s+funds|transfer\s+amount|ERC20:\s+transfer\s+amount/i;
+
+function classifyPrivySubmitError(message: string): string {
+  const m = message.trim();
+  if (INSUFFICIENT_ERC20_RE.test(m)) {
+    return BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.insufficient_campaign_usdc;
+  }
+  return BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_submit_failed;
+}
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function requireEvm0x(value: string, ctx: string): `0x${string}` | null {
+  const t = value.trim();
+  if (!t || !isAddress(t)) {
+    console.error(`${ctx}: invalid EVM address`, { value });
+    return null;
+  }
+  return getAddress(t as `0x${string}`);
+}
+
+async function markSettlementAndRedemptionFailed(input: {
+  settlementId: string;
+  redemptionId: string;
+  lastErrorCode: string;
+}): Promise<void> {
+  await updateActivationSettlementTransaction(input.settlementId, {
+    status: 'failed',
+    last_error_code: input.lastErrorCode,
+  });
+  await syncActivationRedemptionSettlementOutcome({
+    redemptionId: input.redemptionId,
+    nextStatus: 'settlement_failed',
+  });
+}
+
+async function confirmSettlementAndRedemption(input: {
+  settlementId: string;
+  redemptionId: string;
+  txHash: string;
+  privyTransactionId: string | null;
+  submissionAttempt: number;
+  /** When already set (e.g. `submitted_at` from the submit step), preserve it. */
+  submittedAt?: string | null;
+}): Promise<void> {
+  const ts = nowIso();
+  await updateActivationSettlementTransaction(input.settlementId, {
+    status: 'confirmed',
+    tx_hash: input.txHash,
+    privy_transaction_id: input.privyTransactionId,
+    confirmed_at: ts,
+    submitted_at: input.submittedAt?.trim() || ts,
+    last_error_code: null,
+    submission_attempt: input.submissionAttempt,
+  });
+  await syncActivationRedemptionSettlementOutcome({
+    redemptionId: input.redemptionId,
+    nextStatus: 'settlement_confirmed',
+  });
+}
+
+/**
+ * Base (EVM) campaign-wallet → venue-wallet USDC settlement for one
+ * `activation_settlement_transaction` row (`settlement_rail = base`).
+ * Library-only entrypoint for cron (IRL-60); idempotent replays do not double-send.
+ */
+export async function processBaseActivationSettlement(input: {
+  settlementId: string;
+}): Promise<ProcessBaseActivationSettlementResult> {
+  const settlementId = input.settlementId.trim();
+  if (!settlementId) {
+    throw new Error(
+      'processBaseActivationSettlement: settlementId is required'
+    );
+  }
+
+  const row = await getActivationSettlementTransactionById(settlementId);
+  if (!row) {
+    throw new Error(
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_not_found
+    );
+  }
+
+  if (row.settlement_rail !== 'base') {
+    return { outcome: 'skipped', reason: 'settlement_rail_not_base' };
+  }
+
+  const activation = await getSponsoredActivationById(row.activation_id);
+  if (!activation) {
+    throw new Error('Sponsored activation not found for settlement');
+  }
+
+  if (activation.settlement_rail !== 'base') {
+    return { outcome: 'skipped', reason: 'activation_rail_not_base' };
+  }
+
+  if (row.status === 'confirmed' && row.tx_hash) {
+    const redemption = await getActivationRedemptionById(row.redemption_id);
+    if (redemption?.status === 'settlement_pending') {
+      await syncActivationRedemptionSettlementOutcome({
+        redemptionId: row.redemption_id,
+        nextStatus: 'settlement_confirmed',
+      });
+    }
+    return {
+      outcome: 'idempotent_confirmed',
+      settlement: row,
+      txHash: row.tx_hash,
+    };
+  }
+
+  if (row.status === 'failed') {
+    return {
+      outcome: 'terminal_failed',
+      settlement: row,
+      lastErrorCode: row.last_error_code,
+    };
+  }
+
+  const redemption = await getActivationRedemptionById(row.redemption_id);
+  if (!redemption) {
+    throw new Error(
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_not_found
+    );
+  }
+
+  const venueExpected = requireEvm0x(
+    activation.venue_settlement_wallet_address,
+    'venue_settlement_wallet_address'
+  );
+  const campaignExpected = requireEvm0x(
+    activation.campaign_wallet_address,
+    'campaign_wallet_address'
+  );
+  const toParsed = requireEvm0x(row.to_wallet_address, 'to_wallet_address');
+  const fromParsed = requireEvm0x(
+    row.from_wallet_address,
+    'from_wallet_address'
+  );
+
+  if (!venueExpected || !campaignExpected || !toParsed || !fromParsed) {
+    await markSettlementAndRedemptionFailed({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid,
+    });
+    const refreshed = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'config_or_validation_failed',
+      settlement: refreshed ?? row,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid,
+    };
+  }
+
+  if (
+    !sameWalletAddress(
+      row.to_wallet_address,
+      activation.venue_settlement_wallet_address
+    )
+  ) {
+    await markSettlementAndRedemptionFailed({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
+    });
+    const refreshed = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'config_or_validation_failed',
+      settlement: refreshed ?? row,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
+    };
+  }
+
+  if (
+    !sameWalletAddress(
+      row.from_wallet_address,
+      activation.campaign_wallet_address
+    )
+  ) {
+    await markSettlementAndRedemptionFailed({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch,
+    });
+    const refreshed = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'config_or_validation_failed',
+      settlement: refreshed ?? row,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch,
+    };
+  }
+
+  const userWallet = await getPlayerEvmWalletAddressById(redemption.user_id);
+  if (userWallet) {
+    const userNorm = tryNormalizeEvmAddress(userWallet) ?? userWallet.trim();
+    if (userNorm && sameWalletAddress(toParsed, userNorm)) {
+      await markSettlementAndRedemptionFailed({
+        settlementId: row.id,
+        redemptionId: row.redemption_id,
+        lastErrorCode:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
+      });
+      const refreshed = await getActivationSettlementTransactionById(row.id);
+      return {
+        outcome: 'config_or_validation_failed',
+        settlement: refreshed ?? row,
+        lastErrorCode:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
+      };
+    }
+  }
+
+  const cfgParse = baseUsdcAssetConfigSchema.safeParse(
+    activation.usdc_asset_config
+  );
+  if (!cfgParse.success) {
+    await markSettlementAndRedemptionFailed({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract,
+    });
+    const refreshed = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'config_or_validation_failed',
+      settlement: refreshed ?? row,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract,
+    };
+  }
+  const usdcContract = cfgParse.data.contract_address;
+
+  const privyWalletId = activation.privy_campaign_wallet_id?.trim();
+  if (!privyWalletId) {
+    await markSettlementAndRedemptionFailed({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
+    });
+    const refreshed = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'config_or_validation_failed',
+      settlement: refreshed ?? row,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
+    };
+  }
+
+  if (redemption.status !== 'settlement_pending') {
+    if (row.status === 'submitted' || row.status === 'queued') {
+      await markSettlementAndRedemptionFailed({
+        settlementId: row.id,
+        redemptionId: row.redemption_id,
+        lastErrorCode:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid,
+      });
+      const refreshed = await getActivationSettlementTransactionById(row.id);
+      return {
+        outcome: 'config_or_validation_failed',
+        settlement: refreshed ?? row,
+        lastErrorCode:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid,
+      };
+    }
+    return {
+      outcome: 'terminal_failed',
+      settlement: row,
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid,
+    };
+  }
+
+  const referenceId = `activation-settlement:${row.id}`;
+
+  const settlementAmount = row.amount;
+
+  async function finalizeFromTxHash(params: {
+    settlementId: string;
+    redemptionId: string;
+    txHash: `0x${string}`;
+    privyTransactionId: string | null;
+    submissionAttempt: number;
+    submittedAtPreserve?: string | null;
+  }): Promise<void> {
+    const receipt = await getTreasuryTxReceiptStatus(params.txHash);
+    if (receipt === 'reverted') {
+      await markSettlementAndRedemptionFailed({
+        settlementId: params.settlementId,
+        redemptionId: params.redemptionId,
+        lastErrorCode: BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.onchain_reverted,
+      });
+      return;
+    }
+    if (receipt === 'success') {
+      await confirmSettlementAndRedemption({
+        settlementId: params.settlementId,
+        redemptionId: params.redemptionId,
+        txHash: params.txHash,
+        privyTransactionId: params.privyTransactionId,
+        submissionAttempt: params.submissionAttempt,
+        submittedAt: params.submittedAtPreserve,
+      });
+    }
+  }
+
+  async function tryResolveHashFromChain(): Promise<`0x${string}` | null> {
+    return findRecentTreasuryUsdcTransfer({
+      serverWalletAddress: campaignExpected as `0x${string}`,
+      recipientAddress: venueExpected as `0x${string}`,
+      usdcAmount: settlementAmount,
+      erc20ContractAddress: usdcContract,
+    });
+  }
+
+  /** Reconcile `submitted` (Privy id and/or hash) without broadcasting a second transfer. */
+  if (row.status === 'submitted') {
+    let txHash: `0x${string}` | null =
+      row.tx_hash && isAddress(row.tx_hash.trim())
+        ? getAddress(row.tx_hash.trim() as `0x${string}`)
+        : null;
+
+    if (!txHash && row.privy_transaction_id) {
+      try {
+        const waited = await waitForTransaction(row.privy_transaction_id, {
+          timeoutMs: 10_000,
+          initialPollMs: 400,
+          maxPollMs: 2_000,
+        });
+        txHash = waited.transactionHash;
+      } catch (e) {
+        if (e instanceof PrivyRestTransactionFailedError) {
+          await markSettlementAndRedemptionFailed({
+            settlementId: row.id,
+            redemptionId: row.redemption_id,
+            lastErrorCode:
+              BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_transaction_failed,
+          });
+          const refreshed = await getActivationSettlementTransactionById(
+            row.id
+          );
+          return {
+            outcome: 'terminal_failed',
+            settlement: refreshed ?? row,
+            lastErrorCode:
+              BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_transaction_failed,
+          };
+        }
+        if (e instanceof PrivyRestTransactionTimeoutError) {
+          txHash = await tryResolveHashFromChain();
+        } else {
+          throw e;
+        }
+      }
+    }
+
+    if (!txHash) {
+      txHash = await tryResolveHashFromChain();
+    }
+
+    if (txHash) {
+      await finalizeFromTxHash({
+        settlementId: row.id,
+        redemptionId: row.redemption_id,
+        txHash,
+        privyTransactionId: row.privy_transaction_id,
+        submissionAttempt: row.submission_attempt,
+        submittedAtPreserve: row.submitted_at,
+      });
+      const after = await getActivationSettlementTransactionById(row.id);
+      if (after?.status === 'confirmed' && after.tx_hash) {
+        return {
+          outcome: 'confirmed',
+          settlement: after,
+          txHash: after.tx_hash,
+        };
+      }
+      if (after?.status === 'failed') {
+        return {
+          outcome: 'terminal_failed',
+          settlement: after,
+          lastErrorCode: after.last_error_code,
+        };
+      }
+    }
+
+    const latest = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'submitted_pending',
+      settlement: latest ?? row,
+      privyTransactionId: row.privy_transaction_id ?? '',
+    };
+  }
+
+  if (row.status !== 'queued') {
+    return {
+      outcome: 'terminal_failed',
+      settlement: row,
+      lastErrorCode: row.last_error_code,
+    };
+  }
+
+  let submit;
+  try {
+    submit = await submitTreasuryUsdcTransfer({
+      serverWalletId: privyWalletId,
+      serverWalletAddress: campaignExpected,
+      recipientAddress: venueExpected,
+      usdcAmount: row.amount,
+      usdcContractAddress: usdcContract,
+      referenceId,
+    });
+  } catch (e) {
+    if (
+      e instanceof PrivyRestNotConfiguredError ||
+      (e instanceof Error &&
+        /PRIVY_APP_SECRET|NEXT_PUBLIC_PRIVY_APP_ID|PRIVY_APP_ID/i.test(
+          e.message
+        ))
+    ) {
+      await markSettlementAndRedemptionFailed({
+        settlementId: row.id,
+        redemptionId: row.redemption_id,
+        lastErrorCode:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured,
+      });
+      const refreshed = await getActivationSettlementTransactionById(row.id);
+      return {
+        outcome: 'config_or_validation_failed',
+        settlement: refreshed ?? row,
+        lastErrorCode:
+          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured,
+      };
+    }
+    throw e;
+  }
+
+  if (!submit.ok) {
+    const code = classifyPrivySubmitError(submit.error);
+    await markSettlementAndRedemptionFailed({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      lastErrorCode: code,
+    });
+    const refreshed = await getActivationSettlementTransactionById(row.id);
+    return {
+      outcome: 'terminal_failed',
+      settlement: refreshed ?? row,
+      lastErrorCode: code,
+    };
+  }
+
+  const privyTransactionId = submit.privyTransactionId;
+  const submittedAt = nowIso();
+  const nextAttempt = row.submission_attempt + 1;
+
+  const updatedQueued = await updateActivationSettlementIfStatus({
+    settlementId: row.id,
+    ifStatusIn: ['queued'],
+    patch: {
+      status: 'submitted',
+      privy_transaction_id: privyTransactionId,
+      submitted_at: submittedAt,
+      submission_attempt: nextAttempt,
+    },
+  });
+
+  if (!updatedQueued) {
+    const latest = await getActivationSettlementTransactionById(row.id);
+    if (latest?.status === 'confirmed' && latest.tx_hash) {
+      return {
+        outcome: 'idempotent_confirmed',
+        settlement: latest,
+        txHash: latest.tx_hash,
+      };
+    }
+    if (latest) {
+      return processBaseActivationSettlement({ settlementId: latest.id });
+    }
+    throw new Error('Settlement row disappeared after Privy submit');
+  }
+
+  let txHash: `0x${string}` | null = null;
+  if (submit.ok && !('submittedPending' in submit && submit.submittedPending)) {
+    txHash = submit.txHash;
+  } else if (
+    submit.ok &&
+    'submittedPending' in submit &&
+    submit.submittedPending
+  ) {
+    txHash = await tryResolveHashFromChain();
+  }
+
+  if (txHash) {
+    await finalizeFromTxHash({
+      settlementId: row.id,
+      redemptionId: row.redemption_id,
+      txHash,
+      privyTransactionId,
+      submissionAttempt: nextAttempt,
+      submittedAtPreserve: submittedAt,
+    });
+    const after = await getActivationSettlementTransactionById(row.id);
+    if (after?.status === 'confirmed' && after.tx_hash) {
+      return { outcome: 'confirmed', settlement: after, txHash: after.tx_hash };
+    }
+    if (after?.status === 'failed') {
+      return {
+        outcome: 'terminal_failed',
+        settlement: after,
+        lastErrorCode: after.last_error_code,
+      };
+    }
+  }
+
+  const latest = await getActivationSettlementTransactionById(row.id);
+  return {
+    outcome: 'submitted_pending',
+    settlement: latest ?? updatedQueued,
+    privyTransactionId,
+  };
+}

--- a/lib/activation/base-settlement-worker.ts
+++ b/lib/activation/base-settlement-worker.ts
@@ -80,7 +80,9 @@ export type ProcessBaseActivationSettlementResult =
 const INSUFFICIENT_ERC20_RE =
   /exceeds\s+balance|insufficient\s+funds|transfer\s+amount|ERC20:\s+transfer\s+amount/i;
 
-function classifyPrivySubmitError(message: string): string {
+function classifyPrivySubmitError(
+  message: string
+): BaseActivationSettlementErrorCode {
   const m = message.trim();
   if (INSUFFICIENT_ERC20_RE.test(m)) {
     return BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.insufficient_campaign_usdc;
@@ -114,6 +116,25 @@ async function markSettlementAndRedemptionFailed(input: {
     redemptionId: input.redemptionId,
     nextStatus: 'settlement_failed',
   });
+}
+
+async function returnConfigValidationFailed(
+  row: ActivationSettlementTransactionRow,
+  lastErrorCode: BaseActivationSettlementErrorCode
+): Promise<
+  Extract<
+    ProcessBaseActivationSettlementResult,
+    { outcome: 'config_or_validation_failed' }
+  >
+> {
+  await markSettlementAndRedemptionFailed({
+    settlementId: row.id,
+    redemptionId: row.redemption_id,
+    lastErrorCode,
+  });
+  const settlement =
+    (await getActivationSettlementTransactionById(row.id)) ?? row;
+  return { outcome: 'config_or_validation_failed', settlement, lastErrorCode };
 }
 
 async function confirmSettlementAndRedemption(input: {
@@ -221,19 +242,10 @@ export async function processBaseActivationSettlement(input: {
   );
 
   if (!venueExpected || !campaignExpected || !toParsed || !fromParsed) {
-    await markSettlementAndRedemptionFailed({
-      settlementId: row.id,
-      redemptionId: row.redemption_id,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid,
-    });
-    const refreshed = await getActivationSettlementTransactionById(row.id);
-    return {
-      outcome: 'config_or_validation_failed',
-      settlement: refreshed ?? row,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid,
-    };
+    return returnConfigValidationFailed(
+      row,
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid
+    );
   }
 
   if (
@@ -242,19 +254,10 @@ export async function processBaseActivationSettlement(input: {
       activation.venue_settlement_wallet_address
     )
   ) {
-    await markSettlementAndRedemptionFailed({
-      settlementId: row.id,
-      redemptionId: row.redemption_id,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
-    });
-    const refreshed = await getActivationSettlementTransactionById(row.id);
-    return {
-      outcome: 'config_or_validation_failed',
-      settlement: refreshed ?? row,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
-    };
+    return returnConfigValidationFailed(
+      row,
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch
+    );
   }
 
   if (
@@ -263,38 +266,20 @@ export async function processBaseActivationSettlement(input: {
       activation.campaign_wallet_address
     )
   ) {
-    await markSettlementAndRedemptionFailed({
-      settlementId: row.id,
-      redemptionId: row.redemption_id,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch,
-    });
-    const refreshed = await getActivationSettlementTransactionById(row.id);
-    return {
-      outcome: 'config_or_validation_failed',
-      settlement: refreshed ?? row,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch,
-    };
+    return returnConfigValidationFailed(
+      row,
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch
+    );
   }
 
   const userWallet = await getPlayerEvmWalletAddressById(redemption.user_id);
   if (userWallet) {
     const userNorm = tryNormalizeEvmAddress(userWallet) ?? userWallet.trim();
     if (userNorm && sameWalletAddress(toParsed, userNorm)) {
-      await markSettlementAndRedemptionFailed({
-        settlementId: row.id,
-        redemptionId: row.redemption_id,
-        lastErrorCode:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
-      });
-      const refreshed = await getActivationSettlementTransactionById(row.id);
-      return {
-        outcome: 'config_or_validation_failed',
-        settlement: refreshed ?? row,
-        lastErrorCode:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
-      };
+      return returnConfigValidationFailed(
+        row,
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet
+      );
     }
   }
 
@@ -302,54 +287,27 @@ export async function processBaseActivationSettlement(input: {
     activation.usdc_asset_config
   );
   if (!cfgParse.success) {
-    await markSettlementAndRedemptionFailed({
-      settlementId: row.id,
-      redemptionId: row.redemption_id,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract,
-    });
-    const refreshed = await getActivationSettlementTransactionById(row.id);
-    return {
-      outcome: 'config_or_validation_failed',
-      settlement: refreshed ?? row,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract,
-    };
+    return returnConfigValidationFailed(
+      row,
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract
+    );
   }
   const usdcContract = cfgParse.data.contract_address;
 
   const privyWalletId = activation.privy_campaign_wallet_id?.trim();
   if (!privyWalletId) {
-    await markSettlementAndRedemptionFailed({
-      settlementId: row.id,
-      redemptionId: row.redemption_id,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
-    });
-    const refreshed = await getActivationSettlementTransactionById(row.id);
-    return {
-      outcome: 'config_or_validation_failed',
-      settlement: refreshed ?? row,
-      lastErrorCode:
-        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
-    };
+    return returnConfigValidationFailed(
+      row,
+      BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured
+    );
   }
 
   if (redemption.status !== 'settlement_pending') {
     if (row.status === 'submitted' || row.status === 'queued') {
-      await markSettlementAndRedemptionFailed({
-        settlementId: row.id,
-        redemptionId: row.redemption_id,
-        lastErrorCode:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid,
-      });
-      const refreshed = await getActivationSettlementTransactionById(row.id);
-      return {
-        outcome: 'config_or_validation_failed',
-        settlement: refreshed ?? row,
-        lastErrorCode:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid,
-      };
+      return returnConfigValidationFailed(
+        row,
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid
+      );
     }
     return {
       outcome: 'terminal_failed',
@@ -434,9 +392,7 @@ export async function processBaseActivationSettlement(input: {
               BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_transaction_failed,
           };
         }
-        if (e instanceof PrivyRestTransactionTimeoutError) {
-          txHash = await tryResolveHashFromChain();
-        } else {
+        if (!(e instanceof PrivyRestTransactionTimeoutError)) {
           throw e;
         }
       }
@@ -506,19 +462,10 @@ export async function processBaseActivationSettlement(input: {
           e.message
         ))
     ) {
-      await markSettlementAndRedemptionFailed({
-        settlementId: row.id,
-        redemptionId: row.redemption_id,
-        lastErrorCode:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured,
-      });
-      const refreshed = await getActivationSettlementTransactionById(row.id);
-      return {
-        outcome: 'config_or_validation_failed',
-        settlement: refreshed ?? row,
-        lastErrorCode:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured,
-      };
+      return returnConfigValidationFailed(
+        row,
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured
+      );
     }
     throw e;
   }
@@ -569,14 +516,10 @@ export async function processBaseActivationSettlement(input: {
   }
 
   let txHash: `0x${string}` | null = null;
-  if (submit.ok && !('submittedPending' in submit && submit.submittedPending)) {
-    txHash = submit.txHash;
-  } else if (
-    submit.ok &&
-    'submittedPending' in submit &&
-    submit.submittedPending
-  ) {
+  if ('submittedPending' in submit && submit.submittedPending) {
     txHash = await tryResolveHashFromChain();
+  } else {
+    txHash = submit.txHash;
   }
 
   if (txHash) {

--- a/lib/db/activation-redemptions.ts
+++ b/lib/db/activation-redemptions.ts
@@ -387,3 +387,33 @@ export async function getActivationRedemptionByIdempotencyKey(
   if (!data) return null;
   return normalizeRow(data as Record<string, unknown>);
 }
+
+/**
+ * Moves redemption out of `settlement_pending` after settlement worker outcome (IRL-56).
+ * Only updates when the row is still `settlement_pending` so duplicate invocations stay idempotent.
+ */
+export async function syncActivationRedemptionSettlementOutcome(input: {
+  redemptionId: string;
+  nextStatus: Extract<
+    ActivationRedemptionStatus,
+    'settlement_confirmed' | 'settlement_failed'
+  >;
+}): Promise<ActivationRedemptionRow | null> {
+  const now = new Date().toISOString();
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update({ status: input.nextStatus, updated_at: now })
+    .eq('id', input.redemptionId)
+    .eq('status', 'settlement_pending')
+    .select('*')
+    .maybeSingle();
+
+  if (error) {
+    console.error('syncActivationRedemptionSettlementOutcome:', error);
+    throw new Error(
+      error.message || 'Failed to sync redemption settlement status'
+    );
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}

--- a/lib/db/activation-settlement-transactions.ts
+++ b/lib/db/activation-settlement-transactions.ts
@@ -78,3 +78,84 @@ export async function getActivationSettlementTransactionByRedemptionId(
   if (!data) return null;
   return normalizeRow(data as Record<string, unknown>);
 }
+
+export async function getActivationSettlementTransactionById(
+  settlementId: string
+): Promise<ActivationSettlementTransactionRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('id', settlementId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getActivationSettlementTransactionById:', error);
+    throw new Error(error.message || 'Failed to load settlement transaction');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+export type ActivationSettlementTransactionPatch = {
+  status?: ActivationSettlementStatus;
+  tx_hash?: string | null;
+  privy_transaction_id?: string | null;
+  last_error_code?: string | null;
+  queued_at?: string | null;
+  submitted_at?: string | null;
+  confirmed_at?: string | null;
+  submission_attempt?: number;
+};
+
+/**
+ * Updates a settlement row by id (no status guard). Prefer
+ * {@link updateActivationSettlementIfStatus} when moving `queued` → `submitted`
+ * so concurrent workers do not double-apply patches.
+ */
+export async function updateActivationSettlementTransaction(
+  settlementId: string,
+  patch: ActivationSettlementTransactionPatch
+): Promise<ActivationSettlementTransactionRow | null> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .update(patch)
+    .eq('id', settlementId)
+    .select('*')
+    .maybeSingle();
+
+  if (error) {
+    console.error('updateActivationSettlementTransaction:', error);
+    throw new Error(error.message || 'Failed to update settlement transaction');
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}
+
+/**
+ * Conditional update: only rows whose `status` is in `ifStatusIn` are updated.
+ * Returns the updated row, or null when no row matched (e.g. another worker moved status).
+ */
+export async function updateActivationSettlementIfStatus(input: {
+  settlementId: string;
+  ifStatusIn: ActivationSettlementStatus[];
+  patch: ActivationSettlementTransactionPatch;
+}): Promise<ActivationSettlementTransactionRow | null> {
+  let q = supabase.from(TABLE).update(input.patch).eq('id', input.settlementId);
+
+  if (input.ifStatusIn.length === 1) {
+    q = q.eq('status', input.ifStatusIn[0]!);
+  } else {
+    q = q.in('status', input.ifStatusIn);
+  }
+
+  const { data, error } = await q.select('*').maybeSingle();
+
+  if (error) {
+    console.error('updateActivationSettlementIfStatus:', error);
+    throw new Error(
+      error.message || 'Failed to conditionally update settlement transaction'
+    );
+  }
+  if (!data) return null;
+  return normalizeRow(data as Record<string, unknown>);
+}

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -111,6 +111,29 @@ export const getPlayerByWallet = async (walletAddress: string) => {
 };
 
 /**
+ * Primary EVM `wallet_address` for a player, when set (trimmed non-empty).
+ * Used by activation settlement to ensure venue payouts never target the attendee wallet.
+ */
+export async function getPlayerEvmWalletAddressById(
+  playerId: number
+): Promise<string | null> {
+  const { data, error } = await supabase
+    .from('players')
+    .select('wallet_address')
+    .eq('id', playerId)
+    .maybeSingle();
+
+  if (error) {
+    console.error('getPlayerEvmWalletAddressById:', error);
+    throw new Error(error.message || 'Failed to load player wallet');
+  }
+  const w = data?.wallet_address;
+  if (typeof w !== 'string') return null;
+  const t = w.trim();
+  return t.length > 0 ? t : null;
+}
+
+/**
  * Resolve `players.id` for a wallet string. Tries EIP-55 form and the raw
  * trimmed value so lookups work whether the row stores checksummed or
  * all-lowercase EVM addresses.

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -2,8 +2,10 @@ import { randomUUID } from 'crypto';
 import {
   encodeFunctionData,
   erc20Abi,
+  getAddress,
   http,
   hexToBigInt,
+  isAddress,
   parseAbiItem,
   parseUnits,
 } from 'viem';
@@ -87,11 +89,28 @@ async function publicBaseClient() {
   });
 }
 
+function resolveErc20LogAddress(
+  erc20ContractAddress?: string | null
+): `0x${string}` {
+  const trimmed = erc20ContractAddress?.trim();
+  if (trimmed) {
+    if (!isAddress(trimmed)) {
+      throw new Error(
+        'resolveErc20LogAddress: invalid ERC-20 contract address'
+      );
+    }
+    return getAddress(trimmed as `0x${string}`);
+  }
+  return getSpendRailBaseUsdcContractAddress();
+}
+
 async function findRecentTreasuryTransferHash(params: {
   serverWalletAddress: `0x${string}`;
   recipientAddress: `0x${string}`;
   usdcAmount: number;
   fromBlock: bigint | null;
+  /** When set (e.g. activation `usdc_asset_config.contract_address`), scan this contract instead of the spend-rail default. */
+  erc20ContractAddress?: string | null;
 }): Promise<`0x${string}` | null> {
   const publicClient = await publicBaseClient();
   const latest = await publicClient.getBlockNumber();
@@ -141,7 +160,7 @@ async function findRecentTreasuryTransferHash(params: {
     const maxFrom = chunkTo - (MAX_LOG_BLOCK_SPAN - 1n);
     const fromBlock = maxFrom > scanFrom ? maxFrom : scanFrom;
     const logs = await publicClient.getLogs({
-      address: getSpendRailBaseUsdcContractAddress(),
+      address: resolveErc20LogAddress(params.erc20ContractAddress),
       event: TRANSFER_EVENT,
       args: {
         from: params.serverWalletAddress,
@@ -173,6 +192,7 @@ export function findRecentTreasuryUsdcTransfer(params: {
   serverWalletAddress: `0x${string}`;
   recipientAddress: `0x${string}`;
   usdcAmount: number;
+  erc20ContractAddress?: string | null;
 }): Promise<`0x${string}` | null> {
   return findRecentTreasuryTransferHash({ ...params, fromBlock: null });
 }
@@ -187,6 +207,11 @@ export async function submitTreasuryUsdcTransfer(params: {
   recipientAddress: `0x${string}`;
   /** Human-readable USDC amount (6 decimals). */
   usdcAmount: number;
+  /**
+   * ERC-20 contract for the transfer `to` field (USDC on Base).
+   * When omitted, uses the spend-rail env default (`getSpendRailBaseUsdcContractAddress`).
+   */
+  usdcContractAddress?: string | null;
   /** Override Privy poll (e.g. tests). */
   privyHashResolveOptions?: { timeoutMs?: number; pollIntervalMs?: number };
   /** Optional Privy `reference_id` (default: random UUID). */
@@ -205,6 +230,12 @@ export async function submitTreasuryUsdcTransfer(params: {
   }
 
   const referenceId = params.referenceId?.trim() || randomUUID();
+  let usdcContract: `0x${string}`;
+  try {
+    usdcContract = resolveErc20LogAddress(params.usdcContractAddress);
+  } catch {
+    return { ok: false, error: 'Invalid USDC contract address.' };
+  }
   const pollOpts = params.privyHashResolveOptions ?? {};
   // 10 s keeps total function time well within Vercel's 15 s default limit;
   // if Privy hasn't confirmed by then we return submittedPending and the
@@ -241,7 +272,7 @@ export async function submitTreasuryUsdcTransfer(params: {
 
     const sent = await signAndSendTransaction({
       walletId,
-      to: getSpendRailBaseUsdcContractAddress(),
+      to: usdcContract,
       data: transferData,
       value: '0x0',
       sponsor: true,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `processBaseActivationSettlement({ settlementId })` for Base `activation_settlement_transaction` rows: USDC transfer from the campaign Privy server wallet to the venue settlement wallet using the activation `usdc_asset_config.contract_address`, deterministic Privy `reference_id` `activation-settlement:{id}`, venue and user-wallet guards, reconcile for `submitted` (Privy poll and optional on-chain log scan), and redemption sync to `settlement_confirmed` or `settlement_failed`.

## Changes

- `lib/activation/base-settlement-worker.ts` — worker entrypoint and stable `last_error_code` constants.
- `lib/spend-treasury-usdc-transfer.ts` — optional `usdcContractAddress` on `submitTreasuryUsdcTransfer` and `findRecentTreasuryUsdcTransfer`.
- `lib/db/activation-settlement-transactions.ts` — load by id, patch updates, conditional status updates.
- `lib/db/activation-redemptions.ts` — `syncActivationRedemptionSettlementOutcome` when leaving `settlement_pending`.
- `lib/db/players.ts` — `getPlayerEvmWalletAddressById` for the recipient guard.
- `lib/activation/base-settlement-worker.test.ts` — Vitest with mocked Privy/chain/DB.

## Verification

- `yarn test lib/activation/base-settlement-worker.test.ts`
- `yarn test lib/spend-treasury-usdc-transfer.test.ts`
- `yarn eslint` on touched files

Deliberately out of scope: Vercel cron, Stellar settlement, budget totals, Mixpanel, admin dashboard.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-56](https://linear.app/irlenergy/issue/IRL-56/implement-base-campaign-to-venue-settlement-worker)

<div><a href="https://cursor.com/agents/bc-0064de6e-27fb-4b2e-8a57-afc7190af8be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0064de6e-27fb-4b2e-8a57-afc7190af8be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

