### PR TITLE
feat: sponsored activation attendee flow (IRL-59)

### DIFF
--- a/app/activation/[activationId]/page.tsx
+++ b/app/activation/[activationId]/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { Suspense } from 'react';
+import { useParams, useSearchParams } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+import { SponsoredActivationFlow } from '@/components/sponsored-activation/sponsored-activation-flow';
+import { SponsoredActivationPageShell } from '@/components/sponsored-activation/sponsored-activation-page-shell';
+
+function ActivationRouteInner() {
+  const params = useParams<{ activationId: string }>();
+  const searchParams = useSearchParams();
+  const activationId = params.activationId?.trim();
+
+  if (!activationId) {
+    return null;
+  }
+
+  return (
+    <SponsoredActivationFlow
+      activationKey={activationId}
+      source={searchParams.get('source')}
+      sourceRefId={searchParams.get('source_ref_id')}
+    />
+  );
+}
+
+export default function ActivationRoutePage() {
+  return (
+    <Suspense
+      fallback={
+        <SponsoredActivationPageShell showCard={false}>
+          <div className="flex min-h-[40vh] items-center justify-center">
+            <Loader2
+              className="size-8 animate-spin text-white/60"
+              aria-hidden
+            />
+          </div>
+        </SponsoredActivationPageShell>
+      }
+    >
+      <ActivationRouteInner />
+    </Suspense>
+  );
+}

--- a/app/activation/[activationId]/page.tsx
+++ b/app/activation/[activationId]/page.tsx
@@ -12,7 +12,13 @@ function ActivationRouteInner() {
   const activationId = params.activationId?.trim();
 
   if (!activationId) {
-    return null;
+    return (
+      <SponsoredActivationPageShell>
+        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+          This activation link is not valid.
+        </p>
+      </SponsoredActivationPageShell>
+    );
   }
 
   return (

--- a/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockGetActivation = vi.fn();
+const mockListItems = vi.fn();
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  getSponsoredActivationByIdOrSlug: (...a: unknown[]) =>
+    mockGetActivation(...a),
+}));
+
+vi.mock('@/lib/db/activation-reward-items', () => ({
+  listActivationRewardItems: (...a: unknown[]) => mockListItems(...a),
+}));
+
+import { GET } from '../route';
+
+const activation = {
+  id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+  slug: 'pr-drink',
+  title: 'Public Records Drink',
+  sponsor_name: 'Public Records',
+  event_id: null,
+  status: 'active' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0x1111111111111111111111111111111111111111',
+  venue_settlement_wallet_address: '0x2222222222222222222222222222222222222222',
+  usdc_asset_config: {},
+  max_redemptions: 10,
+  max_usdc_budget: null,
+  usdc_settled_total: 0,
+  redemption_count_confirmed: 0,
+  starts_at: '2026-01-01T00:00:00.000Z',
+  ends_at: '2027-01-01T00:00:00.000Z',
+  eligibility_config: {},
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: null,
+  privy_campaign_wallet_id: null,
+};
+
+const activeItem = {
+  id: 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
+  activation_id: activation.id,
+  name: 'House drink',
+  hero_image_url:
+    'https://example.supabase.co/storage/v1/object/public/x/y.webp',
+  description: 'One drink',
+  points_cost: 500,
+  usdc_amount: 7,
+  sort_order: 0,
+  is_active: true,
+  max_per_user: 1,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('GET /api/sponsored-activations/[activationId]', () => {
+  it('returns sanitized activation + first active reward item', async () => {
+    mockGetActivation.mockResolvedValue(activation);
+    mockListItems.mockResolvedValue([activeItem]);
+
+    const res = await GET(
+      new NextRequest('http://localhost/api/sponsored-activations/pr-drink'),
+      { params: { activationId: 'pr-drink' } }
+    );
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.activation).toEqual({
+      title: activation.title,
+      sponsor_name: activation.sponsor_name,
+      slug: activation.slug,
+      status: activation.status,
+      window: {
+        starts_at: activation.starts_at,
+        ends_at: activation.ends_at,
+      },
+    });
+    expect(json.data.rewardItem).toEqual({
+      id: activeItem.id,
+      name: activeItem.name,
+      hero_image_url: activeItem.hero_image_url,
+      description: activeItem.description,
+      points_cost: activeItem.points_cost,
+    });
+    expect(json.data.rewardItem).not.toHaveProperty('usdc_amount');
+  });
+
+  it('returns 404 when activation is missing', async () => {
+    mockGetActivation.mockResolvedValue(null);
+    const res = await GET(
+      new NextRequest('http://localhost/api/sponsored-activations/missing'),
+      { params: { activationId: 'missing' } }
+    );
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 404 when no active reward item', async () => {
+    mockGetActivation.mockResolvedValue(activation);
+    mockListItems.mockResolvedValue([{ ...activeItem, is_active: false }]);
+    const res = await GET(
+      new NextRequest('http://localhost/api/sponsored-activations/pr-drink'),
+      { params: { activationId: 'pr-drink' } }
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/app/api/sponsored-activations/[activationId]/route.ts
+++ b/app/api/sponsored-activations/[activationId]/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest } from 'next/server';
+import { listActivationRewardItems } from '@/lib/db/activation-reward-items';
+import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
+import { apiError, apiSuccess } from '@/lib/api/response';
+
+export const dynamic = 'force-dynamic';
+
+type RouteParams = { params: { activationId: string } };
+
+/**
+ * GET /api/sponsored-activations/{activationIdOrSlug}
+ * Public read: activation display fields + first active reward item (sanitized).
+ */
+export async function GET(_request: NextRequest, { params }: RouteParams) {
+  const activationKey = params.activationId?.trim();
+  if (!activationKey) {
+    return apiError('Missing activation id or slug', 400);
+  }
+
+  const activation = await getSponsoredActivationByIdOrSlug(activationKey);
+  if (!activation) {
+    return apiError('Sponsored activation not found', 404);
+  }
+
+  let items;
+  try {
+    items = await listActivationRewardItems(activation.id);
+  } catch (e) {
+    console.error('GET sponsored activation (reward items):', e);
+    return apiError('Something went wrong', 500);
+  }
+
+  const active = items
+    .filter((i) => i.is_active)
+    .sort((a, b) => {
+      if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
+      return a.created_at.localeCompare(b.created_at);
+    });
+
+  const reward = active[0];
+  if (!reward) {
+    return apiError('Sponsored activation not found', 404);
+  }
+
+  return apiSuccess({
+    activation: {
+      title: activation.title,
+      sponsor_name: activation.sponsor_name,
+      slug: activation.slug,
+      status: activation.status,
+      window: {
+        starts_at: activation.starts_at,
+        ends_at: activation.ends_at,
+      },
+    },
+    rewardItem: {
+      id: reward.id,
+      name: reward.name,
+      hero_image_url: reward.hero_image_url,
+      description: reward.description,
+      points_cost: reward.points_cost,
+    },
+  });
+}

--- a/app/api/sponsored-activations/[activationId]/route.ts
+++ b/app/api/sponsored-activations/[activationId]/route.ts
@@ -30,14 +30,8 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     return apiError('Something went wrong', 500);
   }
 
-  const active = items
-    .filter((i) => i.is_active)
-    .sort((a, b) => {
-      if (a.sort_order !== b.sort_order) return a.sort_order - b.sort_order;
-      return a.created_at.localeCompare(b.created_at);
-    });
-
-  const reward = active[0];
+  // `listActivationRewardItems` orders by sort_order, then created_at ascending.
+  const reward = items.find((i) => i.is_active);
   if (!reward) {
     return apiError('Sponsored activation not found', 404);
   }

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -17,7 +17,11 @@ import type {
 } from '@/lib/types';
 import { initMixpanel, trackEvent } from '@/lib/analytics';
 import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
-import { apiClient, ApiError } from '@/lib/api/client';
+import { ApiError } from '@/lib/api/client';
+import {
+  apiClientBearerGet,
+  apiClientBearerPost,
+} from '@/lib/api/privy-bearer-client';
 import {
   SPEND_ELIGIBILITY_MESSAGES,
   type SpendEligibilityStatus,
@@ -147,29 +151,6 @@ function withTimeout<T>(
   });
 }
 
-/** POST with Bearer token + JSON body. */
-async function spendAuthedPost<T>(
-  token: string,
-  path: string,
-  body: Record<string, unknown>
-): Promise<T> {
-  return apiClient<T>(path, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-}
-
-async function spendAuthedGet<T>(token: string, path: string): Promise<T> {
-  return apiClient<T>(path, {
-    method: 'GET',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-}
-
 function eligibilityToneClass(status: SpendEligibilityStatus): string {
   if (
     status === 'eligible' ||
@@ -234,7 +215,7 @@ export function SpendExperiencePage({
       if (!token || !walletAddress) {
         throw new Error('Missing auth');
       }
-      return spendAuthedPost<SessionResponse>(
+      return apiClientBearerPost<SessionResponse>(
         token,
         `/api/spend-experiences/${experienceId}/sessions`,
         { walletAddress }
@@ -258,7 +239,7 @@ export function SpendExperiencePage({
       if (!token || !walletAddress || !sessionId) {
         throw new Error('Missing auth or session');
       }
-      return spendAuthedPost<ConversionPreviewResponse>(
+      return apiClientBearerPost<ConversionPreviewResponse>(
         token,
         `/api/spend-sessions/${sessionId}/conversion/preview`,
         { walletAddress }
@@ -324,7 +305,7 @@ export function SpendExperiencePage({
       if (!token || !walletAddress || !sessionId) {
         throw new Error('Missing auth or session');
       }
-      return spendAuthedPost<PaymentPrepareResponse>(
+      return apiClientBearerPost<PaymentPrepareResponse>(
         token,
         `/api/spend-sessions/${sessionId}/payment/prepare`,
         { walletAddress }
@@ -350,7 +331,7 @@ export function SpendExperiencePage({
       if (!token || !walletAddress || !sessionId) {
         throw new Error('Missing auth or session');
       }
-      return spendAuthedGet<ReceiptResponse>(
+      return apiClientBearerGet<ReceiptResponse>(
         token,
         `/api/spend-sessions/${sessionId}/receipt`
       );
@@ -382,7 +363,7 @@ export function SpendExperiencePage({
       if (!token || !walletAddress || !sessionId) {
         throw new Error('Missing auth or session');
       }
-      return spendAuthedPost<ConversionConfirmResponse>(
+      return apiClientBearerPost<ConversionConfirmResponse>(
         token,
         `/api/spend-sessions/${sessionId}/conversion/confirm`,
         { walletAddress, intent }
@@ -416,7 +397,7 @@ export function SpendExperiencePage({
       } else if (input.paymentTxHash) {
         body.paymentTxHash = input.paymentTxHash;
       }
-      return spendAuthedPost<PaymentConfirmResponse>(
+      return apiClientBearerPost<PaymentConfirmResponse>(
         token,
         `/api/spend-sessions/${sessionId}/payment/confirm`,
         body

--- a/components/sponsored-activation/sponsored-activation-cancelled.tsx
+++ b/components/sponsored-activation/sponsored-activation-cancelled.tsx
@@ -1,0 +1,12 @@
+'use client';
+
+export function SponsoredActivationCancelled() {
+  return (
+    <div className="flex flex-col gap-3 p-6 text-center md:p-8">
+      <h1 className="title2 text-white">This redemption was cancelled</h1>
+      <p className="body-medium font-grotesk text-white/70">
+        This perk is no longer available on your account for this activation.
+      </p>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import Image from 'next/image';
+import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
+import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
+
+type SponsoredActivationConfirmProps = {
+  read: SponsoredActivationPublicReadResponse;
+  accountEmail: string | null;
+  currentPoints: number;
+  pending: boolean;
+  onConfirm: () => void;
+};
+
+export function SponsoredActivationConfirm({
+  read,
+  accountEmail,
+  currentPoints,
+  pending,
+  onConfirm,
+}: SponsoredActivationConfirmProps) {
+  const { rewardItem, activation } = read;
+  const hero = rewardItem.hero_image_url;
+
+  return (
+    <div className="flex min-h-[70vh] flex-col">
+      <div className="flex flex-1 flex-col gap-5 p-4 pb-36 md:p-6">
+        <p className="body-small font-grotesk uppercase tracking-wide text-white/50">
+          {activation.sponsor_name}
+        </p>
+        <h1 className="title2 text-white">{activation.title}</h1>
+
+        <div className="relative aspect-[4/5] w-full overflow-hidden rounded-md bg-white/5">
+          {hero ? (
+            <Image
+              src={hero}
+              alt={rewardItem.name}
+              fill
+              className="object-cover"
+              sizes="(max-width: 768px) 100vw, 400px"
+              unoptimized
+            />
+          ) : (
+            <div className="flex h-full min-h-[200px] items-center justify-center body-medium font-grotesk text-white/35">
+              {rewardItem.name}
+            </div>
+          )}
+        </div>
+
+        <div className="space-y-3 rounded-md border border-white/10 bg-white/5 p-4">
+          <div className="flex justify-between gap-3">
+            <span className="body-small font-grotesk uppercase tracking-wide text-white/50">
+              You send
+            </span>
+            <span className="body-medium font-grotesk font-semibold text-white">
+              {rewardItem.points_cost.toLocaleString()} PTS
+            </span>
+          </div>
+          <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
+            <span className="body-small font-grotesk uppercase tracking-wide text-white/50">
+              You receive
+            </span>
+            <span className="body-medium font-grotesk font-semibold text-right text-white">
+              {rewardItem.name}
+            </span>
+          </div>
+          {accountEmail ? (
+            <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
+              <span className="body-small font-grotesk text-white/50">
+                Account
+              </span>
+              <span className="body-medium font-grotesk text-right text-white/90">
+                {accountEmail}
+              </span>
+            </div>
+          ) : null}
+          <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
+            <span className="body-small font-grotesk text-white/50">
+              Current points
+            </span>
+            <span className="body-medium font-grotesk text-white">
+              {currentPoints.toLocaleString()}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-white/10 bg-[#0a0a0a]/95 px-4 py-4 backdrop-blur-md md:px-8">
+        <div className="mx-auto w-full max-w-[420px] md:max-w-lg">
+          <SpendPrimaryButton pending={pending} onClick={onConfirm}>
+            Confirm Purchase
+          </SpendPrimaryButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -20,7 +20,6 @@ export function SponsoredActivationConfirm({
   onConfirm,
 }: SponsoredActivationConfirmProps) {
   const { rewardItem, activation } = read;
-  const hero = rewardItem.hero_image_url;
 
   return (
     <div className="flex min-h-[70vh] flex-col">
@@ -31,9 +30,9 @@ export function SponsoredActivationConfirm({
         <h1 className="title2 text-white">{activation.title}</h1>
 
         <div className="relative aspect-[4/5] w-full overflow-hidden rounded-md bg-white/5">
-          {hero ? (
+          {rewardItem.hero_image_url ? (
             <Image
-              src={hero}
+              src={rewardItem.hero_image_url}
               alt={rewardItem.name}
               fill
               className="object-cover"

--- a/components/sponsored-activation/sponsored-activation-expired.tsx
+++ b/components/sponsored-activation/sponsored-activation-expired.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+export function SponsoredActivationExpired() {
+  return (
+    <div className="flex flex-col gap-3 p-6 text-center md:p-8">
+      <h1 className="title2 text-white">This offer has expired</h1>
+      <p className="body-medium font-grotesk text-white/70">
+        This redemption is no longer valid. If you think this is a mistake, ask
+        staff at the venue.
+      </p>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -17,6 +17,10 @@ import { useCurrentPlayer } from '@/hooks/usePlayer';
 import { useTiers } from '@/hooks/useTiers';
 import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
 import { apiClient, ApiError } from '@/lib/api/client';
+import {
+  apiClientBearerGet,
+  apiClientBearerPost,
+} from '@/lib/api/privy-bearer-client';
 import { parseSponsoredActivationEligibilityDeeplink } from '@/lib/sponsored-activation/eligibility-deeplink';
 import {
   isRedeemedLikeStatus,
@@ -34,8 +38,6 @@ type EligibilityPostResponse = {
 };
 
 type EligibilityGetResponse = {
-  activationId: string;
-  eligibilityEvents: unknown[];
   redemptions: ActivationRedemptionRow[];
 };
 
@@ -46,30 +48,7 @@ type ConfirmPurchaseResponse = {
 
 type SwipeRedeemResponse = {
   redemption: ActivationRedemptionRow;
-  settlement: unknown;
 };
-
-async function authedPost<T>(
-  token: string,
-  path: string,
-  body: Record<string, unknown>
-): Promise<T> {
-  return apiClient<T>(path, {
-    method: 'POST',
-    headers: {
-      Authorization: `Bearer ${token}`,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(body),
-  });
-}
-
-async function authedGet<T>(token: string, path: string): Promise<T> {
-  return apiClient<T>(path, {
-    method: 'GET',
-    headers: { Authorization: `Bearer ${token}` },
-  });
-}
 
 type SponsoredActivationFlowProps = {
   activationKey: string;
@@ -121,7 +100,7 @@ export function SponsoredActivationFlow({
     }) => {
       const token = await getAccessToken();
       if (!token) throw new Error('Missing auth');
-      return authedPost<EligibilityPostResponse>(
+      return apiClientBearerPost<EligibilityPostResponse>(
         token,
         `/api/sponsored-activations/${encodeURIComponent(activationKey)}/eligibility`,
         {
@@ -168,7 +147,7 @@ export function SponsoredActivationFlow({
     queryFn: async () => {
       const token = await getAccessToken();
       if (!token || !walletAddress) throw new Error('Missing auth');
-      return authedGet<EligibilityGetResponse>(
+      return apiClientBearerGet<EligibilityGetResponse>(
         token,
         `/api/sponsored-activations/${encodeURIComponent(activationKey)}/eligibility?walletAddress=${encodeURIComponent(walletAddress)}`
       );
@@ -202,7 +181,7 @@ export function SponsoredActivationFlow({
     mutationFn: async (redemptionId: string) => {
       const token = await getAccessToken();
       if (!token || !walletAddress) throw new Error('Missing auth');
-      return authedPost<ConfirmPurchaseResponse>(
+      return apiClientBearerPost<ConfirmPurchaseResponse>(
         token,
         `/api/sponsored-activations/${encodeURIComponent(activationKey)}/confirm-purchase`,
         { walletAddress, redemptionId }
@@ -228,7 +207,7 @@ export function SponsoredActivationFlow({
     mutationFn: async (redemptionId: string) => {
       const token = await getAccessToken();
       if (!token || !walletAddress) throw new Error('Missing auth');
-      return authedPost<SwipeRedeemResponse>(
+      return apiClientBearerPost<SwipeRedeemResponse>(
         token,
         `/api/sponsored-activations/${encodeURIComponent(activationKey)}/swipe-redeem`,
         { walletAddress, redemptionId }
@@ -369,7 +348,7 @@ export function SponsoredActivationFlow({
     );
   }
 
-  if (!redemption && !eligibilityLoading) {
+  if (!redemption) {
     return (
       <SponsoredActivationPageShell>
         <div className="flex flex-col gap-4 p-6 text-center">
@@ -382,10 +361,6 @@ export function SponsoredActivationFlow({
         </div>
       </SponsoredActivationPageShell>
     );
-  }
-
-  if (!redemption) {
-    return null;
   }
 
   if (baseScreen === 'expired') {

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -72,6 +72,7 @@ export function SponsoredActivationFlow({
   const [venueStep, setVenueStep] = useState<'success' | 'swipe'>('success');
   const [redemptionOverride, setRedemptionOverride] =
     useState<ActivationRedemptionRow | null>(null);
+  const [swipeSliderKey, setSwipeSliderKey] = useState(0);
 
   const deeplink = useMemo(
     () => parseSponsoredActivationEligibilityDeeplink(source, sourceRefId),
@@ -109,6 +110,11 @@ export function SponsoredActivationFlow({
           source_ref_id: input.sourceRefId,
         }
       );
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ['sponsored-activation-eligibility-get', activationKey],
+      });
     },
   });
 
@@ -152,19 +158,22 @@ export function SponsoredActivationFlow({
         `/api/sponsored-activations/${encodeURIComponent(activationKey)}/eligibility?walletAddress=${encodeURIComponent(walletAddress)}`
       );
     },
-    enabled: Boolean(user && walletAddress && readQuery.isSuccess && !deeplink),
+    enabled: Boolean(user && walletAddress && readQuery.isSuccess),
     retry: false,
   });
 
   const redemptionsFromServer = useMemo(() => {
-    if (deeplink && recordEligibility.data) {
-      return recordEligibility.data.redemptions;
+    const fromGet = resumeEligibility.data?.redemptions ?? [];
+    const fromPost = recordEligibility.data?.redemptions ?? [];
+    const byId = new Map<string, ActivationRedemptionRow>();
+    for (const row of fromGet) {
+      byId.set(row.id, row);
     }
-    if (!deeplink && resumeEligibility.data) {
-      return resumeEligibility.data.redemptions;
+    for (const row of fromPost) {
+      byId.set(row.id, row);
     }
-    return [];
-  }, [deeplink, recordEligibility.data, resumeEligibility.data]);
+    return Array.from(byId.values());
+  }, [recordEligibility.data, resumeEligibility.data]);
 
   const rewardItemId = readQuery.data?.rewardItem.id;
 
@@ -234,6 +243,7 @@ export function SponsoredActivationFlow({
       }
       const msg = err instanceof Error ? err.message : 'Something went wrong';
       toast.error(msg);
+      setSwipeSliderKey((k) => k + 1);
     },
   });
 
@@ -255,7 +265,7 @@ export function SponsoredActivationFlow({
     !recordEligibility.isError;
 
   const resumeFlowLoading =
-    Boolean(!deeplink && user && walletAddress && readQuery.isSuccess) &&
+    Boolean(user && walletAddress && readQuery.isSuccess) &&
     resumeEligibility.isLoading;
 
   const eligibilityLoading =
@@ -338,7 +348,7 @@ export function SponsoredActivationFlow({
     );
   }
 
-  if (!deeplink && resumeEligibility.isError) {
+  if (resumeEligibility.isError) {
     return (
       <SponsoredActivationPageShell>
         <p className="body-medium font-grotesk p-6 text-center text-white/80">
@@ -434,6 +444,7 @@ export function SponsoredActivationFlow({
               </p>
             </div>
             <SponsoredActivationSwipeSlider
+              key={swipeSliderKey}
               disabled={swipeDisabled}
               onComplete={handleSwipeComplete}
             />

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -1,0 +1,480 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePrivy } from '@privy-io/react-auth';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import { SponsoredActivationPageShell } from '@/components/sponsored-activation/sponsored-activation-page-shell';
+import { SponsoredActivationConfirm } from '@/components/sponsored-activation/sponsored-activation-confirm';
+import { SponsoredActivationSuccess } from '@/components/sponsored-activation/sponsored-activation-success';
+import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
+import { SponsoredActivationRedeemed } from '@/components/sponsored-activation/sponsored-activation-redeemed';
+import { SponsoredActivationExpired } from '@/components/sponsored-activation/sponsored-activation-expired';
+import { SponsoredActivationCancelled } from '@/components/sponsored-activation/sponsored-activation-cancelled';
+import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
+import { useCurrentPlayer } from '@/hooks/usePlayer';
+import { useTiers } from '@/hooks/useTiers';
+import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
+import { apiClient, ApiError } from '@/lib/api/client';
+import { parseSponsoredActivationEligibilityDeeplink } from '@/lib/sponsored-activation/eligibility-deeplink';
+import {
+  isRedeemedLikeStatus,
+  isSwipeAllowedForStatus,
+  pickPrimaryActivationRedemption,
+  resolveSponsoredActivationBaseScreen,
+} from '@/lib/sponsored-activation/flow-routing';
+import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
+import { resolveTierTitleForPoints } from '@/lib/sponsored-activation/tier-label';
+
+type EligibilityPostResponse = {
+  eligibilityEvent: { id: string; activation_id: string };
+  redemptions: ActivationRedemptionRow[];
+  eligible: boolean;
+};
+
+type EligibilityGetResponse = {
+  activationId: string;
+  eligibilityEvents: unknown[];
+  redemptions: ActivationRedemptionRow[];
+};
+
+type ConfirmPurchaseResponse = {
+  redemption: ActivationRedemptionRow;
+  player: { total_points: number };
+};
+
+type SwipeRedeemResponse = {
+  redemption: ActivationRedemptionRow;
+  settlement: unknown;
+};
+
+async function authedPost<T>(
+  token: string,
+  path: string,
+  body: Record<string, unknown>
+): Promise<T> {
+  return apiClient<T>(path, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+async function authedGet<T>(token: string, path: string): Promise<T> {
+  return apiClient<T>(path, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}
+
+type SponsoredActivationFlowProps = {
+  activationKey: string;
+  source: string | null;
+  sourceRefId: string | null;
+};
+
+export function SponsoredActivationFlow({
+  activationKey,
+  source,
+  sourceRefId,
+}: SponsoredActivationFlowProps) {
+  const { user, login, getAccessToken } = usePrivy();
+  const walletAddress = user?.wallet?.address ?? null;
+  const accountEmail = user?.email?.address ?? null;
+  const queryClient = useQueryClient();
+
+  const { data: player } = useCurrentPlayer();
+  const { data: tiers } = useTiers();
+
+  const [venueStep, setVenueStep] = useState<'success' | 'swipe'>('success');
+  const [redemptionOverride, setRedemptionOverride] =
+    useState<ActivationRedemptionRow | null>(null);
+
+  const deeplink = useMemo(
+    () => parseSponsoredActivationEligibilityDeeplink(source, sourceRefId),
+    [source, sourceRefId]
+  );
+
+  useEffect(() => {
+    setVenueStep('success');
+    setRedemptionOverride(null);
+  }, [activationKey]);
+
+  const readQuery = useQuery({
+    queryKey: ['sponsored-activation-read', activationKey] as const,
+    queryFn: () =>
+      apiClient<SponsoredActivationPublicReadResponse>(
+        `/api/sponsored-activations/${encodeURIComponent(activationKey)}`
+      ),
+    enabled: Boolean(activationKey),
+  });
+
+  const recordEligibility = useMutation({
+    mutationFn: async (input: {
+      walletAddress: string;
+      source: 'qr_scan' | 'checkpoint_checkin';
+      sourceRefId: string;
+    }) => {
+      const token = await getAccessToken();
+      if (!token) throw new Error('Missing auth');
+      return authedPost<EligibilityPostResponse>(
+        token,
+        `/api/sponsored-activations/${encodeURIComponent(activationKey)}/eligibility`,
+        {
+          walletAddress: input.walletAddress,
+          source: input.source,
+          source_ref_id: input.sourceRefId,
+        }
+      );
+    },
+  });
+
+  useEffect(() => {
+    if (!deeplink || !user || !walletAddress || !readQuery.isSuccess) return;
+    if (
+      recordEligibility.isPending ||
+      recordEligibility.isSuccess ||
+      recordEligibility.isError
+    ) {
+      return;
+    }
+    recordEligibility.mutate({
+      walletAddress,
+      source: deeplink.source,
+      sourceRefId: deeplink.sourceRefId,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- avoid depending on the full mutation object
+  }, [
+    deeplink,
+    user,
+    walletAddress,
+    readQuery.isSuccess,
+    recordEligibility.isPending,
+    recordEligibility.isSuccess,
+    recordEligibility.isError,
+    recordEligibility.mutate,
+  ]);
+
+  const resumeEligibility = useQuery({
+    queryKey: [
+      'sponsored-activation-eligibility-get',
+      activationKey,
+      walletAddress,
+    ] as const,
+    queryFn: async () => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress) throw new Error('Missing auth');
+      return authedGet<EligibilityGetResponse>(
+        token,
+        `/api/sponsored-activations/${encodeURIComponent(activationKey)}/eligibility?walletAddress=${encodeURIComponent(walletAddress)}`
+      );
+    },
+    enabled: Boolean(user && walletAddress && readQuery.isSuccess && !deeplink),
+    retry: false,
+  });
+
+  const redemptionsFromServer = useMemo(() => {
+    if (deeplink && recordEligibility.data) {
+      return recordEligibility.data.redemptions;
+    }
+    if (!deeplink && resumeEligibility.data) {
+      return resumeEligibility.data.redemptions;
+    }
+    return [];
+  }, [deeplink, recordEligibility.data, resumeEligibility.data]);
+
+  const rewardItemId = readQuery.data?.rewardItem.id;
+
+  const pickedRedemption = useMemo(() => {
+    if (!rewardItemId) return null;
+    return pickPrimaryActivationRedemption(redemptionsFromServer, rewardItemId);
+  }, [redemptionsFromServer, rewardItemId]);
+
+  const redemption = redemptionOverride ?? pickedRedemption;
+
+  const baseScreen = resolveSponsoredActivationBaseScreen(redemption?.status);
+
+  const confirmMutation = useMutation({
+    mutationFn: async (redemptionId: string) => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress) throw new Error('Missing auth');
+      return authedPost<ConfirmPurchaseResponse>(
+        token,
+        `/api/sponsored-activations/${encodeURIComponent(activationKey)}/confirm-purchase`,
+        { walletAddress, redemptionId }
+      );
+    },
+    onSuccess: (data) => {
+      setRedemptionOverride(data.redemption);
+      setVenueStep('success');
+      void queryClient.invalidateQueries({
+        queryKey: ['sponsored-activation-eligibility-get', activationKey],
+      });
+      if (data.redemption.status === 'ready_to_redeem') {
+        toast.success('Purchase confirmed');
+      }
+    },
+    onError: (err) => {
+      const msg = err instanceof Error ? err.message : 'Something went wrong';
+      toast.error(msg);
+    },
+  });
+
+  const swipeMutation = useMutation({
+    mutationFn: async (redemptionId: string) => {
+      const token = await getAccessToken();
+      if (!token || !walletAddress) throw new Error('Missing auth');
+      return authedPost<SwipeRedeemResponse>(
+        token,
+        `/api/sponsored-activations/${encodeURIComponent(activationKey)}/swipe-redeem`,
+        { walletAddress, redemptionId }
+      );
+    },
+    onSuccess: (data) => {
+      setRedemptionOverride(data.redemption);
+      void queryClient.invalidateQueries({
+        queryKey: ['sponsored-activation-eligibility-get', activationKey],
+      });
+    },
+    onError: (err) => {
+      if (err instanceof ApiError && err.status === 400) {
+        const details = err.details as
+          | { redemption?: ActivationRedemptionRow }
+          | undefined;
+        if (details?.redemption) {
+          setRedemptionOverride(details.redemption);
+          if (details.redemption.status === 'expired') {
+            toast.error(err.message);
+            return;
+          }
+        }
+      }
+      const msg = err instanceof Error ? err.message : 'Something went wrong';
+      toast.error(msg);
+    },
+  });
+
+  const handleSwipeComplete = useCallback(() => {
+    if (!redemption?.id || swipeMutation.isPending) return;
+    if (!isSwipeAllowedForStatus(redemption.status)) return;
+    swipeMutation.mutate(redemption.id);
+  }, [redemption, swipeMutation]);
+
+  const balanceAfterPoints =
+    confirmMutation.data?.player.total_points ?? player?.total_points ?? 0;
+  const pointsSpent =
+    redemption?.points_spent ?? readQuery.data?.rewardItem.points_cost ?? 0;
+  const tierTitle = resolveTierTitleForPoints(tiers, balanceAfterPoints);
+
+  const recordFlowLoading =
+    Boolean(deeplink) &&
+    !recordEligibility.isSuccess &&
+    !recordEligibility.isError;
+
+  const resumeFlowLoading =
+    Boolean(!deeplink && user && walletAddress && readQuery.isSuccess) &&
+    resumeEligibility.isLoading;
+
+  const eligibilityLoading =
+    Boolean(user && walletAddress && readQuery.isSuccess) &&
+    (recordFlowLoading || resumeFlowLoading);
+
+  if (readQuery.isLoading) {
+    return (
+      <SponsoredActivationPageShell showCard={false}>
+        <div className="flex min-h-[40vh] items-center justify-center">
+          <Loader2 className="size-8 animate-spin text-white/60" aria-hidden />
+        </div>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (readQuery.error || !readQuery.data) {
+    return (
+      <SponsoredActivationPageShell>
+        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+          This activation link is not available.
+        </p>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  const read = readQuery.data;
+
+  if (!user) {
+    return (
+      <SponsoredActivationPageShell>
+        <div className="flex flex-col gap-6 p-6">
+          <h1 className="title2 text-white">{read.activation.title}</h1>
+          <p className="body-medium font-grotesk text-white/70">
+            Log in to continue with this activation.
+          </p>
+          <SpendPrimaryButton onClick={login}>
+            Log in to continue
+          </SpendPrimaryButton>
+        </div>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (!walletAddress) {
+    return (
+      <SponsoredActivationPageShell>
+        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+          A wallet is required on your IRL account to use this activation.
+        </p>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (eligibilityLoading) {
+    return (
+      <SponsoredActivationPageShell showCard={false}>
+        <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3 px-4">
+          <Loader2 className="size-8 animate-spin text-white/60" aria-hidden />
+          <p className="body-small font-grotesk text-white/50">
+            Checking your activation…
+          </p>
+        </div>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (deeplink && recordEligibility.isError) {
+    const apiMsg =
+      recordEligibility.error instanceof Error
+        ? recordEligibility.error.message
+        : null;
+    return (
+      <SponsoredActivationPageShell>
+        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+          {apiMsg ??
+            'We could not verify eligibility from this link. Please scan again or check with staff.'}
+        </p>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (!deeplink && resumeEligibility.isError) {
+    return (
+      <SponsoredActivationPageShell>
+        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+          We could not load your activation status. Please try again.
+        </p>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (!redemption && !eligibilityLoading) {
+    return (
+      <SponsoredActivationPageShell>
+        <div className="flex flex-col gap-4 p-6 text-center">
+          <h1 className="title2 text-white">{read.activation.title}</h1>
+          <p className="body-medium font-grotesk text-white/75">
+            {deeplink
+              ? 'You do not have an available redemption for this perk yet.'
+              : 'No redemption is on file for this activation. Open the link from your QR code or checkpoint to continue.'}
+          </p>
+        </div>
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (!redemption) {
+    return null;
+  }
+
+  if (baseScreen === 'expired') {
+    return (
+      <SponsoredActivationPageShell>
+        <SponsoredActivationExpired />
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (baseScreen === 'cancelled') {
+    return (
+      <SponsoredActivationPageShell>
+        <SponsoredActivationCancelled />
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (baseScreen === 'redeemed') {
+    return (
+      <SponsoredActivationPageShell>
+        <SponsoredActivationRedeemed perkName={read.rewardItem.name} />
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (baseScreen === 'confirm') {
+    return (
+      <SponsoredActivationPageShell>
+        <SponsoredActivationConfirm
+          read={read}
+          accountEmail={accountEmail}
+          currentPoints={player?.total_points ?? 0}
+          pending={confirmMutation.isPending}
+          onConfirm={() => {
+            if (!redemption.id) return;
+            confirmMutation.mutate(redemption.id);
+          }}
+        />
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  if (baseScreen === 'success_swipe') {
+    const showSwipe = venueStep === 'swipe';
+    const swipeDisabled =
+      swipeMutation.isPending ||
+      isRedeemedLikeStatus(redemption.status) ||
+      !isSwipeAllowedForStatus(redemption.status);
+
+    return (
+      <SponsoredActivationPageShell>
+        {!showSwipe ? (
+          <SponsoredActivationSuccess
+            pointsSpent={pointsSpent}
+            balanceAfter={balanceAfterPoints}
+            tierTitle={tierTitle}
+            perkName={read.rewardItem.name}
+            onContinueToSwipe={() => setVenueStep('swipe')}
+          />
+        ) : (
+          <div className="flex flex-col gap-6 p-4 md:p-6">
+            <div>
+              <h1 className="title2 text-white">Swipe to redeem</h1>
+              <p className="mt-2 body-medium font-grotesk text-white/70">
+                Complete the swipe when staff asks you to redeem{' '}
+                <span className="font-semibold text-white">
+                  {read.rewardItem.name}
+                </span>
+                .
+              </p>
+            </div>
+            <SponsoredActivationSwipeSlider
+              disabled={swipeDisabled}
+              onComplete={handleSwipeComplete}
+            />
+          </div>
+        )}
+      </SponsoredActivationPageShell>
+    );
+  }
+
+  return (
+    <SponsoredActivationPageShell>
+      <div className="p-6 text-center">
+        <p className="body-medium font-grotesk text-white/80">
+          This activation is not available for your account right now.
+        </p>
+      </div>
+    </SponsoredActivationPageShell>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-page-shell.tsx
+++ b/components/sponsored-activation/sponsored-activation-page-shell.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import Header from '@/components/layout/header';
+import { cn } from '@/lib/utils';
+
+type SponsoredActivationPageShellProps = {
+  children: ReactNode;
+  /** When false, full-bleed content (e.g. loading). */
+  showCard?: boolean;
+  className?: string;
+};
+
+/**
+ * Mobile-first shell for `/activation/:id` — dark canvas + header; inner card optional.
+ */
+export function SponsoredActivationPageShell({
+  children,
+  showCard = true,
+  className,
+}: SponsoredActivationPageShellProps) {
+  return (
+    <div
+      className={cn(
+        'relative min-h-screen w-full overflow-x-hidden bg-[#0a0a0a]',
+        className
+      )}
+    >
+      <Header />
+      <main className="relative z-0 mx-auto w-full max-w-[420px] px-4 pb-28 pt-24 md:max-w-lg md:px-6 md:pb-32 md:pt-28">
+        {showCard ? (
+          <div className="overflow-hidden rounded-md border border-white/10 bg-[#141414] shadow-lg">
+            {children}
+          </div>
+        ) : (
+          children
+        )}
+      </main>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-page-shell.tsx
+++ b/components/sponsored-activation/sponsored-activation-page-shell.tsx
@@ -6,7 +6,6 @@ import { cn } from '@/lib/utils';
 
 type SponsoredActivationPageShellProps = {
   children: ReactNode;
-  /** When false, full-bleed content (e.g. loading). */
   showCard?: boolean;
   className?: string;
 };

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+type SponsoredActivationRedeemedProps = {
+  perkName: string;
+};
+
+export function SponsoredActivationRedeemed({
+  perkName,
+}: SponsoredActivationRedeemedProps) {
+  return (
+    <div className="flex flex-col gap-4 p-4 md:p-6">
+      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/15 p-6 text-center">
+        <p className="body-small font-grotesk uppercase tracking-wide text-emerald-200/90">
+          Redeemed
+        </p>
+        <h1 className="mt-2 title2 text-white">Enjoy your perk</h1>
+        <p className="mt-3 body-medium font-grotesk text-white/85">
+          {perkName} is redeemed. Show this screen if staff asks for
+          confirmation.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
+
+type SponsoredActivationSuccessProps = {
+  pointsSpent: number;
+  balanceAfter: number;
+  tierTitle: string | null;
+  perkName: string;
+  onContinueToSwipe: () => void;
+};
+
+export function SponsoredActivationSuccess({
+  pointsSpent,
+  balanceAfter,
+  tierTitle,
+  perkName,
+  onContinueToSwipe,
+}: SponsoredActivationSuccessProps) {
+  return (
+    <div className="flex flex-col gap-6 p-4 md:p-6">
+      <div>
+        <p className="body-small font-grotesk uppercase tracking-wide text-emerald-400/90">
+          Success!
+        </p>
+        <h1 className="mt-2 title2 text-white">You&apos;re almost there</h1>
+      </div>
+
+      <div className="space-y-3 rounded-md border border-white/10 bg-white/5 p-4">
+        <div className="flex justify-between gap-3">
+          <span className="body-small font-grotesk uppercase tracking-wide text-white/50">
+            You spent
+          </span>
+          <span className="body-medium font-grotesk font-semibold text-white">
+            {pointsSpent.toLocaleString()} PTS
+          </span>
+        </div>
+        <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
+          <span className="body-small font-grotesk text-white/50">Balance</span>
+          <span className="body-medium font-grotesk text-white">
+            {balanceAfter.toLocaleString()} PTS
+          </span>
+        </div>
+        {tierTitle ? (
+          <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
+            <span className="body-small font-grotesk text-white/50">Tier</span>
+            <span className="body-medium font-grotesk text-white">
+              {tierTitle}
+            </span>
+          </div>
+        ) : null}
+      </div>
+
+      <div className="rounded-md border border-emerald-500/25 bg-emerald-500/10 p-4">
+        <h2 className="body-medium font-grotesk font-semibold text-white">
+          How to collect
+        </h2>
+        <p className="mt-2 body-medium font-grotesk text-white/80">
+          Show this screen on your phone at the venue to pick up{' '}
+          <span className="font-semibold text-white">{perkName}</span>.
+        </p>
+      </div>
+
+      <SpendPrimaryButton type="button" onClick={onContinueToSwipe}>
+        Swipe to redeem at venue
+      </SpendPrimaryButton>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -24,6 +24,7 @@ export function SponsoredActivationSwipeSlider({
   const [dragPx, setDragPx] = useState(0);
   const dragPxRef = useRef(0);
   const [completed, setCompleted] = useState(false);
+  const completionSentRef = useRef(false);
   const activePointerId = useRef<number | null>(null);
 
   const maxTravel = useCallback(() => {
@@ -35,9 +36,11 @@ export function SponsoredActivationSwipeSlider({
 
   const finishIfNeeded = useCallback(
     (px: number) => {
+      if (completionSentRef.current) return;
       const max = maxTravel();
       if (max <= 0) return;
       if (px >= max * COMPLETE_RATIO) {
+        completionSentRef.current = true;
         setCompleted(true);
         setDragPx(max);
         dragPxRef.current = max;
@@ -49,6 +52,7 @@ export function SponsoredActivationSwipeSlider({
 
   useEffect(() => {
     if (disabled || completed) return;
+    completionSentRef.current = false;
     setDragPx(0);
     dragPxRef.current = 0;
   }, [disabled, completed]);
@@ -88,9 +92,10 @@ export function SponsoredActivationSwipeSlider({
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
-    if (disabled || completed) return;
+    if (disabled || completed || completionSentRef.current) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
+      completionSentRef.current = true;
       const max = maxTravel();
       dragPxRef.current = max;
       setDragPx(max);

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+
+const COMPLETE_RATIO = 0.82;
+
+type SponsoredActivationSwipeSliderProps = {
+  disabled: boolean;
+  onComplete: () => void;
+  label?: string;
+};
+
+/**
+ * Drag-to-complete slider — requires deliberate swipe (not a single tap).
+ */
+export function SponsoredActivationSwipeSlider({
+  disabled,
+  onComplete,
+  label = 'Swipe to redeem',
+}: SponsoredActivationSwipeSliderProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const knobRef = useRef<HTMLDivElement>(null);
+  const [dragPx, setDragPx] = useState(0);
+  const dragPxRef = useRef(0);
+  const [completed, setCompleted] = useState(false);
+  const activePointerId = useRef<number | null>(null);
+
+  const maxTravel = useCallback(() => {
+    const track = trackRef.current;
+    const knob = knobRef.current;
+    if (!track || !knob) return 0;
+    return Math.max(0, track.clientWidth - knob.offsetWidth - 8);
+  }, []);
+
+  const finishIfNeeded = useCallback(
+    (px: number) => {
+      const max = maxTravel();
+      if (max <= 0) return;
+      if (px >= max * COMPLETE_RATIO) {
+        setCompleted(true);
+        setDragPx(max);
+        dragPxRef.current = max;
+        onComplete();
+      }
+    },
+    [maxTravel, onComplete]
+  );
+
+  useEffect(() => {
+    if (disabled || completed) return;
+    setDragPx(0);
+    dragPxRef.current = 0;
+  }, [disabled, completed]);
+
+  const onPointerDown = (e: React.PointerEvent) => {
+    if (disabled || completed) return;
+    activePointerId.current = e.pointerId;
+    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+  };
+
+  const onPointerMove = (e: React.PointerEvent) => {
+    if (disabled || completed) return;
+    if (activePointerId.current !== e.pointerId) return;
+    const track = trackRef.current;
+    const knob = knobRef.current;
+    if (!track || !knob) return;
+    const rect = track.getBoundingClientRect();
+    const knobW = knob.offsetWidth;
+    const max = Math.max(0, rect.width - knobW - 8);
+    const x = e.clientX - rect.left - knobW / 2;
+    const clamped = Math.min(max, Math.max(0, x));
+    dragPxRef.current = clamped;
+    setDragPx(clamped);
+    finishIfNeeded(clamped);
+  };
+
+  const onPointerUp = (e: React.PointerEvent) => {
+    if (activePointerId.current !== e.pointerId) return;
+    activePointerId.current = null;
+    if (disabled || completed) return;
+    const max = maxTravel();
+    const px = dragPxRef.current;
+    if (max > 0 && px < max * COMPLETE_RATIO) {
+      dragPxRef.current = 0;
+      setDragPx(0);
+    }
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (disabled || completed) return;
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      const max = maxTravel();
+      dragPxRef.current = max;
+      setDragPx(max);
+      setCompleted(true);
+      onComplete();
+    }
+  };
+
+  return (
+    <div className="w-full">
+      <div
+        ref={trackRef}
+        role="slider"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={
+          completed
+            ? 100
+            : Math.round((dragPx / Math.max(1, maxTravel())) * 100)
+        }
+        aria-disabled={disabled || completed}
+        aria-label={label}
+        tabIndex={disabled || completed ? -1 : 0}
+        onKeyDown={onKeyDown}
+        className={cn(
+          'relative flex h-14 w-full select-none items-center rounded-full border border-white/15 bg-black/40 px-1',
+          disabled || completed ? 'opacity-50' : 'cursor-pointer'
+        )}
+      >
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
+          <span className="label-small font-grotesk text-white/50">
+            {completed ? 'Redeemed' : label}
+          </span>
+        </div>
+        <div
+          ref={knobRef}
+          onPointerDown={onPointerDown}
+          onPointerMove={onPointerMove}
+          onPointerUp={onPointerUp}
+          onPointerCancel={onPointerUp}
+          style={{ transform: `translateX(${dragPx}px)` }}
+          className={cn(
+            'relative z-10 flex h-12 w-[4.5rem] shrink-0 items-center justify-center rounded-full bg-[#FFF200] text-[#0a0a0a] shadow-md',
+            disabled || completed ? 'pointer-events-none' : 'touch-none'
+          )}
+        >
+          <span className="text-lg" aria-hidden>
+            →
+          </span>
+        </div>
+      </div>
+      <p className="mt-2 body-small font-grotesk text-white/40">
+        Slide the button all the way right. Keyboard: focus the track, then
+        press Enter.
+      </p>
+    </div>
+  );
+}

--- a/components/sponsored-activation/swipe-slider.test.tsx
+++ b/components/sponsored-activation/swipe-slider.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
+
+describe('SponsoredActivationSwipeSlider', () => {
+  it('invokes onComplete once when completed via keyboard', async () => {
+    const user = userEvent.setup();
+    const onComplete = vi.fn();
+    render(
+      <SponsoredActivationSwipeSlider
+        disabled={false}
+        onComplete={onComplete}
+      />
+    );
+    const slider = screen.getByRole('slider');
+    slider.focus();
+    await user.keyboard('{Enter}');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+    await user.keyboard('{Enter}');
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onComplete when disabled', () => {
+    const onComplete = vi.fn();
+    render(<SponsoredActivationSwipeSlider disabled onComplete={onComplete} />);
+    const slider = screen.getByRole('slider');
+    fireEvent.keyDown(slider, { key: 'Enter' });
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+});

--- a/lib/api/privy-bearer-client.ts
+++ b/lib/api/privy-bearer-client.ts
@@ -1,0 +1,28 @@
+import { apiClient } from '@/lib/api/client';
+
+/** Authenticated JSON POST using a Privy access token. */
+export async function apiClientBearerPost<T>(
+  token: string,
+  path: string,
+  body: Record<string, unknown>
+): Promise<T> {
+  return apiClient<T>(path, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+/** Authenticated GET using a Privy access token. */
+export async function apiClientBearerGet<T>(
+  token: string,
+  path: string
+): Promise<T> {
+  return apiClient<T>(path, {
+    method: 'GET',
+    headers: { Authorization: `Bearer ${token}` },
+  });
+}

--- a/lib/db/tiers.ts
+++ b/lib/db/tiers.ts
@@ -1,5 +1,6 @@
 import { supabase } from './client';
 import type { Tier } from '../types';
+import { resolveTierForPoints } from '@/lib/tier-for-points';
 
 // Select specific columns for tier queries
 const TIER_COLUMNS = `
@@ -28,21 +29,7 @@ export const getTiers = async (): Promise<Tier[]> => {
   return (data ?? []) as Tier[];
 };
 
-/**
- * Resolve which tier a player belongs to based on their total points
- */
-export const resolveTierForPoints = (
-  tiers: Tier[],
-  totalPoints: number
-): Tier | null => {
-  return (
-    tiers.find(
-      (tier) =>
-        totalPoints >= tier.min_points &&
-        (tier.max_points === null || totalPoints < tier.max_points)
-    ) ?? null
-  );
-};
+export { resolveTierForPoints };
 
 /**
  * Get the tier for a given point total

--- a/lib/sponsored-activation/__tests__/eligibility-deeplink.test.ts
+++ b/lib/sponsored-activation/__tests__/eligibility-deeplink.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { parseSponsoredActivationEligibilityDeeplink } from '@/lib/sponsored-activation/eligibility-deeplink';
+
+describe('parseSponsoredActivationEligibilityDeeplink', () => {
+  it('accepts qr_scan with ref', () => {
+    expect(
+      parseSponsoredActivationEligibilityDeeplink('qr_scan', 'abc')
+    ).toEqual({ source: 'qr_scan', sourceRefId: 'abc' });
+  });
+
+  it('rejects invalid source', () => {
+    expect(
+      parseSponsoredActivationEligibilityDeeplink('nfc', 'abc')
+    ).toBeNull();
+  });
+
+  it('rejects empty ref', () => {
+    expect(
+      parseSponsoredActivationEligibilityDeeplink('qr_scan', '  ')
+    ).toBeNull();
+  });
+});

--- a/lib/sponsored-activation/__tests__/flow-routing.test.ts
+++ b/lib/sponsored-activation/__tests__/flow-routing.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
+import {
+  pickPrimaryActivationRedemption,
+  resolveSponsoredActivationBaseScreen,
+} from '@/lib/sponsored-activation/flow-routing';
+
+const baseRedemption = {
+  id: 'r1',
+  activation_id: 'a1',
+  reward_item_id: 'item-1',
+  user_id: 1,
+  eligibility_event_id: 'e1',
+  idempotency_key: 'k1',
+  points_spent: 100,
+  usdc_amount_snapshot: null,
+  purchase_confirmed_at: null,
+  redeemed_at: null,
+  cancelled_reason: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+} satisfies Omit<ActivationRedemptionRow, 'status'>;
+
+describe('resolveSponsoredActivationBaseScreen', () => {
+  it('maps available to confirm', () => {
+    expect(resolveSponsoredActivationBaseScreen('available')).toBe('confirm');
+  });
+
+  it('maps ready_to_redeem to success_swipe', () => {
+    expect(resolveSponsoredActivationBaseScreen('ready_to_redeem')).toBe(
+      'success_swipe'
+    );
+  });
+
+  it('maps settlement_pending to redeemed', () => {
+    expect(resolveSponsoredActivationBaseScreen('settlement_pending')).toBe(
+      'redeemed'
+    );
+  });
+
+  it('maps expired and cancelled', () => {
+    expect(resolveSponsoredActivationBaseScreen('expired')).toBe('expired');
+    expect(resolveSponsoredActivationBaseScreen('cancelled')).toBe('cancelled');
+  });
+});
+
+describe('pickPrimaryActivationRedemption', () => {
+  it('prefers redeemed-like over available for the same reward item', () => {
+    const rows: ActivationRedemptionRow[] = [
+      { ...baseRedemption, id: 'a', status: 'available' },
+      { ...baseRedemption, id: 'b', status: 'settlement_pending' },
+    ];
+    const picked = pickPrimaryActivationRedemption(rows, 'item-1');
+    expect(picked?.id).toBe('b');
+  });
+});

--- a/lib/sponsored-activation/eligibility-deeplink.ts
+++ b/lib/sponsored-activation/eligibility-deeplink.ts
@@ -1,0 +1,19 @@
+import type { SponsoredActivationUserEligibilitySource } from '@/lib/schemas/activation-eligibility';
+
+export type ValidEligibilityDeeplink = {
+  source: SponsoredActivationUserEligibilitySource;
+  sourceRefId: string;
+};
+
+/**
+ * v1: only `qr_scan` and `checkpoint_checkin` with non-empty `source_ref_id` trigger auto POST.
+ */
+export function parseSponsoredActivationEligibilityDeeplink(
+  source: string | null,
+  sourceRefId: string | null
+): ValidEligibilityDeeplink | null {
+  if (source !== 'qr_scan' && source !== 'checkpoint_checkin') return null;
+  const ref = sourceRefId?.trim();
+  if (!ref) return null;
+  return { source, sourceRefId: ref };
+}

--- a/lib/sponsored-activation/flow-routing.ts
+++ b/lib/sponsored-activation/flow-routing.ts
@@ -1,0 +1,75 @@
+import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
+import type { ActivationRedemptionStatus } from '@/lib/schemas/activation-redemption';
+
+const REDEEMED_LIKE_STATUSES = new Set<ActivationRedemptionStatus>([
+  'redeemed',
+  'settlement_pending',
+  'settlement_confirmed',
+  'settlement_failed',
+]);
+
+const READY_FOR_VENUE_STATUSES = new Set<ActivationRedemptionStatus>([
+  'ready_to_redeem',
+  'purchase_confirmed',
+]);
+
+const CONFIRM_STATUSES = new Set<ActivationRedemptionStatus>([
+  'available',
+  'eligible',
+]);
+
+export type SponsoredActivationBaseScreen =
+  | 'confirm'
+  | 'success_swipe'
+  | 'redeemed'
+  | 'expired'
+  | 'cancelled';
+
+/**
+ * Maps redemption status to the primary full-screen step (before local Success vs Swipe split).
+ */
+export function resolveSponsoredActivationBaseScreen(
+  status: ActivationRedemptionStatus | undefined
+): SponsoredActivationBaseScreen | 'unknown' {
+  if (!status) return 'unknown';
+  if (status === 'expired') return 'expired';
+  if (status === 'cancelled') return 'cancelled';
+  if (REDEEMED_LIKE_STATUSES.has(status)) return 'redeemed';
+  if (READY_FOR_VENUE_STATUSES.has(status)) return 'success_swipe';
+  if (CONFIRM_STATUSES.has(status)) return 'confirm';
+  return 'unknown';
+}
+
+export function isRedeemedLikeStatus(
+  status: ActivationRedemptionStatus | undefined
+): boolean {
+  return status != null && REDEEMED_LIKE_STATUSES.has(status);
+}
+
+export function isSwipeAllowedForStatus(
+  status: ActivationRedemptionStatus | undefined
+): boolean {
+  return status != null && READY_FOR_VENUE_STATUSES.has(status);
+}
+
+function redemptionStatusPriority(status: ActivationRedemptionStatus): number {
+  if (REDEEMED_LIKE_STATUSES.has(status)) return 50;
+  if (READY_FOR_VENUE_STATUSES.has(status)) return 40;
+  if (status === 'expired') return 30;
+  if (status === 'cancelled') return 20;
+  if (CONFIRM_STATUSES.has(status)) return 10;
+  return 0;
+}
+
+/** Pilot: single reward item — pick the highest-priority redemption row for that item. */
+export function pickPrimaryActivationRedemption(
+  redemptions: ActivationRedemptionRow[],
+  rewardItemId: string
+): ActivationRedemptionRow | null {
+  const matches = redemptions.filter((r) => r.reward_item_id === rewardItemId);
+  if (!matches.length) return null;
+  return [...matches].sort(
+    (a, b) =>
+      redemptionStatusPriority(b.status) - redemptionStatusPriority(a.status)
+  )[0];
+}

--- a/lib/sponsored-activation/public-read.ts
+++ b/lib/sponsored-activation/public-read.ts
@@ -1,0 +1,19 @@
+import type { SponsoredActivationStatus } from '@/lib/db/sponsored-activations';
+
+/** Public GET `/api/sponsored-activations/[activationIdOrSlug]` — safe for unauthenticated clients. */
+export type SponsoredActivationPublicReadResponse = {
+  activation: {
+    title: string;
+    sponsor_name: string;
+    slug: string;
+    status: SponsoredActivationStatus;
+    window: { starts_at: string; ends_at: string };
+  };
+  rewardItem: {
+    id: string;
+    name: string;
+    hero_image_url: string | null;
+    description: string | null;
+    points_cost: number;
+  };
+};

--- a/lib/sponsored-activation/tier-label.ts
+++ b/lib/sponsored-activation/tier-label.ts
@@ -1,0 +1,15 @@
+import type { Tier } from '@/lib/types';
+
+/** Client-safe tier resolution (mirrors `lib/db/tiers.resolveTierForPoints`). */
+export function resolveTierTitleForPoints(
+  tiers: Tier[] | undefined,
+  totalPoints: number
+): string | null {
+  if (!tiers?.length) return null;
+  const tier = tiers.find(
+    (t) =>
+      totalPoints >= t.min_points &&
+      (t.max_points === null || totalPoints < t.max_points)
+  );
+  return tier?.title ?? null;
+}

--- a/lib/sponsored-activation/tier-label.ts
+++ b/lib/sponsored-activation/tier-label.ts
@@ -1,15 +1,11 @@
 import type { Tier } from '@/lib/types';
+import { resolveTierForPoints } from '@/lib/tier-for-points';
 
-/** Client-safe tier resolution (mirrors `lib/db/tiers.resolveTierForPoints`). */
+/** Tier title for display after a points balance change (uses shared tier window logic). */
 export function resolveTierTitleForPoints(
   tiers: Tier[] | undefined,
   totalPoints: number
 ): string | null {
   if (!tiers?.length) return null;
-  const tier = tiers.find(
-    (t) =>
-      totalPoints >= t.min_points &&
-      (t.max_points === null || totalPoints < t.max_points)
-  );
-  return tier?.title ?? null;
+  return resolveTierForPoints(tiers, totalPoints)?.title ?? null;
 }

--- a/lib/tier-for-points.ts
+++ b/lib/tier-for-points.ts
@@ -1,0 +1,17 @@
+import type { Tier } from '@/lib/types';
+
+/**
+ * Pure tier lookup for a point total (no I/O). Shared by DB helpers and client UI.
+ */
+export function resolveTierForPoints(
+  tiers: Tier[],
+  totalPoints: number
+): Tier | null {
+  return (
+    tiers.find(
+      (tier) =>
+        totalPoints >= tier.min_points &&
+        (tier.max_points === null || totalPoints < tier.max_points)
+    ) ?? null
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Public Records sponsored activation attendee experience for IRL-59: confirm purchase, success, swipe-to-redeem, and passive terminal states, wired to existing eligibility, confirm-purchase, and swipe-redeem APIs.

## Changes

- **Route** `app/activation/[activationId]/page.tsx` — client page with `Suspense` for `useSearchParams`; supports UUID or slug in the path segment.
- **Public read API** `GET /api/sponsored-activations/[activationId]` — returns sanitized activation display fields plus the first active reward item by `sort_order` (no USDC, wallets, or settlement rail in the payload). Returns 404 when the activation is missing or there is no active reward item.
- **Components** under `components/sponsored-activation/` — shell, confirm (4:5 hero, sticky confirm CTA), success (points, tier, how to collect), swipe slider (drag plus keyboard), redeemed, expired, and cancelled terminals, and flow orchestration in `SponsoredActivationFlow`.
- **Lib helpers** `lib/sponsored-activation/` — deeplink query parsing for v1 sources, redemption status routing, primary redemption picker, tier label helper, and public read types.
- **Tests** — Vitest for the new GET route, flow routing and deeplink parsing, and swipe keyboard guard and disabled behavior.

## Verification

- Targeted `yarn test` for sponsored-activation paths passed; the full Vitest suite still reports unrelated failures elsewhere in the repo.
- `yarn lint --file` on touched files passed; pre-commit `yarn build` succeeded on commit.

## Notes

- User-facing copy avoids USDC, chain, wallet addresses, and transaction hashes.
- Settlement-related redemption statuses and `redeemed` map to the same Redeemed screen per the product brief.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-59](https://linear.app/irlenergy/issue/IRL-59/build-sponsored-activation-user-flow-ui-figma)

<div><a href="https://cursor.com/agents/bc-ecfe9365-2a4e-4d5d-ac37-8bad3ab65676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecfe9365-2a4e-4d5d-ac37-8bad3ab65676"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

