### PR TITLE
feat(sponsored-settlement): IRL-60 retry policy, budget at confirm, finalize USDC

### DIFF
--- a/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/__tests__/route.test.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/__tests__/route.test.ts
@@ -81,4 +81,14 @@ describe('POST /api/admin/.../settlements/.../retry', () => {
     });
     expect(res.status).toBe(400);
   });
+
+  it('maps REDEMPTION_NOT_ELIGIBLE_FOR_RETRY to 400', async () => {
+    mockAdminReset.mockRejectedValue(
+      new Error('REDEMPTION_NOT_ELIGIBLE_FOR_RETRY')
+    );
+    const res = await POST(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1', settlementId: 'set-1' },
+    });
+    expect(res.status).toBe(400);
+  });
 });

--- a/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/__tests__/route.test.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/__tests__/route.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockGetSettlement = vi.fn();
+const mockAdminReset = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/activation-settlement-transactions', () => ({
+  getActivationSettlementTransactionById: (...a: unknown[]) =>
+    mockGetSettlement(...a),
+  adminResetActivationSettlementForRetryAtomic: (...a: unknown[]) =>
+    mockAdminReset(...a),
+}));
+
+import { POST } from '../route';
+
+const settlementRow = (activationId: string) => ({
+  id: 'set-1',
+  activation_id: activationId,
+  redemption_id: 'red-1',
+  settlement_rail: 'base' as const,
+  status: 'failed' as const,
+  amount: 1,
+  from_wallet_address: 'a',
+  to_wallet_address: 'b',
+  tx_hash: null,
+  submission_attempt: 5,
+  last_error_code: 'x',
+  queued_at: null,
+  submitted_at: null,
+  confirmed_at: null,
+  privy_transaction_id: null,
+});
+
+describe('POST /api/admin/.../settlements/.../retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ isValid: true });
+    mockGetSettlement.mockResolvedValue(settlementRow('act-1'));
+    mockAdminReset.mockResolvedValue('reset');
+  });
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await POST(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1', settlementId: 'set-1' },
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it('resets settlement via RPC when admin', async () => {
+    const res = await POST(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1', settlementId: 'set-1' },
+    });
+    expect(res.status).toBe(200);
+    expect(mockAdminReset).toHaveBeenCalledWith({
+      settlementId: 'set-1',
+      activationId: 'act-1',
+    });
+  });
+
+  it('returns 404 when settlement is not under activation', async () => {
+    mockGetSettlement.mockResolvedValue(settlementRow('other-act'));
+    const res = await POST(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1', settlementId: 'set-1' },
+    });
+    expect(res.status).toBe(404);
+    expect(mockAdminReset).not.toHaveBeenCalled();
+  });
+
+  it('maps SETTLEMENT_NOT_ELIGIBLE_FOR_RETRY to 400', async () => {
+    mockAdminReset.mockRejectedValue(
+      new Error('SETTLEMENT_NOT_ELIGIBLE_FOR_RETRY')
+    );
+    const res = await POST(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1', settlementId: 'set-1' },
+    });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest } from 'next/server';
+import {
+  adminResetActivationSettlementForRetryAtomic,
+  getActivationSettlementTransactionById,
+} from '@/lib/db/activation-settlement-transactions';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+
+interface RouteParams {
+  params: { activationId: string; settlementId: string };
+}
+
+/** POST /api/admin/sponsored-activations/{activationId}/settlements/{settlementId}/retry */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const activationId = params.activationId?.trim();
+    const settlementId = params.settlementId?.trim();
+    if (!activationId || !settlementId) {
+      return apiError('Missing activation or settlement id', 400);
+    }
+
+    const settlement =
+      await getActivationSettlementTransactionById(settlementId);
+    if (!settlement || settlement.activation_id !== activationId) {
+      return apiError('Settlement not found', 404);
+    }
+
+    await adminResetActivationSettlementForRetryAtomic({
+      settlementId,
+      activationId,
+    });
+
+    return apiSuccess({ ok: true, settlementId });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : '';
+    if (message.includes('SETTLEMENT_NOT_ELIGIBLE_FOR_RETRY')) {
+      return apiError('Settlement cannot be retried in its current state', 400);
+    }
+    console.error(
+      'POST /api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry:',
+      error
+    );
+    return apiError('Failed to reset settlement for retry', 500);
+  }
+}

--- a/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry/route.ts
@@ -10,7 +10,6 @@ interface RouteParams {
   params: { activationId: string; settlementId: string };
 }
 
-/** POST /api/admin/sponsored-activations/{activationId}/settlements/{settlementId}/retry */
 export async function POST(request: NextRequest, { params }: RouteParams) {
   try {
     const adminCheck = await requireAdmin(request);
@@ -40,6 +39,9 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     const message = error instanceof Error ? error.message : '';
     if (message.includes('SETTLEMENT_NOT_ELIGIBLE_FOR_RETRY')) {
       return apiError('Settlement cannot be retried in its current state', 400);
+    }
+    if (message.includes('REDEMPTION_NOT_ELIGIBLE_FOR_RETRY')) {
+      return apiError('Redemption cannot be retried in its current state', 400);
     }
     console.error(
       'POST /api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry:',

--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
@@ -208,6 +208,20 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     expect(j.error).toBe('This reward is no longer available');
   });
 
+  it('returns 400 when USDC budget cap would be exceeded (RPC)', async () => {
+    mockGetRedemptionById.mockResolvedValue(redemptionRow('available'));
+    mockConfirmRpc.mockRejectedValue(
+      new Error('ACTIVATION_PURCHASE_USDC_BUDGET_EXCEEDED')
+    );
+
+    const res = await POST(postReq({ walletAddress: wallet, redemptionId }), {
+      params: { activationId: activeActivation.id },
+    });
+    expect(res.status).toBe(400);
+    const j = await res.json();
+    expect(j.error).toBe('This reward is no longer available');
+  });
+
   it('is idempotent when redemption is already ready_to_redeem', async () => {
     mockGetRedemptionById.mockResolvedValue(redemptionRow('ready_to_redeem'));
     mockConfirmRpc.mockResolvedValue({

--- a/database/confirm-activation-purchase-atomic.sql
+++ b/database/confirm-activation-purchase-atomic.sql
@@ -1,6 +1,7 @@
 -- IRL-54: Atomic confirm purchase for sponsored activations (points + redemption + cap increment).
+-- IRL-60: Optional USDC budget cap at confirm (settled + inflight settlements + committed snapshots + this reward).
 -- Idempotent when redemption is already past `available` (no second deduct, no cap bump).
-
+-- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION confirm_activation_purchase_atomic(
   p_redemption_id UUID,
   p_player_id BIGINT,
@@ -21,6 +22,9 @@ DECLARE
   v_nt INTEGER;
   v_lifetime_confirms INTEGER;
   v_daily_confirms INTEGER;
+  v_inflight NUMERIC(24, 8);
+  v_committed NUMERIC(24, 8);
+  v_this_usdc NUMERIC(24, 8);
 BEGIN
   IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
     RAISE EXCEPTION 'ACTIVATION_PURCHASE_WALLET_REQUIRED';
@@ -40,7 +44,6 @@ BEGIN
     RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_MISMATCH';
   END IF;
 
-  -- Idempotent: already confirmed or later success path (no mutation).
   IF v_red.status IN (
     'ready_to_redeem',
     'redeemed',
@@ -76,8 +79,6 @@ BEGIN
     RAISE EXCEPTION 'ACTIVATION_PURCHASE_ACTIVATION_NOT_FOUND';
   END IF;
 
-  -- Per-user purchase caps (activation eligibility config), evaluated after activation row lock
-  -- so concurrent confirms for the same user cannot race past limits (IRL-54).
   SELECT COUNT(*)::INTEGER
   INTO v_lifetime_confirms
   FROM activation_redemption ar
@@ -144,6 +145,28 @@ BEGIN
     RAISE EXCEPTION 'ACTIVATION_PURCHASE_INVALID_POINTS_COST';
   END IF;
 
+  v_this_usdc := COALESCE(v_item.usdc_amount, 0);
+  IF v_act.max_usdc_budget IS NOT NULL AND v_this_usdc > 0 THEN
+    SELECT COALESCE(SUM(st.amount), 0)
+    INTO v_inflight
+    FROM activation_settlement_transaction st
+    WHERE st.activation_id = v_act.id
+      AND st.status IN ('not_started', 'queued', 'submitted', 'retrying');
+
+    SELECT COALESCE(SUM(ar.usdc_amount_snapshot), 0)
+    INTO v_committed
+    FROM activation_redemption ar
+    WHERE ar.activation_id = v_act.id
+      AND ar.id IS DISTINCT FROM v_red.id
+      AND ar.status IN ('purchase_confirmed', 'ready_to_redeem')
+      AND ar.usdc_amount_snapshot IS NOT NULL
+      AND ar.usdc_amount_snapshot > 0;
+
+    IF (v_act.usdc_settled_total + v_inflight + v_committed + v_this_usdc) > v_act.max_usdc_budget THEN
+      RAISE EXCEPTION 'ACTIVATION_PURCHASE_USDC_BUDGET_EXCEEDED';
+    END IF;
+  END IF;
+
   SELECT id, COALESCE(total_points, 0)::INTEGER
   INTO v_player_row_id, v_player_total
   FROM players
@@ -188,6 +211,5 @@ END;
 $$ LANGUAGE plpgsql;
 
 COMMENT ON FUNCTION confirm_activation_purchase_atomic IS
-  'IRL-54: Atomically deduct points (when points_cost > 0), bump activation redemption_count_confirmed, '
-  'and move activation_redemption from available to ready_to_redeem. Idempotent for later statuses. '
-  'Enforces per-user lifetime and UTC-daily purchase caps after locking the activation row.';
+  'IRL-54 + IRL-60: Atomically confirm purchase; optional USDC budget cap (settled + inflight settlements + '
+  'committed redemption snapshots + this reward) vs max_usdc_budget.';

--- a/database/irl-58-activation-settlement-confirm-fail.sql
+++ b/database/irl-58-activation-settlement-confirm-fail.sql
@@ -1,4 +1,6 @@
 -- IRL-58: Atomic settlement confirm/fail with redemption status sync (no usdc_settled_total).
+-- Follow-on: database/irl-60-settlement-retry-budget.sql replaces confirm/fail with retry policy,
+-- usdc_settled_total finalize, Stellar submit RPC, promote + admin reset (run migrations in order).
 
 CREATE OR REPLACE FUNCTION confirm_activation_settlement_atomic(
   p_settlement_id UUID,

--- a/database/irl-60-settlement-retry-budget.sql
+++ b/database/irl-60-settlement-retry-budget.sql
@@ -1,0 +1,496 @@
+-- IRL-60: USDC budget at confirm, finalize usdc_settled_total on settlement confirm,
+-- retry/exhaust failure policy (no next_retry_at), promote retrying→queued, Stellar submit RPC,
+-- admin manual retry reset.
+
+-- ---------------------------------------------------------------------------
+-- confirm_activation_purchase_atomic: block when USDC budget would be exceeded
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION confirm_activation_purchase_atomic(
+  p_redemption_id UUID,
+  p_player_id BIGINT,
+  p_wallet_address TEXT,
+  p_max_purchase_confirms_per_user INTEGER,
+  p_max_purchase_confirms_per_user_per_day INTEGER
+) RETURNS TABLE (
+  outcome TEXT,
+  player_total_points INTEGER
+) AS $$
+DECLARE
+  v_red activation_redemption%ROWTYPE;
+  v_act sponsored_activation%ROWTYPE;
+  v_item activation_reward_item%ROWTYPE;
+  v_player_total INTEGER;
+  v_player_row_id BIGINT;
+  v_points INTEGER;
+  v_nt INTEGER;
+  v_lifetime_confirms INTEGER;
+  v_daily_confirms INTEGER;
+  v_inflight NUMERIC(24, 8);
+  v_committed NUMERIC(24, 8);
+  v_this_usdc NUMERIC(24, 8);
+BEGIN
+  IF p_wallet_address IS NULL OR length(trim(p_wallet_address)) = 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_WALLET_REQUIRED';
+  END IF;
+
+  SELECT *
+  INTO v_red
+  FROM activation_redemption
+  WHERE id = p_redemption_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_NOT_FOUND';
+  END IF;
+
+  IF v_red.user_id IS DISTINCT FROM p_player_id THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_MISMATCH';
+  END IF;
+
+  IF v_red.status IN (
+    'ready_to_redeem',
+    'redeemed',
+    'settlement_pending',
+    'settlement_confirmed',
+    'settlement_failed',
+    'purchase_confirmed'
+  ) THEN
+    SELECT COALESCE(total_points, 0)::INTEGER
+    INTO v_player_total
+    FROM players
+    WHERE id = p_player_id;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_NOT_FOUND';
+    END IF;
+
+    RETURN QUERY SELECT 'already_confirmed'::TEXT, v_player_total;
+    RETURN;
+  END IF;
+
+  IF v_red.status IS DISTINCT FROM 'available' THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_INVALID_STATUS';
+  END IF;
+
+  SELECT *
+  INTO v_act
+  FROM sponsored_activation
+  WHERE id = v_red.activation_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_ACTIVATION_NOT_FOUND';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_lifetime_confirms
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_act.id
+    AND ar.user_id = v_red.user_id
+    AND ar.purchase_confirmed_at IS NOT NULL;
+
+  IF v_lifetime_confirms >= p_max_purchase_confirms_per_user THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_LIFETIME_USER_LIMIT_EXCEEDED';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_daily_confirms
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_act.id
+    AND ar.user_id = v_red.user_id
+    AND ar.purchase_confirmed_at IS NOT NULL
+    AND (ar.purchase_confirmed_at AT TIME ZONE 'UTC')::date =
+        (now() AT TIME ZONE 'UTC')::date;
+
+  IF v_daily_confirms >= p_max_purchase_confirms_per_user_per_day THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_DAILY_USER_LIMIT_EXCEEDED';
+  END IF;
+
+  SELECT *
+  INTO v_item
+  FROM activation_reward_item
+  WHERE id = v_red.reward_item_id
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_item.activation_id IS DISTINCT FROM v_act.id THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_REWARD_ITEM_MISMATCH';
+  END IF;
+
+  IF NOT v_item.is_active THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_REWARD_INACTIVE';
+  END IF;
+
+  SELECT COUNT(*)::INTEGER
+  INTO v_nt
+  FROM activation_redemption ar
+  WHERE ar.activation_id = v_red.activation_id
+    AND ar.user_id = v_red.user_id
+    AND ar.reward_item_id = v_red.reward_item_id
+    AND ar.status NOT IN (
+      'redeemed',
+      'settlement_confirmed',
+      'cancelled',
+      'expired',
+      'settlement_failed'
+    );
+
+  IF v_nt > v_item.max_per_user THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_MAX_PER_USER';
+  END IF;
+
+  IF v_act.max_redemptions IS NOT NULL
+     AND v_act.redemption_count_confirmed >= v_act.max_redemptions THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_CAP_EXCEEDED';
+  END IF;
+
+  v_points := v_item.points_cost::INTEGER;
+  IF v_points IS NULL OR v_points < 0 THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_INVALID_POINTS_COST';
+  END IF;
+
+  v_this_usdc := COALESCE(v_item.usdc_amount, 0);
+  IF v_act.max_usdc_budget IS NOT NULL AND v_this_usdc > 0 THEN
+    SELECT COALESCE(SUM(st.amount), 0)
+    INTO v_inflight
+    FROM activation_settlement_transaction st
+    WHERE st.activation_id = v_act.id
+      AND st.status IN ('not_started', 'queued', 'submitted', 'retrying');
+
+    SELECT COALESCE(SUM(ar.usdc_amount_snapshot), 0)
+    INTO v_committed
+    FROM activation_redemption ar
+    WHERE ar.activation_id = v_act.id
+      AND ar.id IS DISTINCT FROM v_red.id
+      AND ar.status IN ('purchase_confirmed', 'ready_to_redeem')
+      AND ar.usdc_amount_snapshot IS NOT NULL
+      AND ar.usdc_amount_snapshot > 0;
+
+    IF (v_act.usdc_settled_total + v_inflight + v_committed + v_this_usdc) > v_act.max_usdc_budget THEN
+      RAISE EXCEPTION 'ACTIVATION_PURCHASE_USDC_BUDGET_EXCEEDED';
+    END IF;
+  END IF;
+
+  SELECT id, COALESCE(total_points, 0)::INTEGER
+  INTO v_player_row_id, v_player_total
+  FROM players
+  WHERE id = p_player_id
+    AND lower(trim(wallet_address)) = lower(trim(p_wallet_address))
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'ACTIVATION_PURCHASE_PLAYER_MISMATCH';
+  END IF;
+
+  IF v_points > 0 THEN
+    IF v_player_total < v_points THEN
+      RAISE EXCEPTION 'ACTIVATION_PURCHASE_INSUFFICIENT_POINTS';
+    END IF;
+
+    UPDATE players
+    SET
+      total_points = COALESCE(total_points, 0) - v_points,
+      updated_at = NOW()
+    WHERE id = v_player_row_id
+    RETURNING total_points::INTEGER INTO v_player_total;
+  END IF;
+
+  UPDATE sponsored_activation
+  SET
+    redemption_count_confirmed = redemption_count_confirmed + 1,
+    updated_at = NOW()
+  WHERE id = v_act.id;
+
+  UPDATE activation_redemption
+  SET
+    status = 'ready_to_redeem',
+    points_spent = v_points,
+    usdc_amount_snapshot = v_item.usdc_amount,
+    purchase_confirmed_at = COALESCE(purchase_confirmed_at, NOW()),
+    updated_at = NOW()
+  WHERE id = v_red.id;
+
+  RETURN QUERY SELECT 'created'::TEXT, v_player_total;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION confirm_activation_purchase_atomic IS
+  'IRL-54 + IRL-60: Atomically confirm purchase; optional USDC budget cap (settled + inflight settlements + '
+  'committed redemption snapshots + this reward) vs max_usdc_budget.';
+
+-- ---------------------------------------------------------------------------
+-- confirm_activation_settlement_atomic: bump usdc_settled_total; optional privy + submitted_at
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION confirm_activation_settlement_atomic(
+  p_settlement_id UUID,
+  p_tx_hash TEXT,
+  p_privy_transaction_id TEXT DEFAULT NULL,
+  p_preserve_submitted_at TIMESTAMPTZ DEFAULT NULL
+)
+RETURNS TEXT AS $$
+DECLARE
+  v_redemption_id UUID;
+  v_status TEXT;
+  v_amount NUMERIC(24, 8);
+  v_activation_id UUID;
+  v_trim_privy TEXT;
+  v_rcount INTEGER;
+BEGIN
+  SELECT redemption_id, status, amount, activation_id
+  INTO v_redemption_id, v_status, v_amount, v_activation_id
+  FROM activation_settlement_transaction
+  WHERE id = p_settlement_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SETTLEMENT_NOT_FOUND';
+  END IF;
+
+  IF v_status = 'confirmed' THEN
+    RETURN 'already_confirmed';
+  END IF;
+
+  v_trim_privy := NULLIF(trim(COALESCE(p_privy_transaction_id, '')), '');
+
+  UPDATE activation_settlement_transaction
+  SET
+    status = 'confirmed',
+    tx_hash = trim(p_tx_hash),
+    privy_transaction_id = CASE
+      WHEN v_trim_privy IS NOT NULL THEN left(v_trim_privy, 512)
+      ELSE privy_transaction_id
+    END,
+    confirmed_at = COALESCE(confirmed_at, NOW()),
+    submitted_at = COALESCE(
+      p_preserve_submitted_at,
+      submitted_at,
+      NOW()
+    ),
+    last_error_code = NULL
+  WHERE id = p_settlement_id
+    AND status IN ('queued', 'submitted');
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SETTLEMENT_INVALID_STATE';
+  END IF;
+
+  UPDATE activation_redemption
+  SET status = 'settlement_confirmed', updated_at = NOW()
+  WHERE id = v_redemption_id
+    AND status = 'settlement_pending';
+
+  GET DIAGNOSTICS v_rcount = ROW_COUNT;
+  IF v_rcount = 0 THEN
+    RAISE EXCEPTION 'REDEMPTION_SETTLEMENT_STATE_MISMATCH';
+  END IF;
+
+  UPDATE sponsored_activation
+  SET
+    usdc_settled_total = usdc_settled_total + v_amount,
+    updated_at = NOW()
+  WHERE id = v_activation_id;
+
+  RETURN 'confirmed';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION confirm_activation_settlement_atomic IS
+  'IRL-58 + IRL-60: Confirms settlement, increments sponsored_activation.usdc_settled_total, syncs redemption.';
+
+-- ---------------------------------------------------------------------------
+-- record_activation_settlement_failure_atomic: uniform retry vs exhaust
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION record_activation_settlement_failure_atomic(
+  p_settlement_id UUID,
+  p_last_error_code TEXT
+)
+RETURNS TEXT AS $$
+DECLARE
+  v_redemption_id UUID;
+  v_status TEXT;
+  v_attempt INTEGER;
+  v_new_attempt INTEGER;
+  v_queued_at TIMESTAMPTZ;
+  v_err TEXT;
+BEGIN
+  SELECT redemption_id, status, submission_attempt, queued_at
+  INTO v_redemption_id, v_status, v_attempt, v_queued_at
+  FROM activation_settlement_transaction
+  WHERE id = p_settlement_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SETTLEMENT_NOT_FOUND';
+  END IF;
+
+  IF v_status = 'confirmed' THEN
+    RETURN 'already_confirmed';
+  END IF;
+
+  IF v_status = 'failed' THEN
+    RETURN 'already_failed';
+  END IF;
+
+  IF v_status NOT IN ('queued', 'submitted', 'retrying', 'not_started') THEN
+    RAISE EXCEPTION 'SETTLEMENT_INVALID_STATE';
+  END IF;
+
+  v_new_attempt := v_attempt + 1;
+  v_err := left(trim(COALESCE(p_last_error_code, '')), 128);
+
+  IF v_new_attempt >= 5
+     OR (v_queued_at IS NOT NULL AND NOW() >= v_queued_at + INTERVAL '24 hours') THEN
+    UPDATE activation_settlement_transaction
+    SET
+      status = 'failed',
+      last_error_code = v_err,
+      submission_attempt = v_new_attempt
+    WHERE id = p_settlement_id;
+
+    UPDATE activation_redemption
+    SET status = 'settlement_failed', updated_at = NOW()
+    WHERE id = v_redemption_id
+      AND status = 'settlement_pending';
+
+    RETURN 'exhausted';
+  END IF;
+
+  UPDATE activation_settlement_transaction
+  SET
+    status = 'retrying',
+    last_error_code = v_err,
+    submission_attempt = v_new_attempt,
+    tx_hash = NULL,
+    privy_transaction_id = NULL,
+    submitted_at = NULL
+  WHERE id = p_settlement_id;
+
+  RETURN 'retry_scheduled';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION record_activation_settlement_failure_atomic IS
+  'IRL-60: After a failed settlement attempt, either schedule retry (retrying) or exhaust (failed + redemption).';
+
+DROP FUNCTION IF EXISTS fail_activation_settlement_atomic(UUID, TEXT);
+
+-- ---------------------------------------------------------------------------
+-- promote_activation_settlement_retrying_to_queued: cron batch (backoff from queued_at + submission_attempt)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION promote_activation_settlement_retrying_to_queued()
+RETURNS INTEGER AS $$
+DECLARE
+  v_updated INTEGER;
+BEGIN
+  WITH due AS (
+    SELECT id
+    FROM activation_settlement_transaction
+    WHERE status = 'retrying'
+      AND queued_at IS NOT NULL
+      AND NOW() >= queued_at
+        + (
+            LEAST(
+              30 * POWER(2::numeric, GREATEST(submission_attempt - 1, 0)),
+              7200
+            ) * INTERVAL '1 second'
+          )
+  )
+  UPDATE activation_settlement_transaction st
+  SET status = 'queued'
+  FROM due
+  WHERE st.id = due.id;
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+  RETURN v_updated;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION promote_activation_settlement_retrying_to_queued IS
+  'IRL-60: Moves retrying settlements whose backoff window elapsed back to queued (backoff from queued_at).';
+
+-- ---------------------------------------------------------------------------
+-- mark_activation_settlement_submitted_atomic: queued → submitted, increment attempts
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION mark_activation_settlement_submitted_atomic(
+  p_settlement_id UUID,
+  p_tx_hash TEXT
+) RETURNS BOOLEAN AS $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  UPDATE activation_settlement_transaction
+  SET
+    status = 'submitted',
+    tx_hash = trim(p_tx_hash),
+    submitted_at = NOW(),
+    submission_attempt = submission_attempt + 1
+  WHERE id = p_settlement_id
+    AND status = 'queued';
+
+  GET DIAGNOSTICS v_count = ROW_COUNT;
+  RETURN v_count > 0;
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION mark_activation_settlement_submitted_atomic IS
+  'IRL-60: Idempotent queued→submitted with submission_attempt increment (Stellar rail).';
+
+-- ---------------------------------------------------------------------------
+-- admin_reset_activation_settlement_for_retry_atomic
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION admin_reset_activation_settlement_for_retry_atomic(
+  p_settlement_id UUID,
+  p_activation_id UUID
+) RETURNS TEXT AS $$
+DECLARE
+  v_redemption_id UUID;
+  v_rows INTEGER;
+BEGIN
+  SELECT st.redemption_id
+  INTO v_redemption_id
+  FROM activation_settlement_transaction st
+  INNER JOIN activation_redemption ar ON ar.id = st.redemption_id
+  WHERE st.id = p_settlement_id
+    AND st.activation_id = p_activation_id
+    AND st.status = 'failed'
+    AND ar.status = 'settlement_failed'
+  FOR UPDATE OF st, ar;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'SETTLEMENT_NOT_ELIGIBLE_FOR_RETRY';
+  END IF;
+
+  UPDATE activation_settlement_transaction
+  SET
+    status = 'queued',
+    last_error_code = NULL,
+    tx_hash = NULL,
+    privy_transaction_id = NULL,
+    submission_attempt = 0,
+    queued_at = NOW(),
+    submitted_at = NULL,
+    confirmed_at = NULL
+  WHERE id = p_settlement_id
+    AND activation_id = p_activation_id
+    AND status = 'failed';
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  IF v_rows = 0 THEN
+    RAISE EXCEPTION 'SETTLEMENT_NOT_ELIGIBLE_FOR_RETRY';
+  END IF;
+
+  UPDATE activation_redemption
+  SET status = 'settlement_pending', updated_at = NOW()
+  WHERE id = v_redemption_id
+    AND status = 'settlement_failed';
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  IF v_rows = 0 THEN
+    RAISE EXCEPTION 'REDEMPTION_NOT_ELIGIBLE_FOR_RETRY';
+  END IF;
+
+  RETURN 'reset';
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION admin_reset_activation_settlement_for_retry_atomic IS
+  'IRL-60: Ops manual retry — failed settlement row back to queued with fresh queued_at; redemption to settlement_pending.';

--- a/lib/activation/base-settlement-worker.test.ts
+++ b/lib/activation/base-settlement-worker.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockGetSettlementById = vi.fn();
-const mockUpdateSettlement = vi.fn();
 const mockUpdateSettlementIfStatus = vi.fn();
+const mockConfirmSettlement = vi.fn();
+const mockRecordFailure = vi.fn();
 const mockGetActivationById = vi.fn();
 const mockGetRedemptionById = vi.fn();
 const mockSyncRedemption = vi.fn();
@@ -15,10 +16,12 @@ const mockWaitForTransaction = vi.fn();
 vi.mock('@/lib/db/activation-settlement-transactions', () => ({
   getActivationSettlementTransactionById: (...a: unknown[]) =>
     mockGetSettlementById(...a),
-  updateActivationSettlementTransaction: (...a: unknown[]) =>
-    mockUpdateSettlement(...a),
   updateActivationSettlementIfStatus: (...a: unknown[]) =>
     mockUpdateSettlementIfStatus(...a),
+  confirmActivationSettlementAtomic: (...a: unknown[]) =>
+    mockConfirmSettlement(...a),
+  recordActivationSettlementFailureAtomic: (...a: unknown[]) =>
+    mockRecordFailure(...a),
 }));
 
 vi.mock('@/lib/db/sponsored-activations', () => ({
@@ -130,12 +133,6 @@ function baseRedemption(overrides: Record<string, unknown> = {}) {
 describe('processBaseActivationSettlement', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUpdateSettlement.mockImplementation(
-      async (_id: string, patch: object) => ({
-        ...baseSettlement(),
-        ...patch,
-      })
-    );
     mockUpdateSettlementIfStatus.mockImplementation(
       async (_input: { patch: object }) => ({
         ...baseSettlement({ status: 'submitted' }),
@@ -144,6 +141,8 @@ describe('processBaseActivationSettlement', () => {
     );
     mockGetReceiptStatus.mockResolvedValue('success');
     mockGetPlayerWallet.mockResolvedValue(null);
+    mockConfirmSettlement.mockResolvedValue('confirmed');
+    mockRecordFailure.mockResolvedValue('retry_scheduled');
   });
 
   it('skips when settlement rail is not base', async () => {
@@ -175,7 +174,7 @@ describe('processBaseActivationSettlement', () => {
     expect(mockSubmitTreasury).not.toHaveBeenCalled();
   });
 
-  it('happy path: submits with activation USDC contract, confirms, syncs redemption', async () => {
+  it('happy path: submits with activation USDC contract, confirms via RPC', async () => {
     mockGetSettlementById
       .mockResolvedValueOnce(baseSettlement())
       .mockResolvedValue({
@@ -219,18 +218,31 @@ describe('processBaseActivationSettlement', () => {
     if (r.outcome === 'confirmed') {
       expect(r.txHash).toBe(txHash);
     }
-    expect(mockSyncRedemption).toHaveBeenCalledWith({
-      redemptionId: 'red-1',
-      nextStatus: 'settlement_confirmed',
-    });
-  });
-
-  it('fails venue guard when to_wallet_address does not match activation venue', async () => {
-    mockGetSettlementById.mockResolvedValue(
-      baseSettlement({
-        to_wallet_address: '0x3333333333333333333333333333333333333333',
+    expect(mockConfirmSettlement).toHaveBeenCalledWith(
+      expect.objectContaining({
+        settlementId: 'settle-1',
+        txHash,
+        privyTransactionId: 'privy-tx-1',
       })
     );
+    expect(mockSyncRedemption).not.toHaveBeenCalled();
+  });
+
+  it('records retry when venue guard fails', async () => {
+    mockGetSettlementById
+      .mockResolvedValueOnce(
+        baseSettlement({
+          to_wallet_address: '0x3333333333333333333333333333333333333333',
+        })
+      )
+      .mockResolvedValue(
+        baseSettlement({
+          to_wallet_address: '0x3333333333333333333333333333333333333333',
+          status: 'retrying',
+          last_error_code:
+            BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
+        })
+      );
     mockGetActivationById.mockResolvedValue(baseActivation());
     mockGetRedemptionById.mockResolvedValue(baseRedemption());
 
@@ -238,20 +250,25 @@ describe('processBaseActivationSettlement', () => {
       settlementId: 'settle-1',
     });
 
-    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(r.outcome).toBe('retry_scheduled');
     expect(mockSubmitTreasury).not.toHaveBeenCalled();
-    expect(mockUpdateSettlement).toHaveBeenCalledWith(
-      'settle-1',
-      expect.objectContaining({
-        status: 'failed',
-        last_error_code:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
-      })
-    );
+    expect(mockRecordFailure).toHaveBeenCalledWith({
+      settlementId: 'settle-1',
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch,
+    });
   });
 
-  it('fails when recipient would be user embedded wallet', async () => {
-    mockGetSettlementById.mockResolvedValue(baseSettlement());
+  it('records retry when recipient would be user embedded wallet', async () => {
+    mockGetSettlementById
+      .mockResolvedValueOnce(baseSettlement())
+      .mockResolvedValue(
+        baseSettlement({
+          status: 'retrying',
+          last_error_code:
+            BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
+        })
+      );
     mockGetActivationById.mockResolvedValue(baseActivation());
     mockGetRedemptionById.mockResolvedValue(baseRedemption());
     mockGetPlayerWallet.mockResolvedValue(venue);
@@ -260,15 +277,13 @@ describe('processBaseActivationSettlement', () => {
       settlementId: 'settle-1',
     });
 
-    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(r.outcome).toBe('retry_scheduled');
     expect(mockSubmitTreasury).not.toHaveBeenCalled();
-    expect(mockUpdateSettlement).toHaveBeenCalledWith(
-      'settle-1',
-      expect.objectContaining({
-        last_error_code:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
-      })
-    );
+    expect(mockRecordFailure).toHaveBeenCalledWith({
+      settlementId: 'settle-1',
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet,
+    });
   });
 
   it('idempotent when already confirmed', async () => {
@@ -329,16 +344,26 @@ describe('processBaseActivationSettlement', () => {
       })
     );
     expect(r.outcome).toBe('confirmed');
+    expect(mockConfirmSettlement).toHaveBeenCalled();
   });
 
-  it('insufficient campaign USDC → settlement_failed + error code', async () => {
-    mockGetSettlementById.mockResolvedValue(baseSettlement());
+  it('exhausts after insufficient campaign USDC when policy says so', async () => {
+    mockGetSettlementById
+      .mockResolvedValueOnce(baseSettlement())
+      .mockResolvedValue(
+        baseSettlement({
+          status: 'failed',
+          last_error_code:
+            BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.insufficient_campaign_usdc,
+        })
+      );
     mockGetActivationById.mockResolvedValue(baseActivation());
     mockGetRedemptionById.mockResolvedValue(baseRedemption());
     mockSubmitTreasury.mockResolvedValue({
       ok: false,
       error: 'ERC20: transfer amount exceeds balance',
     });
+    mockRecordFailure.mockResolvedValue('exhausted');
 
     const r = await processBaseActivationSettlement({
       settlementId: 'settle-1',
@@ -350,16 +375,19 @@ describe('processBaseActivationSettlement', () => {
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.insufficient_campaign_usdc
       );
     }
-    expect(mockUpdateSettlement).toHaveBeenCalledWith(
-      'settle-1',
-      expect.objectContaining({
-        status: 'failed',
-      })
-    );
+    expect(mockRecordFailure).toHaveBeenCalled();
   });
 
-  it('missing privy_campaign_wallet_id → failed without submit', async () => {
-    mockGetSettlementById.mockResolvedValue(baseSettlement());
+  it('records retry when privy campaign wallet id is missing', async () => {
+    mockGetSettlementById
+      .mockResolvedValueOnce(baseSettlement())
+      .mockResolvedValue(
+        baseSettlement({
+          status: 'retrying',
+          last_error_code:
+            BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
+        })
+      );
     mockGetActivationById.mockResolvedValue(
       baseActivation({ privy_campaign_wallet_id: null })
     );
@@ -369,21 +397,27 @@ describe('processBaseActivationSettlement', () => {
       settlementId: 'settle-1',
     });
 
-    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(r.outcome).toBe('retry_scheduled');
     expect(mockSubmitTreasury).not.toHaveBeenCalled();
-    expect(mockUpdateSettlement).toHaveBeenCalledWith(
-      'settle-1',
-      expect.objectContaining({
-        last_error_code:
-          BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
-      })
-    );
+    expect(mockRecordFailure).toHaveBeenCalledWith({
+      settlementId: 'settle-1',
+      lastErrorCode:
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured,
+    });
   });
 
-  it('Privy REST not configured → config failure after submit attempt', async () => {
+  it('records retry when Privy REST is not configured', async () => {
     const { PrivyRestNotConfiguredError } =
       await import('@/lib/privy-server-rest');
-    mockGetSettlementById.mockResolvedValue(baseSettlement());
+    mockGetSettlementById
+      .mockResolvedValueOnce(baseSettlement())
+      .mockResolvedValue(
+        baseSettlement({
+          status: 'retrying',
+          last_error_code:
+            BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured,
+        })
+      );
     mockGetActivationById.mockResolvedValue(baseActivation());
     mockGetRedemptionById.mockResolvedValue(baseRedemption());
     mockSubmitTreasury.mockRejectedValue(new PrivyRestNotConfiguredError());
@@ -392,7 +426,8 @@ describe('processBaseActivationSettlement', () => {
       settlementId: 'settle-1',
     });
 
-    expect(r.outcome).toBe('config_or_validation_failed');
+    expect(r.outcome).toBe('retry_scheduled');
     expect(mockSubmitTreasury).toHaveBeenCalled();
+    expect(mockRecordFailure).toHaveBeenCalled();
   });
 });

--- a/lib/activation/base-settlement-worker.ts
+++ b/lib/activation/base-settlement-worker.ts
@@ -136,18 +136,6 @@ async function recordFailureAndShapeResult(
   return { outcome: 'terminal_failed', settlement, lastErrorCode: code };
 }
 
-async function recordFailureAfterWorkerError(
-  row: ActivationSettlementTransactionRow,
-  lastErrorCode: BaseActivationSettlementErrorCode
-): Promise<
-  Extract<
-    ProcessBaseActivationSettlementResult,
-    { outcome: 'retry_scheduled' | 'terminal_failed' }
-  >
-> {
-  return recordFailureAndShapeResult(row, lastErrorCode);
-}
-
 /**
  * Base (EVM) campaign-wallet → venue-wallet USDC settlement for one
  * `activation_settlement_transaction` row (`settlement_rail = base`).
@@ -163,13 +151,13 @@ export async function processBaseActivationSettlement(input: {
     );
   }
 
-  const rowResult = await getActivationSettlementTransactionById(settlementId);
-  if (!rowResult) {
+  const loaded = await getActivationSettlementTransactionById(settlementId);
+  if (!loaded) {
     throw new Error(
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_not_found
     );
   }
-  const row = rowResult;
+  const row = loaded;
 
   if (row.settlement_rail !== 'base') {
     return { outcome: 'skipped', reason: 'settlement_rail_not_base' };
@@ -233,7 +221,7 @@ export async function processBaseActivationSettlement(input: {
   );
 
   if (!venueExpected || !campaignExpected || !toParsed || !fromParsed) {
-    return recordFailureAfterWorkerError(
+    return recordFailureAndShapeResult(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid
     );
@@ -245,7 +233,7 @@ export async function processBaseActivationSettlement(input: {
       activation.venue_settlement_wallet_address
     )
   ) {
-    return recordFailureAfterWorkerError(
+    return recordFailureAndShapeResult(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch
     );
@@ -257,7 +245,7 @@ export async function processBaseActivationSettlement(input: {
       activation.campaign_wallet_address
     )
   ) {
-    return recordFailureAfterWorkerError(
+    return recordFailureAndShapeResult(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch
     );
@@ -267,7 +255,7 @@ export async function processBaseActivationSettlement(input: {
   if (userWallet) {
     const userNorm = tryNormalizeEvmAddress(userWallet) ?? userWallet.trim();
     if (userNorm && sameWalletAddress(toParsed, userNorm)) {
-      return recordFailureAfterWorkerError(
+      return recordFailureAndShapeResult(
         row,
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet
       );
@@ -278,7 +266,7 @@ export async function processBaseActivationSettlement(input: {
     activation.usdc_asset_config
   );
   if (!cfgParse.success) {
-    return recordFailureAfterWorkerError(
+    return recordFailureAndShapeResult(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract
     );
@@ -287,7 +275,7 @@ export async function processBaseActivationSettlement(input: {
 
   const privyWalletId = activation.privy_campaign_wallet_id?.trim();
   if (!privyWalletId) {
-    return recordFailureAfterWorkerError(
+    return recordFailureAndShapeResult(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured
     );
@@ -295,7 +283,7 @@ export async function processBaseActivationSettlement(input: {
 
   if (redemption.status !== 'settlement_pending') {
     if (row.status === 'submitted' || row.status === 'queued') {
-      return recordFailureAfterWorkerError(
+      return recordFailureAndShapeResult(
         row,
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid
       );
@@ -446,7 +434,7 @@ export async function processBaseActivationSettlement(input: {
           e.message
         ))
     ) {
-      return recordFailureAfterWorkerError(
+      return recordFailureAndShapeResult(
         row,
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured
       );

--- a/lib/activation/base-settlement-worker.ts
+++ b/lib/activation/base-settlement-worker.ts
@@ -4,9 +4,10 @@ import {
   syncActivationRedemptionSettlementOutcome,
 } from '@/lib/db/activation-redemptions';
 import {
+  confirmActivationSettlementAtomic,
   getActivationSettlementTransactionById,
+  recordActivationSettlementFailureAtomic,
   updateActivationSettlementIfStatus,
-  updateActivationSettlementTransaction,
   type ActivationSettlementTransactionRow,
 } from '@/lib/db/activation-settlement-transactions';
 import { getPlayerEvmWalletAddressById } from '@/lib/db/players';
@@ -49,12 +50,20 @@ export type BaseActivationSettlementErrorCode =
 export type ProcessBaseActivationSettlementResult =
   | {
       outcome: 'skipped';
-      reason: 'settlement_rail_not_base' | 'activation_rail_not_base';
+      reason:
+        | 'settlement_rail_not_base'
+        | 'activation_rail_not_base'
+        | 'settlement_in_retry_backoff';
     }
   | {
       outcome: 'idempotent_confirmed';
       settlement: ActivationSettlementTransactionRow;
       txHash: string;
+    }
+  | {
+      outcome: 'retry_scheduled';
+      settlement: ActivationSettlementTransactionRow;
+      lastErrorCode: string;
     }
   | {
       outcome: 'terminal_failed';
@@ -70,12 +79,15 @@ export type ProcessBaseActivationSettlementResult =
       outcome: 'submitted_pending';
       settlement: ActivationSettlementTransactionRow;
       privyTransactionId: string;
-    }
-  | {
-      outcome: 'config_or_validation_failed';
-      settlement: ActivationSettlementTransactionRow;
-      lastErrorCode: BaseActivationSettlementErrorCode;
     };
+
+export type BaseSettlementWorkerRunSummary = {
+  processed: number;
+  confirmed: number;
+  failed: number;
+  skipped: number;
+  scheduledRetry: number;
+};
 
 const INSUFFICIENT_ERC20_RE =
   /exceeds\s+balance|insufficient\s+funds|transfer\s+amount|ERC20:\s+transfer\s+amount/i;
@@ -103,63 +115,37 @@ function requireEvm0x(value: string, ctx: string): `0x${string}` | null {
   return getAddress(t as `0x${string}`);
 }
 
-async function markSettlementAndRedemptionFailed(input: {
-  settlementId: string;
-  redemptionId: string;
-  lastErrorCode: string;
-}): Promise<void> {
-  await updateActivationSettlementTransaction(input.settlementId, {
-    status: 'failed',
-    last_error_code: input.lastErrorCode,
+async function recordFailureAndShapeResult(
+  row: ActivationSettlementTransactionRow,
+  code: string
+): Promise<
+  Extract<
+    ProcessBaseActivationSettlementResult,
+    { outcome: 'retry_scheduled' | 'terminal_failed' }
+  >
+> {
+  const rec = await recordActivationSettlementFailureAtomic({
+    settlementId: row.id,
+    lastErrorCode: code,
   });
-  await syncActivationRedemptionSettlementOutcome({
-    redemptionId: input.redemptionId,
-    nextStatus: 'settlement_failed',
-  });
+  const settlement =
+    (await getActivationSettlementTransactionById(row.id)) ?? row;
+  if (rec === 'retry_scheduled') {
+    return { outcome: 'retry_scheduled', settlement, lastErrorCode: code };
+  }
+  return { outcome: 'terminal_failed', settlement, lastErrorCode: code };
 }
 
-async function returnConfigValidationFailed(
+async function recordFailureAfterWorkerError(
   row: ActivationSettlementTransactionRow,
   lastErrorCode: BaseActivationSettlementErrorCode
 ): Promise<
   Extract<
     ProcessBaseActivationSettlementResult,
-    { outcome: 'config_or_validation_failed' }
+    { outcome: 'retry_scheduled' | 'terminal_failed' }
   >
 > {
-  await markSettlementAndRedemptionFailed({
-    settlementId: row.id,
-    redemptionId: row.redemption_id,
-    lastErrorCode,
-  });
-  const settlement =
-    (await getActivationSettlementTransactionById(row.id)) ?? row;
-  return { outcome: 'config_or_validation_failed', settlement, lastErrorCode };
-}
-
-async function confirmSettlementAndRedemption(input: {
-  settlementId: string;
-  redemptionId: string;
-  txHash: string;
-  privyTransactionId: string | null;
-  submissionAttempt: number;
-  /** When already set (e.g. `submitted_at` from the submit step), preserve it. */
-  submittedAt?: string | null;
-}): Promise<void> {
-  const ts = nowIso();
-  await updateActivationSettlementTransaction(input.settlementId, {
-    status: 'confirmed',
-    tx_hash: input.txHash,
-    privy_transaction_id: input.privyTransactionId,
-    confirmed_at: ts,
-    submitted_at: input.submittedAt?.trim() || ts,
-    last_error_code: null,
-    submission_attempt: input.submissionAttempt,
-  });
-  await syncActivationRedemptionSettlementOutcome({
-    redemptionId: input.redemptionId,
-    nextStatus: 'settlement_confirmed',
-  });
+  return recordFailureAndShapeResult(row, lastErrorCode);
 }
 
 /**
@@ -177,12 +163,13 @@ export async function processBaseActivationSettlement(input: {
     );
   }
 
-  const row = await getActivationSettlementTransactionById(settlementId);
-  if (!row) {
+  const rowResult = await getActivationSettlementTransactionById(settlementId);
+  if (!rowResult) {
     throw new Error(
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_not_found
     );
   }
+  const row = rowResult;
 
   if (row.settlement_rail !== 'base') {
     return { outcome: 'skipped', reason: 'settlement_rail_not_base' };
@@ -220,6 +207,10 @@ export async function processBaseActivationSettlement(input: {
     };
   }
 
+  if (row.status === 'retrying') {
+    return { outcome: 'skipped', reason: 'settlement_in_retry_backoff' };
+  }
+
   const redemption = await getActivationRedemptionById(row.redemption_id);
   if (!redemption) {
     throw new Error(
@@ -242,7 +233,7 @@ export async function processBaseActivationSettlement(input: {
   );
 
   if (!venueExpected || !campaignExpected || !toParsed || !fromParsed) {
-    return returnConfigValidationFailed(
+    return recordFailureAfterWorkerError(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.settlement_wallet_invalid
     );
@@ -254,7 +245,7 @@ export async function processBaseActivationSettlement(input: {
       activation.venue_settlement_wallet_address
     )
   ) {
-    return returnConfigValidationFailed(
+    return recordFailureAfterWorkerError(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.venue_wallet_mismatch
     );
@@ -266,7 +257,7 @@ export async function processBaseActivationSettlement(input: {
       activation.campaign_wallet_address
     )
   ) {
-    return returnConfigValidationFailed(
+    return recordFailureAfterWorkerError(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_mismatch
     );
@@ -276,7 +267,7 @@ export async function processBaseActivationSettlement(input: {
   if (userWallet) {
     const userNorm = tryNormalizeEvmAddress(userWallet) ?? userWallet.trim();
     if (userNorm && sameWalletAddress(toParsed, userNorm)) {
-      return returnConfigValidationFailed(
+      return recordFailureAfterWorkerError(
         row,
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.recipient_is_user_wallet
       );
@@ -287,7 +278,7 @@ export async function processBaseActivationSettlement(input: {
     activation.usdc_asset_config
   );
   if (!cfgParse.success) {
-    return returnConfigValidationFailed(
+    return recordFailureAfterWorkerError(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.invalid_usdc_contract
     );
@@ -296,7 +287,7 @@ export async function processBaseActivationSettlement(input: {
 
   const privyWalletId = activation.privy_campaign_wallet_id?.trim();
   if (!privyWalletId) {
-    return returnConfigValidationFailed(
+    return recordFailureAfterWorkerError(
       row,
       BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.campaign_wallet_not_configured
     );
@@ -304,7 +295,7 @@ export async function processBaseActivationSettlement(input: {
 
   if (redemption.status !== 'settlement_pending') {
     if (row.status === 'submitted' || row.status === 'queued') {
-      return returnConfigValidationFailed(
+      return recordFailureAfterWorkerError(
         row,
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.redemption_status_invalid
       );
@@ -323,31 +314,29 @@ export async function processBaseActivationSettlement(input: {
 
   async function finalizeFromTxHash(params: {
     settlementId: string;
-    redemptionId: string;
     txHash: `0x${string}`;
     privyTransactionId: string | null;
-    submissionAttempt: number;
     submittedAtPreserve?: string | null;
-  }): Promise<void> {
+  }): Promise<Extract<
+    ProcessBaseActivationSettlementResult,
+    { outcome: 'retry_scheduled' | 'terminal_failed' }
+  > | null> {
     const receipt = await getTreasuryTxReceiptStatus(params.txHash);
     if (receipt === 'reverted') {
-      await markSettlementAndRedemptionFailed({
-        settlementId: params.settlementId,
-        redemptionId: params.redemptionId,
-        lastErrorCode: BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.onchain_reverted,
-      });
-      return;
+      return recordFailureAndShapeResult(
+        row,
+        BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.onchain_reverted
+      );
     }
     if (receipt === 'success') {
-      await confirmSettlementAndRedemption({
+      await confirmActivationSettlementAtomic({
         settlementId: params.settlementId,
-        redemptionId: params.redemptionId,
         txHash: params.txHash,
         privyTransactionId: params.privyTransactionId,
-        submissionAttempt: params.submissionAttempt,
-        submittedAt: params.submittedAtPreserve,
+        preserveSubmittedAt: params.submittedAtPreserve ?? null,
       });
     }
+    return null;
   }
 
   async function tryResolveHashFromChain(): Promise<`0x${string}` | null> {
@@ -376,21 +365,10 @@ export async function processBaseActivationSettlement(input: {
         txHash = waited.transactionHash;
       } catch (e) {
         if (e instanceof PrivyRestTransactionFailedError) {
-          await markSettlementAndRedemptionFailed({
-            settlementId: row.id,
-            redemptionId: row.redemption_id,
-            lastErrorCode:
-              BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_transaction_failed,
-          });
-          const refreshed = await getActivationSettlementTransactionById(
-            row.id
+          return recordFailureAndShapeResult(
+            row,
+            BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_transaction_failed
           );
-          return {
-            outcome: 'terminal_failed',
-            settlement: refreshed ?? row,
-            lastErrorCode:
-              BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_transaction_failed,
-          };
         }
         if (!(e instanceof PrivyRestTransactionTimeoutError)) {
           throw e;
@@ -403,20 +381,26 @@ export async function processBaseActivationSettlement(input: {
     }
 
     if (txHash) {
-      await finalizeFromTxHash({
+      const early = await finalizeFromTxHash({
         settlementId: row.id,
-        redemptionId: row.redemption_id,
         txHash,
         privyTransactionId: row.privy_transaction_id,
-        submissionAttempt: row.submission_attempt,
         submittedAtPreserve: row.submitted_at,
       });
+      if (early) return early;
       const after = await getActivationSettlementTransactionById(row.id);
       if (after?.status === 'confirmed' && after.tx_hash) {
         return {
           outcome: 'confirmed',
           settlement: after,
           txHash: after.tx_hash,
+        };
+      }
+      if (after?.status === 'retrying') {
+        return {
+          outcome: 'retry_scheduled',
+          settlement: after,
+          lastErrorCode: after.last_error_code ?? '',
         };
       }
       if (after?.status === 'failed') {
@@ -462,7 +446,7 @@ export async function processBaseActivationSettlement(input: {
           e.message
         ))
     ) {
-      return returnConfigValidationFailed(
+      return recordFailureAfterWorkerError(
         row,
         BASE_ACTIVATION_SETTLEMENT_ERROR_CODES.privy_not_configured
       );
@@ -472,17 +456,7 @@ export async function processBaseActivationSettlement(input: {
 
   if (!submit.ok) {
     const code = classifyPrivySubmitError(submit.error);
-    await markSettlementAndRedemptionFailed({
-      settlementId: row.id,
-      redemptionId: row.redemption_id,
-      lastErrorCode: code,
-    });
-    const refreshed = await getActivationSettlementTransactionById(row.id);
-    return {
-      outcome: 'terminal_failed',
-      settlement: refreshed ?? row,
-      lastErrorCode: code,
-    };
+    return recordFailureAndShapeResult(row, code);
   }
 
   const privyTransactionId = submit.privyTransactionId;
@@ -523,17 +497,23 @@ export async function processBaseActivationSettlement(input: {
   }
 
   if (txHash) {
-    await finalizeFromTxHash({
+    const early = await finalizeFromTxHash({
       settlementId: row.id,
-      redemptionId: row.redemption_id,
       txHash,
       privyTransactionId,
-      submissionAttempt: nextAttempt,
       submittedAtPreserve: submittedAt,
     });
+    if (early) return early;
     const after = await getActivationSettlementTransactionById(row.id);
     if (after?.status === 'confirmed' && after.tx_hash) {
       return { outcome: 'confirmed', settlement: after, txHash: after.tx_hash };
+    }
+    if (after?.status === 'retrying') {
+      return {
+        outcome: 'retry_scheduled',
+        settlement: after,
+        lastErrorCode: after.last_error_code ?? '',
+      };
     }
     if (after?.status === 'failed') {
       return {
@@ -550,4 +530,65 @@ export async function processBaseActivationSettlement(input: {
     settlement: latest ?? updatedQueued,
     privyTransactionId,
   };
+}
+
+export async function runBaseSettlementWorkerBatch(
+  settlements: ActivationSettlementTransactionRow[]
+): Promise<BaseSettlementWorkerRunSummary> {
+  const summary: BaseSettlementWorkerRunSummary = {
+    processed: 0,
+    confirmed: 0,
+    failed: 0,
+    skipped: 0,
+    scheduledRetry: 0,
+  };
+
+  for (const row of settlements) {
+    if (row.settlement_rail !== 'base') {
+      summary.skipped += 1;
+      continue;
+    }
+
+    summary.processed += 1;
+    try {
+      const result = await processBaseActivationSettlement({
+        settlementId: row.id,
+      });
+      if (
+        result.outcome === 'confirmed' ||
+        result.outcome === 'idempotent_confirmed'
+      ) {
+        summary.confirmed += 1;
+      } else if (result.outcome === 'terminal_failed') {
+        summary.failed += 1;
+      } else if (result.outcome === 'retry_scheduled') {
+        summary.scheduledRetry += 1;
+      } else {
+        summary.skipped += 1;
+      }
+    } catch (e) {
+      console.error('processBaseActivationSettlement:', row.id, e);
+      try {
+        const rec = await recordActivationSettlementFailureAtomic({
+          settlementId: row.id,
+          lastErrorCode: 'worker_exception',
+        });
+        if (rec === 'exhausted' || rec === 'already_failed') {
+          summary.failed += 1;
+        } else if (rec === 'retry_scheduled') {
+          summary.scheduledRetry += 1;
+        } else {
+          summary.skipped += 1;
+        }
+      } catch (failErr) {
+        console.error(
+          'recordActivationSettlementFailureAtomic after worker_exception:',
+          failErr
+        );
+        summary.skipped += 1;
+      }
+    }
+  }
+
+  return summary;
 }

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -92,7 +92,8 @@ function mapRpcOrUnexpectedError(message: string): {
   if (
     message.includes('ACTIVATION_PURCHASE_CAP_EXCEEDED') ||
     message.includes('ACTIVATION_PURCHASE_MAX_PER_USER') ||
-    message.includes('ACTIVATION_PURCHASE_REWARD_INACTIVE')
+    message.includes('ACTIVATION_PURCHASE_REWARD_INACTIVE') ||
+    message.includes('ACTIVATION_PURCHASE_USDC_BUDGET_EXCEEDED')
   ) {
     return { status: 400, error: 'This reward is no longer available' };
   }

--- a/lib/activation/run-sponsored-settlement-cron.test.ts
+++ b/lib/activation/run-sponsored-settlement-cron.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockPromote = vi.fn();
+const mockListBase = vi.fn();
+const mockListStellar = vi.fn();
+const mockRunBase = vi.fn();
+const mockRunStellar = vi.fn();
+
+vi.mock('@/lib/db/activation-settlement-transactions', () => ({
+  getSponsoredSettlementBatchSize: () => 10,
+  listBaseActivationSettlementsForWorker: (...a: unknown[]) =>
+    mockListBase(...a),
+  listStellarActivationSettlementsForWorker: (...a: unknown[]) =>
+    mockListStellar(...a),
+  promoteActivationSettlementRetryingToQueued: (...a: unknown[]) =>
+    mockPromote(...a),
+}));
+
+vi.mock('@/lib/activation/base-settlement-worker', () => ({
+  runBaseSettlementWorkerBatch: (...a: unknown[]) => mockRunBase(...a),
+}));
+
+vi.mock('@/lib/activation/settlement-worker-stellar', () => ({
+  runStellarSettlementWorkerBatch: (...a: unknown[]) => mockRunStellar(...a),
+}));
+
+import { runSponsoredSettlementCronOrchestrated } from '@/lib/activation/settlement-orchestration';
+
+describe('runSponsoredSettlementCronOrchestrated', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPromote.mockResolvedValue(2);
+    mockListBase.mockResolvedValue([{ id: 'b1' }]);
+    mockListStellar.mockResolvedValue([{ id: 's1' }]);
+    mockRunBase.mockResolvedValue({
+      processed: 1,
+      confirmed: 1,
+      failed: 0,
+      skipped: 0,
+      scheduledRetry: 0,
+    });
+    mockRunStellar.mockResolvedValue({
+      processed: 1,
+      confirmed: 0,
+      failed: 0,
+      skipped: 1,
+      scheduledRetry: 0,
+    });
+  });
+
+  it('promotes retrying rows then runs Base and Stellar batches', async () => {
+    const r = await runSponsoredSettlementCronOrchestrated();
+    expect(mockPromote).toHaveBeenCalledTimes(1);
+    expect(mockListBase).toHaveBeenCalledWith(10);
+    expect(mockListStellar).toHaveBeenCalledWith(10);
+    expect(mockRunBase).toHaveBeenCalledWith([{ id: 'b1' }]);
+    expect(mockRunStellar).toHaveBeenCalledWith([{ id: 's1' }]);
+    expect(r.promotedRetryingToQueued).toBe(2);
+    expect(r.candidateSettlements).toEqual({ base: 1, stellar: 1 });
+  });
+});

--- a/lib/activation/run-sponsored-settlement-cron.ts
+++ b/lib/activation/run-sponsored-settlement-cron.ts
@@ -1,36 +1,11 @@
-import {
-  getSponsoredSettlementBatchSize,
-  listStellarActivationSettlementsForWorker,
-} from '@/lib/db/activation-settlement-transactions';
-import { runStellarSettlementWorkerBatch } from '@/lib/activation/settlement-worker-stellar';
+import { runSponsoredSettlementCronOrchestrated } from '@/lib/activation/settlement-orchestration';
+import type { SponsoredSettlementCronResult } from '@/lib/activation/settlement-orchestration';
 
-export type SponsoredSettlementCronResult = {
-  batchSize: number;
-  candidateSettlements: number;
-  stellar: {
-    processed: number;
-    confirmed: number;
-    failed: number;
-    skipped: number;
-  };
-  base: {
-    processed: 0;
-    message: 'deferred_to_irl_56';
-  };
-};
+export type { SponsoredSettlementCronResult };
 
 /**
- * Shared sponsored-settlement cron (IRL-58: Stellar branch; Base deferred to IRL-56).
+ * Shared sponsored-settlement cron (IRL-60): promote `retrying` → `queued`, then Base + Stellar workers.
  */
 export async function runSponsoredSettlementCron(): Promise<SponsoredSettlementCronResult> {
-  const batchSize = getSponsoredSettlementBatchSize();
-  const candidates = await listStellarActivationSettlementsForWorker(batchSize);
-  const stellarSummary = await runStellarSettlementWorkerBatch(candidates);
-
-  return {
-    batchSize,
-    candidateSettlements: candidates.length,
-    stellar: stellarSummary,
-    base: { processed: 0, message: 'deferred_to_irl_56' },
-  };
+  return runSponsoredSettlementCronOrchestrated();
 }

--- a/lib/activation/settlement-orchestration.test.ts
+++ b/lib/activation/settlement-orchestration.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { computeSettlementRetryBackoffSeconds } from '@/lib/activation/settlement-orchestration';
+
+describe('computeSettlementRetryBackoffSeconds', () => {
+  it('matches IRL-60 schedule (30s doubling, 2h cap)', () => {
+    expect(computeSettlementRetryBackoffSeconds(1)).toBe(30);
+    expect(computeSettlementRetryBackoffSeconds(2)).toBe(60);
+    expect(computeSettlementRetryBackoffSeconds(3)).toBe(120);
+    expect(computeSettlementRetryBackoffSeconds(10)).toBe(7200);
+    expect(computeSettlementRetryBackoffSeconds(0)).toBe(30);
+  });
+});

--- a/lib/activation/settlement-orchestration.ts
+++ b/lib/activation/settlement-orchestration.ts
@@ -1,0 +1,74 @@
+import {
+  getSponsoredSettlementBatchSize,
+  listBaseActivationSettlementsForWorker,
+  listStellarActivationSettlementsForWorker,
+  promoteActivationSettlementRetryingToQueued,
+} from '@/lib/db/activation-settlement-transactions';
+import { runBaseSettlementWorkerBatch } from '@/lib/activation/base-settlement-worker';
+import { runStellarSettlementWorkerBatch } from '@/lib/activation/settlement-worker-stellar';
+
+/**
+ * Backoff seconds after a failed attempt, keyed by `submission_attempt` on the settlement row
+ * after the failure is recorded (IRL-60). Matches
+ * `promote_activation_settlement_retrying_to_queued` in `database/irl-60-settlement-retry-budget.sql`.
+ *
+ * Eligibility for dequeue uses settlement `queued_at` (first enqueue) plus this delay; the 24h
+ * window is enforced separately inside `record_activation_settlement_failure_atomic`.
+ */
+export function computeSettlementRetryBackoffSeconds(
+  submissionAttempt: number
+): number {
+  const a = Math.max(0, Math.trunc(submissionAttempt) - 1);
+  return Math.min(30 * 2 ** a, 7200);
+}
+
+export type SponsoredSettlementCronResult = {
+  batchSize: number;
+  promotedRetryingToQueued: number;
+  candidateSettlements: { base: number; stellar: number };
+  stellar: {
+    processed: number;
+    confirmed: number;
+    failed: number;
+    skipped: number;
+    scheduledRetry: number;
+  };
+  base: {
+    processed: number;
+    confirmed: number;
+    failed: number;
+    skipped: number;
+    scheduledRetry: number;
+  };
+};
+
+/**
+ * Promotes `retrying` rows whose backoff window has elapsed, then runs Base + Stellar workers
+ * on `queued` / `submitted` candidates (IRL-60).
+ */
+export async function runSponsoredSettlementCronOrchestrated(): Promise<SponsoredSettlementCronResult> {
+  const batchSize = getSponsoredSettlementBatchSize();
+  const promotedRetryingToQueued =
+    await promoteActivationSettlementRetryingToQueued();
+
+  const [baseCandidates, stellarCandidates] = await Promise.all([
+    listBaseActivationSettlementsForWorker(batchSize),
+    listStellarActivationSettlementsForWorker(batchSize),
+  ]);
+
+  const [baseSummary, stellarSummary] = await Promise.all([
+    runBaseSettlementWorkerBatch(baseCandidates),
+    runStellarSettlementWorkerBatch(stellarCandidates),
+  ]);
+
+  return {
+    batchSize,
+    promotedRetryingToQueued,
+    candidateSettlements: {
+      base: baseCandidates.length,
+      stellar: stellarCandidates.length,
+    },
+    stellar: stellarSummary,
+    base: baseSummary,
+  };
+}

--- a/lib/activation/settlement-worker-stellar.test.ts
+++ b/lib/activation/settlement-worker-stellar.test.ts
@@ -145,20 +145,16 @@ describe('processStellarActivationSettlement', () => {
     expect(mockConfirm).not.toHaveBeenCalled();
   });
 
-  it('schedules retry when Horizon poll is still pending', async () => {
+  it('leaves submitted row unchanged when Horizon poll is still pending', async () => {
     mockPoll.mockResolvedValue('pending');
-    mockRecord.mockResolvedValue('retry_scheduled');
     const result = await processStellarActivationSettlement(
       settlementRow({
         status: 'submitted',
         tx_hash: 'existing-hash',
       })
     );
-    expect(result).toBe('retry_scheduled');
-    expect(mockRecord).toHaveBeenCalledWith({
-      settlementId: 'set-1',
-      lastErrorCode: 'stellar_tx_poll_pending',
-    });
+    expect(result).toBe('skipped');
+    expect(mockRecord).not.toHaveBeenCalled();
     expect(mockConfirm).not.toHaveBeenCalled();
   });
 

--- a/lib/activation/settlement-worker-stellar.test.ts
+++ b/lib/activation/settlement-worker-stellar.test.ts
@@ -7,7 +7,7 @@ const VENUE = 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF';
 
 const mockGetActivation = vi.fn();
 const mockConfirm = vi.fn();
-const mockFail = vi.fn();
+const mockRecord = vi.fn();
 const mockMarkSubmitted = vi.fn();
 const mockSubmit = vi.fn();
 const mockPoll = vi.fn();
@@ -20,7 +20,8 @@ vi.mock('@/lib/db/sponsored-activations', () => ({
 vi.mock('@/lib/db/activation-settlement-transactions', () => ({
   confirmActivationSettlementAtomic: (...args: unknown[]) =>
     mockConfirm(...args),
-  failActivationSettlementAtomic: (...args: unknown[]) => mockFail(...args),
+  recordActivationSettlementFailureAtomic: (...args: unknown[]) =>
+    mockRecord(...args),
   markActivationSettlementSubmitted: (...args: unknown[]) =>
     mockMarkSubmitted(...args),
 }));
@@ -92,7 +93,7 @@ describe('processStellarActivationSettlement', () => {
     mockMarkSubmitted.mockResolvedValue(true);
     mockPoll.mockResolvedValue('success');
     mockConfirm.mockResolvedValue('confirmed');
-    mockFail.mockResolvedValue('failed');
+    mockRecord.mockResolvedValue('exhausted');
   });
 
   it('skips non-stellar rail', async () => {
@@ -137,9 +138,26 @@ describe('processStellarActivationSettlement', () => {
     });
     const result = await processStellarActivationSettlement(settlementRow());
     expect(result).toBe('failed');
-    expect(mockFail).toHaveBeenCalledWith({
+    expect(mockRecord).toHaveBeenCalledWith({
       settlementId: 'set-1',
       lastErrorCode: 'insufficient_usdc_or_reserve',
+    });
+    expect(mockConfirm).not.toHaveBeenCalled();
+  });
+
+  it('schedules retry when Horizon poll is still pending', async () => {
+    mockPoll.mockResolvedValue('pending');
+    mockRecord.mockResolvedValue('retry_scheduled');
+    const result = await processStellarActivationSettlement(
+      settlementRow({
+        status: 'submitted',
+        tx_hash: 'existing-hash',
+      })
+    );
+    expect(result).toBe('retry_scheduled');
+    expect(mockRecord).toHaveBeenCalledWith({
+      settlementId: 'set-1',
+      lastErrorCode: 'stellar_tx_poll_pending',
     });
     expect(mockConfirm).not.toHaveBeenCalled();
   });

--- a/lib/activation/settlement-worker-stellar.ts
+++ b/lib/activation/settlement-worker-stellar.ts
@@ -93,7 +93,9 @@ async function confirmWithTxHash(
     return recordSettlementFailure(settlementId, 'stellar_tx_failed_on_ledger');
   }
   if (poll === 'pending') {
-    return recordSettlementFailure(settlementId, 'stellar_tx_poll_pending');
+    // Keep `submitted` + tx_hash for the next cron tick; never clear the hash or
+    // re-queue, or a second submit could double-pay while the first tx settles.
+    return 'skipped';
   }
 
   const outcome = await confirmActivationSettlementAtomic({

--- a/lib/activation/settlement-worker-stellar.ts
+++ b/lib/activation/settlement-worker-stellar.ts
@@ -131,7 +131,13 @@ export async function processStellarActivationSettlement(
     return recordSettlementFailure(settlement.id, validationError);
   }
 
-  const privyCampaignWalletId = activation.privy_campaign_wallet_id!.trim();
+  const privyCampaignWalletId = activation.privy_campaign_wallet_id?.trim();
+  if (!privyCampaignWalletId) {
+    return recordSettlementFailure(
+      settlement.id,
+      'missing_privy_campaign_wallet_id'
+    );
+  }
 
   if (settlement.status === 'submitted') {
     const txHash = settlement.tx_hash?.trim();

--- a/lib/activation/settlement-worker-stellar.ts
+++ b/lib/activation/settlement-worker-stellar.ts
@@ -1,8 +1,8 @@
 import type { ActivationSettlementTransactionRow } from '@/lib/db/activation-settlement-transactions';
 import {
   confirmActivationSettlementAtomic,
-  failActivationSettlementAtomic,
   markActivationSettlementSubmitted,
+  recordActivationSettlementFailureAtomic,
 } from '@/lib/db/activation-settlement-transactions';
 import {
   getSponsoredActivationById,
@@ -17,13 +17,15 @@ export type StellarSettlementWorkerItemResult =
   | 'confirmed'
   | 'already_confirmed'
   | 'failed'
-  | 'already_failed';
+  | 'already_failed'
+  | 'retry_scheduled';
 
 export type StellarSettlementWorkerRunSummary = {
   processed: number;
   confirmed: number;
   failed: number;
   skipped: number;
+  scheduledRetry: number;
 };
 
 function normalizeG(address: string): string | null {
@@ -68,16 +70,17 @@ function validateSettlementBundle(
   return null;
 }
 
-async function failSettlement(
+async function recordSettlementFailure(
   settlementId: string,
   errorCode: string
 ): Promise<StellarSettlementWorkerItemResult> {
-  const outcome = await failActivationSettlementAtomic({
+  const outcome = await recordActivationSettlementFailureAtomic({
     settlementId,
     lastErrorCode: errorCode,
   });
   if (outcome === 'already_confirmed') return 'already_confirmed';
   if (outcome === 'already_failed') return 'already_failed';
+  if (outcome === 'retry_scheduled') return 'retry_scheduled';
   return 'failed';
 }
 
@@ -87,10 +90,10 @@ async function confirmWithTxHash(
 ): Promise<StellarSettlementWorkerItemResult> {
   const poll = await pollStellarSettlementTxOutcome(txHash);
   if (poll === 'failed') {
-    return failSettlement(settlementId, 'stellar_tx_failed_on_ledger');
+    return recordSettlementFailure(settlementId, 'stellar_tx_failed_on_ledger');
   }
   if (poll === 'pending') {
-    return failSettlement(settlementId, 'stellar_tx_poll_pending');
+    return recordSettlementFailure(settlementId, 'stellar_tx_poll_pending');
   }
 
   const outcome = await confirmActivationSettlementAtomic({
@@ -114,15 +117,18 @@ export async function processStellarActivationSettlement(
   if (settlement.status === 'failed') {
     return 'already_failed';
   }
+  if (settlement.status === 'retrying') {
+    return 'skipped';
+  }
 
   const activation = await getSponsoredActivationById(settlement.activation_id);
   if (!activation) {
-    return failSettlement(settlement.id, 'activation_not_found');
+    return recordSettlementFailure(settlement.id, 'activation_not_found');
   }
 
   const validationError = validateSettlementBundle(settlement, activation);
   if (validationError) {
-    return failSettlement(settlement.id, validationError);
+    return recordSettlementFailure(settlement.id, validationError);
   }
 
   const privyCampaignWalletId = activation.privy_campaign_wallet_id!.trim();
@@ -130,7 +136,10 @@ export async function processStellarActivationSettlement(
   if (settlement.status === 'submitted') {
     const txHash = settlement.tx_hash?.trim();
     if (!txHash) {
-      return failSettlement(settlement.id, 'submitted_missing_tx_hash');
+      return recordSettlementFailure(
+        settlement.id,
+        'submitted_missing_tx_hash'
+      );
     }
     return confirmWithTxHash(settlement.id, txHash);
   }
@@ -148,7 +157,7 @@ export async function processStellarActivationSettlement(
   });
 
   if (!submit.ok) {
-    return failSettlement(settlement.id, submit.reason);
+    return recordSettlementFailure(settlement.id, submit.reason);
   }
 
   const markedSubmitted = await markActivationSettlementSubmitted({
@@ -175,6 +184,7 @@ export async function runStellarSettlementWorkerBatch(
     confirmed: 0,
     failed: 0,
     skipped: 0,
+    scheduledRetry: 0,
   };
 
   for (const row of settlements) {
@@ -190,16 +200,30 @@ export async function runStellarSettlementWorkerBatch(
         summary.confirmed += 1;
       } else if (result === 'failed' || result === 'already_failed') {
         summary.failed += 1;
+      } else if (result === 'retry_scheduled') {
+        summary.scheduledRetry += 1;
       } else {
         summary.skipped += 1;
       }
     } catch (e) {
       console.error('processStellarActivationSettlement:', row.id, e);
       try {
-        await failSettlement(row.id, 'worker_exception');
-        summary.failed += 1;
+        const r = await recordActivationSettlementFailureAtomic({
+          settlementId: row.id,
+          lastErrorCode: 'worker_exception',
+        });
+        if (r === 'exhausted' || r === 'already_failed') {
+          summary.failed += 1;
+        } else if (r === 'retry_scheduled') {
+          summary.scheduledRetry += 1;
+        } else {
+          summary.skipped += 1;
+        }
       } catch (failErr) {
-        console.error('failSettlement after worker_exception:', failErr);
+        console.error(
+          'recordActivationSettlementFailureAtomic after worker_exception:',
+          failErr
+        );
         summary.skipped += 1;
       }
     }

--- a/lib/db/activation-settlement-transactions.ts
+++ b/lib/db/activation-settlement-transactions.ts
@@ -36,6 +36,18 @@ function toInt(value: unknown): number {
   return Number.isNaN(n) ? 0 : Math.trunc(n);
 }
 
+function parseSettlementRpcTextOutcome<T extends string>(
+  data: unknown,
+  allowed: readonly T[],
+  rpcLabel: string
+): T {
+  const outcome = typeof data === 'string' ? data : String(data ?? '');
+  if ((allowed as readonly string[]).includes(outcome)) {
+    return outcome as T;
+  }
+  throw new Error(`Unexpected RPC response from ${rpcLabel}`);
+}
+
 function normalizeRow(
   row: Record<string, unknown>
 ): ActivationSettlementTransactionRow {
@@ -174,45 +186,39 @@ export function getSponsoredSettlementBatchSize(): number {
 }
 
 /**
- * Stellar settlements eligible for worker: `queued` (submit) or `submitted` with tx_hash (poll only).
+ * Settlements eligible for worker dequeue: `queued` (submit) or `submitted` (poll / finalize).
  */
-export async function listStellarActivationSettlementsForWorker(
+export async function listActivationSettlementsForWorker(
+  rail: SettlementRail,
   limit: number
 ): Promise<ActivationSettlementTransactionRow[]> {
   const { data, error } = await supabase
     .from(TABLE)
     .select('*')
-    .eq('settlement_rail', 'stellar')
+    .eq('settlement_rail', rail)
     .in('status', ['queued', 'submitted'])
     .order('queued_at', { ascending: true, nullsFirst: false })
     .limit(limit);
 
   if (error) {
-    console.error('listStellarActivationSettlementsForWorker:', error);
+    console.error('listActivationSettlementsForWorker:', { rail, error });
     throw new Error(error.message || 'Failed to list settlement transactions');
   }
   return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
 }
 
-/**
- * Base settlements eligible for worker dequeue (IRL-56 library; cron wiring in IRL-60).
- */
+/** Stellar rail; see {@link listActivationSettlementsForWorker}. */
+export async function listStellarActivationSettlementsForWorker(
+  limit: number
+): Promise<ActivationSettlementTransactionRow[]> {
+  return listActivationSettlementsForWorker('stellar', limit);
+}
+
+/** Base rail; see {@link listActivationSettlementsForWorker}. */
 export async function listBaseActivationSettlementsForWorker(
   limit: number
 ): Promise<ActivationSettlementTransactionRow[]> {
-  const { data, error } = await supabase
-    .from(TABLE)
-    .select('*')
-    .eq('settlement_rail', 'base')
-    .in('status', ['queued', 'submitted'])
-    .order('queued_at', { ascending: true, nullsFirst: false })
-    .limit(limit);
-
-  if (error) {
-    console.error('listBaseActivationSettlementsForWorker:', error);
-    throw new Error(error.message || 'Failed to list settlement transactions');
-  }
-  return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+  return listActivationSettlementsForWorker('base', limit);
 }
 
 export async function markActivationSettlementSubmitted(input: {
@@ -260,11 +266,10 @@ export async function confirmActivationSettlementAtomic(input: {
     );
   }
 
-  const outcome = typeof data === 'string' ? data : String(data ?? '');
-  if (outcome === 'already_confirmed') return 'already_confirmed';
-  if (outcome === 'confirmed') return 'confirmed';
-  throw new Error(
-    'Unexpected RPC response from confirm_activation_settlement_atomic'
+  return parseSettlementRpcTextOutcome(
+    data,
+    ['confirmed', 'already_confirmed'] as const,
+    'confirm_activation_settlement_atomic'
   );
 }
 
@@ -292,13 +297,15 @@ export async function recordActivationSettlementFailureAtomic(input: {
     );
   }
 
-  const outcome = typeof data === 'string' ? data : String(data ?? '');
-  if (outcome === 'already_confirmed') return 'already_confirmed';
-  if (outcome === 'already_failed') return 'already_failed';
-  if (outcome === 'exhausted') return 'exhausted';
-  if (outcome === 'retry_scheduled') return 'retry_scheduled';
-  throw new Error(
-    'Unexpected RPC response from record_activation_settlement_failure_atomic'
+  return parseSettlementRpcTextOutcome(
+    data,
+    [
+      'retry_scheduled',
+      'exhausted',
+      'already_confirmed',
+      'already_failed',
+    ] as const,
+    'record_activation_settlement_failure_atomic'
   );
 }
 
@@ -340,9 +347,9 @@ export async function adminResetActivationSettlementForRetryAtomic(input: {
         'admin_reset_activation_settlement_for_retry_atomic failed'
     );
   }
-  const outcome = typeof data === 'string' ? data : String(data ?? '');
-  if (outcome === 'reset') return 'reset';
-  throw new Error(
-    'Unexpected RPC response from admin_reset_activation_settlement_for_retry_atomic'
+  return parseSettlementRpcTextOutcome(
+    data,
+    ['reset'] as const,
+    'admin_reset_activation_settlement_for_retry_atomic'
   );
 }

--- a/lib/db/activation-settlement-transactions.ts
+++ b/lib/db/activation-settlement-transactions.ts
@@ -219,24 +219,19 @@ export async function markActivationSettlementSubmitted(input: {
   settlementId: string;
   txHash: string;
 }): Promise<boolean> {
-  const { data, error } = await supabase
-    .from(TABLE)
-    .update({
-      status: 'submitted',
-      tx_hash: input.txHash.trim(),
-      submitted_at: new Date().toISOString(),
-      submission_attempt: 1,
-    })
-    .eq('id', input.settlementId)
-    .eq('status', 'queued')
-    .select('id')
-    .maybeSingle();
+  const { data, error } = await supabase.rpc(
+    'mark_activation_settlement_submitted_atomic',
+    {
+      p_settlement_id: input.settlementId,
+      p_tx_hash: input.txHash,
+    }
+  );
 
   if (error) {
     console.error('markActivationSettlementSubmitted:', error);
     throw new Error(error.message || 'Failed to mark settlement submitted');
   }
-  return data != null;
+  return data === true;
 }
 
 export type ConfirmActivationSettlementRpcOutcome =
@@ -246,12 +241,16 @@ export type ConfirmActivationSettlementRpcOutcome =
 export async function confirmActivationSettlementAtomic(input: {
   settlementId: string;
   txHash: string;
+  privyTransactionId?: string | null;
+  preserveSubmittedAt?: string | null;
 }): Promise<ConfirmActivationSettlementRpcOutcome> {
   const { data, error } = await supabase.rpc(
     'confirm_activation_settlement_atomic',
     {
       p_settlement_id: input.settlementId,
       p_tx_hash: input.txHash,
+      p_privy_transaction_id: input.privyTransactionId ?? null,
+      p_preserve_submitted_at: input.preserveSubmittedAt ?? null,
     }
   );
 
@@ -269,17 +268,18 @@ export async function confirmActivationSettlementAtomic(input: {
   );
 }
 
-export type FailActivationSettlementRpcOutcome =
-  | 'failed'
+export type RecordActivationSettlementFailureRpcOutcome =
+  | 'retry_scheduled'
+  | 'exhausted'
   | 'already_confirmed'
   | 'already_failed';
 
-export async function failActivationSettlementAtomic(input: {
+export async function recordActivationSettlementFailureAtomic(input: {
   settlementId: string;
   lastErrorCode: string;
-}): Promise<FailActivationSettlementRpcOutcome> {
+}): Promise<RecordActivationSettlementFailureRpcOutcome> {
   const { data, error } = await supabase.rpc(
-    'fail_activation_settlement_atomic',
+    'record_activation_settlement_failure_atomic',
     {
       p_settlement_id: input.settlementId,
       p_last_error_code: input.lastErrorCode,
@@ -288,15 +288,61 @@ export async function failActivationSettlementAtomic(input: {
 
   if (error) {
     throw new Error(
-      error.message || 'fail_activation_settlement_atomic failed'
+      error.message || 'record_activation_settlement_failure_atomic failed'
     );
   }
 
   const outcome = typeof data === 'string' ? data : String(data ?? '');
   if (outcome === 'already_confirmed') return 'already_confirmed';
   if (outcome === 'already_failed') return 'already_failed';
-  if (outcome === 'failed') return 'failed';
+  if (outcome === 'exhausted') return 'exhausted';
+  if (outcome === 'retry_scheduled') return 'retry_scheduled';
   throw new Error(
-    'Unexpected RPC response from fail_activation_settlement_atomic'
+    'Unexpected RPC response from record_activation_settlement_failure_atomic'
+  );
+}
+
+export async function promoteActivationSettlementRetryingToQueued(): Promise<number> {
+  const { data, error } = await supabase.rpc(
+    'promote_activation_settlement_retrying_to_queued',
+    {}
+  );
+
+  if (error) {
+    console.error('promoteActivationSettlementRetryingToQueued:', error);
+    throw new Error(
+      error.message || 'promote_activation_settlement_retrying_to_queued failed'
+    );
+  }
+  if (typeof data === 'number' && Number.isFinite(data)) return data;
+  if (typeof data === 'string') {
+    const n = Number.parseInt(data, 10);
+    if (Number.isFinite(n)) return n;
+  }
+  return 0;
+}
+
+export async function adminResetActivationSettlementForRetryAtomic(input: {
+  settlementId: string;
+  activationId: string;
+}): Promise<'reset'> {
+  const { data, error } = await supabase.rpc(
+    'admin_reset_activation_settlement_for_retry_atomic',
+    {
+      p_settlement_id: input.settlementId,
+      p_activation_id: input.activationId,
+    }
+  );
+
+  if (error) {
+    throw new Error(
+      error.message ||
+        'admin_reset_activation_settlement_for_retry_atomic failed'
+    );
+  }
+  const outcome = typeof data === 'string' ? data : String(data ?? '');
+  if (outcome === 'reset') return 'reset';
+  throw new Error(
+    'Unexpected RPC response from admin_reset_activation_settlement_for_retry_atomic'
   );
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements **IRL-60** (settlement retry policy and budget reservation): USDC budget enforcement at purchase confirm (PRD math), `usdc_settled_total` bump on settlement confirm, uniform worker failure handling with retry vs exhaust (max 5 attempts, 24h from `queued_at`, exponential backoff from `submission_attempt` without a `next_retry_at` column), cron orchestration for Base and Stellar, and admin manual retry API.

## Key changes

- **SQL** (`database/irl-60-settlement-retry-budget.sql`): extends `confirm_activation_purchase_atomic`; updates `confirm_activation_settlement_atomic` (optional Privy id and `submitted_at` preservation, `usdc_settled_total` only after redemption updates), adds `record_activation_settlement_failure_atomic`, `promote_activation_settlement_retrying_to_queued`, `mark_activation_settlement_submitted_atomic`, `admin_reset_activation_settlement_for_retry_atomic`; drops legacy `fail_activation_settlement_atomic`.
- **Workers**: Base and Stellar delegate failures to `recordActivationSettlementFailureAtomic`; success confirms via `confirmActivationSettlementAtomic`.
- **Cron** (`lib/activation/settlement-orchestration.ts`): promote `retrying` to `queued`, then run Base and Stellar batches (`run-sponsored-settlement-cron.ts`).
- **Admin**: `POST /api/admin/sponsored-activations/[activationId]/settlements/[settlementId]/retry` with `requireAdmin`.
- **API copy**: `ACTIVATION_PURCHASE_USDC_BUDGET_EXCEEDED` maps like other cap errors (“This reward is no longer available”).

## Backoff and dequeue

Cron eligibility for `retrying` rows uses **`queued_at` + min(30 × 2^(submission_attempt − 1), 7200) seconds**, matching `promote_activation_settlement_retrying_to_queued` (see JSDoc on `settlement-orchestration.ts`).

## Tests

Vitest coverage for backoff math, cron wiring with mocked workers, Base and Stellar worker behavior, admin retry route, and confirm-purchase USDC budget error mapping. Full `yarn test` still reports unrelated failures elsewhere on the default branch.

## Apply migration

Run `database/irl-60-settlement-retry-budget.sql` on Supabase after review. `database/confirm-activation-purchase-atomic.sql` is updated in-repo for reference.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-60](https://linear.app/irlenergy/issue/IRL-60/implement-settlement-retry-policy-and-budget-reservation)

<div><a href="https://cursor.com/agents/bc-40359a71-e980-43ef-a0d0-f04fac0578ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-40359a71-e980-43ef-a0d0-f04fac0578ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

