### PR TITLE
feat(admin): sponsored activation ops dashboard (IRL-62)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -16,6 +16,7 @@ import {
   BookOpen,
   Users,
   CreditCard,
+  CircleDollarSign,
   Globe,
 } from 'lucide-react';
 
@@ -83,6 +84,13 @@ const SECTIONS: AdminSection[] = [
     href: '/admin/spend-experiences',
     icon: <CreditCard className="h-6 w-6" />,
     color: 'bg-amber-50 text-amber-600 border-amber-200',
+  },
+  {
+    title: 'Sponsored Activations',
+    description: 'Sponsor-funded activations, settlements, and redemptions',
+    href: '/admin/sponsored-activations',
+    icon: <CircleDollarSign className="h-6 w-6" />,
+    color: 'bg-lime-50 text-lime-700 border-lime-200',
   },
   {
     title: 'City Guides',

--- a/app/admin/spend-experiences/page.tsx
+++ b/app/admin/spend-experiences/page.tsx
@@ -18,6 +18,7 @@ import { SpendExperienceFormPanel } from './spend-experience-form-panel';
 import { SpendExperienceList } from './spend-experience-list';
 import type { SpendServerWalletFundingMetadata } from '@/lib/spend-server-wallet';
 import type { SpendRailCatalogEntry } from '@/lib/spend-rail-config/types';
+import { readApiErrorMessage } from '@/lib/admin/read-api-error-message';
 
 const QUERY_KEY = ['admin-spend-experiences'] as const;
 const RAILS_CATALOG_QUERY_KEY = ['admin-spend-rails-catalog'] as const;
@@ -113,15 +114,6 @@ export default function AdminSpendExperiencesPage() {
     setPanelOpen(false);
     setEditing(null);
   }, []);
-
-  const readApiErrorMessage = useCallback(
-    (body: Record<string, unknown>, fallback: string) => {
-      if (typeof body.error === 'string') return body.error;
-      if (typeof body.message === 'string') return body.message;
-      return fallback;
-    },
-    []
-  );
 
   const saveMutation = useMutation<CreateSpendExperienceResponse, Error>({
     mutationFn: async () => {

--- a/app/admin/sponsored-activations/[activationId]/page.tsx
+++ b/app/admin/sponsored-activations/[activationId]/page.tsx
@@ -1,0 +1,724 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import Link from 'next/link';
+import { useParams } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
+import { Loader2, ArrowLeft, ExternalLink, X } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { initMixpanel, trackEvent } from '@/lib/analytics';
+import { ANALYTICS_EVENTS } from '@/lib/analytics/events';
+import type {
+  SponsoredActivationAdminRedemptionRow,
+  SponsoredActivationAdminTiles,
+  SponsoredActivationConfirmedSettlementRow,
+  SponsoredActivationPendingSettlementRow,
+} from '@/lib/db/sponsored-activation-admin';
+
+type ActivationEnvelope = {
+  id: string;
+  title: string;
+  status: 'draft' | 'active' | 'paused' | 'ended';
+  settlement_rail: 'base' | 'stellar';
+  max_usdc_budget: number | null;
+  max_redemptions: number | null;
+};
+
+type DashboardApiResponse = {
+  activation: ActivationEnvelope;
+  tiles: SponsoredActivationAdminTiles;
+  confirmedSettlements: SponsoredActivationConfirmedSettlementRow[];
+  pendingSettlements: SponsoredActivationPendingSettlementRow[];
+  redemptions: SponsoredActivationAdminRedemptionRow[];
+};
+
+function fmtUsdc(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return '—';
+  const rounded = Math.round(n * 1e6) / 1e6;
+  return `$${rounded.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 6,
+  })}`;
+}
+
+function fmtInt(n: number | null | undefined): string {
+  if (n === null || n === undefined || Number.isNaN(n)) return '—';
+  return n.toLocaleString();
+}
+
+function statusBadgeClass(status: ActivationEnvelope['status']): string {
+  switch (status) {
+    case 'active':
+      return 'bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-200';
+    case 'paused':
+      return 'bg-amber-100 text-amber-900 dark:bg-amber-950 dark:text-amber-200';
+    case 'ended':
+      return 'bg-neutral-200 text-neutral-800 dark:bg-neutral-800 dark:text-neutral-200';
+    default:
+      return 'bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-200';
+  }
+}
+
+export default function AdminSponsoredActivationDetailPage() {
+  const params = useParams<{ activationId: string }>();
+  const activationId = params.activationId;
+  const queryClient = useQueryClient();
+  const { user, login, getAccessToken } = usePrivy();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [adminLoading, setAdminLoading] = useState(true);
+  const [selectedRedemptionId, setSelectedRedemptionId] = useState<
+    string | null
+  >(null);
+
+  const checkAdminStatus = useCallback(async () => {
+    if (!user?.email?.address) return false;
+    try {
+      const response = await fetch('/api/admin/auth', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
+      });
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return data.isAdmin;
+    } catch {
+      return false;
+    }
+  }, [user?.email?.address, getAccessToken]);
+
+  useEffect(() => {
+    const verify = async () => {
+      if (user?.email?.address) {
+        setIsAdmin(await checkAdminStatus());
+        setAdminLoading(false);
+      } else if (user === null) {
+        setIsAdmin(false);
+        setAdminLoading(false);
+      }
+    };
+    void verify();
+  }, [user, checkAdminStatus]);
+
+  const dashboardQueryKey = useMemo(
+    () => ['admin-sponsored-activation-dashboard', activationId] as const,
+    [activationId]
+  );
+
+  const {
+    data: dashboard,
+    isLoading,
+    error,
+  } = useQuery<DashboardApiResponse>({
+    queryKey: dashboardQueryKey,
+    queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch(
+        `/api/admin/sponsored-activations/${encodeURIComponent(activationId!)}/dashboard`,
+        { headers: auth }
+      );
+      if (response.status === 404) {
+        throw new Error('Activation not found');
+      }
+      if (!response.ok) throw new Error('Failed to load dashboard');
+      const j = await response.json();
+      const payload = j.data as DashboardApiResponse | undefined;
+      if (!payload?.activation) throw new Error('Invalid dashboard response');
+      return payload;
+    },
+    enabled: Boolean(activationId && isAdmin && user?.email?.address),
+  });
+
+  useEffect(() => {
+    if (!dashboard?.activation?.id) return;
+    const run = async () => {
+      const token =
+        process.env.NEXT_PUBLIC_MIXPANEL_TOKEN || process.env.MIXPANEL_TOKEN;
+      if (token) {
+        await initMixpanel(token);
+      }
+      if (user?.id) {
+        trackEvent(
+          ANALYTICS_EVENTS.SPONSORED_ACTIVATION_ADMIN_DASHBOARD_VIEWED,
+          {
+            sponsored_activation_id: dashboard.activation.id,
+            settlement_rail: dashboard.activation.settlement_rail,
+            user_id: user.id,
+          }
+        );
+      }
+    };
+    void run();
+  }, [
+    dashboard?.activation?.id,
+    dashboard?.activation?.settlement_rail,
+    user?.id,
+  ]);
+
+  const retryMutation = useMutation({
+    mutationFn: async (settlementId: string) => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch(
+        `/api/admin/sponsored-activations/${encodeURIComponent(activationId!)}/settlements/${encodeURIComponent(settlementId)}/retry`,
+        { method: 'POST', headers: auth }
+      );
+      const body = (await response.json()) as {
+        error?: string;
+        message?: string;
+      };
+      if (!response.ok) {
+        const msg =
+          typeof body.error === 'string'
+            ? body.error
+            : typeof body.message === 'string'
+              ? body.message
+              : `Request failed (${response.status})`;
+        throw new Error(msg);
+      }
+      return body;
+    },
+    onSuccess: async () => {
+      toast.success('Settlement queued for retry');
+      await queryClient.invalidateQueries({ queryKey: dashboardQueryKey });
+    },
+    onError: (e: Error) => {
+      toast.error(e.message || 'Retry failed');
+    },
+  });
+
+  const selectedRedemption = useMemo(() => {
+    if (!dashboard || !selectedRedemptionId) return null;
+    return (
+      dashboard.redemptions.find((r) => r.id === selectedRedemptionId) ?? null
+    );
+  }, [dashboard, selectedRedemptionId]);
+
+  if (adminLoading || (user && isAdmin === null)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+        <p className="text-gray-600">Please log in to access admin.</p>
+        <Button onClick={login}>Log In</Button>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-red-600">
+          Unauthorized: You don&apos;t have admin access.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6 pb-24 dark:bg-neutral-950">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-6">
+          <Link
+            href="/admin/sponsored-activations"
+            className="mb-3 inline-flex items-center gap-1 text-sm text-blue-700 hover:underline dark:text-blue-400"
+          >
+            <ArrowLeft className="size-4" />
+            All activations
+          </Link>
+          {isLoading && (
+            <div className="flex items-center gap-2 text-neutral-500">
+              <Loader2 className="size-5 animate-spin" />
+              Loading dashboard…
+            </div>
+          )}
+          {error && (
+            <p className="text-red-600">
+              {error instanceof Error ? error.message : 'Failed to load'}
+            </p>
+          )}
+          {dashboard && (
+            <div className="flex flex-wrap items-center gap-3">
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-neutral-100">
+                {dashboard.activation.title}
+              </h1>
+              <span
+                className={`rounded-full px-2.5 py-0.5 text-xs font-medium capitalize ${statusBadgeClass(dashboard.activation.status)}`}
+              >
+                {dashboard.activation.status}
+              </span>
+            </div>
+          )}
+        </div>
+
+        {dashboard && (
+          <>
+            <div className="mb-8 grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
+              <Tile
+                label="Check-ins verified"
+                value={fmtInt(dashboard.tiles.checkInsVerified)}
+              />
+              <Tile
+                label="Redemptions created"
+                hint="Not eligible or available"
+                value={fmtInt(dashboard.tiles.redemptionsCreated)}
+              />
+              <Tile
+                label="Redemptions confirmed"
+                value={fmtInt(dashboard.tiles.redemptionsConfirmed)}
+              />
+              <Tile
+                label="USDC settled"
+                value={fmtUsdc(dashboard.tiles.usdcSettledTotal)}
+              />
+              <Tile
+                label="Reserved (inflight + committed)"
+                value={fmtUsdc(dashboard.tiles.reservedUsdc)}
+              />
+              <Tile
+                label="Budget remaining"
+                hint={
+                  dashboard.activation.max_usdc_budget == null
+                    ? 'No USDC budget cap'
+                    : undefined
+                }
+                value={
+                  dashboard.tiles.budgetRemainingUsdc == null
+                    ? '—'
+                    : fmtUsdc(dashboard.tiles.budgetRemainingUsdc)
+                }
+              />
+              <Tile
+                label="Redemptions remaining"
+                hint={
+                  dashboard.activation.max_redemptions == null
+                    ? 'No redemption cap'
+                    : undefined
+                }
+                value={
+                  dashboard.tiles.redemptionsRemaining == null
+                    ? '—'
+                    : fmtInt(dashboard.tiles.redemptionsRemaining)
+                }
+              />
+              <Tile
+                label="Settlement rail"
+                value={dashboard.tiles.settlementRail}
+              />
+            </div>
+
+            <section className="mb-8">
+              <h2 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                Confirmed settlements
+              </h2>
+              <p className="mb-2 text-xs text-neutral-500">
+                Newest rows first (up to 150, no pagination).
+              </p>
+              <div className="overflow-x-auto rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+                <table className="w-full min-w-[640px] text-left text-sm">
+                  <thead className="border-b border-neutral-200 bg-neutral-50 text-xs dark:border-neutral-800 dark:bg-neutral-950">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Confirmed</th>
+                      <th className="px-3 py-2 font-medium">Amount</th>
+                      <th className="px-3 py-2 font-medium">Tx</th>
+                      <th className="px-3 py-2 font-medium">Redemption</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.confirmedSettlements.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={4}
+                          className="px-3 py-6 text-center text-neutral-500"
+                        >
+                          No confirmed settlements yet.
+                        </td>
+                      </tr>
+                    ) : (
+                      dashboard.confirmedSettlements.map((row) => (
+                        <tr
+                          key={row.id}
+                          className="border-b border-neutral-100 last:border-0 dark:border-neutral-800"
+                        >
+                          <td className="px-3 py-2 text-xs text-neutral-700 dark:text-neutral-300">
+                            {row.confirmedAt
+                              ? new Date(row.confirmedAt).toLocaleString()
+                              : '—'}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-xs">
+                            {fmtUsdc(row.amount)}
+                          </td>
+                          <td className="px-3 py-2">
+                            {row.explorerTxUrl && row.txHash ? (
+                              <a
+                                href={row.explorerTxUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="inline-flex items-center gap-0.5 text-blue-700 hover:underline dark:text-blue-400"
+                              >
+                                <span className="font-mono text-[11px]">
+                                  {row.txHash.slice(0, 10)}…
+                                </span>
+                                <ExternalLink className="size-3" />
+                              </a>
+                            ) : (
+                              <span className="text-neutral-400">—</span>
+                            )}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-[11px] text-neutral-600 dark:text-neutral-400">
+                            {row.redemptionId}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section className="mb-8">
+              <h2 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                Failed / pending settlements
+              </h2>
+              <p className="mb-2 text-xs text-neutral-500">
+                Queued, submitted, retrying, and failed (excludes not_started).
+              </p>
+              <div className="overflow-x-auto rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+                <table className="w-full min-w-[720px] text-left text-sm">
+                  <thead className="border-b border-neutral-200 bg-neutral-50 text-xs dark:border-neutral-800 dark:bg-neutral-950">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">Amount</th>
+                      <th className="px-3 py-2 font-medium">Attempts</th>
+                      <th className="px-3 py-2 font-medium">Last error</th>
+                      <th className="px-3 py-2 font-medium">Redemption</th>
+                      <th className="px-3 py-2 font-medium">Actions</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.pendingSettlements.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={6}
+                          className="px-3 py-6 text-center text-neutral-500"
+                        >
+                          No pending or failed settlements.
+                        </td>
+                      </tr>
+                    ) : (
+                      dashboard.pendingSettlements.map((row) => (
+                        <tr
+                          key={row.id}
+                          className="border-b border-neutral-100 last:border-0 dark:border-neutral-800"
+                        >
+                          <td className="px-3 py-2 text-xs capitalize">
+                            {row.status}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-xs">
+                            {fmtUsdc(row.amount)}
+                          </td>
+                          <td className="px-3 py-2 text-xs">
+                            {row.submissionAttempt}
+                          </td>
+                          <td className="max-w-[200px] truncate px-3 py-2 text-xs text-red-700 dark:text-red-400">
+                            {row.lastErrorCode ?? '—'}
+                          </td>
+                          <td className="px-3 py-2 font-mono text-[11px] text-neutral-600 dark:text-neutral-400">
+                            {row.redemptionId}
+                          </td>
+                          <td className="px-3 py-2">
+                            {row.canManualRetry ? (
+                              <Button
+                                size="sm"
+                                variant="outline"
+                                disabled={retryMutation.isPending}
+                                onClick={() => retryMutation.mutate(row.id)}
+                              >
+                                Retry
+                              </Button>
+                            ) : (
+                              <span className="text-xs text-neutral-400">
+                                —
+                              </span>
+                            )}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+
+            <section>
+              <h2 className="mb-2 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+                Redemptions
+              </h2>
+              <p className="mb-2 text-xs text-neutral-500">
+                Newest rows first (up to 150, no pagination).
+              </p>
+              <div className="overflow-x-auto rounded-lg border border-neutral-200 bg-white dark:border-neutral-800 dark:bg-neutral-900">
+                <table className="w-full min-w-[800px] text-left text-sm">
+                  <thead className="border-b border-neutral-200 bg-neutral-50 text-xs dark:border-neutral-800 dark:bg-neutral-950">
+                    <tr>
+                      <th className="px-3 py-2 font-medium">User</th>
+                      <th className="px-3 py-2 font-medium">Reward</th>
+                      <th className="px-3 py-2 font-medium">Points</th>
+                      <th className="px-3 py-2 font-medium">Status</th>
+                      <th className="px-3 py-2 font-medium">Settlement</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {dashboard.redemptions.map((r) => {
+                      const active = selectedRedemptionId === r.id;
+                      return (
+                        <tr
+                          key={r.id}
+                          role="button"
+                          tabIndex={0}
+                          onClick={() =>
+                            setSelectedRedemptionId(active ? null : r.id)
+                          }
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter' || e.key === ' ') {
+                              e.preventDefault();
+                              setSelectedRedemptionId(active ? null : r.id);
+                            }
+                          }}
+                          className={`cursor-pointer border-b border-neutral-100 last:border-0 dark:border-neutral-800 ${
+                            active
+                              ? 'bg-blue-50 dark:bg-blue-950/40'
+                              : 'hover:bg-neutral-50 dark:hover:bg-neutral-800/60'
+                          }`}
+                        >
+                          <td className="px-3 py-2 text-xs">
+                            <div className="font-mono text-[11px] text-neutral-600">
+                              id {r.userId}
+                            </div>
+                            <div>{r.username ?? '—'}</div>
+                          </td>
+                          <td className="px-3 py-2 text-xs">
+                            {r.rewardDisplayName}
+                          </td>
+                          <td className="px-3 py-2 text-xs">
+                            {r.pointsSpent ?? '—'}
+                          </td>
+                          <td className="px-3 py-2 text-xs capitalize">
+                            {r.status}
+                          </td>
+                          <td className="px-3 py-2 text-xs">
+                            {r.settlement?.status ?? '—'}
+                          </td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          </>
+        )}
+      </div>
+
+      {selectedRedemption && (
+        <>
+          <button
+            type="button"
+            aria-label="Close redemption details"
+            className="fixed inset-0 z-40 bg-black/25 dark:bg-black/50"
+            onClick={() => setSelectedRedemptionId(null)}
+          />
+          <aside className="fixed inset-y-0 right-0 z-50 flex w-full max-w-md flex-col border-l border-neutral-200 bg-white shadow-xl dark:border-neutral-800 dark:bg-neutral-950">
+            <div className="flex items-center justify-between border-b border-neutral-200 px-4 py-3 dark:border-neutral-800">
+              <h3 className="text-sm font-semibold text-neutral-900 dark:text-neutral-100">
+                Redemption drilldown
+              </h3>
+              <button
+                type="button"
+                className="rounded p-1 text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-900"
+                onClick={() => setSelectedRedemptionId(null)}
+                aria-label="Close"
+              >
+                <X className="size-5" />
+              </button>
+            </div>
+            <div className="flex-1 space-y-4 overflow-y-auto p-4 text-sm">
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Player
+                </div>
+                <div className="font-mono text-xs">
+                  id {selectedRedemption.userId}
+                </div>
+                <div>{selectedRedemption.username ?? '—'}</div>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Reward
+                </div>
+                <div>{selectedRedemption.rewardDisplayName}</div>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Points
+                </div>
+                <div>{selectedRedemption.pointsSpent ?? '—'}</div>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Status
+                </div>
+                <div className="capitalize">{selectedRedemption.status}</div>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Timeline
+                </div>
+                <ul className="mt-1 space-y-1 text-xs text-neutral-700 dark:text-neutral-300">
+                  <li>
+                    Created:{' '}
+                    {new Date(selectedRedemption.createdAt).toLocaleString()}
+                  </li>
+                  <li>
+                    Purchase confirmed:{' '}
+                    {selectedRedemption.purchaseConfirmedAt
+                      ? new Date(
+                          selectedRedemption.purchaseConfirmedAt
+                        ).toLocaleString()
+                      : '—'}
+                  </li>
+                  <li>
+                    Redeemed:{' '}
+                    {selectedRedemption.redeemedAt
+                      ? new Date(selectedRedemption.redeemedAt).toLocaleString()
+                      : '—'}
+                  </li>
+                  <li>
+                    Updated:{' '}
+                    {new Date(selectedRedemption.updatedAt).toLocaleString()}
+                  </li>
+                </ul>
+              </div>
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Settlement
+                </div>
+                {selectedRedemption.settlement ? (
+                  <ul className="mt-1 space-y-1 text-xs text-neutral-700 dark:text-neutral-300">
+                    <li className="capitalize">
+                      Status: {selectedRedemption.settlement.status}
+                    </li>
+                    <li>
+                      Amount: {fmtUsdc(selectedRedemption.settlement.amount)}
+                    </li>
+                    <li className="break-all">
+                      Tx:{' '}
+                      {selectedRedemption.settlement.explorerTxUrl &&
+                      selectedRedemption.settlement.txHash ? (
+                        <a
+                          href={selectedRedemption.settlement.explorerTxUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="text-blue-700 hover:underline dark:text-blue-400"
+                        >
+                          {selectedRedemption.settlement.txHash}
+                        </a>
+                      ) : (
+                        (selectedRedemption.settlement.txHash ?? '—')
+                      )}
+                    </li>
+                    <li>
+                      Queued:{' '}
+                      {selectedRedemption.settlement.queuedAt
+                        ? new Date(
+                            selectedRedemption.settlement.queuedAt
+                          ).toLocaleString()
+                        : '—'}
+                    </li>
+                    <li>
+                      Submitted:{' '}
+                      {selectedRedemption.settlement.submittedAt
+                        ? new Date(
+                            selectedRedemption.settlement.submittedAt
+                          ).toLocaleString()
+                        : '—'}
+                    </li>
+                    <li>
+                      Confirmed:{' '}
+                      {selectedRedemption.settlement.confirmedAt
+                        ? new Date(
+                            selectedRedemption.settlement.confirmedAt
+                          ).toLocaleString()
+                        : '—'}
+                    </li>
+                    {selectedRedemption.settlement.lastErrorCode && (
+                      <li className="text-red-700 dark:text-red-400">
+                        Error: {selectedRedemption.settlement.lastErrorCode}
+                      </li>
+                    )}
+                  </ul>
+                ) : (
+                  <p className="text-xs text-neutral-500">No settlement row.</p>
+                )}
+              </div>
+              <div>
+                <div className="text-xs font-medium text-neutral-500">
+                  Eligibility
+                </div>
+                <ul className="mt-1 space-y-1 text-xs text-neutral-700 dark:text-neutral-300">
+                  <li>Source: {selectedRedemption.eligibility.source}</li>
+                  <li className="break-all">
+                    Source ref:{' '}
+                    {selectedRedemption.eligibility.sourceRefId ?? '—'}
+                  </li>
+                  <li>
+                    Occurred:{' '}
+                    {new Date(
+                      selectedRedemption.eligibility.occurredAt
+                    ).toLocaleString()}
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </aside>
+        </>
+      )}
+    </div>
+  );
+}
+
+function Tile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint?: string;
+}) {
+  return (
+    <div className="rounded-xl border border-neutral-200 bg-white p-4 shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+      <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+        {label}
+      </div>
+      <div className="mt-1 text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+        {value}
+      </div>
+      {hint && (
+        <div className="mt-1 text-[11px] text-neutral-500 dark:text-neutral-400">
+          {hint}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/admin/sponsored-activations/[activationId]/page.tsx
+++ b/app/admin/sponsored-activations/[activationId]/page.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
 import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
+import { readApiErrorMessage } from '@/lib/admin/read-api-error-message';
 import { Loader2, ArrowLeft, ExternalLink, X } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
@@ -17,12 +18,16 @@ import type {
   SponsoredActivationConfirmedSettlementRow,
   SponsoredActivationPendingSettlementRow,
 } from '@/lib/db/sponsored-activation-admin';
+import type {
+  SettlementRail,
+  SponsoredActivationStatus,
+} from '@/lib/db/sponsored-activations';
 
 type ActivationEnvelope = {
   id: string;
   title: string;
-  status: 'draft' | 'active' | 'paused' | 'ended';
-  settlement_rail: 'base' | 'stellar';
+  status: SponsoredActivationStatus;
+  settlement_rail: SettlementRail;
   max_usdc_budget: number | null;
   max_redemptions: number | null;
 };
@@ -35,18 +40,31 @@ type DashboardApiResponse = {
   redemptions: SponsoredActivationAdminRedemptionRow[];
 };
 
-function fmtUsdc(n: number | null | undefined): string {
+function formatIfNumber(
+  n: number | null | undefined,
+  format: (v: number) => string
+): string {
   if (n === null || n === undefined || Number.isNaN(n)) return '—';
-  const rounded = Math.round(n * 1e6) / 1e6;
-  return `$${rounded.toLocaleString(undefined, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 6,
-  })}`;
+  return format(n);
+}
+
+function fmtUsdc(n: number | null | undefined): string {
+  return formatIfNumber(n, (v) => {
+    const rounded = Math.round(v * 1e6) / 1e6;
+    return `$${rounded.toLocaleString(undefined, {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 6,
+    })}`;
+  });
 }
 
 function fmtInt(n: number | null | undefined): string {
-  if (n === null || n === undefined || Number.isNaN(n)) return '—';
-  return n.toLocaleString();
+  return formatIfNumber(n, (v) => v.toLocaleString());
+}
+
+function fmtLocalDateTime(value: string | null | undefined): string {
+  if (!value) return '—';
+  return new Date(value).toLocaleString();
 }
 
 function statusBadgeClass(status: ActivationEnvelope['status']): string {
@@ -60,6 +78,47 @@ function statusBadgeClass(status: ActivationEnvelope['status']): string {
     default:
       return 'bg-slate-100 text-slate-800 dark:bg-slate-900 dark:text-slate-200';
   }
+}
+
+function SettlementExplorerTxLink({
+  explorerTxUrl,
+  txHash,
+  variant,
+}: {
+  explorerTxUrl: string | null;
+  txHash: string | null;
+  variant: 'compact' | 'full';
+}) {
+  if (!txHash?.trim()) {
+    return <span className="text-neutral-400">—</span>;
+  }
+  if (!explorerTxUrl?.trim()) {
+    return (
+      <span className="break-all font-mono text-[11px] text-neutral-700 dark:text-neutral-300">
+        {txHash}
+      </span>
+    );
+  }
+  const label = variant === 'compact' ? `${txHash.slice(0, 10)}…` : txHash;
+  return (
+    <a
+      href={explorerTxUrl}
+      target="_blank"
+      rel="noopener noreferrer"
+      className={
+        variant === 'compact'
+          ? 'inline-flex items-center gap-0.5 text-blue-700 hover:underline dark:text-blue-400'
+          : 'inline-flex flex-wrap items-center gap-0.5 break-all text-blue-700 hover:underline dark:text-blue-400'
+      }
+    >
+      {variant === 'compact' ? (
+        <span className="font-mono text-[11px]">{label}</span>
+      ) : (
+        <span>{label}</span>
+      )}
+      <ExternalLink className="size-3 shrink-0" />
+    </a>
+  );
 }
 
 export default function AdminSponsoredActivationDetailPage() {
@@ -105,10 +164,10 @@ export default function AdminSponsoredActivationDetailPage() {
     void verify();
   }, [user, checkAdminStatus]);
 
-  const dashboardQueryKey = useMemo(
-    () => ['admin-sponsored-activation-dashboard', activationId] as const,
-    [activationId]
-  );
+  const dashboardQueryKey = [
+    'admin-sponsored-activation-dashboard',
+    activationId,
+  ] as const;
 
   const {
     data: dashboard,
@@ -117,21 +176,24 @@ export default function AdminSponsoredActivationDetailPage() {
   } = useQuery<DashboardApiResponse>({
     queryKey: dashboardQueryKey,
     queryFn: async () => {
+      if (!activationId) throw new Error('Missing activation id');
       const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
-        `/api/admin/sponsored-activations/${encodeURIComponent(activationId!)}/dashboard`,
+        `/api/admin/sponsored-activations/${encodeURIComponent(activationId)}/dashboard`,
         { headers: auth }
       );
       if (response.status === 404) {
         throw new Error('Activation not found');
       }
       if (!response.ok) throw new Error('Failed to load dashboard');
-      const j = await response.json();
+      const j = (await response.json()) as Record<string, unknown>;
       const payload = j.data as DashboardApiResponse | undefined;
       if (!payload?.activation) throw new Error('Invalid dashboard response');
       return payload;
     },
     enabled: Boolean(activationId && isAdmin && user?.email?.address),
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 
   useEffect(() => {
@@ -162,23 +224,17 @@ export default function AdminSponsoredActivationDetailPage() {
 
   const retryMutation = useMutation({
     mutationFn: async (settlementId: string) => {
+      if (!activationId) throw new Error('Missing activation id');
       const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch(
-        `/api/admin/sponsored-activations/${encodeURIComponent(activationId!)}/settlements/${encodeURIComponent(settlementId)}/retry`,
+        `/api/admin/sponsored-activations/${encodeURIComponent(activationId)}/settlements/${encodeURIComponent(settlementId)}/retry`,
         { method: 'POST', headers: auth }
       );
-      const body = (await response.json()) as {
-        error?: string;
-        message?: string;
-      };
+      const body = (await response.json()) as Record<string, unknown>;
       if (!response.ok) {
-        const msg =
-          typeof body.error === 'string'
-            ? body.error
-            : typeof body.message === 'string'
-              ? body.message
-              : `Request failed (${response.status})`;
-        throw new Error(msg);
+        throw new Error(
+          readApiErrorMessage(body, `Request failed (${response.status})`)
+        );
       }
       return body;
     },
@@ -191,12 +247,11 @@ export default function AdminSponsoredActivationDetailPage() {
     },
   });
 
-  const selectedRedemption = useMemo(() => {
-    if (!dashboard || !selectedRedemptionId) return null;
-    return (
-      dashboard.redemptions.find((r) => r.id === selectedRedemptionId) ?? null
-    );
-  }, [dashboard, selectedRedemptionId]);
+  const selectedRedemption =
+    dashboard && selectedRedemptionId
+      ? (dashboard.redemptions.find((r) => r.id === selectedRedemptionId) ??
+        null)
+      : null;
 
   if (adminLoading || (user && isAdmin === null)) {
     return (
@@ -351,29 +406,17 @@ export default function AdminSponsoredActivationDetailPage() {
                           className="border-b border-neutral-100 last:border-0 dark:border-neutral-800"
                         >
                           <td className="px-3 py-2 text-xs text-neutral-700 dark:text-neutral-300">
-                            {row.confirmedAt
-                              ? new Date(row.confirmedAt).toLocaleString()
-                              : '—'}
+                            {fmtLocalDateTime(row.confirmedAt)}
                           </td>
                           <td className="px-3 py-2 font-mono text-xs">
                             {fmtUsdc(row.amount)}
                           </td>
                           <td className="px-3 py-2">
-                            {row.explorerTxUrl && row.txHash ? (
-                              <a
-                                href={row.explorerTxUrl}
-                                target="_blank"
-                                rel="noopener noreferrer"
-                                className="inline-flex items-center gap-0.5 text-blue-700 hover:underline dark:text-blue-400"
-                              >
-                                <span className="font-mono text-[11px]">
-                                  {row.txHash.slice(0, 10)}…
-                                </span>
-                                <ExternalLink className="size-3" />
-                              </a>
-                            ) : (
-                              <span className="text-neutral-400">—</span>
-                            )}
+                            <SettlementExplorerTxLink
+                              explorerTxUrl={row.explorerTxUrl}
+                              txHash={row.txHash}
+                              variant="compact"
+                            />
                           </td>
                           <td className="px-3 py-2 font-mono text-[11px] text-neutral-600 dark:text-neutral-400">
                             {row.redemptionId}
@@ -586,26 +629,17 @@ export default function AdminSponsoredActivationDetailPage() {
                 </div>
                 <ul className="mt-1 space-y-1 text-xs text-neutral-700 dark:text-neutral-300">
                   <li>
-                    Created:{' '}
-                    {new Date(selectedRedemption.createdAt).toLocaleString()}
+                    Created: {fmtLocalDateTime(selectedRedemption.createdAt)}
                   </li>
                   <li>
                     Purchase confirmed:{' '}
-                    {selectedRedemption.purchaseConfirmedAt
-                      ? new Date(
-                          selectedRedemption.purchaseConfirmedAt
-                        ).toLocaleString()
-                      : '—'}
+                    {fmtLocalDateTime(selectedRedemption.purchaseConfirmedAt)}
                   </li>
                   <li>
-                    Redeemed:{' '}
-                    {selectedRedemption.redeemedAt
-                      ? new Date(selectedRedemption.redeemedAt).toLocaleString()
-                      : '—'}
+                    Redeemed: {fmtLocalDateTime(selectedRedemption.redeemedAt)}
                   </li>
                   <li>
-                    Updated:{' '}
-                    {new Date(selectedRedemption.updatedAt).toLocaleString()}
+                    Updated: {fmtLocalDateTime(selectedRedemption.updatedAt)}
                   </li>
                 </ul>
               </div>
@@ -623,43 +657,29 @@ export default function AdminSponsoredActivationDetailPage() {
                     </li>
                     <li className="break-all">
                       Tx:{' '}
-                      {selectedRedemption.settlement.explorerTxUrl &&
-                      selectedRedemption.settlement.txHash ? (
-                        <a
-                          href={selectedRedemption.settlement.explorerTxUrl}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-700 hover:underline dark:text-blue-400"
-                        >
-                          {selectedRedemption.settlement.txHash}
-                        </a>
-                      ) : (
-                        (selectedRedemption.settlement.txHash ?? '—')
-                      )}
+                      <SettlementExplorerTxLink
+                        explorerTxUrl={
+                          selectedRedemption.settlement.explorerTxUrl
+                        }
+                        txHash={selectedRedemption.settlement.txHash}
+                        variant="full"
+                      />
                     </li>
                     <li>
                       Queued:{' '}
-                      {selectedRedemption.settlement.queuedAt
-                        ? new Date(
-                            selectedRedemption.settlement.queuedAt
-                          ).toLocaleString()
-                        : '—'}
+                      {fmtLocalDateTime(selectedRedemption.settlement.queuedAt)}
                     </li>
                     <li>
                       Submitted:{' '}
-                      {selectedRedemption.settlement.submittedAt
-                        ? new Date(
-                            selectedRedemption.settlement.submittedAt
-                          ).toLocaleString()
-                        : '—'}
+                      {fmtLocalDateTime(
+                        selectedRedemption.settlement.submittedAt
+                      )}
                     </li>
                     <li>
                       Confirmed:{' '}
-                      {selectedRedemption.settlement.confirmedAt
-                        ? new Date(
-                            selectedRedemption.settlement.confirmedAt
-                          ).toLocaleString()
-                        : '—'}
+                      {fmtLocalDateTime(
+                        selectedRedemption.settlement.confirmedAt
+                      )}
                     </li>
                     {selectedRedemption.settlement.lastErrorCode && (
                       <li className="text-red-700 dark:text-red-400">
@@ -683,9 +703,9 @@ export default function AdminSponsoredActivationDetailPage() {
                   </li>
                   <li>
                     Occurred:{' '}
-                    {new Date(
+                    {fmtLocalDateTime(
                       selectedRedemption.eligibility.occurredAt
-                    ).toLocaleString()}
+                    )}
                   </li>
                 </ul>
               </div>

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -68,6 +68,8 @@ export default function AdminSponsoredActivationsListPage() {
       return (data.activations ?? []) as ActivationListRow[];
     },
     enabled: !!isAdmin && !!user?.email?.address,
+    staleTime: 60_000,
+    refetchOnWindowFocus: false,
   });
 
   if (adminLoading || (user && isAdmin === null)) {

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useQuery } from '@tanstack/react-query';
+import { usePrivy } from '@privy-io/react-auth';
+import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
+import { Loader2, ArrowLeft, CircleDollarSign } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+
+/** Mirrors `GET /api/admin/sponsored-activations` rows (avoid `lib/db` in client bundles). */
+type ActivationListRow = {
+  id: string;
+  slug: string;
+  title: string;
+  sponsor_name: string;
+  status: string;
+  settlement_rail: string;
+};
+
+export default function AdminSponsoredActivationsListPage() {
+  const { user, login, getAccessToken } = usePrivy();
+  const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
+  const [adminLoading, setAdminLoading] = useState(true);
+
+  const checkAdminStatus = useCallback(async () => {
+    if (!user?.email?.address) return false;
+    try {
+      const response = await fetch('/api/admin/auth', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...(await adminApiAuthHeaders(getAccessToken)),
+        },
+        body: JSON.stringify({}),
+      });
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return data.isAdmin;
+    } catch {
+      return false;
+    }
+  }, [user?.email?.address, getAccessToken]);
+
+  useEffect(() => {
+    const verify = async () => {
+      if (user?.email?.address) {
+        setIsAdmin(await checkAdminStatus());
+        setAdminLoading(false);
+      } else if (user === null) {
+        setIsAdmin(false);
+        setAdminLoading(false);
+      }
+    };
+    void verify();
+  }, [user, checkAdminStatus]);
+
+  const { data: activations = [], isLoading } = useQuery<ActivationListRow[]>({
+    queryKey: ['admin-sponsored-activations-list'],
+    queryFn: async () => {
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch('/api/admin/sponsored-activations', {
+        headers: auth,
+      });
+      if (!response.ok) throw new Error('Failed to load activations');
+      const responseData = await response.json();
+      const data = responseData.data || responseData;
+      return (data.activations ?? []) as ActivationListRow[];
+    },
+    enabled: !!isAdmin && !!user?.email?.address,
+  });
+
+  if (adminLoading || (user && isAdmin === null)) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <Loader2 className="h-8 w-8 animate-spin text-gray-400" />
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center gap-4">
+        <p className="text-gray-600">Please log in to access admin.</p>
+        <Button onClick={login}>Log In</Button>
+      </div>
+    );
+  }
+
+  if (!isAdmin) {
+    return (
+      <div className="flex min-h-screen items-center justify-center">
+        <p className="text-red-600">
+          Unauthorized: You don&apos;t have admin access.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen bg-gray-50 p-6 dark:bg-neutral-950">
+      <div className="mx-auto max-w-5xl">
+        <div className="mb-8">
+          <Link
+            href="/admin"
+            className="mb-4 inline-flex items-center gap-1 text-sm text-blue-700 hover:underline dark:text-blue-400"
+          >
+            <ArrowLeft className="size-4" />
+            Admin home
+          </Link>
+          <div className="flex items-center gap-3">
+            <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+              <CircleDollarSign className="size-6" />
+            </div>
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900 dark:text-neutral-100">
+                Sponsored activations
+              </h1>
+              <p className="text-sm text-gray-500 dark:text-neutral-400">
+                Public Records activation health and settlement ops.
+              </p>
+            </div>
+          </div>
+        </div>
+
+        {isLoading ? (
+          <div className="flex justify-center py-16">
+            <Loader2 className="size-8 animate-spin text-neutral-400" />
+          </div>
+        ) : activations.length === 0 ? (
+          <p className="text-neutral-600 dark:text-neutral-400">
+            No sponsored activations yet.
+          </p>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+            <table className="w-full text-left text-sm">
+              <thead className="border-b border-gray-200 bg-gray-50 dark:border-neutral-800 dark:bg-neutral-950">
+                <tr>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                    Title
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                    Status
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                    Rail
+                  </th>
+                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                    Slug
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {activations.map((a) => (
+                  <tr
+                    key={a.id}
+                    className="border-b border-gray-100 last:border-0 dark:border-neutral-800"
+                  >
+                    <td className="px-4 py-3">
+                      <Link
+                        href={`/admin/sponsored-activations/${encodeURIComponent(a.id)}`}
+                        className="font-medium text-blue-700 hover:underline dark:text-blue-400"
+                      >
+                        {a.title}
+                      </Link>
+                      <div className="text-xs text-neutral-500">
+                        {a.sponsor_name}
+                      </div>
+                    </td>
+                    <td className="px-4 py-3 capitalize text-neutral-800 dark:text-neutral-200">
+                      {a.status}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-neutral-700 dark:text-neutral-300">
+                      {a.settlement_rail}
+                    </td>
+                    <td className="px-4 py-3 font-mono text-xs text-neutral-600 dark:text-neutral-400">
+                      {a.slug}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/api/admin/sponsored-activations/[activationId]/dashboard/__tests__/route.test.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/dashboard/__tests__/route.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockLoadDashboard = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/sponsored-activation-admin', () => ({
+  loadSponsoredActivationAdminDashboard: (...a: unknown[]) =>
+    mockLoadDashboard(...a),
+}));
+
+vi.mock('@/lib/activation/explorer-url', () => ({
+  sponsoredActivationAdminEnvelope: (row: Record<string, unknown>) => ({
+    ...row,
+    campaign_wallet_explorer_url: 'https://ex/c',
+    venue_settlement_wallet_explorer_url: 'https://ex/v',
+    settlement_explorer_tx_url_template: 'https://ex/tx/{txHash}',
+  }),
+}));
+
+import { GET } from '../route';
+
+const activationRow = {
+  id: 'act-1',
+  slug: 's1',
+  title: 'T',
+  sponsor_name: 'S',
+  event_id: null,
+  status: 'active' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0x1',
+  venue_settlement_wallet_address: '0x2',
+  usdc_asset_config: {},
+  max_redemptions: 10,
+  max_usdc_budget: 100,
+  usdc_settled_total: 5,
+  redemption_count_confirmed: 2,
+  starts_at: '2026-01-01T00:00:00.000Z',
+  ends_at: '2026-02-01T00:00:00.000Z',
+  eligibility_config: {},
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: null,
+  privy_campaign_wallet_id: null,
+};
+
+describe('GET /api/admin/sponsored-activations/[activationId]/dashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({ isValid: true });
+    mockLoadDashboard.mockResolvedValue({
+      activation: activationRow,
+      tiles: {
+        checkInsVerified: 3,
+        redemptionsCreated: 4,
+        redemptionsConfirmed: 2,
+        usdcSettledTotal: 5,
+        reservedUsdc: 1,
+        budgetRemainingUsdc: 94,
+        redemptionsRemaining: 8,
+        settlementRail: 'base',
+      },
+      confirmedSettlements: [],
+      pendingSettlements: [],
+      redemptions: [],
+    });
+  });
+
+  it('returns 403 when not admin', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const res = await GET(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1' },
+    });
+    expect(res.status).toBe(403);
+    expect(mockLoadDashboard).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 when activation is missing', async () => {
+    mockLoadDashboard.mockResolvedValue(null);
+    const res = await GET(new NextRequest('http://localhost'), {
+      params: { activationId: 'missing' },
+    });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns aggregated dashboard payload when admin', async () => {
+    const res = await GET(new NextRequest('http://localhost'), {
+      params: { activationId: 'act-1' },
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const data = body.data ?? body;
+    expect(data.tiles.checkInsVerified).toBe(3);
+    expect(data.tiles.redemptionsCreated).toBe(4);
+    expect(data.tiles.redemptionsConfirmed).toBe(2);
+    expect(data.tiles.usdcSettledTotal).toBe(5);
+    expect(data.tiles.reservedUsdc).toBe(1);
+    expect(data.tiles.budgetRemainingUsdc).toBe(94);
+    expect(data.tiles.redemptionsRemaining).toBe(8);
+    expect(data.activation.id).toBe('act-1');
+    expect(data.activation.settlement_explorer_tx_url_template).toContain('tx');
+  });
+});

--- a/app/api/admin/sponsored-activations/[activationId]/dashboard/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/dashboard/route.ts
@@ -1,0 +1,41 @@
+import { NextRequest } from 'next/server';
+import { apiError, apiSuccess } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+import { sponsoredActivationAdminEnvelope } from '@/lib/activation/explorer-url';
+import { loadSponsoredActivationAdminDashboard } from '@/lib/db/sponsored-activation-admin';
+
+interface RouteParams {
+  params: { activationId: string };
+}
+
+/** GET /api/admin/sponsored-activations/{activationId}/dashboard */
+export async function GET(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const key = params.activationId?.trim();
+    if (!key) {
+      return apiError('Missing activation id', 400);
+    }
+
+    const bundle = await loadSponsoredActivationAdminDashboard(key);
+    if (!bundle) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    const { activation, ...rest } = bundle;
+    return apiSuccess({
+      activation: sponsoredActivationAdminEnvelope(activation),
+      ...rest,
+    });
+  } catch (error) {
+    console.error(
+      'GET /api/admin/sponsored-activations/[activationId]/dashboard:',
+      error
+    );
+    return apiError('Failed to load sponsored activation dashboard', 500);
+  }
+}

--- a/app/api/admin/sponsored-activations/[activationId]/dashboard/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/dashboard/route.ts
@@ -16,8 +16,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return apiError('Unauthorized - Admin access required', 403);
     }
 
-    const key = params.activationId?.trim();
-    if (!key) {
+    const key = params.activationId;
+    if (!key?.trim()) {
       return apiError('Missing activation id', 400);
     }
 

--- a/lib/admin/read-api-error-message.ts
+++ b/lib/admin/read-api-error-message.ts
@@ -1,0 +1,9 @@
+/** Parse `apiError` / legacy `{ message }` shapes from JSON admin API responses. */
+export function readApiErrorMessage(
+  body: Record<string, unknown>,
+  fallback: string
+): string {
+  if (typeof body.error === 'string') return body.error;
+  if (typeof body.message === 'string') return body.message;
+  return fallback;
+}

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -56,6 +56,10 @@ export const ANALYTICS_EVENTS = {
   SPEND_WALLET_READINESS_STARTED: 'spend_wallet_readiness_started',
   SPEND_WALLET_READINESS_COMPLETED: 'spend_wallet_readiness_completed',
   SPEND_WALLET_READINESS_FAILED: 'spend_wallet_readiness_failed',
+
+  /** Admin ops dashboard for sponsored activations (IRL-62 / FR-9). */
+  SPONSORED_ACTIVATION_ADMIN_DASHBOARD_VIEWED:
+    'sponsored_activation_admin_dashboard_viewed',
 } as const;
 
 export type AnalyticsEventName =

--- a/lib/db/__tests__/sponsored-activation-admin.test.ts
+++ b/lib/db/__tests__/sponsored-activation-admin.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeBudgetRemainingUsdc,
+  computeRedemptionsRemaining,
+  computeReservedUsdcFromRaw,
+} from '../sponsored-activation-admin';
+
+describe('sponsored-activation-admin helpers', () => {
+  it('computes reserved USDC from inflight settlements and committed redemptions', () => {
+    expect(
+      computeReservedUsdcFromRaw({
+        inflightSettlementRows: [{ amount: 1.5 }, { amount: 0.5 }],
+        committedRedemptionRows: [
+          { usdc_amount_snapshot: 2 },
+          { usdc_amount_snapshot: 0 },
+          { usdc_amount_snapshot: null },
+        ],
+      })
+    ).toBe(4);
+  });
+
+  it('computes budget remaining when capped', () => {
+    expect(
+      computeBudgetRemainingUsdc({
+        maxUsdcBudget: 100,
+        usdcSettledTotal: 10,
+        reservedUsdc: 15,
+      })
+    ).toBe(75);
+  });
+
+  it('returns null budget remaining when there is no cap', () => {
+    expect(
+      computeBudgetRemainingUsdc({
+        maxUsdcBudget: null,
+        usdcSettledTotal: 10,
+        reservedUsdc: 5,
+      })
+    ).toBeNull();
+  });
+
+  it('computes redemptions remaining from activation counters', () => {
+    expect(
+      computeRedemptionsRemaining({
+        maxRedemptions: 10,
+        redemptionCountConfirmed: 3,
+      })
+    ).toBe(7);
+  });
+
+  it('returns null redemptions remaining when uncapped', () => {
+    expect(
+      computeRedemptionsRemaining({
+        maxRedemptions: null,
+        redemptionCountConfirmed: 99,
+      })
+    ).toBeNull();
+  });
+
+  it('never returns negative redemptions remaining', () => {
+    expect(
+      computeRedemptionsRemaining({
+        maxRedemptions: 2,
+        redemptionCountConfirmed: 5,
+      })
+    ).toBe(0);
+  });
+});

--- a/lib/db/activation-redemptions.ts
+++ b/lib/db/activation-redemptions.ts
@@ -35,7 +35,9 @@ function toIntOrNull(value: unknown): number | null {
   return Number.isNaN(n) ? null : Math.trunc(n);
 }
 
-function normalizeRow(row: Record<string, unknown>): ActivationRedemptionRow {
+export function normalizeActivationRedemptionRow(
+  row: Record<string, unknown>
+): ActivationRedemptionRow {
   return {
     id: String(row.id),
     activation_id: String(row.activation_id),
@@ -76,7 +78,9 @@ export async function listRedemptionsForUserActivation(input: {
     console.error('listRedemptionsForUserActivation:', error);
     throw new Error(error.message || 'Failed to list redemptions');
   }
-  return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+  return (data ?? []).map((r) =>
+    normalizeActivationRedemptionRow(r as Record<string, unknown>)
+  );
 }
 
 export async function listRedemptionsForEligibilityEvent(
@@ -91,7 +95,9 @@ export async function listRedemptionsForEligibilityEvent(
     console.error('listRedemptionsForEligibilityEvent:', error);
     throw new Error(error.message || 'Failed to list redemptions for event');
   }
-  return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+  return (data ?? []).map((r) =>
+    normalizeActivationRedemptionRow(r as Record<string, unknown>)
+  );
 }
 
 export type InsertActivationRedemptionInput = {
@@ -130,7 +136,7 @@ export async function insertActivationRedemption(
     console.error('insertActivationRedemption:', error);
     throw new Error(error.message || 'Failed to create redemption');
   }
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationRedemptionRow(data as Record<string, unknown>);
 }
 
 export async function getActivationRedemptionById(
@@ -146,7 +152,7 @@ export async function getActivationRedemptionById(
     throw new Error(error.message || 'Failed to load redemption');
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationRedemptionRow(data as Record<string, unknown>);
 }
 
 /** Counts completed confirm-purchase outcomes for rate limits (IRL-54). */
@@ -385,7 +391,7 @@ export async function getActivationRedemptionByIdempotencyKey(
     throw new Error(error.message || 'Failed to load redemption');
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationRedemptionRow(data as Record<string, unknown>);
 }
 
 /**
@@ -415,5 +421,5 @@ export async function syncActivationRedemptionSettlementOutcome(input: {
     );
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationRedemptionRow(data as Record<string, unknown>);
 }

--- a/lib/db/activation-settlement-transactions.ts
+++ b/lib/db/activation-settlement-transactions.ts
@@ -48,7 +48,7 @@ function parseSettlementRpcTextOutcome<T extends string>(
   throw new Error(`Unexpected RPC response from ${rpcLabel}`);
 }
 
-function normalizeRow(
+export function normalizeActivationSettlementTransactionRow(
   row: Record<string, unknown>
 ): ActivationSettlementTransactionRow {
   return {
@@ -88,7 +88,9 @@ export async function getActivationSettlementTransactionByRedemptionId(
     throw new Error(error.message || 'Failed to load settlement transaction');
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationSettlementTransactionRow(
+    data as Record<string, unknown>
+  );
 }
 
 export async function getActivationSettlementTransactionById(
@@ -105,7 +107,9 @@ export async function getActivationSettlementTransactionById(
     throw new Error(error.message || 'Failed to load settlement transaction');
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationSettlementTransactionRow(
+    data as Record<string, unknown>
+  );
 }
 
 export type ActivationSettlementTransactionPatch = {
@@ -140,7 +144,9 @@ export async function updateActivationSettlementTransaction(
     throw new Error(error.message || 'Failed to update settlement transaction');
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationSettlementTransactionRow(
+    data as Record<string, unknown>
+  );
 }
 
 /**
@@ -169,7 +175,9 @@ export async function updateActivationSettlementIfStatus(input: {
     );
   }
   if (!data) return null;
-  return normalizeRow(data as Record<string, unknown>);
+  return normalizeActivationSettlementTransactionRow(
+    data as Record<string, unknown>
+  );
 }
 
 const MAX_SETTLEMENT_BATCH = 500;
@@ -204,7 +212,9 @@ export async function listActivationSettlementsForWorker(
     console.error('listActivationSettlementsForWorker:', { rail, error });
     throw new Error(error.message || 'Failed to list settlement transactions');
   }
-  return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+  return (data ?? []).map((r) =>
+    normalizeActivationSettlementTransactionRow(r as Record<string, unknown>)
+  );
 }
 
 /** Stellar rail; see {@link listActivationSettlementsForWorker}. */

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -1,0 +1,642 @@
+import { supabase } from '@/lib/db/client';
+import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
+import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
+import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
+import type { ActivationSettlementTransactionRow } from '@/lib/db/activation-settlement-transactions';
+import type { ActivationRedemptionStatus } from '@/lib/schemas/activation-redemption';
+import { formatSettlementExplorerTxUrl } from '@/lib/spend-rail-config';
+
+/** Newest-first row caps for admin dashboard feeds (IRL-62). */
+export const SPONSORED_ACTIVATION_ADMIN_FEED_CAP = 150;
+
+const INFLIGHT_SETTLEMENT_STATUSES = [
+  'not_started',
+  'queued',
+  'submitted',
+  'retrying',
+] as const;
+
+const CONFIRMED_REDEMPTION_STATUSES: ActivationRedemptionStatus[] = [
+  'redeemed',
+  'settlement_pending',
+  'settlement_confirmed',
+  'settlement_failed',
+];
+
+const PENDING_SETTLEMENT_STATUSES = [
+  'queued',
+  'submitted',
+  'retrying',
+  'failed',
+] as const;
+
+function toNumber(value: unknown): number {
+  if (typeof value === 'number' && !Number.isNaN(value)) return value;
+  if (typeof value === 'string') {
+    const n = Number(value);
+    if (!Number.isNaN(n)) return n;
+  }
+  return NaN;
+}
+
+function sumNumeric(rows: { amount?: unknown }[], key: 'amount'): number {
+  let t = 0;
+  for (const r of rows) {
+    const n = toNumber(r[key]);
+    if (!Number.isNaN(n)) t += n;
+  }
+  return t;
+}
+
+function sumUsdcSnapshots(rows: { usdc_amount_snapshot?: unknown }[]): number {
+  let t = 0;
+  for (const r of rows) {
+    const n = toNumber(r.usdc_amount_snapshot);
+    if (!Number.isNaN(n) && n > 0) t += n;
+  }
+  return t;
+}
+
+/**
+ * Matches `confirm_activation_purchase_atomic` reserved USDC math (IRL-60):
+ * inflight settlements (`not_started|queued|submitted|retrying`) plus committed
+ * redemptions (`purchase_confirmed|ready_to_redeem` with snapshot &gt; 0).
+ */
+export function computeReservedUsdcFromRaw(input: {
+  inflightSettlementRows: { amount: unknown }[];
+  committedRedemptionRows: { usdc_amount_snapshot: unknown }[];
+}): number {
+  return (
+    sumNumeric(input.inflightSettlementRows, 'amount') +
+    sumUsdcSnapshots(input.committedRedemptionRows)
+  );
+}
+
+export function computeBudgetRemainingUsdc(input: {
+  maxUsdcBudget: number | null;
+  usdcSettledTotal: number;
+  reservedUsdc: number;
+}): number | null {
+  if (input.maxUsdcBudget == null) return null;
+  return input.maxUsdcBudget - input.usdcSettledTotal - input.reservedUsdc;
+}
+
+export function computeRedemptionsRemaining(input: {
+  maxRedemptions: number | null;
+  redemptionCountConfirmed: number;
+}): number | null {
+  if (input.maxRedemptions == null) return null;
+  return Math.max(0, input.maxRedemptions - input.redemptionCountConfirmed);
+}
+
+export type SponsoredActivationAdminTiles = {
+  checkInsVerified: number;
+  redemptionsCreated: number;
+  redemptionsConfirmed: number;
+  usdcSettledTotal: number;
+  reservedUsdc: number;
+  budgetRemainingUsdc: number | null;
+  redemptionsRemaining: number | null;
+  settlementRail: SponsoredActivationRow['settlement_rail'];
+};
+
+export type SponsoredActivationConfirmedSettlementRow = {
+  id: string;
+  redemptionId: string;
+  amount: number;
+  txHash: string | null;
+  confirmedAt: string | null;
+  explorerTxUrl: string | null;
+};
+
+export type SponsoredActivationPendingSettlementRow = {
+  id: string;
+  redemptionId: string;
+  redemptionStatus: ActivationRedemptionStatus;
+  status: ActivationSettlementTransactionRow['status'];
+  amount: number;
+  txHash: string | null;
+  queuedAt: string | null;
+  submittedAt: string | null;
+  lastErrorCode: string | null;
+  submissionAttempt: number;
+  /** True when manual admin retry RPC is expected to succeed (IRL-60). */
+  canManualRetry: boolean;
+};
+
+export type SponsoredActivationAdminRedemptionRow = {
+  id: string;
+  userId: number;
+  username: string | null;
+  rewardDisplayName: string;
+  pointsSpent: number | null;
+  usdcAmountSnapshot: number | null;
+  status: ActivationRedemptionStatus;
+  createdAt: string;
+  updatedAt: string;
+  purchaseConfirmedAt: string | null;
+  redeemedAt: string | null;
+  settlement: {
+    id: string;
+    status: ActivationSettlementTransactionRow['status'];
+    amount: number;
+    txHash: string | null;
+    explorerTxUrl: string | null;
+    queuedAt: string | null;
+    submittedAt: string | null;
+    confirmedAt: string | null;
+    lastErrorCode: string | null;
+  } | null;
+  eligibility: {
+    source: string;
+    sourceRefId: string | null;
+    occurredAt: string;
+  };
+};
+
+export type SponsoredActivationAdminDashboardPayload = {
+  tiles: SponsoredActivationAdminTiles;
+  confirmedSettlements: SponsoredActivationConfirmedSettlementRow[];
+  pendingSettlements: SponsoredActivationPendingSettlementRow[];
+  redemptions: SponsoredActivationAdminRedemptionRow[];
+};
+
+async function countEligibilityEvents(activationId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('activation_eligibility_event')
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', activationId);
+  if (error) {
+    console.error('countEligibilityEvents:', error);
+    throw new Error(error.message || 'Failed to count eligibility events');
+  }
+  return count ?? 0;
+}
+
+async function countRedemptionsCreated(activationId: string): Promise<number> {
+  const { count, error } = await supabase
+    .from('activation_redemption')
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', activationId)
+    .not('status', 'in', '(eligible,available)');
+  if (error) {
+    console.error('countRedemptionsCreated:', error);
+    throw new Error(error.message || 'Failed to count created redemptions');
+  }
+  return count ?? 0;
+}
+
+async function countRedemptionsConfirmed(
+  activationId: string
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('activation_redemption')
+    .select('id', { count: 'exact', head: true })
+    .eq('activation_id', activationId)
+    .in('status', CONFIRMED_REDEMPTION_STATUSES);
+  if (error) {
+    console.error('countRedemptionsConfirmed:', error);
+    throw new Error(error.message || 'Failed to count confirmed redemptions');
+  }
+  return count ?? 0;
+}
+
+async function fetchInflightSettlementAmountRows(
+  activationId: string
+): Promise<{ amount: unknown }[]> {
+  const { data, error } = await supabase
+    .from('activation_settlement_transaction')
+    .select('amount')
+    .eq('activation_id', activationId)
+    .in('status', [...INFLIGHT_SETTLEMENT_STATUSES]);
+  if (error) {
+    console.error('fetchInflightSettlementAmountRows:', error);
+    throw new Error(error.message || 'Failed to load inflight settlements');
+  }
+  return data ?? [];
+}
+
+async function fetchCommittedRedemptionSnapshotRows(
+  activationId: string
+): Promise<{ usdc_amount_snapshot: unknown }[]> {
+  const { data, error } = await supabase
+    .from('activation_redemption')
+    .select('usdc_amount_snapshot')
+    .eq('activation_id', activationId)
+    .in('status', ['purchase_confirmed', 'ready_to_redeem'])
+    .not('usdc_amount_snapshot', 'is', null)
+    .gt('usdc_amount_snapshot', 0);
+  if (error) {
+    console.error('fetchCommittedRedemptionSnapshotRows:', error);
+    throw new Error(
+      error.message || 'Failed to load committed redemption USDC'
+    );
+  }
+  return data ?? [];
+}
+
+async function listConfirmedSettlements(
+  activationId: string,
+  rail: SponsoredActivationRow['settlement_rail']
+): Promise<SponsoredActivationConfirmedSettlementRow[]> {
+  const { data, error } = await supabase
+    .from('activation_settlement_transaction')
+    .select('id, redemption_id, amount, tx_hash, confirmed_at, status')
+    .eq('activation_id', activationId)
+    .eq('status', 'confirmed')
+    .order('confirmed_at', { ascending: false, nullsFirst: false })
+    .limit(SPONSORED_ACTIVATION_ADMIN_FEED_CAP);
+  if (error) {
+    console.error('listConfirmedSettlements:', error);
+    throw new Error(error.message || 'Failed to list confirmed settlements');
+  }
+  const rows = data ?? [];
+  return rows.map((r) => {
+    const txHash = r.tx_hash == null ? null : String(r.tx_hash);
+    return {
+      id: String(r.id),
+      redemptionId: String(r.redemption_id),
+      amount: toNumber(r.amount),
+      txHash,
+      confirmedAt: r.confirmed_at == null ? null : String(r.confirmed_at),
+      explorerTxUrl: formatSettlementExplorerTxUrl(rail, txHash),
+    };
+  });
+}
+
+async function listPendingSettlements(
+  activationId: string
+): Promise<ActivationSettlementTransactionRow[]> {
+  const { data, error } = await supabase
+    .from('activation_settlement_transaction')
+    .select('*')
+    .eq('activation_id', activationId)
+    .in('status', [...PENDING_SETTLEMENT_STATUSES])
+    .order('id', { ascending: false })
+    .limit(SPONSORED_ACTIVATION_ADMIN_FEED_CAP);
+  if (error) {
+    console.error('listPendingSettlements:', error);
+    throw new Error(error.message || 'Failed to list pending settlements');
+  }
+  return (data ?? []).map((r) => ({
+    id: String(r.id),
+    redemption_id: String(r.redemption_id),
+    activation_id: String(r.activation_id),
+    settlement_rail:
+      r.settlement_rail as SponsoredActivationRow['settlement_rail'],
+    status: r.status as ActivationSettlementTransactionRow['status'],
+    amount: toNumber(r.amount),
+    from_wallet_address: String(r.from_wallet_address),
+    to_wallet_address: String(r.to_wallet_address),
+    tx_hash: r.tx_hash == null ? null : String(r.tx_hash),
+    submission_attempt: Number(r.submission_attempt) || 0,
+    last_error_code:
+      r.last_error_code == null ? null : String(r.last_error_code),
+    queued_at: r.queued_at == null ? null : String(r.queued_at),
+    submitted_at: r.submitted_at == null ? null : String(r.submitted_at),
+    confirmed_at: r.confirmed_at == null ? null : String(r.confirmed_at),
+    privy_transaction_id:
+      r.privy_transaction_id == null ? null : String(r.privy_transaction_id),
+  }));
+}
+
+async function listLatestRedemptions(
+  activationId: string
+): Promise<ActivationRedemptionRow[]> {
+  const { data, error } = await supabase
+    .from('activation_redemption')
+    .select('*')
+    .eq('activation_id', activationId)
+    .order('created_at', { ascending: false })
+    .limit(SPONSORED_ACTIVATION_ADMIN_FEED_CAP);
+  if (error) {
+    console.error('listLatestRedemptions:', error);
+    throw new Error(error.message || 'Failed to list redemptions');
+  }
+  return (data ?? []).map((r) => ({
+    id: String(r.id),
+    activation_id: String(r.activation_id),
+    reward_item_id: String(r.reward_item_id),
+    user_id: Number(r.user_id),
+    eligibility_event_id: String(r.eligibility_event_id),
+    status: r.status as ActivationRedemptionStatus,
+    idempotency_key: String(r.idempotency_key),
+    points_spent:
+      r.points_spent === null || r.points_spent === undefined
+        ? null
+        : Number(r.points_spent),
+    usdc_amount_snapshot:
+      r.usdc_amount_snapshot === null || r.usdc_amount_snapshot === undefined
+        ? null
+        : toNumber(r.usdc_amount_snapshot),
+    purchase_confirmed_at:
+      r.purchase_confirmed_at == null ? null : String(r.purchase_confirmed_at),
+    redeemed_at: r.redeemed_at == null ? null : String(r.redeemed_at),
+    cancelled_reason:
+      r.cancelled_reason == null ? null : String(r.cancelled_reason),
+    created_at: String(r.created_at),
+    updated_at: String(r.updated_at),
+  }));
+}
+
+type PlayerMini = { id: number; username: string | null };
+type RewardMini = { id: string; name: string };
+type EligibilityMini = {
+  id: string;
+  source: string;
+  source_ref_id: string | null;
+  occurred_at: string;
+};
+
+async function fetchPlayersByIds(
+  ids: number[]
+): Promise<Map<number, PlayerMini>> {
+  const uniq = [...new Set(ids)].filter((n) => Number.isFinite(n));
+  const map = new Map<number, PlayerMini>();
+  if (uniq.length === 0) return map;
+  const { data, error } = await supabase
+    .from('players')
+    .select('id, username')
+    .in('id', uniq);
+  if (error) {
+    console.error('fetchPlayersByIds:', error);
+    throw new Error(error.message || 'Failed to load players');
+  }
+  for (const row of data ?? []) {
+    map.set(Number(row.id), {
+      id: Number(row.id),
+      username: row.username == null ? null : String(row.username),
+    });
+  }
+  return map;
+}
+
+async function fetchRewardItemsByIds(
+  ids: string[]
+): Promise<Map<string, RewardMini>> {
+  const uniq = [...new Set(ids)].filter(Boolean);
+  const map = new Map<string, RewardMini>();
+  if (uniq.length === 0) return map;
+  const { data, error } = await supabase
+    .from('activation_reward_item')
+    .select('id, name')
+    .in('id', uniq);
+  if (error) {
+    console.error('fetchRewardItemsByIds:', error);
+    throw new Error(error.message || 'Failed to load reward items');
+  }
+  for (const row of data ?? []) {
+    map.set(String(row.id), {
+      id: String(row.id),
+      name: String(row.name),
+    });
+  }
+  return map;
+}
+
+async function fetchEligibilityEventsByIds(
+  ids: string[]
+): Promise<Map<string, EligibilityMini>> {
+  const uniq = [...new Set(ids)].filter(Boolean);
+  const map = new Map<string, EligibilityMini>();
+  if (uniq.length === 0) return map;
+  const { data, error } = await supabase
+    .from('activation_eligibility_event')
+    .select('id, source, source_ref_id, occurred_at')
+    .in('id', uniq);
+  if (error) {
+    console.error('fetchEligibilityEventsByIds:', error);
+    throw new Error(error.message || 'Failed to load eligibility events');
+  }
+  for (const row of data ?? []) {
+    map.set(String(row.id), {
+      id: String(row.id),
+      source: String(row.source),
+      source_ref_id:
+        row.source_ref_id == null ? null : String(row.source_ref_id),
+      occurred_at: String(row.occurred_at),
+    });
+  }
+  return map;
+}
+
+async function fetchSettlementsByRedemptionIds(
+  redemptionIds: string[]
+): Promise<Map<string, ActivationSettlementTransactionRow>> {
+  const uniq = [...new Set(redemptionIds)].filter(Boolean);
+  const map = new Map<string, ActivationSettlementTransactionRow>();
+  if (uniq.length === 0) return map;
+  const { data, error } = await supabase
+    .from('activation_settlement_transaction')
+    .select('*')
+    .in('redemption_id', uniq);
+  if (error) {
+    console.error('fetchSettlementsByRedemptionIds:', error);
+    throw new Error(error.message || 'Failed to load settlements');
+  }
+  for (const r of data ?? []) {
+    const row: ActivationSettlementTransactionRow = {
+      id: String(r.id),
+      redemption_id: String(r.redemption_id),
+      activation_id: String(r.activation_id),
+      settlement_rail:
+        r.settlement_rail as SponsoredActivationRow['settlement_rail'],
+      status: r.status as ActivationSettlementTransactionRow['status'],
+      amount: toNumber(r.amount),
+      from_wallet_address: String(r.from_wallet_address),
+      to_wallet_address: String(r.to_wallet_address),
+      tx_hash: r.tx_hash == null ? null : String(r.tx_hash),
+      submission_attempt: Number(r.submission_attempt) || 0,
+      last_error_code:
+        r.last_error_code == null ? null : String(r.last_error_code),
+      queued_at: r.queued_at == null ? null : String(r.queued_at),
+      submitted_at: r.submitted_at == null ? null : String(r.submitted_at),
+      confirmed_at: r.confirmed_at == null ? null : String(r.confirmed_at),
+      privy_transaction_id:
+        r.privy_transaction_id == null ? null : String(r.privy_transaction_id),
+    };
+    map.set(row.redemption_id, row);
+  }
+  return map;
+}
+
+/**
+ * Aggregated read model for the admin sponsored activation ops dashboard (IRL-62).
+ * Returns `null` when the activation id/slug does not exist.
+ */
+export async function loadSponsoredActivationAdminDashboard(
+  activationIdOrSlug: string
+): Promise<
+  | (SponsoredActivationAdminDashboardPayload & {
+      activation: SponsoredActivationRow;
+    })
+  | null
+> {
+  const activation = await getSponsoredActivationByIdOrSlug(
+    activationIdOrSlug.trim()
+  );
+  if (!activation) return null;
+
+  const id = activation.id;
+  const rail = activation.settlement_rail;
+
+  const [
+    checkInsVerified,
+    redemptionsCreated,
+    redemptionsConfirmed,
+    inflightRows,
+    committedRows,
+    confirmedSettlements,
+    pendingSettlementRows,
+    redemptionRows,
+  ] = await Promise.all([
+    countEligibilityEvents(id),
+    countRedemptionsCreated(id),
+    countRedemptionsConfirmed(id),
+    fetchInflightSettlementAmountRows(id),
+    fetchCommittedRedemptionSnapshotRows(id),
+    listConfirmedSettlements(id, rail),
+    listPendingSettlements(id),
+    listLatestRedemptions(id),
+  ]);
+
+  const reservedUsdc = computeReservedUsdcFromRaw({
+    inflightSettlementRows: inflightRows,
+    committedRedemptionRows: committedRows,
+  });
+
+  const budgetRemainingUsdc = computeBudgetRemainingUsdc({
+    maxUsdcBudget: activation.max_usdc_budget,
+    usdcSettledTotal: activation.usdc_settled_total,
+    reservedUsdc,
+  });
+
+  const redemptionsRemaining = computeRedemptionsRemaining({
+    maxRedemptions: activation.max_redemptions,
+    redemptionCountConfirmed: activation.redemption_count_confirmed,
+  });
+
+  const tiles: SponsoredActivationAdminTiles = {
+    checkInsVerified,
+    redemptionsCreated,
+    redemptionsConfirmed,
+    usdcSettledTotal: activation.usdc_settled_total,
+    reservedUsdc,
+    budgetRemainingUsdc,
+    redemptionsRemaining,
+    settlementRail: rail,
+  };
+
+  const redemptionStatusById = new Map(
+    redemptionRows.map((r) => [r.id, r.status])
+  );
+  const extraRedemptionIds = pendingSettlementRows
+    .map((s) => s.redemption_id)
+    .filter((rid) => !redemptionStatusById.has(rid));
+  let mergedStatusMap = redemptionStatusById;
+  if (extraRedemptionIds.length > 0) {
+    const { data, error } = await supabase
+      .from('activation_redemption')
+      .select('id, status')
+      .in('id', [...new Set(extraRedemptionIds)]);
+    if (error) {
+      console.error('load pending redemption statuses:', error);
+      throw new Error(error.message || 'Failed to load redemption statuses');
+    }
+    mergedStatusMap = new Map(mergedStatusMap);
+    for (const row of data ?? []) {
+      mergedStatusMap.set(
+        String(row.id),
+        row.status as ActivationRedemptionStatus
+      );
+    }
+  }
+
+  const pendingSettlements: SponsoredActivationPendingSettlementRow[] =
+    pendingSettlementRows.map((s) => {
+      const redemptionStatus =
+        mergedStatusMap.get(s.redemption_id) ?? 'eligible';
+      const canManualRetry =
+        s.status === 'failed' && redemptionStatus === 'settlement_failed';
+      return {
+        id: s.id,
+        redemptionId: s.redemption_id,
+        redemptionStatus,
+        status: s.status,
+        amount: s.amount,
+        txHash: s.tx_hash,
+        queuedAt: s.queued_at,
+        submittedAt: s.submitted_at,
+        lastErrorCode: s.last_error_code,
+        submissionAttempt: s.submission_attempt,
+        canManualRetry,
+      };
+    });
+
+  const userIds = redemptionRows.map((r) => r.user_id);
+  const rewardIds = redemptionRows.map((r) => r.reward_item_id);
+  const eligIds = redemptionRows.map((r) => r.eligibility_event_id);
+  const redIds = redemptionRows.map((r) => r.id);
+
+  const [playersById, rewardsById, eligById, settlementByRedemptionId] =
+    await Promise.all([
+      fetchPlayersByIds(userIds),
+      fetchRewardItemsByIds(rewardIds),
+      fetchEligibilityEventsByIds(eligIds),
+      fetchSettlementsByRedemptionIds(redIds),
+    ]);
+
+  const redemptions: SponsoredActivationAdminRedemptionRow[] =
+    redemptionRows.map((r) => {
+      const player = playersById.get(r.user_id);
+      const reward = rewardsById.get(r.reward_item_id);
+      const elig = eligById.get(r.eligibility_event_id);
+      const st = settlementByRedemptionId.get(r.id);
+      const txHash = st?.tx_hash ?? null;
+      return {
+        id: r.id,
+        userId: r.user_id,
+        username: player?.username ?? null,
+        rewardDisplayName: reward?.name ?? '(unknown reward)',
+        pointsSpent: r.points_spent,
+        usdcAmountSnapshot: r.usdc_amount_snapshot,
+        status: r.status,
+        createdAt: r.created_at,
+        updatedAt: r.updated_at,
+        purchaseConfirmedAt: r.purchase_confirmed_at,
+        redeemedAt: r.redeemed_at,
+        settlement: st
+          ? {
+              id: st.id,
+              status: st.status,
+              amount: st.amount,
+              txHash: st.tx_hash,
+              explorerTxUrl: formatSettlementExplorerTxUrl(rail, txHash),
+              queuedAt: st.queued_at,
+              submittedAt: st.submitted_at,
+              confirmedAt: st.confirmed_at,
+              lastErrorCode: st.last_error_code,
+            }
+          : null,
+        eligibility: elig
+          ? {
+              source: elig.source,
+              sourceRefId: elig.source_ref_id,
+              occurredAt: elig.occurred_at,
+            }
+          : {
+              source: 'unknown',
+              sourceRefId: null,
+              occurredAt: r.created_at,
+            },
+      };
+    });
+
+  return {
+    activation,
+    tiles,
+    confirmedSettlements,
+    pendingSettlements,
+    redemptions,
+  };
+}

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -1,7 +1,10 @@
 import { supabase } from '@/lib/db/client';
 import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
-import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
+import {
+  normalizeActivationRedemptionRow,
+  type ActivationRedemptionRow,
+} from '@/lib/db/activation-redemptions';
 import {
   normalizeActivationSettlementTransactionRow,
   type ActivationSettlementTransactionRow,
@@ -299,30 +302,9 @@ async function listLatestRedemptions(
     console.error('listLatestRedemptions:', error);
     throw new Error(error.message || 'Failed to list redemptions');
   }
-  return (data ?? []).map((r) => ({
-    id: String(r.id),
-    activation_id: String(r.activation_id),
-    reward_item_id: String(r.reward_item_id),
-    user_id: Number(r.user_id),
-    eligibility_event_id: String(r.eligibility_event_id),
-    status: r.status as ActivationRedemptionStatus,
-    idempotency_key: String(r.idempotency_key),
-    points_spent:
-      r.points_spent === null || r.points_spent === undefined
-        ? null
-        : Number(r.points_spent),
-    usdc_amount_snapshot:
-      r.usdc_amount_snapshot === null || r.usdc_amount_snapshot === undefined
-        ? null
-        : toNumber(r.usdc_amount_snapshot),
-    purchase_confirmed_at:
-      r.purchase_confirmed_at == null ? null : String(r.purchase_confirmed_at),
-    redeemed_at: r.redeemed_at == null ? null : String(r.redeemed_at),
-    cancelled_reason:
-      r.cancelled_reason == null ? null : String(r.cancelled_reason),
-    created_at: String(r.created_at),
-    updated_at: String(r.updated_at),
-  }));
+  return (data ?? []).map((r) =>
+    normalizeActivationRedemptionRow(r as Record<string, unknown>)
+  );
 }
 
 type PlayerMini = { id: number; username: string | null };

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -2,7 +2,10 @@ import { supabase } from '@/lib/db/client';
 import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
-import type { ActivationSettlementTransactionRow } from '@/lib/db/activation-settlement-transactions';
+import {
+  normalizeActivationSettlementTransactionRow,
+  type ActivationSettlementTransactionRow,
+} from '@/lib/db/activation-settlement-transactions';
 import type { ActivationRedemptionStatus } from '@/lib/schemas/activation-redemption';
 import { formatSettlementExplorerTxUrl } from '@/lib/spend-rail-config';
 
@@ -39,10 +42,10 @@ function toNumber(value: unknown): number {
   return NaN;
 }
 
-function sumNumeric(rows: { amount?: unknown }[], key: 'amount'): number {
+function sumInflightSettlementAmounts(rows: { amount?: unknown }[]): number {
   let t = 0;
   for (const r of rows) {
-    const n = toNumber(r[key]);
+    const n = toNumber(r.amount);
     if (!Number.isNaN(n)) t += n;
   }
   return t;
@@ -67,7 +70,7 @@ export function computeReservedUsdcFromRaw(input: {
   committedRedemptionRows: { usdc_amount_snapshot: unknown }[];
 }): number {
   return (
-    sumNumeric(input.inflightSettlementRows, 'amount') +
+    sumInflightSettlementAmounts(input.inflightSettlementRows) +
     sumUsdcSnapshots(input.committedRedemptionRows)
   );
 }
@@ -278,26 +281,9 @@ async function listPendingSettlements(
     console.error('listPendingSettlements:', error);
     throw new Error(error.message || 'Failed to list pending settlements');
   }
-  return (data ?? []).map((r) => ({
-    id: String(r.id),
-    redemption_id: String(r.redemption_id),
-    activation_id: String(r.activation_id),
-    settlement_rail:
-      r.settlement_rail as SponsoredActivationRow['settlement_rail'],
-    status: r.status as ActivationSettlementTransactionRow['status'],
-    amount: toNumber(r.amount),
-    from_wallet_address: String(r.from_wallet_address),
-    to_wallet_address: String(r.to_wallet_address),
-    tx_hash: r.tx_hash == null ? null : String(r.tx_hash),
-    submission_attempt: Number(r.submission_attempt) || 0,
-    last_error_code:
-      r.last_error_code == null ? null : String(r.last_error_code),
-    queued_at: r.queued_at == null ? null : String(r.queued_at),
-    submitted_at: r.submitted_at == null ? null : String(r.submitted_at),
-    confirmed_at: r.confirmed_at == null ? null : String(r.confirmed_at),
-    privy_transaction_id:
-      r.privy_transaction_id == null ? null : String(r.privy_transaction_id),
-  }));
+  return (data ?? []).map((r) =>
+    normalizeActivationSettlementTransactionRow(r as Record<string, unknown>)
+  );
 }
 
 async function listLatestRedemptions(
@@ -435,26 +421,9 @@ async function fetchSettlementsByRedemptionIds(
     throw new Error(error.message || 'Failed to load settlements');
   }
   for (const r of data ?? []) {
-    const row: ActivationSettlementTransactionRow = {
-      id: String(r.id),
-      redemption_id: String(r.redemption_id),
-      activation_id: String(r.activation_id),
-      settlement_rail:
-        r.settlement_rail as SponsoredActivationRow['settlement_rail'],
-      status: r.status as ActivationSettlementTransactionRow['status'],
-      amount: toNumber(r.amount),
-      from_wallet_address: String(r.from_wallet_address),
-      to_wallet_address: String(r.to_wallet_address),
-      tx_hash: r.tx_hash == null ? null : String(r.tx_hash),
-      submission_attempt: Number(r.submission_attempt) || 0,
-      last_error_code:
-        r.last_error_code == null ? null : String(r.last_error_code),
-      queued_at: r.queued_at == null ? null : String(r.queued_at),
-      submitted_at: r.submitted_at == null ? null : String(r.submitted_at),
-      confirmed_at: r.confirmed_at == null ? null : String(r.confirmed_at),
-      privy_transaction_id:
-        r.privy_transaction_id == null ? null : String(r.privy_transaction_id),
-    };
+    const row = normalizeActivationSettlementTransactionRow(
+      r as Record<string, unknown>
+    );
     map.set(row.redemption_id, row);
   }
   return map;
@@ -530,10 +499,10 @@ export async function loadSponsoredActivationAdminDashboard(
   const redemptionStatusById = new Map(
     redemptionRows.map((r) => [r.id, r.status])
   );
+  const mergedStatusMap = new Map(redemptionStatusById);
   const extraRedemptionIds = pendingSettlementRows
     .map((s) => s.redemption_id)
-    .filter((rid) => !redemptionStatusById.has(rid));
-  let mergedStatusMap = redemptionStatusById;
+    .filter((rid) => !mergedStatusMap.has(rid));
   if (extraRedemptionIds.length > 0) {
     const { data, error } = await supabase
       .from('activation_redemption')
@@ -543,7 +512,6 @@ export async function loadSponsoredActivationAdminDashboard(
       console.error('load pending redemption statuses:', error);
       throw new Error(error.message || 'Failed to load redemption statuses');
     }
-    mergedStatusMap = new Map(mergedStatusMap);
     for (const row of data ?? []) {
       mergedStatusMap.set(
         String(row.id),
@@ -592,7 +560,6 @@ export async function loadSponsoredActivationAdminDashboard(
       const reward = rewardsById.get(r.reward_item_id);
       const elig = eligById.get(r.eligibility_event_id);
       const st = settlementByRedemptionId.get(r.id);
-      const txHash = st?.tx_hash ?? null;
       return {
         id: r.id,
         userId: r.user_id,
@@ -611,7 +578,10 @@ export async function loadSponsoredActivationAdminDashboard(
               status: st.status,
               amount: st.amount,
               txHash: st.tx_hash,
-              explorerTxUrl: formatSettlementExplorerTxUrl(rail, txHash),
+              explorerTxUrl: formatSettlementExplorerTxUrl(
+                rail,
+                st.tx_hash ?? null
+              ),
               queuedAt: st.queued_at,
               submittedAt: st.submitted_at,
               confirmedAt: st.confirmed_at,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Closes IRL-62.

## Summary

This change adds a Privy-gated admin **Sponsored activations** section: a list of activations, a per-activation ops dashboard backed by a new read API, and client wiring for settlement retry and Mixpanel.

## What changed

- **Admin home** (`app/admin/page.tsx`): new tile linking to `/admin/sponsored-activations`.
- **List** (`app/admin/sponsored-activations/page.tsx`): loads existing `GET /api/admin/sponsored-activations` with `adminApiAuthHeaders` + admin gate.
- **Detail** (`app/admin/sponsored-activations/[activationId]/page.tsx`): tiles, confirmed settlement feed (explorer URLs from `formatSettlementExplorerTxUrl`), failed/pending settlements with **Retry** when `canManualRetry` (failed settlement + `settlement_failed` redemption per IRL-60 RPC), redemptions table with row select + right **side panel** drilldown. Fires `sponsored_activation_admin_dashboard_viewed` when dashboard data is present. No export UI.
- **API** (`app/api/admin/sponsored-activations/[activationId]/dashboard/route.ts`): `requireAdmin`, returns activation envelope + `tiles`, `confirmedSettlements`, `pendingSettlements`, `redemptions` (feeds capped at 150 rows).
- **DB** (`lib/db/sponsored-activation-admin.ts`): counts and sums aligned with PRD / IRL-60 (`confirm_activation_purchase_atomic` reserved USDC definition).
- **Analytics** (`lib/analytics/events.ts`): `SPONSORED_ACTIVATION_ADMIN_DASHBOARD_VIEWED` → `sponsored_activation_admin_dashboard_viewed`.
- **Tests**: dashboard route (403 + aggregation payload) and pure helpers for reserved/budget/redemptions remaining.

## Verification

- `yarn test sponsored-activation-admin dashboard`
- `yarn lint` (project-wide; no new errors in touched files)
- `yarn build` (pre-commit hook)

## Out of scope (per issue)

Activation CRUD UI, pause/end controls, CSV/export, pagination beyond caps, sponsor role, worker changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-62](https://linear.app/irlenergy/issue/IRL-62/build-admin-sponsored-activation-dashboard-no-export)

<div><a href="https://cursor.com/agents/bc-d574d01d-4349-4edb-8332-145f91bff8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d574d01d-4349-4edb-8332-145f91bff8a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

