### PR TITLE
feat(analytics): sponsored activation Mixpanel funnel (IRL-61)

### DIFF
--- a/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
@@ -74,10 +74,12 @@ describe('GET /api/sponsored-activations/[activationId]', () => {
     expect(res.status).toBe(200);
     expect(json.success).toBe(true);
     expect(json.data.activation).toEqual({
+      id: activation.id,
       title: activation.title,
       sponsor_name: activation.sponsor_name,
       slug: activation.slug,
       status: activation.status,
+      settlement_rail: activation.settlement_rail,
       window: {
         starts_at: activation.starts_at,
         ends_at: activation.ends_at,

--- a/app/api/sponsored-activations/[activationId]/cancel-redemption/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/cancel-redemption/__tests__/route.test.ts
@@ -8,6 +8,15 @@ const mockGetRedemptionById = vi.fn();
 const mockCancelRpc = vi.fn();
 const mockGetPlayerByWallet = vi.fn();
 
+const mockTrackCancelled = vi.fn();
+const mockResolveIdentity = vi.fn();
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: (...a: unknown[]) => mockResolveIdentity(...a),
+  trackSponsoredRedemptionCancelled: (...a: unknown[]) =>
+    mockTrackCancelled(...a),
+}));
+
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
@@ -96,6 +105,7 @@ function postReq(body: unknown, activationSegment = activeActivation.id) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockResolveIdentity.mockReturnValue('mixpanel-distinct');
   mockVerifyWallet.mockResolvedValue({
     authorized: true,
     userId: 'privy-user-1',
@@ -133,6 +143,7 @@ describe('POST /api/sponsored-activations/[activationId]/cancel-redemption', () 
       walletAddress: expect.stringMatching(/^0x[a-fA-F0-9]{40}$/),
       reason: 'changed mind',
     });
+    expect(mockTrackCancelled).toHaveBeenCalledTimes(1);
   });
 
   it('is idempotent when redemption is already cancelled', async () => {
@@ -145,6 +156,7 @@ describe('POST /api/sponsored-activations/[activationId]/cancel-redemption', () 
     expect(res.status).toBe(200);
     const j = await res.json();
     expect(j.data.redemption.status).toBe('cancelled');
+    expect(mockTrackCancelled).not.toHaveBeenCalled();
   });
 
   it('returns 400 when redemption is not ready_to_redeem', async () => {

--- a/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/confirm-purchase/__tests__/route.test.ts
@@ -29,6 +29,18 @@ vi.mock('@/lib/db/activation-reward-items', () => ({
   getActivationRewardItemById: (...a: unknown[]) => mockGetRewardItem(...a),
 }));
 
+const mockTrackPurchaseConfirmed = vi.fn();
+const mockTrackCapReached = vi.fn();
+const mockResolveIdentity = vi.fn();
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: (...a: unknown[]) => mockResolveIdentity(...a),
+  trackSponsoredRedemptionPurchaseConfirmed: (...a: unknown[]) =>
+    mockTrackPurchaseConfirmed(...a),
+  trackSponsoredActivationCapReached: (...a: unknown[]) =>
+    mockTrackCapReached(...a),
+}));
+
 vi.mock('@/lib/db/players', () => ({
   getPlayerByWallet: (...a: unknown[]) => mockGetPlayerByWallet(...a),
   createOrUpdatePlayer: (...a: unknown[]) => mockCreateOrUpdatePlayer(...a),
@@ -120,6 +132,7 @@ function postReq(body: unknown, activationSegment = activeActivation.id) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockResolveIdentity.mockReturnValue('mixpanel-distinct');
   mockVerifyWallet.mockResolvedValue({
     authorized: true,
     userId: 'privy-user-1',
@@ -163,6 +176,20 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
       maxPurchaseConfirmsPerUserPerDay:
         eligibilityConfig.max_events_per_user_per_day,
     });
+    expect(mockTrackPurchaseConfirmed).toHaveBeenCalledTimes(1);
+    expect(mockTrackPurchaseConfirmed).toHaveBeenCalledWith(
+      'mixpanel-distinct',
+      expect.objectContaining({
+        activation_id: activeActivation.id,
+        redemption_id: redemptionId,
+        user_id: 1,
+        reward_item_id: rewardItem.id,
+        status: 'ready_to_redeem',
+      })
+    );
+    expect(mockTrackPurchaseConfirmed.mock.calls[0][1]).not.toHaveProperty(
+      'wallet_address'
+    );
   });
 
   it('returns 400 when points are insufficient', async () => {
@@ -206,6 +233,15 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error).toBe('This reward is no longer available');
+    expect(mockTrackCapReached).toHaveBeenCalledTimes(1);
+    expect(mockTrackCapReached).toHaveBeenCalledWith(
+      'mixpanel-distinct',
+      expect.objectContaining({
+        activation_id: activeActivation.id,
+        redemption_id: redemptionId,
+        user_id: 1,
+      })
+    );
   });
 
   it('returns 400 when USDC budget cap would be exceeded (RPC)', async () => {
@@ -220,6 +256,7 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error).toBe('This reward is no longer available');
+    expect(mockTrackCapReached).not.toHaveBeenCalled();
   });
 
   it('is idempotent when redemption is already ready_to_redeem', async () => {
@@ -237,6 +274,7 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     expect(j.data.redemption.status).toBe('ready_to_redeem');
     expect(j.data.player.total_points).toBe(90);
     expect(mockGetRewardItem).not.toHaveBeenCalled();
+    expect(mockTrackPurchaseConfirmed).not.toHaveBeenCalled();
   });
 
   it('allows idempotent confirm when activation is paused (replay)', async () => {
@@ -255,6 +293,7 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     });
     expect(res.status).toBe(200);
     expect(mockConfirmRpc).toHaveBeenCalled();
+    expect(mockTrackPurchaseConfirmed).not.toHaveBeenCalled();
   });
 
   it('returns 400 when max_per_user is exceeded (RPC)', async () => {
@@ -269,6 +308,7 @@ describe('POST /api/sponsored-activations/[activationId]/confirm-purchase', () =
     expect(res.status).toBe(400);
     const j = await res.json();
     expect(j.error).toBe('This reward is no longer available');
+    expect(mockTrackCapReached).not.toHaveBeenCalled();
   });
 
   it('returns 401 when Privy wallet auth fails', async () => {

--- a/app/api/sponsored-activations/[activationId]/eligibility/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/eligibility/__tests__/route.test.ts
@@ -17,6 +17,15 @@ const mockGetTiers = vi.fn();
 const mockGetPlayerByWallet = vi.fn();
 const mockCreateOrUpdatePlayer = vi.fn();
 
+const mockTrackEligibilityRecorded = vi.fn();
+const mockResolveIdentity = vi.fn();
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: (...a: unknown[]) => mockResolveIdentity(...a),
+  trackSponsoredActivationEligibilityRecorded: (...a: unknown[]) =>
+    mockTrackEligibilityRecorded(...a),
+}));
+
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
@@ -133,6 +142,7 @@ describe('POST /api/sponsored-activations/[activationId]/eligibility', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-06-15T12:00:00.000Z'));
     vi.clearAllMocks();
+    mockResolveIdentity.mockReturnValue('mixpanel-distinct');
     mockVerifyWallet.mockResolvedValue({
       authorized: true,
       userId: 'privy-user-1',
@@ -284,6 +294,14 @@ describe('POST /api/sponsored-activations/[activationId]/eligibility', () => {
     expect(j.data.eligible).toBe(true);
     expect(mockInsertEvent).toHaveBeenCalled();
     expect(mockInsertRedemption).toHaveBeenCalled();
+    expect(mockTrackEligibilityRecorded).toHaveBeenCalledTimes(1);
+    expect(mockTrackEligibilityRecorded).toHaveBeenCalledWith(
+      'mixpanel-distinct',
+      expect.objectContaining({
+        activation_id: activeActivation.id,
+        user_id: 99,
+      })
+    );
   });
 
   it('returns 429 when daily cap is already reached', async () => {
@@ -353,6 +371,7 @@ describe('POST /api/sponsored-activations/[activationId]/eligibility', () => {
     expect(j.data.eligibilityEvent.id).toBe(existing.id);
     expect(j.data.eligible).toBe(true);
     expect(mockInsertEvent).not.toHaveBeenCalled();
+    expect(mockTrackEligibilityRecorded).not.toHaveBeenCalled();
   });
 
   it('resolves activation by slug when path is not a UUID', async () => {

--- a/app/api/sponsored-activations/[activationId]/eligibility/route.ts
+++ b/app/api/sponsored-activations/[activationId]/eligibility/route.ts
@@ -3,6 +3,10 @@ import {
   getPrivyUserIdFromRequest,
   verifyWalletOwnership,
 } from '@/lib/api/privy';
+import {
+  resolveServerIdentity,
+  trackSponsoredActivationEligibilityRecorded,
+} from '@/lib/analytics/server';
 import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
 import {
   buildActivationRedemptionIdempotencyKey,
@@ -242,6 +246,22 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   } catch (e) {
     console.error('POST sponsored activation eligibility (insert event):', e);
     return apiError('Failed to record eligibility', 500);
+  }
+
+  try {
+    const privyUserId = await getPrivyUserIdFromRequest(request);
+    const distinctId = resolveServerIdentity({
+      privyUserId: privyUserId ?? undefined,
+      walletAddress: walletStored,
+      playerId,
+    });
+    trackSponsoredActivationEligibilityRecorded(distinctId, {
+      activation_id: activation.id,
+      settlement_rail: activation.settlement_rail,
+      user_id: playerId,
+    });
+  } catch {
+    /* analytics best-effort */
   }
 
   const rewardItems = await listActivationRewardItems(activation.id);

--- a/app/api/sponsored-activations/[activationId]/eligibility/route.ts
+++ b/app/api/sponsored-activations/[activationId]/eligibility/route.ts
@@ -1,13 +1,5 @@
 import { NextRequest } from 'next/server';
-import {
-  getPrivyUserIdFromRequest,
-  verifyWalletOwnership,
-} from '@/lib/api/privy';
-import {
-  resolveServerIdentity,
-  trackSponsoredActivationEligibilityRecorded,
-} from '@/lib/analytics/server';
-import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
+import { assertPrivyWalletAuth } from '@/lib/activation/activation-wallet-gate';
 import {
   buildActivationRedemptionIdempotencyKey,
   checkEligibilityEventRateLimits,
@@ -15,6 +7,9 @@ import {
   userHasBlockingRedemptionForRewardItem,
 } from '@/lib/activation/eligibility';
 import { canActivationAcceptUserRedemptionFlow } from '@/lib/activation/lifecycle';
+import { trackSponsoredActivationEligibilityRecorded } from '@/lib/analytics/server';
+import { emitSponsoredAnalyticsForWalletRequest } from '@/lib/analytics/sponsored-wallet-request-tracking';
+import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
 import {
   countEligibilityEventsForUserActivation,
   countEligibilityEventsForUserActivationInUtcWindow,
@@ -52,32 +47,7 @@ const eligibilityWalletQuerySchema = z
     message: 'walletAddress must be a valid EVM address',
   });
 
-function mapEligibilityFailureMessage(reason: string): string {
-  if (
-    reason === 'checkpoint_requirement_not_met' ||
-    reason === 'tier_requirement_not_met'
-  ) {
-    return 'Eligibility requirements were not met';
-  }
-  return 'Eligibility requirements were not met';
-}
-
-async function assertPrivyWalletAuth(
-  request: NextRequest,
-  walletAddress: string
-): Promise<
-  { ok: true } | { ok: false; response: ReturnType<typeof apiError> }
-> {
-  const auth = await verifyWalletOwnership(request, walletAddress);
-  if (!auth.authorized || !auth.userId) {
-    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
-  }
-  const tokenUser = await getPrivyUserIdFromRequest(request);
-  if (!tokenUser || tokenUser !== auth.userId) {
-    return { ok: false, response: apiError('Unauthorized', 401) };
-  }
-  return { ok: true };
-}
+const ELIGIBILITY_RULES_NOT_MET = 'Eligibility requirements were not met';
 
 async function resolvePlayerForEligibility(walletAddress: string): Promise<{
   playerId: number;
@@ -194,7 +164,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     playerTotalPoints: totalPoints,
   });
   if (!rules.ok) {
-    return apiError(mapEligibilityFailureMessage(rules.reason), 400);
+    return apiError(ELIGIBILITY_RULES_NOT_MET, 400);
   }
 
   const { startIso, endIso } = getUtcDayBounds();
@@ -248,21 +218,17 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     return apiError('Failed to record eligibility', 500);
   }
 
-  try {
-    const privyUserId = await getPrivyUserIdFromRequest(request);
-    const distinctId = resolveServerIdentity({
-      privyUserId: privyUserId ?? undefined,
-      walletAddress: walletStored,
-      playerId,
-    });
-    trackSponsoredActivationEligibilityRecorded(distinctId, {
-      activation_id: activation.id,
-      settlement_rail: activation.settlement_rail,
-      user_id: playerId,
-    });
-  } catch {
-    /* analytics best-effort */
-  }
+  await emitSponsoredAnalyticsForWalletRequest(
+    request,
+    walletStored,
+    playerId,
+    (distinctId) =>
+      trackSponsoredActivationEligibilityRecorded(distinctId, {
+        activation_id: activation.id,
+        settlement_rail: activation.settlement_rail,
+        user_id: playerId,
+      })
+  );
 
   const rewardItems = await listActivationRewardItems(activation.id);
   const activeItems = rewardItems.filter((i) => i.is_active);

--- a/app/api/sponsored-activations/[activationId]/route.ts
+++ b/app/api/sponsored-activations/[activationId]/route.ts
@@ -38,10 +38,12 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
 
   return apiSuccess({
     activation: {
+      id: activation.id,
       title: activation.title,
       sponsor_name: activation.sponsor_name,
       slug: activation.slug,
       status: activation.status,
+      settlement_rail: activation.settlement_rail,
       window: {
         starts_at: activation.starts_at,
         ends_at: activation.ends_at,

--- a/app/api/sponsored-activations/[activationId]/swipe-redeem/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/swipe-redeem/__tests__/route.test.ts
@@ -10,6 +10,19 @@ const mockGetPlayerByWallet = vi.fn();
 const mockCreateOrUpdatePlayer = vi.fn();
 const mockGetSettlementByRedemptionId = vi.fn();
 
+const mockTrackRedeemed = vi.fn();
+const mockTrackQueued = vi.fn();
+const mockTrackExpired = vi.fn();
+const mockResolveIdentity = vi.fn();
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: (...a: unknown[]) => mockResolveIdentity(...a),
+  trackSponsoredRedemptionRedeemed: (...a: unknown[]) =>
+    mockTrackRedeemed(...a),
+  trackSponsoredSettlementQueued: (...a: unknown[]) => mockTrackQueued(...a),
+  trackSponsoredRedemptionExpired: (...a: unknown[]) => mockTrackExpired(...a),
+}));
+
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
@@ -126,6 +139,7 @@ function postReq(body: unknown, activationSegment = activeActivation.id) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockResolveIdentity.mockReturnValue('mixpanel-distinct');
   mockVerifyWallet.mockResolvedValue({
     authorized: true,
     userId: 'privy-user-1',
@@ -167,6 +181,16 @@ describe('POST /api/sponsored-activations/[activationId]/swipe-redeem', () => {
       maxSwipeRedeemsPerUserPerDay:
         eligibilityConfig.max_events_per_user_per_day,
     });
+    expect(mockTrackRedeemed).toHaveBeenCalledTimes(1);
+    expect(mockTrackQueued).toHaveBeenCalledTimes(1);
+    expect(mockTrackQueued).toHaveBeenCalledWith(
+      'mixpanel-distinct',
+      expect.objectContaining({
+        settlement_id: settlementRow.id,
+        usdc_amount: settlementRow.amount,
+        redemption_id: redemptionId,
+      })
+    );
   });
 
   it('returns 400 when redemption is not ready_to_redeem (wrong status)', async () => {
@@ -197,6 +221,8 @@ describe('POST /api/sponsored-activations/[activationId]/swipe-redeem', () => {
     const j = await res.json();
     expect(j.data.redemption.status).toBe('settlement_pending');
     expect(j.data.settlement.id).toBe(settlementRow.id);
+    expect(mockTrackRedeemed).not.toHaveBeenCalled();
+    expect(mockTrackQueued).not.toHaveBeenCalled();
   });
 
   it('returns idempotent 200 when activation is paused but redemption already swiped', async () => {
@@ -259,6 +285,9 @@ describe('POST /api/sponsored-activations/[activationId]/swipe-redeem', () => {
     const j = await res.json();
     expect(j.error).toBe('This redemption is no longer valid');
     expect(j.details?.redemption?.status).toBe('expired');
+    expect(mockTrackExpired).toHaveBeenCalledTimes(1);
+    expect(mockTrackRedeemed).not.toHaveBeenCalled();
+    expect(mockTrackQueued).not.toHaveBeenCalled();
   });
 
   it('returns 400 when activation is paused on a new swipe (not idempotent)', async () => {

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
 import { Loader2 } from 'lucide-react';
@@ -30,6 +30,13 @@ import {
 } from '@/lib/sponsored-activation/flow-routing';
 import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
 import { resolveTierTitleForPoints } from '@/lib/sponsored-activation/tier-label';
+import {
+  isInitialized,
+  trackSponsoredActivationViewed,
+  trackSponsoredRedemptionConfirmViewed,
+  trackSponsoredRedemptionSwipeStarted,
+  waitForInitialization,
+} from '@/lib/analytics';
 
 type EligibilityPostResponse = {
   eligibilityEvent: { id: string; activation_id: string };
@@ -66,13 +73,17 @@ export function SponsoredActivationFlow({
   const accountEmail = user?.email?.address ?? null;
   const queryClient = useQueryClient();
 
-  const { data: player } = useCurrentPlayer();
+  const { data: player, isFetched: playerDetailsFetched } = useCurrentPlayer();
   const { data: tiers } = useTiers();
 
   const [venueStep, setVenueStep] = useState<'success' | 'swipe'>('success');
   const [redemptionOverride, setRedemptionOverride] =
     useState<ActivationRedemptionRow | null>(null);
   const [swipeSliderKey, setSwipeSliderKey] = useState(0);
+
+  const activationViewEmittedRef = useRef(false);
+  const confirmScreenEmittedRef = useRef(false);
+  const swipeGestureReportedRef = useRef(false);
 
   const deeplink = useMemo(
     () => parseSponsoredActivationEligibilityDeeplink(source, sourceRefId),
@@ -82,7 +93,14 @@ export function SponsoredActivationFlow({
   useEffect(() => {
     setVenueStep('success');
     setRedemptionOverride(null);
+    activationViewEmittedRef.current = false;
+    confirmScreenEmittedRef.current = false;
+    swipeGestureReportedRef.current = false;
   }, [activationKey]);
+
+  useEffect(() => {
+    swipeGestureReportedRef.current = false;
+  }, [swipeSliderKey]);
 
   const readQuery = useQuery({
     queryKey: ['sponsored-activation-read', activationKey] as const,
@@ -162,6 +180,33 @@ export function SponsoredActivationFlow({
     retry: false,
   });
 
+  const eligibilityResumeReady =
+    !readQuery.isSuccess || !walletAddress || resumeEligibility.isFetched;
+
+  const playerIdentityReady = !walletAddress || playerDetailsFetched;
+
+  const activationViewReady =
+    readQuery.isSuccess &&
+    Boolean(readQuery.data) &&
+    eligibilityResumeReady &&
+    playerIdentityReady;
+
+  useEffect(() => {
+    if (!activationViewReady || !readQuery.data) return;
+    if (activationViewEmittedRef.current) return;
+    activationViewEmittedRef.current = true;
+    const snapshot = readQuery.data;
+    void waitForInitialization().then(() => {
+      if (!isInitialized()) return;
+      trackSponsoredActivationViewed({
+        activation_id: snapshot.activation.id,
+        settlement_rail: snapshot.activation.settlement_rail,
+        user_id: player?.id,
+        reward_item_id: snapshot.rewardItem.id,
+      });
+    });
+  }, [activationViewReady, readQuery.data, player?.id]);
+
   const redemptionsFromServer = useMemo(() => {
     const fromGet = resumeEligibility.data?.redemptions ?? [];
     const fromPost = recordEligibility.data?.redemptions ?? [];
@@ -185,6 +230,23 @@ export function SponsoredActivationFlow({
   const redemption = redemptionOverride ?? pickedRedemption;
 
   const baseScreen = resolveSponsoredActivationBaseScreen(redemption?.status);
+
+  useEffect(() => {
+    if (baseScreen !== 'confirm' || !readQuery.data) return;
+    if (confirmScreenEmittedRef.current) return;
+    confirmScreenEmittedRef.current = true;
+    const snapshot = readQuery.data;
+    void waitForInitialization().then(() => {
+      if (!isInitialized()) return;
+      trackSponsoredRedemptionConfirmViewed({
+        activation_id: snapshot.activation.id,
+        settlement_rail: snapshot.activation.settlement_rail,
+        user_id: player?.id,
+        reward_item_id: snapshot.rewardItem.id,
+        redemption_id: redemption?.id,
+      });
+    });
+  }, [baseScreen, readQuery.data, redemption?.id, player?.id]);
 
   const confirmMutation = useMutation({
     mutationFn: async (redemptionId: string) => {
@@ -252,6 +314,22 @@ export function SponsoredActivationFlow({
     if (!isSwipeAllowedForStatus(redemption.status)) return;
     swipeMutation.mutate(redemption.id);
   }, [redemption, swipeMutation]);
+
+  const handleSwipeGestureStart = useCallback(() => {
+    if (!readQuery.data || swipeGestureReportedRef.current) return;
+    swipeGestureReportedRef.current = true;
+    const read = readQuery.data;
+    void waitForInitialization().then(() => {
+      if (!isInitialized()) return;
+      trackSponsoredRedemptionSwipeStarted({
+        activation_id: read.activation.id,
+        settlement_rail: read.activation.settlement_rail,
+        user_id: player?.id,
+        reward_item_id: read.rewardItem.id,
+        redemption_id: redemption?.id,
+      });
+    });
+  }, [readQuery.data, player?.id, redemption?.id]);
 
   const balanceAfterPoints =
     confirmMutation.data?.player.total_points ?? player?.total_points ?? 0;
@@ -446,6 +524,7 @@ export function SponsoredActivationFlow({
             <SponsoredActivationSwipeSlider
               key={swipeSliderKey}
               disabled={swipeDisabled}
+              onSwipeGestureStart={handleSwipeGestureStart}
               onComplete={handleSwipeComplete}
             />
           </div>

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -38,6 +38,13 @@ import {
   waitForInitialization,
 } from '@/lib/analytics';
 
+function runWhenMixpanelReady(run: () => void): void {
+  void waitForInitialization().then(() => {
+    if (!isInitialized()) return;
+    run();
+  });
+}
+
 type EligibilityPostResponse = {
   eligibilityEvent: { id: string; activation_id: string };
   redemptions: ActivationRedemptionRow[];
@@ -196,8 +203,7 @@ export function SponsoredActivationFlow({
     if (activationViewEmittedRef.current) return;
     activationViewEmittedRef.current = true;
     const snapshot = readQuery.data;
-    void waitForInitialization().then(() => {
-      if (!isInitialized()) return;
+    runWhenMixpanelReady(() => {
       trackSponsoredActivationViewed({
         activation_id: snapshot.activation.id,
         settlement_rail: snapshot.activation.settlement_rail,
@@ -236,8 +242,7 @@ export function SponsoredActivationFlow({
     if (confirmScreenEmittedRef.current) return;
     confirmScreenEmittedRef.current = true;
     const snapshot = readQuery.data;
-    void waitForInitialization().then(() => {
-      if (!isInitialized()) return;
+    runWhenMixpanelReady(() => {
       trackSponsoredRedemptionConfirmViewed({
         activation_id: snapshot.activation.id,
         settlement_rail: snapshot.activation.settlement_rail,
@@ -319,8 +324,7 @@ export function SponsoredActivationFlow({
     if (!readQuery.data || swipeGestureReportedRef.current) return;
     swipeGestureReportedRef.current = true;
     const read = readQuery.data;
-    void waitForInitialization().then(() => {
-      if (!isInitialized()) return;
+    runWhenMixpanelReady(() => {
       trackSponsoredRedemptionSwipeStarted({
         activation_id: read.activation.id,
         settlement_rail: read.activation.settlement_rail,

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -8,6 +8,8 @@ const COMPLETE_RATIO = 0.82;
 type SponsoredActivationSwipeSliderProps = {
   disabled: boolean;
   onComplete: () => void;
+  /** Fires when the user begins a swipe (pointer down on knob). */
+  onSwipeGestureStart?: () => void;
   label?: string;
 };
 
@@ -17,6 +19,7 @@ type SponsoredActivationSwipeSliderProps = {
 export function SponsoredActivationSwipeSlider({
   disabled,
   onComplete,
+  onSwipeGestureStart,
   label = 'Swipe to redeem',
 }: SponsoredActivationSwipeSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
@@ -59,6 +62,7 @@ export function SponsoredActivationSwipeSlider({
 
   const onPointerDown = (e: React.PointerEvent) => {
     if (disabled || completed) return;
+    onSwipeGestureStart?.();
     activePointerId.current = e.pointerId;
     (e.target as HTMLElement).setPointerCapture(e.pointerId);
   };
@@ -95,6 +99,7 @@ export function SponsoredActivationSwipeSlider({
     if (disabled || completed || completionSentRef.current) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
+      onSwipeGestureStart?.();
       completionSentRef.current = true;
       const max = maxTravel();
       dragPxRef.current = max;

--- a/lib/activation/base-settlement-worker.test.ts
+++ b/lib/activation/base-settlement-worker.test.ts
@@ -65,6 +65,13 @@ vi.mock('@/lib/privy-server-rest', () => {
   };
 });
 
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: vi.fn(() => 'mixpanel-test'),
+  trackSponsoredSettlementSubmitted: vi.fn(),
+  trackSponsoredSettlementConfirmed: vi.fn(),
+  trackSponsoredSettlementFailed: vi.fn(),
+}));
+
 import {
   BASE_ACTIVATION_SETTLEMENT_ERROR_CODES,
   processBaseActivationSettlement,

--- a/lib/activation/base-settlement-worker.ts
+++ b/lib/activation/base-settlement-worker.ts
@@ -1,5 +1,11 @@
 import { getAddress, isAddress } from 'viem';
 import {
+  resolveServerIdentity,
+  trackSponsoredSettlementConfirmed,
+  trackSponsoredSettlementFailed,
+  trackSponsoredSettlementSubmitted,
+} from '@/lib/analytics/server';
+import {
   getActivationRedemptionById,
   syncActivationRedemptionSettlementOutcome,
 } from '@/lib/db/activation-redemptions';
@@ -115,6 +121,31 @@ function requireEvm0x(value: string, ctx: string): `0x${string}` | null {
   return getAddress(t as `0x${string}`);
 }
 
+async function emitSponsoredSettlementFailedOnExhausted(
+  row: ActivationSettlementTransactionRow,
+  settlement: ActivationSettlementTransactionRow
+): Promise<void> {
+  const redemptionTr = await getActivationRedemptionById(row.redemption_id);
+  if (!redemptionTr) return;
+  try {
+    const distinctId = resolveServerIdentity({
+      playerId: redemptionTr.user_id,
+    });
+    trackSponsoredSettlementFailed(distinctId, {
+      activation_id: row.activation_id,
+      settlement_rail: row.settlement_rail,
+      user_id: redemptionTr.user_id,
+      reward_item_id: redemptionTr.reward_item_id,
+      redemption_id: row.redemption_id,
+      settlement_id: row.id,
+      status: settlement.status,
+      usdc_amount: settlement.amount,
+    });
+  } catch {
+    /* best-effort */
+  }
+}
+
 async function recordFailureAndShapeResult(
   row: ActivationSettlementTransactionRow,
   code: string
@@ -130,6 +161,9 @@ async function recordFailureAndShapeResult(
   });
   const settlement =
     (await getActivationSettlementTransactionById(row.id)) ?? row;
+  if (rec === 'exhausted') {
+    await emitSponsoredSettlementFailedOnExhausted(row, settlement);
+  }
   if (rec === 'retry_scheduled') {
     return { outcome: 'retry_scheduled', settlement, lastErrorCode: code };
   }
@@ -317,12 +351,39 @@ export async function processBaseActivationSettlement(input: {
       );
     }
     if (receipt === 'success') {
-      await confirmActivationSettlementAtomic({
+      const confirmOutcome = await confirmActivationSettlementAtomic({
         settlementId: params.settlementId,
         txHash: params.txHash,
         privyTransactionId: params.privyTransactionId,
         preserveSubmittedAt: params.submittedAtPreserve ?? null,
       });
+      if (confirmOutcome === 'confirmed') {
+        const settlementAfter =
+          (await getActivationSettlementTransactionById(params.settlementId)) ??
+          row;
+        const redemptionTr = await getActivationRedemptionById(
+          row.redemption_id
+        );
+        if (redemptionTr) {
+          try {
+            const distinctId = resolveServerIdentity({
+              playerId: redemptionTr.user_id,
+            });
+            trackSponsoredSettlementConfirmed(distinctId, {
+              activation_id: row.activation_id,
+              settlement_rail: row.settlement_rail,
+              user_id: redemptionTr.user_id,
+              reward_item_id: redemptionTr.reward_item_id,
+              redemption_id: row.redemption_id,
+              settlement_id: row.id,
+              status: settlementAfter.status,
+              usdc_amount: settlementAfter.amount,
+            });
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
     }
     return null;
   }
@@ -477,6 +538,29 @@ export async function processBaseActivationSettlement(input: {
     throw new Error('Settlement row disappeared after Privy submit');
   }
 
+  {
+    const redemptionTr = await getActivationRedemptionById(row.redemption_id);
+    if (redemptionTr) {
+      try {
+        const distinctId = resolveServerIdentity({
+          playerId: redemptionTr.user_id,
+        });
+        trackSponsoredSettlementSubmitted(distinctId, {
+          activation_id: row.activation_id,
+          settlement_rail: row.settlement_rail,
+          user_id: redemptionTr.user_id,
+          reward_item_id: redemptionTr.reward_item_id,
+          redemption_id: row.redemption_id,
+          settlement_id: row.id,
+          status: updatedQueued.status,
+          usdc_amount: updatedQueued.amount,
+        });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
+
   let txHash: `0x${string}` | null = null;
   if ('submittedPending' in submit && submit.submittedPending) {
     txHash = await tryResolveHashFromChain();
@@ -561,6 +645,12 @@ export async function runBaseSettlementWorkerBatch(
           settlementId: row.id,
           lastErrorCode: 'worker_exception',
         });
+        if (rec === 'exhausted') {
+          const latest = await getActivationSettlementTransactionById(row.id);
+          if (latest) {
+            await emitSponsoredSettlementFailedOnExhausted(row, latest);
+          }
+        }
         if (rec === 'exhausted' || rec === 'already_failed') {
           summary.failed += 1;
         } else if (rec === 'retry_scheduled') {

--- a/lib/activation/cancel-redemption.ts
+++ b/lib/activation/cancel-redemption.ts
@@ -4,11 +4,8 @@ import {
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
 import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
-import { getPrivyUserIdFromRequest } from '@/lib/api/privy';
-import {
-  resolveServerIdentity,
-  trackSponsoredRedemptionCancelled,
-} from '@/lib/analytics/server';
+import { trackSponsoredRedemptionCancelled } from '@/lib/analytics/server';
+import { emitSponsoredAnalyticsForWalletRequest } from '@/lib/analytics/sponsored-wallet-request-tracking';
 import {
   apiError,
   apiValidationError,
@@ -139,23 +136,19 @@ export async function runCancelActivationRedemption(input: {
   }
 
   if (cancelRpc.outcome === 'cancelled') {
-    try {
-      const privyUserId = await getPrivyUserIdFromRequest(input.request);
-      const distinctId = resolveServerIdentity({
-        privyUserId: privyUserId ?? undefined,
-        walletAddress: walletKey,
-        playerId,
-      });
-      trackSponsoredRedemptionCancelled(distinctId, {
-        activation_id: activation.id,
-        settlement_rail: activation.settlement_rail,
-        user_id: playerId,
-        reward_item_id: redemption.reward_item_id,
-        redemption_id: redemptionId,
-      });
-    } catch {
-      /* analytics best-effort */
-    }
+    await emitSponsoredAnalyticsForWalletRequest(
+      input.request,
+      walletKey,
+      playerId,
+      (distinctId) =>
+        trackSponsoredRedemptionCancelled(distinctId, {
+          activation_id: activation.id,
+          settlement_rail: activation.settlement_rail,
+          user_id: playerId,
+          reward_item_id: redemption.reward_item_id,
+          redemption_id: redemptionId,
+        })
+    );
   }
 
   let fresh: ActivationRedemptionRow | null;

--- a/lib/activation/cancel-redemption.ts
+++ b/lib/activation/cancel-redemption.ts
@@ -4,6 +4,11 @@ import {
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
 import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
+import { getPrivyUserIdFromRequest } from '@/lib/api/privy';
+import {
+  resolveServerIdentity,
+  trackSponsoredRedemptionCancelled,
+} from '@/lib/analytics/server';
 import {
   apiError,
   apiValidationError,
@@ -13,6 +18,7 @@ import {
   cancelActivationRedemptionAtomic,
   getActivationRedemptionById,
   type ActivationRedemptionRow,
+  type CancelActivationRedemptionRpcResult,
 } from '@/lib/db/activation-redemptions';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { activationCancelRedemptionBodySchema } from '@/lib/schemas/activation-cancel-redemption';
@@ -115,8 +121,9 @@ export async function runCancelActivationRedemption(input: {
     };
   }
 
+  let cancelRpc: CancelActivationRedemptionRpcResult;
   try {
-    await cancelActivationRedemptionAtomic({
+    cancelRpc = await cancelActivationRedemptionAtomic({
       redemptionId,
       playerId,
       walletAddress: walletKey,
@@ -129,6 +136,26 @@ export async function runCancelActivationRedemption(input: {
       ok: false,
       response: apiError(mapped.error, mapped.status),
     };
+  }
+
+  if (cancelRpc.outcome === 'cancelled') {
+    try {
+      const privyUserId = await getPrivyUserIdFromRequest(input.request);
+      const distinctId = resolveServerIdentity({
+        privyUserId: privyUserId ?? undefined,
+        walletAddress: walletKey,
+        playerId,
+      });
+      trackSponsoredRedemptionCancelled(distinctId, {
+        activation_id: activation.id,
+        settlement_rail: activation.settlement_rail,
+        user_id: playerId,
+        reward_item_id: redemption.reward_item_id,
+        redemption_id: redemptionId,
+      });
+    } catch {
+      /* analytics best-effort */
+    }
   }
 
   let fresh: ActivationRedemptionRow | null;

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -4,6 +4,11 @@ import {
   verifyWalletOwnership,
 } from '@/lib/api/privy';
 import {
+  resolveServerIdentity,
+  trackSponsoredActivationCapReached,
+  trackSponsoredRedemptionPurchaseConfirmed,
+} from '@/lib/analytics/server';
+import {
   apiError,
   apiValidationError,
   type ApiResponse,
@@ -89,9 +94,13 @@ function mapRpcOrUnexpectedError(message: string): {
       error: 'You do not have enough points for this reward',
     };
   }
+  if (message.includes('ACTIVATION_PURCHASE_CAP_EXCEEDED')) {
+    return { status: 400, error: 'This reward is no longer available' };
+  }
+  if (message.includes('ACTIVATION_PURCHASE_MAX_PER_USER')) {
+    return { status: 400, error: 'This reward is no longer available' };
+  }
   if (
-    message.includes('ACTIVATION_PURCHASE_CAP_EXCEEDED') ||
-    message.includes('ACTIVATION_PURCHASE_MAX_PER_USER') ||
     message.includes('ACTIVATION_PURCHASE_REWARD_INACTIVE') ||
     message.includes('ACTIVATION_PURCHASE_USDC_BUDGET_EXCEEDED')
   ) {
@@ -265,6 +274,25 @@ export async function runConfirmActivationPurchase(input: {
     });
   } catch (e) {
     const msg = e instanceof Error ? e.message : '';
+    if (msg.includes('ACTIVATION_PURCHASE_CAP_EXCEEDED')) {
+      try {
+        const privyUserId = await getPrivyUserIdFromRequest(input.request);
+        const distinctId = resolveServerIdentity({
+          privyUserId: privyUserId ?? undefined,
+          walletAddress: walletKey,
+          playerId,
+        });
+        trackSponsoredActivationCapReached(distinctId, {
+          activation_id: activation.id,
+          settlement_rail: activation.settlement_rail,
+          user_id: playerId,
+          reward_item_id: redemption.reward_item_id,
+          redemption_id: redemptionId,
+        });
+      } catch {
+        /* analytics best-effort */
+      }
+    }
     const mapped = mapRpcOrUnexpectedError(msg);
     return {
       ok: false,
@@ -287,6 +315,28 @@ export async function runConfirmActivationPurchase(input: {
       ok: false,
       response: apiError('Something went wrong', 500),
     };
+  }
+
+  if (rpc.outcome === 'created') {
+    try {
+      const privyUserId = await getPrivyUserIdFromRequest(input.request);
+      const distinctId = resolveServerIdentity({
+        privyUserId: privyUserId ?? undefined,
+        walletAddress: walletKey,
+        playerId,
+      });
+      trackSponsoredRedemptionPurchaseConfirmed(distinctId, {
+        activation_id: activation.id,
+        settlement_rail: activation.settlement_rail,
+        user_id: playerId,
+        reward_item_id: fresh.reward_item_id,
+        redemption_id: fresh.id,
+        status: fresh.status,
+        points_spent: fresh.points_spent ?? undefined,
+      });
+    } catch {
+      /* analytics best-effort */
+    }
   }
 
   return {

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -1,13 +1,13 @@
 import { NextRequest, type NextResponse } from 'next/server';
 import {
-  getPrivyUserIdFromRequest,
-  verifyWalletOwnership,
-} from '@/lib/api/privy';
+  assertPrivyWalletAuth,
+  resolvePlayerForWallet,
+} from '@/lib/activation/activation-wallet-gate';
 import {
-  resolveServerIdentity,
   trackSponsoredActivationCapReached,
   trackSponsoredRedemptionPurchaseConfirmed,
 } from '@/lib/analytics/server';
+import { emitSponsoredAnalyticsForWalletRequest } from '@/lib/analytics/sponsored-wallet-request-tracking';
 import {
   apiError,
   apiValidationError,
@@ -22,7 +22,6 @@ import {
   type ConfirmActivationPurchaseRpcResult,
 } from '@/lib/db/activation-redemptions';
 import { getActivationRewardItemById } from '@/lib/db/activation-reward-items';
-import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { safeParseActivationEligibilityRulesConfig } from '@/lib/schemas/activation-eligibility-config';
 import { activationConfirmPurchaseBodySchema } from '@/lib/schemas/activation-confirm-purchase';
@@ -49,39 +48,6 @@ function isActivationPurchaseConfirmIdempotentReplay(
   status: ActivationRedemptionStatus
 ): boolean {
   return PURCHASE_CONFIRM_IDEMPOTENT_STATUSES.has(status);
-}
-
-async function assertPrivyWalletAuth(
-  request: NextRequest,
-  walletAddress: string
-): Promise<
-  { ok: true } | { ok: false; response: NextResponse<ApiResponse<unknown>> }
-> {
-  const auth = await verifyWalletOwnership(request, walletAddress);
-  if (!auth.authorized || !auth.userId) {
-    return { ok: false, response: apiError(auth.error ?? 'Unauthorized', 401) };
-  }
-  const tokenUser = await getPrivyUserIdFromRequest(request);
-  if (!tokenUser || tokenUser !== auth.userId) {
-    return { ok: false, response: apiError('Unauthorized', 401) };
-  }
-  return { ok: true };
-}
-
-async function resolvePlayerForWallet(
-  normalizedWalletAddress: string
-): Promise<{ playerId: number }> {
-  let player = await getPlayerByWallet(normalizedWalletAddress);
-  if (!player?.id) {
-    player = await createOrUpdatePlayer({
-      wallet_address: normalizedWalletAddress,
-      total_points: 0,
-    });
-  }
-  if (!player?.id) {
-    throw new Error('Failed to resolve player for wallet');
-  }
-  return { playerId: player.id };
 }
 
 function mapRpcOrUnexpectedError(message: string): {
@@ -275,23 +241,19 @@ export async function runConfirmActivationPurchase(input: {
   } catch (e) {
     const msg = e instanceof Error ? e.message : '';
     if (msg.includes('ACTIVATION_PURCHASE_CAP_EXCEEDED')) {
-      try {
-        const privyUserId = await getPrivyUserIdFromRequest(input.request);
-        const distinctId = resolveServerIdentity({
-          privyUserId: privyUserId ?? undefined,
-          walletAddress: walletKey,
-          playerId,
-        });
-        trackSponsoredActivationCapReached(distinctId, {
-          activation_id: activation.id,
-          settlement_rail: activation.settlement_rail,
-          user_id: playerId,
-          reward_item_id: redemption.reward_item_id,
-          redemption_id: redemptionId,
-        });
-      } catch {
-        /* analytics best-effort */
-      }
+      await emitSponsoredAnalyticsForWalletRequest(
+        input.request,
+        walletKey,
+        playerId,
+        (distinctId) =>
+          trackSponsoredActivationCapReached(distinctId, {
+            activation_id: activation.id,
+            settlement_rail: activation.settlement_rail,
+            user_id: playerId,
+            reward_item_id: redemption.reward_item_id,
+            redemption_id: redemptionId,
+          })
+      );
     }
     const mapped = mapRpcOrUnexpectedError(msg);
     return {
@@ -318,25 +280,21 @@ export async function runConfirmActivationPurchase(input: {
   }
 
   if (rpc.outcome === 'created') {
-    try {
-      const privyUserId = await getPrivyUserIdFromRequest(input.request);
-      const distinctId = resolveServerIdentity({
-        privyUserId: privyUserId ?? undefined,
-        walletAddress: walletKey,
-        playerId,
-      });
-      trackSponsoredRedemptionPurchaseConfirmed(distinctId, {
-        activation_id: activation.id,
-        settlement_rail: activation.settlement_rail,
-        user_id: playerId,
-        reward_item_id: fresh.reward_item_id,
-        redemption_id: fresh.id,
-        status: fresh.status,
-        points_spent: fresh.points_spent ?? undefined,
-      });
-    } catch {
-      /* analytics best-effort */
-    }
+    await emitSponsoredAnalyticsForWalletRequest(
+      input.request,
+      walletKey,
+      playerId,
+      (distinctId) =>
+        trackSponsoredRedemptionPurchaseConfirmed(distinctId, {
+          activation_id: activation.id,
+          settlement_rail: activation.settlement_rail,
+          user_id: playerId,
+          reward_item_id: fresh.reward_item_id,
+          redemption_id: fresh.id,
+          status: fresh.status,
+          points_spent: fresh.points_spent ?? undefined,
+        })
+    );
   }
 
   return {

--- a/lib/activation/settlement-worker-stellar.test.ts
+++ b/lib/activation/settlement-worker-stellar.test.ts
@@ -11,10 +11,24 @@ const mockRecord = vi.fn();
 const mockMarkSubmitted = vi.fn();
 const mockSubmit = vi.fn();
 const mockPoll = vi.fn();
+const mockGetSettlementById = vi.fn();
+const mockGetRedemptionById = vi.fn();
+
+vi.mock('@/lib/analytics/server', () => ({
+  resolveServerIdentity: vi.fn(() => 'mixpanel-test'),
+  trackSponsoredSettlementSubmitted: vi.fn(),
+  trackSponsoredSettlementConfirmed: vi.fn(),
+  trackSponsoredSettlementFailed: vi.fn(),
+}));
 
 vi.mock('@/lib/db/sponsored-activations', () => ({
   getSponsoredActivationById: (...args: unknown[]) =>
     mockGetActivation(...args),
+}));
+
+vi.mock('@/lib/db/activation-redemptions', () => ({
+  getActivationRedemptionById: (...args: unknown[]) =>
+    mockGetRedemptionById(...args),
 }));
 
 vi.mock('@/lib/db/activation-settlement-transactions', () => ({
@@ -24,6 +38,8 @@ vi.mock('@/lib/db/activation-settlement-transactions', () => ({
     mockRecord(...args),
   markActivationSettlementSubmitted: (...args: unknown[]) =>
     mockMarkSubmitted(...args),
+  getActivationSettlementTransactionById: (...args: unknown[]) =>
+    mockGetSettlementById(...args),
 }));
 
 vi.mock('@/lib/activation/stellar-settlement-submit', () => ({
@@ -94,6 +110,25 @@ describe('processStellarActivationSettlement', () => {
     mockPoll.mockResolvedValue('success');
     mockConfirm.mockResolvedValue('confirmed');
     mockRecord.mockResolvedValue('exhausted');
+    mockGetSettlementById.mockImplementation(async (id: string) =>
+      settlementRow({ id })
+    );
+    mockGetRedemptionById.mockResolvedValue({
+      id: 'red-1',
+      activation_id: 'act-1',
+      reward_item_id: 'ri-1',
+      user_id: 7,
+      eligibility_event_id: 'e',
+      status: 'settlement_pending',
+      idempotency_key: 'k',
+      points_spent: 10,
+      usdc_amount_snapshot: 1,
+      purchase_confirmed_at: '2026-01-01T00:00:00.000Z',
+      redeemed_at: '2026-01-01T00:01:00.000Z',
+      cancelled_reason: null,
+      created_at: '2026-01-01T00:00:00.000Z',
+      updated_at: '2026-01-01T00:00:00.000Z',
+    });
   });
 
   it('skips non-stellar rail', async () => {

--- a/lib/activation/settlement-worker-stellar.ts
+++ b/lib/activation/settlement-worker-stellar.ts
@@ -193,13 +193,8 @@ export async function processStellarActivationSettlement(
     return recordSettlementFailure(settlement.id, validationError);
   }
 
-  const privyCampaignWalletId = activation.privy_campaign_wallet_id?.trim();
-  if (!privyCampaignWalletId) {
-    return recordSettlementFailure(
-      settlement.id,
-      'missing_privy_campaign_wallet_id'
-    );
-  }
+  // `validateSettlementBundle` rejects missing `privy_campaign_wallet_id`.
+  const privyCampaignWalletId = activation.privy_campaign_wallet_id!.trim();
 
   if (settlement.status === 'submitted') {
     const txHash = settlement.tx_hash?.trim();

--- a/lib/activation/settlement-worker-stellar.ts
+++ b/lib/activation/settlement-worker-stellar.ts
@@ -1,9 +1,17 @@
 import type { ActivationSettlementTransactionRow } from '@/lib/db/activation-settlement-transactions';
 import {
+  resolveServerIdentity,
+  trackSponsoredSettlementConfirmed,
+  trackSponsoredSettlementFailed,
+  trackSponsoredSettlementSubmitted,
+} from '@/lib/analytics/server';
+import {
   confirmActivationSettlementAtomic,
+  getActivationSettlementTransactionById,
   markActivationSettlementSubmitted,
   recordActivationSettlementFailureAtomic,
 } from '@/lib/db/activation-settlement-transactions';
+import { getActivationRedemptionById } from '@/lib/db/activation-redemptions';
 import {
   getSponsoredActivationById,
   type SponsoredActivationRow,
@@ -81,6 +89,33 @@ async function recordSettlementFailure(
   if (outcome === 'already_confirmed') return 'already_confirmed';
   if (outcome === 'already_failed') return 'already_failed';
   if (outcome === 'retry_scheduled') return 'retry_scheduled';
+  if (outcome === 'exhausted') {
+    const stRow = await getActivationSettlementTransactionById(settlementId);
+    if (stRow) {
+      const redemptionTr = await getActivationRedemptionById(
+        stRow.redemption_id
+      );
+      if (redemptionTr) {
+        try {
+          const distinctId = resolveServerIdentity({
+            playerId: redemptionTr.user_id,
+          });
+          trackSponsoredSettlementFailed(distinctId, {
+            activation_id: stRow.activation_id,
+            settlement_rail: stRow.settlement_rail,
+            user_id: redemptionTr.user_id,
+            reward_item_id: redemptionTr.reward_item_id,
+            redemption_id: stRow.redemption_id,
+            settlement_id: stRow.id,
+            status: stRow.status,
+            usdc_amount: stRow.amount,
+          });
+        } catch {
+          /* best-effort */
+        }
+      }
+    }
+  }
   return 'failed';
 }
 
@@ -102,6 +137,31 @@ async function confirmWithTxHash(
     settlementId,
     txHash,
   });
+  if (outcome === 'confirmed') {
+    const stRow = await getActivationSettlementTransactionById(settlementId);
+    const redemptionTr = stRow
+      ? await getActivationRedemptionById(stRow.redemption_id)
+      : null;
+    if (stRow && redemptionTr) {
+      try {
+        const distinctId = resolveServerIdentity({
+          playerId: redemptionTr.user_id,
+        });
+        trackSponsoredSettlementConfirmed(distinctId, {
+          activation_id: stRow.activation_id,
+          settlement_rail: stRow.settlement_rail,
+          user_id: redemptionTr.user_id,
+          reward_item_id: redemptionTr.reward_item_id,
+          redemption_id: stRow.redemption_id,
+          settlement_id: stRow.id,
+          status: stRow.status,
+          usdc_amount: stRow.amount,
+        });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
   return outcome === 'already_confirmed' ? 'already_confirmed' : 'confirmed';
 }
 
@@ -172,6 +232,33 @@ export async function processStellarActivationSettlement(
     settlementId: settlement.id,
     txHash: submit.txHash,
   });
+  if (markedSubmitted) {
+    const redemptionTr = await getActivationRedemptionById(
+      settlement.redemption_id
+    );
+    const stRow =
+      (await getActivationSettlementTransactionById(settlement.id)) ??
+      settlement;
+    if (redemptionTr) {
+      try {
+        const distinctId = resolveServerIdentity({
+          playerId: redemptionTr.user_id,
+        });
+        trackSponsoredSettlementSubmitted(distinctId, {
+          activation_id: stRow.activation_id,
+          settlement_rail: stRow.settlement_rail,
+          user_id: redemptionTr.user_id,
+          reward_item_id: redemptionTr.reward_item_id,
+          redemption_id: stRow.redemption_id,
+          settlement_id: stRow.id,
+          status: stRow.status,
+          usdc_amount: stRow.amount,
+        });
+      } catch {
+        /* best-effort */
+      }
+    }
+  }
   if (!markedSubmitted) {
     // Row was no longer `queued` (concurrent worker or DB race). Do not re-submit; still try to confirm this hash on-ledger.
     console.warn(
@@ -220,6 +307,33 @@ export async function runStellarSettlementWorkerBatch(
           settlementId: row.id,
           lastErrorCode: 'worker_exception',
         });
+        if (r === 'exhausted') {
+          const latest = await getActivationSettlementTransactionById(row.id);
+          if (latest) {
+            const redemptionTr = await getActivationRedemptionById(
+              latest.redemption_id
+            );
+            if (redemptionTr) {
+              try {
+                const distinctId = resolveServerIdentity({
+                  playerId: redemptionTr.user_id,
+                });
+                trackSponsoredSettlementFailed(distinctId, {
+                  activation_id: latest.activation_id,
+                  settlement_rail: latest.settlement_rail,
+                  user_id: redemptionTr.user_id,
+                  reward_item_id: redemptionTr.reward_item_id,
+                  redemption_id: latest.redemption_id,
+                  settlement_id: latest.id,
+                  status: latest.status,
+                  usdc_amount: latest.amount,
+                });
+              } catch {
+                /* best-effort */
+              }
+            }
+          }
+        }
         if (r === 'exhausted' || r === 'already_failed') {
           summary.failed += 1;
         } else if (r === 'retry_scheduled') {

--- a/lib/activation/swipe-redeem.ts
+++ b/lib/activation/swipe-redeem.ts
@@ -4,6 +4,13 @@ import {
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
 import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
+import { getPrivyUserIdFromRequest } from '@/lib/api/privy';
+import {
+  resolveServerIdentity,
+  trackSponsoredRedemptionExpired,
+  trackSponsoredRedemptionRedeemed,
+  trackSponsoredSettlementQueued,
+} from '@/lib/analytics/server';
 import {
   apiError,
   apiValidationError,
@@ -200,6 +207,25 @@ export async function runSwipeActivationRedeem(input: {
   }
 
   if (rpc.outcome === 'expired') {
+    try {
+      const privyUserId = await getPrivyUserIdFromRequest(input.request);
+      const distinctId = resolveServerIdentity({
+        privyUserId: privyUserId ?? undefined,
+        walletAddress: walletKey,
+        playerId,
+      });
+      trackSponsoredRedemptionExpired(distinctId, {
+        activation_id: activation.id,
+        settlement_rail: activation.settlement_rail,
+        user_id: playerId,
+        reward_item_id: freshRedemption.reward_item_id,
+        redemption_id: freshRedemption.id,
+        status: freshRedemption.status,
+        points_spent: freshRedemption.points_spent ?? undefined,
+      });
+    } catch {
+      /* analytics best-effort */
+    }
     return {
       ok: false,
       response: apiError('This redemption is no longer valid', 400, {
@@ -228,6 +254,34 @@ export async function runSwipeActivationRedeem(input: {
       ok: false,
       response: apiError('Something went wrong', 500),
     };
+  }
+
+  if (rpc.outcome === 'created') {
+    try {
+      const privyUserId = await getPrivyUserIdFromRequest(input.request);
+      const distinctId = resolveServerIdentity({
+        privyUserId: privyUserId ?? undefined,
+        walletAddress: walletKey,
+        playerId,
+      });
+      const redemptionProps = {
+        activation_id: activation.id,
+        settlement_rail: activation.settlement_rail,
+        user_id: playerId,
+        reward_item_id: freshRedemption.reward_item_id,
+        redemption_id: freshRedemption.id,
+        status: freshRedemption.status,
+        points_spent: freshRedemption.points_spent ?? undefined,
+      };
+      trackSponsoredRedemptionRedeemed(distinctId, redemptionProps);
+      trackSponsoredSettlementQueued(distinctId, {
+        ...redemptionProps,
+        settlement_id: settlement.id,
+        usdc_amount: settlement.amount,
+      });
+    } catch {
+      /* analytics best-effort */
+    }
   }
 
   return {

--- a/lib/activation/swipe-redeem.ts
+++ b/lib/activation/swipe-redeem.ts
@@ -4,13 +4,12 @@ import {
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
 import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
-import { getPrivyUserIdFromRequest } from '@/lib/api/privy';
 import {
-  resolveServerIdentity,
   trackSponsoredRedemptionExpired,
   trackSponsoredRedemptionRedeemed,
   trackSponsoredSettlementQueued,
 } from '@/lib/analytics/server';
+import { emitSponsoredAnalyticsForWalletRequest } from '@/lib/analytics/sponsored-wallet-request-tracking';
 import {
   apiError,
   apiValidationError,
@@ -207,25 +206,21 @@ export async function runSwipeActivationRedeem(input: {
   }
 
   if (rpc.outcome === 'expired') {
-    try {
-      const privyUserId = await getPrivyUserIdFromRequest(input.request);
-      const distinctId = resolveServerIdentity({
-        privyUserId: privyUserId ?? undefined,
-        walletAddress: walletKey,
-        playerId,
-      });
-      trackSponsoredRedemptionExpired(distinctId, {
-        activation_id: activation.id,
-        settlement_rail: activation.settlement_rail,
-        user_id: playerId,
-        reward_item_id: freshRedemption.reward_item_id,
-        redemption_id: freshRedemption.id,
-        status: freshRedemption.status,
-        points_spent: freshRedemption.points_spent ?? undefined,
-      });
-    } catch {
-      /* analytics best-effort */
-    }
+    await emitSponsoredAnalyticsForWalletRequest(
+      input.request,
+      walletKey,
+      playerId,
+      (distinctId) =>
+        trackSponsoredRedemptionExpired(distinctId, {
+          activation_id: activation.id,
+          settlement_rail: activation.settlement_rail,
+          user_id: playerId,
+          reward_item_id: freshRedemption.reward_item_id,
+          redemption_id: freshRedemption.id,
+          status: freshRedemption.status,
+          points_spent: freshRedemption.points_spent ?? undefined,
+        })
+    );
     return {
       ok: false,
       response: apiError('This redemption is no longer valid', 400, {
@@ -257,31 +252,28 @@ export async function runSwipeActivationRedeem(input: {
   }
 
   if (rpc.outcome === 'created') {
-    try {
-      const privyUserId = await getPrivyUserIdFromRequest(input.request);
-      const distinctId = resolveServerIdentity({
-        privyUserId: privyUserId ?? undefined,
-        walletAddress: walletKey,
-        playerId,
-      });
-      const redemptionProps = {
-        activation_id: activation.id,
-        settlement_rail: activation.settlement_rail,
-        user_id: playerId,
-        reward_item_id: freshRedemption.reward_item_id,
-        redemption_id: freshRedemption.id,
-        status: freshRedemption.status,
-        points_spent: freshRedemption.points_spent ?? undefined,
-      };
-      trackSponsoredRedemptionRedeemed(distinctId, redemptionProps);
-      trackSponsoredSettlementQueued(distinctId, {
-        ...redemptionProps,
-        settlement_id: settlement.id,
-        usdc_amount: settlement.amount,
-      });
-    } catch {
-      /* analytics best-effort */
-    }
+    await emitSponsoredAnalyticsForWalletRequest(
+      input.request,
+      walletKey,
+      playerId,
+      (distinctId) => {
+        const redemptionProps = {
+          activation_id: activation.id,
+          settlement_rail: activation.settlement_rail,
+          user_id: playerId,
+          reward_item_id: freshRedemption.reward_item_id,
+          redemption_id: freshRedemption.id,
+          status: freshRedemption.status,
+          points_spent: freshRedemption.points_spent ?? undefined,
+        };
+        trackSponsoredRedemptionRedeemed(distinctId, redemptionProps);
+        trackSponsoredSettlementQueued(distinctId, {
+          ...redemptionProps,
+          settlement_id: settlement.id,
+          usdc_amount: settlement.amount,
+        });
+      }
+    );
   }
 
   return {

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import type { UserProperties } from './types';
+import { ANALYTICS_EVENTS } from './events';
+import type {
+  SponsoredActivationClientEventProps,
+  UserProperties,
+} from './types';
 
 let _mixpanelInitialized = false;
 let _mixpanelInstance: typeof import('mixpanel-browser').default | null = null;
@@ -157,6 +161,34 @@ export function trackPageView(
   };
 
   mixpanel.track('$pageview', pageProperties);
+}
+
+/** Sponsored activation funnel (IRL-61) — client payloads must not include USDC or wallet addresses. */
+export function trackSponsoredActivationViewed(
+  properties: SponsoredActivationClientEventProps
+): void {
+  trackEvent(
+    ANALYTICS_EVENTS.SPONSORED_ACTIVATION_VIEWED,
+    compactMixpanelProps(properties as Record<string, unknown>)
+  );
+}
+
+export function trackSponsoredRedemptionConfirmViewed(
+  properties: SponsoredActivationClientEventProps
+): void {
+  trackEvent(
+    ANALYTICS_EVENTS.SPONSORED_REDEMPTION_CONFIRM_VIEWED,
+    compactMixpanelProps(properties as Record<string, unknown>)
+  );
+}
+
+export function trackSponsoredRedemptionSwipeStarted(
+  properties: SponsoredActivationClientEventProps
+): void {
+  trackEvent(
+    ANALYTICS_EVENTS.SPONSORED_REDEMPTION_SWIPE_STARTED,
+    compactMixpanelProps(properties as Record<string, unknown>)
+  );
 }
 
 /**

--- a/lib/analytics/client.ts
+++ b/lib/analytics/client.ts
@@ -1,5 +1,6 @@
 'use client';
 
+import { compactAnalyticsEventProps } from './compact-props';
 import { ANALYTICS_EVENTS } from './events';
 import type {
   SponsoredActivationClientEventProps,
@@ -87,16 +88,6 @@ export function trackEvent(
   mixpanel.track(eventName, properties);
 }
 
-function compactMixpanelProps(
-  properties: Record<string, unknown>
-): Record<string, string | number | boolean> {
-  return Object.fromEntries(
-    Object.entries(properties).filter(
-      ([, v]) => v !== undefined && v !== null && v !== ''
-    )
-  ) as Record<string, string | number | boolean>;
-}
-
 /**
  * Mixpanel super properties that persist for the session (updated on each call).
  */
@@ -107,7 +98,7 @@ export function registerSuperProperties(
   if (!_mixpanelInitialized) return;
 
   const mixpanel = getMixpanel();
-  const cleaned = compactMixpanelProps(properties);
+  const cleaned = compactAnalyticsEventProps(properties);
   if (Object.keys(cleaned).length === 0) return;
   mixpanel.register(cleaned);
 }
@@ -122,7 +113,7 @@ export function registerSuperPropertiesOnce(
   if (!_mixpanelInitialized) return;
 
   const mixpanel = getMixpanel();
-  const cleaned = compactMixpanelProps(properties);
+  const cleaned = compactAnalyticsEventProps(properties);
   if (Object.keys(cleaned).length === 0) return;
   mixpanel.register_once(cleaned);
 }
@@ -169,7 +160,7 @@ export function trackSponsoredActivationViewed(
 ): void {
   trackEvent(
     ANALYTICS_EVENTS.SPONSORED_ACTIVATION_VIEWED,
-    compactMixpanelProps(properties as Record<string, unknown>)
+    compactAnalyticsEventProps(properties as Record<string, unknown>)
   );
 }
 
@@ -178,7 +169,7 @@ export function trackSponsoredRedemptionConfirmViewed(
 ): void {
   trackEvent(
     ANALYTICS_EVENTS.SPONSORED_REDEMPTION_CONFIRM_VIEWED,
-    compactMixpanelProps(properties as Record<string, unknown>)
+    compactAnalyticsEventProps(properties as Record<string, unknown>)
   );
 }
 
@@ -187,7 +178,7 @@ export function trackSponsoredRedemptionSwipeStarted(
 ): void {
   trackEvent(
     ANALYTICS_EVENTS.SPONSORED_REDEMPTION_SWIPE_STARTED,
-    compactMixpanelProps(properties as Record<string, unknown>)
+    compactAnalyticsEventProps(properties as Record<string, unknown>)
   );
 }
 

--- a/lib/analytics/compact-props.ts
+++ b/lib/analytics/compact-props.ts
@@ -1,0 +1,12 @@
+/**
+ * Drops null, undefined, and empty-string values before sending to Mixpanel.
+ */
+export function compactAnalyticsEventProps(
+  properties: Record<string, unknown>
+): Record<string, string | number | boolean> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(
+      ([, v]) => v !== undefined && v !== null && v !== ''
+    )
+  ) as Record<string, string | number | boolean>;
+}

--- a/lib/analytics/events.ts
+++ b/lib/analytics/events.ts
@@ -56,6 +56,23 @@ export const ANALYTICS_EVENTS = {
   SPEND_WALLET_READINESS_STARTED: 'spend_wallet_readiness_started',
   SPEND_WALLET_READINESS_COMPLETED: 'spend_wallet_readiness_completed',
   SPEND_WALLET_READINESS_FAILED: 'spend_wallet_readiness_failed',
+
+  /** Public Records sponsored activation funnel (IRL-61). */
+  SPONSORED_ACTIVATION_VIEWED: 'sponsored_activation_viewed',
+  SPONSORED_ACTIVATION_ELIGIBILITY_RECORDED:
+    'sponsored_activation_eligibility_recorded',
+  SPONSORED_REDEMPTION_CONFIRM_VIEWED: 'sponsored_redemption_confirm_viewed',
+  SPONSORED_REDEMPTION_PURCHASE_CONFIRMED:
+    'sponsored_redemption_purchase_confirmed',
+  SPONSORED_REDEMPTION_SWIPE_STARTED: 'sponsored_redemption_swipe_started',
+  SPONSORED_REDEMPTION_REDEEMED: 'sponsored_redemption_redeemed',
+  SPONSORED_REDEMPTION_CANCELLED: 'sponsored_redemption_cancelled',
+  SPONSORED_REDEMPTION_EXPIRED: 'sponsored_redemption_expired',
+  SPONSORED_SETTLEMENT_QUEUED: 'sponsored_settlement_queued',
+  SPONSORED_SETTLEMENT_SUBMITTED: 'sponsored_settlement_submitted',
+  SPONSORED_SETTLEMENT_CONFIRMED: 'sponsored_settlement_confirmed',
+  SPONSORED_SETTLEMENT_FAILED: 'sponsored_settlement_failed',
+  SPONSORED_ACTIVATION_CAP_REACHED: 'sponsored_activation_cap_reached',
 } as const;
 
 export type AnalyticsEventName =

--- a/lib/analytics/index.ts
+++ b/lib/analytics/index.ts
@@ -18,6 +18,9 @@ export {
   hasOptedOutTracking,
   registerSuperProperties,
   registerSuperPropertiesOnce,
+  trackSponsoredActivationViewed,
+  trackSponsoredRedemptionConfirmViewed,
+  trackSponsoredRedemptionSwipeStarted,
 } from './client';
 
 // Identity resolver
@@ -41,6 +44,16 @@ export {
   trackSpendRedemptionStarted,
   trackSpendRedemptionCompleted,
   trackCityMilestone,
+  trackSponsoredActivationEligibilityRecorded,
+  trackSponsoredRedemptionPurchaseConfirmed,
+  trackSponsoredActivationCapReached,
+  trackSponsoredRedemptionRedeemed,
+  trackSponsoredRedemptionCancelled,
+  trackSponsoredRedemptionExpired,
+  trackSponsoredSettlementQueued,
+  trackSponsoredSettlementSubmitted,
+  trackSponsoredSettlementConfirmed,
+  trackSponsoredSettlementFailed,
 } from './server';
 
 // Event constants
@@ -60,4 +73,7 @@ export type {
   SpendRedemptionStartedProperties,
   SpendRedemptionCompletedProperties,
   CityMilestoneProperties,
+  SponsoredActivationClientEventProps,
+  SponsoredActivationServerRedemptionEventProps,
+  SponsoredActivationServerSettlementEventProps,
 } from './types';

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -16,6 +16,8 @@ import type {
   SpendPilotPaymentEventProperties,
   SpendPilotRailMutationBlockedProperties,
   SpendPilotWalletReadinessEventProperties,
+  SponsoredActivationServerRedemptionEventProps,
+  SponsoredActivationServerSettlementEventProps,
 } from './types';
 import { ANALYTICS_EVENTS } from './events';
 import { resolveDistinctId, type IdentityInput } from './identity';
@@ -404,4 +406,125 @@ export function trackSpendWalletReadinessFailed(
   properties: SpendPilotWalletReadinessEventProperties
 ): void {
   trackSpendWalletReadiness('failed', distinctId, properties);
+}
+
+function compactAnalyticsProps(
+  properties: Record<string, unknown>
+): Record<string, string | number | boolean> {
+  return Object.fromEntries(
+    Object.entries(properties).filter(
+      ([, v]) => v !== undefined && v !== null && v !== ''
+    )
+  ) as Record<string, string | number | boolean>;
+}
+
+/** Sponsored activation: eligibility row inserted (POST, not idempotent replay). */
+export function trackSponsoredActivationEligibilityRecorded(
+  distinctId: string,
+  properties: SponsoredActivationServerRedemptionEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_ACTIVATION_ELIGIBILITY_RECORDED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredRedemptionPurchaseConfirmed(
+  distinctId: string,
+  properties: SponsoredActivationServerRedemptionEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_REDEMPTION_PURCHASE_CONFIRMED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredActivationCapReached(
+  distinctId: string,
+  properties: SponsoredActivationServerRedemptionEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_ACTIVATION_CAP_REACHED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredRedemptionRedeemed(
+  distinctId: string,
+  properties: SponsoredActivationServerRedemptionEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_REDEMPTION_REDEEMED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredRedemptionCancelled(
+  distinctId: string,
+  properties: SponsoredActivationServerRedemptionEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_REDEMPTION_CANCELLED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredRedemptionExpired(
+  distinctId: string,
+  properties: SponsoredActivationServerRedemptionEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_REDEMPTION_EXPIRED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredSettlementQueued(
+  distinctId: string,
+  properties: SponsoredActivationServerSettlementEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_QUEUED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredSettlementSubmitted(
+  distinctId: string,
+  properties: SponsoredActivationServerSettlementEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_SUBMITTED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredSettlementConfirmed(
+  distinctId: string,
+  properties: SponsoredActivationServerSettlementEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_CONFIRMED,
+    compactAnalyticsProps({ ...properties })
+  );
+}
+
+export function trackSponsoredSettlementFailed(
+  distinctId: string,
+  properties: SponsoredActivationServerSettlementEventProps
+): void {
+  trackEvent(
+    distinctId,
+    ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_FAILED,
+    compactAnalyticsProps({ ...properties })
+  );
 }

--- a/lib/analytics/server.ts
+++ b/lib/analytics/server.ts
@@ -19,6 +19,7 @@ import type {
   SponsoredActivationServerRedemptionEventProps,
   SponsoredActivationServerSettlementEventProps,
 } from './types';
+import { compactAnalyticsEventProps } from './compact-props';
 import { ANALYTICS_EVENTS } from './events';
 import { resolveDistinctId, type IdentityInput } from './identity';
 
@@ -408,14 +409,18 @@ export function trackSpendWalletReadinessFailed(
   trackSpendWalletReadiness('failed', distinctId, properties);
 }
 
-function compactAnalyticsProps(
-  properties: Record<string, unknown>
-): Record<string, string | number | boolean> {
-  return Object.fromEntries(
-    Object.entries(properties).filter(
-      ([, v]) => v !== undefined && v !== null && v !== ''
-    )
-  ) as Record<string, string | number | boolean>;
+function trackSponsoredActivationMixpanelEvent(
+  distinctId: string,
+  eventName: string,
+  properties:
+    | SponsoredActivationServerRedemptionEventProps
+    | SponsoredActivationServerSettlementEventProps
+): void {
+  trackEvent(
+    distinctId,
+    eventName,
+    compactAnalyticsEventProps(properties as Record<string, unknown>)
+  );
 }
 
 /** Sponsored activation: eligibility row inserted (POST, not idempotent replay). */
@@ -423,10 +428,10 @@ export function trackSponsoredActivationEligibilityRecorded(
   distinctId: string,
   properties: SponsoredActivationServerRedemptionEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_ACTIVATION_ELIGIBILITY_RECORDED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -434,10 +439,10 @@ export function trackSponsoredRedemptionPurchaseConfirmed(
   distinctId: string,
   properties: SponsoredActivationServerRedemptionEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_REDEMPTION_PURCHASE_CONFIRMED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -445,10 +450,10 @@ export function trackSponsoredActivationCapReached(
   distinctId: string,
   properties: SponsoredActivationServerRedemptionEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_ACTIVATION_CAP_REACHED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -456,10 +461,10 @@ export function trackSponsoredRedemptionRedeemed(
   distinctId: string,
   properties: SponsoredActivationServerRedemptionEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_REDEMPTION_REDEEMED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -467,10 +472,10 @@ export function trackSponsoredRedemptionCancelled(
   distinctId: string,
   properties: SponsoredActivationServerRedemptionEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_REDEMPTION_CANCELLED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -478,10 +483,10 @@ export function trackSponsoredRedemptionExpired(
   distinctId: string,
   properties: SponsoredActivationServerRedemptionEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_REDEMPTION_EXPIRED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -489,10 +494,10 @@ export function trackSponsoredSettlementQueued(
   distinctId: string,
   properties: SponsoredActivationServerSettlementEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_QUEUED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -500,10 +505,10 @@ export function trackSponsoredSettlementSubmitted(
   distinctId: string,
   properties: SponsoredActivationServerSettlementEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_SUBMITTED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -511,10 +516,10 @@ export function trackSponsoredSettlementConfirmed(
   distinctId: string,
   properties: SponsoredActivationServerSettlementEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_CONFIRMED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }
 
@@ -522,9 +527,9 @@ export function trackSponsoredSettlementFailed(
   distinctId: string,
   properties: SponsoredActivationServerSettlementEventProps
 ): void {
-  trackEvent(
+  trackSponsoredActivationMixpanelEvent(
     distinctId,
     ANALYTICS_EVENTS.SPONSORED_SETTLEMENT_FAILED,
-    compactAnalyticsProps({ ...properties })
+    properties
   );
 }

--- a/lib/analytics/sponsored-wallet-request-tracking.ts
+++ b/lib/analytics/sponsored-wallet-request-tracking.ts
@@ -1,0 +1,27 @@
+import type { NextRequest } from 'next/server';
+import { getPrivyUserIdFromRequest } from '@/lib/api/privy';
+import { resolveServerIdentity } from '@/lib/analytics/server';
+
+/**
+ * Resolves distinct_id from the Privy-authenticated request + wallet, then runs
+ * `emit` (typically Mixpanel). Swallows errors so HTTP flows are not blocked.
+ */
+export async function emitSponsoredAnalyticsForWalletRequest(
+  request: NextRequest,
+  walletAddress: string,
+  playerId: number,
+  emit: (distinctId: string) => void
+): Promise<void> {
+  try {
+    const privyUserId = await getPrivyUserIdFromRequest(request);
+    emit(
+      resolveServerIdentity({
+        privyUserId: privyUserId ?? undefined,
+        walletAddress,
+        playerId,
+      })
+    );
+  } catch {
+    /* analytics best-effort */
+  }
+}

--- a/lib/analytics/types.ts
+++ b/lib/analytics/types.ts
@@ -270,3 +270,28 @@ export interface SpendPilotWalletReadinessEventProperties {
   /** True when Stellar readiness was already `completed` in the database (no new orchestration). */
   resumed_from_completed_row?: boolean;
 }
+
+/** Client-safe sponsored activation analytics (no USDC amounts, no wallet addresses). */
+export type SponsoredActivationClientEventProps = {
+  activation_id: string;
+  settlement_rail?: string;
+  user_id?: number;
+  reward_item_id?: string;
+  redemption_id?: string;
+  settlement_id?: string;
+  status?: string;
+  points_spent?: number;
+};
+
+/** Server sponsored redemption / eligibility events (no wallet addresses). */
+export type SponsoredActivationServerRedemptionEventProps =
+  SponsoredActivationClientEventProps;
+
+/**
+ * Server-only settlement lifecycle events — may include `usdc_amount` (IRL-61).
+ * Do not send these payloads to the browser.
+ */
+export type SponsoredActivationServerSettlementEventProps =
+  SponsoredActivationClientEventProps & {
+    usdc_amount?: number;
+  };

--- a/lib/sponsored-activation/public-read.ts
+++ b/lib/sponsored-activation/public-read.ts
@@ -1,12 +1,17 @@
-import type { SponsoredActivationStatus } from '@/lib/db/sponsored-activations';
+import type {
+  SettlementRail,
+  SponsoredActivationStatus,
+} from '@/lib/db/sponsored-activations';
 
 /** Public GET `/api/sponsored-activations/[activationIdOrSlug]` — safe for unauthenticated clients. */
 export type SponsoredActivationPublicReadResponse = {
   activation: {
+    id: string;
     title: string;
     sponsor_name: string;
     slug: string;
     status: SponsoredActivationStatus;
+    settlement_rail: SettlementRail;
     window: { starts_at: string; ends_at: string };
   };
   rewardItem: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements IRL-61: Mixpanel instrumentation for the Public Records sponsored activation funnel and settlement lifecycle, per the implementation brief in the issue description.

**Merge status:** Branch is merged with latest `main` (includes sponsored activation admin dashboard work). The only textual conflict was in `lib/analytics/events.ts` (IRL-61 event block vs IRL-62 admin dashboard constant); resolution keeps **both** constant groups.

## What changed

- **Event constants and types** in `lib/analytics/events.ts`, `lib/analytics/types.ts`, plus **server** (`trackSponsored*`) and **client** helpers in `lib/analytics/server.ts` / `client.ts`, re-exported from `lib/analytics/index.ts`.
- **Server emits** (via `resolveServerIdentity`, no wallet addresses on redemption/eligibility payloads): eligibility insert, confirm-purchase (`created` only), cap exceeded (`ACTIVATION_PURCHASE_CAP_EXCEEDED` only), swipe (`created` / `expired`), cancel (`cancelled` only), settlement workers on real transitions with `usdc_amount` on settlement events.
- **Client** (`SponsoredActivationFlow`, swipe slider): events after Mixpanel init; payloads exclude USDC and wallet addresses.
- **Public read API** adds `activation.id` and `activation.settlement_rail` for safe client props.
- **Vitest**: `vi.mock('@/lib/analytics/server')` on sponsored activation route tests; worker tests mock analytics where needed.

## How to verify

- `yarn test` on sponsored activation routes and settlement worker tests.
- `yarn lint` / `yarn build`.

## Out of scope (per brief)

- Business-logic changes beyond analytics (admin dashboard view event from IRL-62 is present on `main` and preserved in `ANALYTICS_EVENTS`).
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [IRL-61](https://linear.app/irlenergy/issue/IRL-61/add-mixpanel-analytics-for-sponsored-activation)

<div><a href="https://cursor.com/agents/bc-05ecca4d-5b3d-4e09-baed-188a4062d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-05ecca4d-5b3d-4e09-baed-188a4062d1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

