### PR TITLE
feat(admin): add sponsored activation create CTA and form

### DIFF
--- a/app/admin/sponsored-activations/form-state.test.ts
+++ b/app/admin/sponsored-activations/form-state.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import {
+  emptySponsoredActivationForm,
+  formStateToCreatePayload,
+} from './form-state';
+
+describe('formStateToCreatePayload', () => {
+  it('builds a base rail create body with eligibility', () => {
+    const form = {
+      ...emptySponsoredActivationForm(),
+      slug: 'pr-drink',
+      title: 'Drink credit',
+      sponsor_name: 'Public Records',
+      venue_settlement_wallet_address:
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      required_checkpoint_ids: 'cp-1, cp-2',
+    };
+    const payload = formStateToCreatePayload(form);
+    expect(payload.settlement_rail).toBe('base');
+    expect(payload.slug).toBe('pr-drink');
+    expect(payload.eligibility_config.required_checkpoint_ids).toEqual([
+      'cp-1',
+      'cp-2',
+    ]);
+    if (payload.settlement_rail === 'base') {
+      expect(payload.usdc_asset_config.contract_address).toBeTruthy();
+    }
+  });
+
+  it('requires at least one cap', () => {
+    const form = {
+      ...emptySponsoredActivationForm(),
+      slug: 'x',
+      title: 't',
+      sponsor_name: 's',
+      venue_settlement_wallet_address:
+        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      max_redemptions: '',
+      max_usdc_budget: '',
+      required_checkpoint_ids: 'cp-1',
+    };
+    expect(() => formStateToCreatePayload(form)).toThrow(/max redemptions/i);
+  });
+});

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -1,0 +1,190 @@
+import type { SettlementRail } from '@/lib/db/sponsored-activations';
+import type { AdminCreateSponsoredActivationRequest } from '@/lib/schemas/sponsored-activation';
+
+/** Mainnet Base USDC — same default as `SPEND_RAIL_BASE_USDC_USDC_CONTRACT` in `.env.local.example`. */
+export const DEFAULT_BASE_USDC_CONTRACT =
+  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+
+export type SponsoredActivationFormState = {
+  slug: string;
+  title: string;
+  sponsor_name: string;
+  event_id: string;
+  settlement_rail: SettlementRail;
+  venue_settlement_wallet_address: string;
+  base_usdc_contract: string;
+  stellar_asset_code: string;
+  stellar_usdc_issuer: string;
+  max_redemptions: string;
+  max_usdc_budget: string;
+  starts_at_local: string;
+  ends_at_local: string;
+  max_events_per_user: string;
+  max_events_per_user_per_day: string;
+  required_checkpoint_ids: string;
+  min_tier: string;
+};
+
+export function isoToDatetimeLocalValue(iso: string): string {
+  const d = new Date(iso);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+}
+
+export function datetimeLocalToIso(value: string): string {
+  return new Date(value).toISOString();
+}
+
+function defaultWindow(): { start: string; end: string } {
+  const start = new Date();
+  const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
+  return { start: start.toISOString(), end: end.toISOString() };
+}
+
+export function emptySponsoredActivationForm(): SponsoredActivationFormState {
+  const { start, end } = defaultWindow();
+  return {
+    slug: '',
+    title: '',
+    sponsor_name: '',
+    event_id: '',
+    settlement_rail: 'base',
+    venue_settlement_wallet_address: '',
+    base_usdc_contract: DEFAULT_BASE_USDC_CONTRACT,
+    stellar_asset_code: 'USDC',
+    stellar_usdc_issuer: '',
+    max_redemptions: '100',
+    max_usdc_budget: '',
+    starts_at_local: isoToDatetimeLocalValue(start),
+    ends_at_local: isoToDatetimeLocalValue(end),
+    max_events_per_user: '50',
+    max_events_per_user_per_day: '10',
+    required_checkpoint_ids: '',
+    min_tier: '',
+  };
+}
+
+function parsePositiveIntField(
+  raw: string,
+  fieldLabel: string
+): number | null | undefined {
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  const n = Number(trimmed);
+  if (!Number.isInteger(n) || n <= 0) {
+    throw new Error(`${fieldLabel} must be a positive whole number`);
+  }
+  return n;
+}
+
+function parseOptionalPositiveDecimal(
+  raw: string,
+  fieldLabel: string
+): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || n <= 0) {
+    throw new Error(`${fieldLabel} must be a positive number`);
+  }
+  return n;
+}
+
+/** Builds the admin POST body from panel form state. */
+export function formStateToCreatePayload(
+  form: SponsoredActivationFormState
+): AdminCreateSponsoredActivationRequest {
+  const slug = form.slug.trim();
+  const title = form.title.trim();
+  const sponsor_name = form.sponsor_name.trim();
+  if (!slug) throw new Error('Slug is required');
+  if (!title) throw new Error('Title is required');
+  if (!sponsor_name) throw new Error('Sponsor name is required');
+
+  const venue = form.venue_settlement_wallet_address.trim();
+  if (!venue) throw new Error('Venue settlement wallet is required');
+
+  const max_redemptions = parsePositiveIntField(
+    form.max_redemptions,
+    'Max redemptions'
+  );
+  const max_usdc_budget = parseOptionalPositiveDecimal(
+    form.max_usdc_budget,
+    'Max USDC budget'
+  );
+  if (max_redemptions == null && max_usdc_budget == null) {
+    throw new Error('Set max redemptions and/or max USDC budget');
+  }
+
+  const checkpointIds = form.required_checkpoint_ids
+    .split(/[,\n]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+  if (checkpointIds.length === 0) {
+    throw new Error('At least one required checkpoint ID is needed');
+  }
+
+  const max_events_per_user = parsePositiveIntField(
+    form.max_events_per_user,
+    'Max events per user'
+  );
+  const max_events_per_user_per_day = parsePositiveIntField(
+    form.max_events_per_user_per_day,
+    'Max events per user per day'
+  );
+  if (max_events_per_user == null || max_events_per_user_per_day == null) {
+    throw new Error('Eligibility event caps are required');
+  }
+
+  const minTierRaw = form.min_tier.trim();
+  let min_tier: number | undefined;
+  if (minTierRaw) {
+    const n = Number(minTierRaw);
+    if (!Number.isInteger(n) || n <= 0) {
+      throw new Error('Min tier must be a positive whole number');
+    }
+    min_tier = n;
+  }
+
+  const eligibility_config = {
+    max_events_per_user,
+    max_events_per_user_per_day,
+    required_checkpoint_ids: checkpointIds,
+    ...(min_tier != null ? { min_tier } : {}),
+  };
+
+  const common = {
+    slug,
+    title,
+    sponsor_name,
+    event_id: form.event_id.trim() || null,
+    max_redemptions: max_redemptions ?? null,
+    max_usdc_budget,
+    starts_at: datetimeLocalToIso(form.starts_at_local),
+    ends_at: datetimeLocalToIso(form.ends_at_local),
+    eligibility_config,
+  };
+
+  if (form.settlement_rail === 'base') {
+    const contract = form.base_usdc_contract.trim();
+    if (!contract) throw new Error('Base USDC contract address is required');
+    return {
+      ...common,
+      settlement_rail: 'base',
+      venue_settlement_wallet_address: venue,
+      usdc_asset_config: { contract_address: contract },
+    } as AdminCreateSponsoredActivationRequest;
+  }
+
+  const asset_code = form.stellar_asset_code.trim();
+  const issuer = form.stellar_usdc_issuer.trim();
+  if (!asset_code) throw new Error('Stellar asset code is required');
+  if (!issuer) throw new Error('Stellar USDC issuer is required');
+
+  return {
+    ...common,
+    settlement_rail: 'stellar',
+    venue_settlement_wallet_address: venue,
+    usdc_asset_config: { asset_code, issuer },
+  } as AdminCreateSponsoredActivationRequest;
+}

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -1,9 +1,9 @@
 import type { SettlementRail } from '@/lib/db/sponsored-activations';
 import type { AdminCreateSponsoredActivationRequest } from '@/lib/schemas/sponsored-activation';
+import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
 
-/** Mainnet Base USDC — same default as `SPEND_RAIL_BASE_USDC_USDC_CONTRACT` in `.env.local.example`. */
-export const DEFAULT_BASE_USDC_CONTRACT =
-  '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913';
+/** Default Base USDC mint (canonical `POSTER_CHECKOUT_USDC_ADDRESS_BASE`). */
+export const DEFAULT_BASE_USDC_CONTRACT = POSTER_CHECKOUT_USDC_ADDRESS_BASE;
 
 export type SponsoredActivationFormState = {
   slug: string;
@@ -67,7 +67,7 @@ export function emptySponsoredActivationForm(): SponsoredActivationFormState {
 function parsePositiveIntField(
   raw: string,
   fieldLabel: string
-): number | null | undefined {
+): number | undefined {
   const trimmed = raw.trim();
   if (!trimmed) return undefined;
   const n = Number(trimmed);

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useEffect, useState } from 'react';
+import { memo, useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
@@ -10,6 +10,7 @@ import { readApiErrorMessage } from '@/lib/admin/read-api-error-message';
 import { Loader2, ArrowLeft, CircleDollarSign, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
+import type { AdminCreateSponsoredActivationRequest } from '@/lib/schemas/sponsored-activation';
 import {
   emptySponsoredActivationForm,
   formStateToCreatePayload,
@@ -28,6 +29,96 @@ type ActivationListRow = {
 };
 
 const LIST_QUERY_KEY = ['admin-sponsored-activations-list'] as const;
+
+type SponsoredActivationsListBodyProps = {
+  isLoading: boolean;
+  activations: ActivationListRow[];
+  onNew: () => void;
+};
+
+const SponsoredActivationsListBody = memo(
+  function SponsoredActivationsListBody({
+    isLoading,
+    activations,
+    onNew,
+  }: SponsoredActivationsListBodyProps) {
+    if (isLoading) {
+      return (
+        <div className="flex justify-center py-16">
+          <Loader2 className="size-8 animate-spin text-neutral-400" />
+        </div>
+      );
+    }
+    if (activations.length === 0) {
+      return (
+        <div className="rounded-xl border border-dashed border-neutral-300 bg-white px-6 py-12 text-center dark:border-neutral-700 dark:bg-neutral-900">
+          <p className="text-neutral-600 dark:text-neutral-400">
+            No sponsored activations yet.
+          </p>
+          <Button
+            type="button"
+            className="mt-4 gap-1 bg-black text-white hover:bg-black/85"
+            onClick={onNew}
+          >
+            <Plus className="size-4" />
+            Create your first activation
+          </Button>
+        </div>
+      );
+    }
+    return (
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
+        <table className="w-full text-left text-sm">
+          <thead className="border-b border-gray-200 bg-gray-50 dark:border-neutral-800 dark:bg-neutral-950">
+            <tr>
+              <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                Title
+              </th>
+              <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                Status
+              </th>
+              <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                Rail
+              </th>
+              <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                Slug
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {activations.map((a) => (
+              <tr
+                key={a.id}
+                className="border-b border-gray-100 last:border-0 dark:border-neutral-800"
+              >
+                <td className="px-4 py-3">
+                  <Link
+                    href={`/admin/sponsored-activations/${encodeURIComponent(a.id)}`}
+                    className="font-medium text-blue-700 hover:underline dark:text-blue-400"
+                  >
+                    {a.title}
+                  </Link>
+                  <div className="text-xs text-neutral-500">
+                    {a.sponsor_name}
+                  </div>
+                </td>
+                <td className="px-4 py-3 capitalize text-neutral-800 dark:text-neutral-200">
+                  {a.status}
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-neutral-700 dark:text-neutral-300">
+                  {a.settlement_rail}
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-neutral-600 dark:text-neutral-400">
+                  {a.slug}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+);
 
 export default function AdminSponsoredActivationsListPage() {
   const router = useRouter();
@@ -98,9 +189,12 @@ export default function AdminSponsoredActivationsListPage() {
     setPanelOpen(true);
   }, []);
 
-  const createMutation = useMutation({
-    mutationFn: async () => {
-      const payload = formStateToCreatePayload(form);
+  const createMutation = useMutation<
+    { id: string },
+    Error,
+    AdminCreateSponsoredActivationRequest
+  >({
+    mutationFn: async (payload) => {
       const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/sponsored-activations', {
         method: 'POST',
@@ -118,10 +212,8 @@ export default function AdminSponsoredActivationsListPage() {
       if (!response.ok) {
         throw new Error(readApiErrorMessage(j, 'Create failed'));
       }
-      const dataWrap = j.data as { activation?: { id: string } } | undefined;
-      const activation =
-        dataWrap?.activation ??
-        (j as { activation?: { id: string } }).activation;
+      const dataObj = j.data as { activation?: { id: string } } | undefined;
+      const activation = dataObj?.activation;
       if (!activation?.id) {
         throw new Error(readApiErrorMessage(j, 'Create failed'));
       }
@@ -140,13 +232,14 @@ export default function AdminSponsoredActivationsListPage() {
   });
 
   const handleCreate = useCallback(() => {
+    let payload: AdminCreateSponsoredActivationRequest;
     try {
-      formStateToCreatePayload(form);
+      payload = formStateToCreatePayload(form);
     } catch (e) {
       toast.error(e instanceof Error ? e.message : 'Invalid form');
       return;
     }
-    createMutation.mutate();
+    createMutation.mutate(payload);
   }, [form, createMutation]);
 
   if (adminLoading || (user && isAdmin === null)) {
@@ -212,75 +305,11 @@ export default function AdminSponsoredActivationsListPage() {
           </div>
         </div>
 
-        {isLoading ? (
-          <div className="flex justify-center py-16">
-            <Loader2 className="size-8 animate-spin text-neutral-400" />
-          </div>
-        ) : activations.length === 0 ? (
-          <div className="rounded-xl border border-dashed border-neutral-300 bg-white px-6 py-12 text-center dark:border-neutral-700 dark:bg-neutral-900">
-            <p className="text-neutral-600 dark:text-neutral-400">
-              No sponsored activations yet.
-            </p>
-            <Button
-              type="button"
-              className="mt-4 gap-1 bg-black text-white hover:bg-black/85"
-              onClick={openCreate}
-            >
-              <Plus className="size-4" />
-              Create your first activation
-            </Button>
-          </div>
-        ) : (
-          <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
-            <table className="w-full text-left text-sm">
-              <thead className="border-b border-gray-200 bg-gray-50 dark:border-neutral-800 dark:bg-neutral-950">
-                <tr>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
-                    Title
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
-                    Status
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
-                    Rail
-                  </th>
-                  <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
-                    Slug
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {activations.map((a) => (
-                  <tr
-                    key={a.id}
-                    className="border-b border-gray-100 last:border-0 dark:border-neutral-800"
-                  >
-                    <td className="px-4 py-3">
-                      <Link
-                        href={`/admin/sponsored-activations/${encodeURIComponent(a.id)}`}
-                        className="font-medium text-blue-700 hover:underline dark:text-blue-400"
-                      >
-                        {a.title}
-                      </Link>
-                      <div className="text-xs text-neutral-500">
-                        {a.sponsor_name}
-                      </div>
-                    </td>
-                    <td className="px-4 py-3 capitalize text-neutral-800 dark:text-neutral-200">
-                      {a.status}
-                    </td>
-                    <td className="px-4 py-3 font-mono text-xs text-neutral-700 dark:text-neutral-300">
-                      {a.settlement_rail}
-                    </td>
-                    <td className="px-4 py-3 font-mono text-xs text-neutral-600 dark:text-neutral-400">
-                      {a.slug}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-        )}
+        <SponsoredActivationsListBody
+          isLoading={isLoading}
+          activations={activations}
+          onNew={openCreate}
+        />
       </div>
 
       <SponsoredActivationFormPanel

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -2,11 +2,20 @@
 
 import { useCallback, useEffect, useState } from 'react';
 import Link from 'next/link';
-import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
 import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
-import { Loader2, ArrowLeft, CircleDollarSign } from 'lucide-react';
+import { readApiErrorMessage } from '@/lib/admin/read-api-error-message';
+import { Loader2, ArrowLeft, CircleDollarSign, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { toast } from 'sonner';
+import {
+  emptySponsoredActivationForm,
+  formStateToCreatePayload,
+  type SponsoredActivationFormState,
+} from './form-state';
+import { SponsoredActivationFormPanel } from './sponsored-activation-form-panel';
 
 /** Mirrors `GET /api/admin/sponsored-activations` rows (avoid `lib/db` in client bundles). */
 type ActivationListRow = {
@@ -18,10 +27,18 @@ type ActivationListRow = {
   settlement_rail: string;
 };
 
+const LIST_QUERY_KEY = ['admin-sponsored-activations-list'] as const;
+
 export default function AdminSponsoredActivationsListPage() {
+  const router = useRouter();
   const { user, login, getAccessToken } = usePrivy();
+  const queryClient = useQueryClient();
   const [isAdmin, setIsAdmin] = useState<boolean | null>(null);
   const [adminLoading, setAdminLoading] = useState(true);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const [form, setForm] = useState<SponsoredActivationFormState>(
+    emptySponsoredActivationForm()
+  );
 
   const checkAdminStatus = useCallback(async () => {
     if (!user?.email?.address) return false;
@@ -56,7 +73,7 @@ export default function AdminSponsoredActivationsListPage() {
   }, [user, checkAdminStatus]);
 
   const { data: activations = [], isLoading } = useQuery<ActivationListRow[]>({
-    queryKey: ['admin-sponsored-activations-list'],
+    queryKey: LIST_QUERY_KEY,
     queryFn: async () => {
       const auth = await adminApiAuthHeaders(getAccessToken);
       const response = await fetch('/api/admin/sponsored-activations', {
@@ -71,6 +88,66 @@ export default function AdminSponsoredActivationsListPage() {
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });
+
+  const closePanel = useCallback(() => {
+    setPanelOpen(false);
+  }, []);
+
+  const openCreate = useCallback(() => {
+    setForm(emptySponsoredActivationForm());
+    setPanelOpen(true);
+  }, []);
+
+  const createMutation = useMutation({
+    mutationFn: async () => {
+      const payload = formStateToCreatePayload(form);
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch('/api/admin/sponsored-activations', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          ...auth,
+          'Idempotency-Key': crypto.randomUUID(),
+        },
+        body: JSON.stringify(payload),
+      });
+      const j = (await response.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+      if (!response.ok) {
+        throw new Error(readApiErrorMessage(j, 'Create failed'));
+      }
+      const dataWrap = j.data as { activation?: { id: string } } | undefined;
+      const activation =
+        dataWrap?.activation ??
+        (j as { activation?: { id: string } }).activation;
+      if (!activation?.id) {
+        throw new Error(readApiErrorMessage(j, 'Create failed'));
+      }
+      return activation;
+    },
+    onSuccess: (activation) => {
+      void queryClient.invalidateQueries({ queryKey: LIST_QUERY_KEY });
+      toast.success('Sponsored activation created (draft)');
+      setPanelOpen(false);
+      setForm(emptySponsoredActivationForm());
+      router.push(
+        `/admin/sponsored-activations/${encodeURIComponent(activation.id)}`
+      );
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const handleCreate = useCallback(() => {
+    try {
+      formStateToCreatePayload(form);
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Invalid form');
+      return;
+    }
+    createMutation.mutate();
+  }, [form, createMutation]);
 
   if (adminLoading || (user && isAdmin === null)) {
     return (
@@ -110,18 +187,28 @@ export default function AdminSponsoredActivationsListPage() {
             <ArrowLeft className="size-4" />
             Admin home
           </Link>
-          <div className="flex items-center gap-3">
-            <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
-              <CircleDollarSign className="size-6" />
+          <div className="flex flex-wrap items-start justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-900 dark:bg-amber-950 dark:text-amber-300">
+                <CircleDollarSign className="size-6" />
+              </div>
+              <div>
+                <h1 className="text-2xl font-bold text-gray-900 dark:text-neutral-100">
+                  Sponsored activations
+                </h1>
+                <p className="text-sm text-gray-500 dark:text-neutral-400">
+                  Public Records activation health and settlement ops.
+                </p>
+              </div>
             </div>
-            <div>
-              <h1 className="text-2xl font-bold text-gray-900 dark:text-neutral-100">
-                Sponsored activations
-              </h1>
-              <p className="text-sm text-gray-500 dark:text-neutral-400">
-                Public Records activation health and settlement ops.
-              </p>
-            </div>
+            <Button
+              type="button"
+              onClick={openCreate}
+              className="gap-1 bg-black text-white hover:bg-black/85"
+            >
+              <Plus className="size-4" />
+              New activation
+            </Button>
           </div>
         </div>
 
@@ -130,9 +217,19 @@ export default function AdminSponsoredActivationsListPage() {
             <Loader2 className="size-8 animate-spin text-neutral-400" />
           </div>
         ) : activations.length === 0 ? (
-          <p className="text-neutral-600 dark:text-neutral-400">
-            No sponsored activations yet.
-          </p>
+          <div className="rounded-xl border border-dashed border-neutral-300 bg-white px-6 py-12 text-center dark:border-neutral-700 dark:bg-neutral-900">
+            <p className="text-neutral-600 dark:text-neutral-400">
+              No sponsored activations yet.
+            </p>
+            <Button
+              type="button"
+              className="mt-4 gap-1 bg-black text-white hover:bg-black/85"
+              onClick={openCreate}
+            >
+              <Plus className="size-4" />
+              Create your first activation
+            </Button>
+          </div>
         ) : (
           <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm dark:border-neutral-800 dark:bg-neutral-900">
             <table className="w-full text-left text-sm">
@@ -185,6 +282,15 @@ export default function AdminSponsoredActivationsListPage() {
           </div>
         )}
       </div>
+
+      <SponsoredActivationFormPanel
+        open={panelOpen}
+        form={form}
+        setForm={setForm}
+        isSaving={createMutation.isPending}
+        onClose={closePanel}
+        onSubmit={handleCreate}
+      />
     </div>
   );
 }

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -1,4 +1,4 @@
-import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
 import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
@@ -22,18 +22,6 @@ export type SponsoredActivationFormPanelProps = {
   onClose: () => void;
   onSubmit: () => void;
 };
-
-function submitButtonContent(isSaving: boolean): ReactNode {
-  if (isSaving) {
-    return (
-      <>
-        <Loader2 className="mr-2 size-4 animate-spin" />
-        Creating…
-      </>
-    );
-  }
-  return 'Create activation';
-}
 
 export function SponsoredActivationFormPanel({
   open,
@@ -340,7 +328,14 @@ export function SponsoredActivationFormPanel({
             disabled={isSaving}
             onClick={onSubmit}
           >
-            {submitButtonContent(isSaving)}
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-2 size-4 animate-spin" />
+                Creating…
+              </>
+            ) : (
+              'Create activation'
+            )}
           </Button>
         </div>
       </div>

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -1,0 +1,349 @@
+import type { Dispatch, ReactNode, SetStateAction } from 'react';
+import { Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import type { SettlementRail } from '@/lib/db/sponsored-activations';
+import type { SponsoredActivationFormState } from './form-state';
+
+export type SponsoredActivationFormPanelProps = {
+  open: boolean;
+  form: SponsoredActivationFormState;
+  setForm: Dispatch<SetStateAction<SponsoredActivationFormState>>;
+  isSaving: boolean;
+  onClose: () => void;
+  onSubmit: () => void;
+};
+
+function submitButtonContent(isSaving: boolean): ReactNode {
+  if (isSaving) {
+    return (
+      <>
+        <Loader2 className="mr-2 size-4 animate-spin" />
+        Creating…
+      </>
+    );
+  }
+  return 'Create activation';
+}
+
+export function SponsoredActivationFormPanel({
+  open,
+  form,
+  setForm,
+  isSaving,
+  onClose,
+  onSubmit,
+}: SponsoredActivationFormPanelProps) {
+  if (!open) return null;
+
+  const isBase = form.settlement_rail === 'base';
+
+  return (
+    <div className="fixed inset-0 z-50 flex justify-end">
+      <button
+        type="button"
+        className="absolute inset-0 bg-black/40 backdrop-blur-sm"
+        aria-label="Close panel"
+        onClick={onClose}
+      />
+      <div className="relative flex h-full w-full max-w-lg flex-col bg-white shadow-2xl dark:bg-neutral-900">
+        <div className="flex items-center justify-between border-b border-neutral-200 px-5 py-4 dark:border-neutral-800">
+          <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">
+            New sponsored activation
+          </h2>
+          <button
+            type="button"
+            className="rounded-lg p-1.5 text-neutral-500 hover:bg-neutral-100 dark:hover:bg-neutral-800"
+            onClick={onClose}
+          >
+            ×
+          </button>
+        </div>
+        <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
+          <div className="space-y-2">
+            <Label htmlFor="sa-title">Title</Label>
+            <Input
+              id="sa-title"
+              value={form.title}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, title: ev.target.value }))
+              }
+              placeholder="e.g. Public Records drink credit"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sa-slug">Slug</Label>
+            <Input
+              id="sa-slug"
+              value={form.slug}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, slug: ev.target.value }))
+              }
+              placeholder="public-records-drink"
+              className="font-mono text-sm"
+            />
+            <p className="text-xs text-neutral-500">
+              Public path: /activation/{'{slug}'}
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sa-sponsor">Sponsor name</Label>
+            <Input
+              id="sa-sponsor"
+              value={form.sponsor_name}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, sponsor_name: ev.target.value }))
+              }
+              placeholder="e.g. Public Records"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sa-event">Event ID (optional)</Label>
+            <Input
+              id="sa-event"
+              value={form.event_id}
+              onChange={(ev) =>
+                setForm((f) => ({ ...f, event_id: ev.target.value }))
+              }
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>Settlement rail</Label>
+            <Select
+              value={form.settlement_rail}
+              onValueChange={(v) =>
+                setForm((f) => ({
+                  ...f,
+                  settlement_rail: v as SettlementRail,
+                }))
+              }
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Select rail" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="base">Base</SelectItem>
+                <SelectItem value="stellar">Stellar</SelectItem>
+              </SelectContent>
+            </Select>
+            <p className="text-xs text-neutral-500">
+              Campaign wallet is provisioned automatically (Privy).
+            </p>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sa-venue">Venue settlement wallet</Label>
+            <Input
+              id="sa-venue"
+              value={form.venue_settlement_wallet_address}
+              onChange={(ev) =>
+                setForm((f) => ({
+                  ...f,
+                  venue_settlement_wallet_address: ev.target.value,
+                }))
+              }
+              placeholder={isBase ? '0x…' : 'G…'}
+              className="font-mono text-sm"
+            />
+          </div>
+          {isBase ? (
+            <div className="space-y-2">
+              <Label htmlFor="sa-base-contract">Base USDC contract</Label>
+              <Input
+                id="sa-base-contract"
+                value={form.base_usdc_contract}
+                onChange={(ev) =>
+                  setForm((f) => ({
+                    ...f,
+                    base_usdc_contract: ev.target.value,
+                  }))
+                }
+                className="font-mono text-sm"
+              />
+            </div>
+          ) : (
+            <>
+              <div className="space-y-2">
+                <Label htmlFor="sa-stellar-code">Stellar asset code</Label>
+                <Input
+                  id="sa-stellar-code"
+                  value={form.stellar_asset_code}
+                  onChange={(ev) =>
+                    setForm((f) => ({
+                      ...f,
+                      stellar_asset_code: ev.target.value,
+                    }))
+                  }
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="sa-stellar-issuer">Stellar USDC issuer</Label>
+                <Input
+                  id="sa-stellar-issuer"
+                  value={form.stellar_usdc_issuer}
+                  onChange={(ev) =>
+                    setForm((f) => ({
+                      ...f,
+                      stellar_usdc_issuer: ev.target.value,
+                    }))
+                  }
+                  placeholder="G…"
+                  className="font-mono text-sm"
+                />
+              </div>
+            </>
+          )}
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="sa-max-redemptions">Max redemptions</Label>
+              <Input
+                id="sa-max-redemptions"
+                type="number"
+                min={1}
+                value={form.max_redemptions}
+                onChange={(ev) =>
+                  setForm((f) => ({ ...f, max_redemptions: ev.target.value }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sa-max-budget">Max USDC budget</Label>
+              <Input
+                id="sa-max-budget"
+                type="number"
+                min={0}
+                step="any"
+                value={form.max_usdc_budget}
+                onChange={(ev) =>
+                  setForm((f) => ({ ...f, max_usdc_budget: ev.target.value }))
+                }
+                placeholder="Optional"
+              />
+            </div>
+          </div>
+          <p className="text-xs text-neutral-500">
+            At least one cap (redemptions or budget) is required.
+          </p>
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-2">
+              <Label htmlFor="sa-starts">Starts</Label>
+              <Input
+                id="sa-starts"
+                type="datetime-local"
+                value={form.starts_at_local}
+                onChange={(ev) =>
+                  setForm((f) => ({ ...f, starts_at_local: ev.target.value }))
+                }
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="sa-ends">Ends</Label>
+              <Input
+                id="sa-ends"
+                type="datetime-local"
+                value={form.ends_at_local}
+                onChange={(ev) =>
+                  setForm((f) => ({ ...f, ends_at_local: ev.target.value }))
+                }
+              />
+            </div>
+          </div>
+          <div className="rounded-lg border border-neutral-200 p-3 dark:border-neutral-700">
+            <p className="mb-3 text-sm font-medium text-neutral-800 dark:text-neutral-200">
+              Eligibility
+            </p>
+            <div className="space-y-3">
+              <div className="grid grid-cols-2 gap-3">
+                <div className="space-y-2">
+                  <Label htmlFor="sa-max-events">Max events / user</Label>
+                  <Input
+                    id="sa-max-events"
+                    type="number"
+                    min={1}
+                    value={form.max_events_per_user}
+                    onChange={(ev) =>
+                      setForm((f) => ({
+                        ...f,
+                        max_events_per_user: ev.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label htmlFor="sa-max-events-day">
+                    Max events / user / day
+                  </Label>
+                  <Input
+                    id="sa-max-events-day"
+                    type="number"
+                    min={1}
+                    value={form.max_events_per_user_per_day}
+                    onChange={(ev) =>
+                      setForm((f) => ({
+                        ...f,
+                        max_events_per_user_per_day: ev.target.value,
+                      }))
+                    }
+                  />
+                </div>
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="sa-checkpoints">Required checkpoint IDs</Label>
+                <Textarea
+                  id="sa-checkpoints"
+                  className="min-h-[72px] font-mono text-sm"
+                  value={form.required_checkpoint_ids}
+                  onChange={(ev) =>
+                    setForm((f) => ({
+                      ...f,
+                      required_checkpoint_ids: ev.target.value,
+                    }))
+                  }
+                  placeholder="cp-abc, cp-def (comma or newline separated)"
+                />
+              </div>
+              <div className="space-y-2">
+                <Label htmlFor="sa-min-tier">Min tier (optional)</Label>
+                <Input
+                  id="sa-min-tier"
+                  type="number"
+                  min={1}
+                  value={form.min_tier}
+                  onChange={(ev) =>
+                    setForm((f) => ({ ...f, min_tier: ev.target.value }))
+                  }
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="flex gap-2 border-t border-neutral-200 px-5 py-4 dark:border-neutral-800">
+          <Button
+            type="button"
+            variant="outline"
+            className="flex-1"
+            onClick={onClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            className="flex-1 bg-black text-white hover:bg-black/85"
+            disabled={isSaving}
+            onClick={onSubmit}
+          >
+            {submitButtonContent(isSaving)}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The sponsored activations admin list page had no way to create an activation from the UI. Creation was only available via `POST /api/admin/sponsored-activations`.

This PR adds a **New activation** CTA (header + empty state) that opens a slide-over form panel, following the same pattern as `/admin/spend-experiences`.

## How to create an activation

| What | Path |
|------|------|
| **Admin UI** | `/admin/sponsored-activations` → **New activation** (slide-over form) |
| **API** | `POST /api/admin/sponsored-activations` (requires admin auth + `Idempotency-Key` header) |
| **After create** | Redirects to `/admin/sponsored-activations/{id}` (dashboard) |

There is no separate `/new` page route; the form is an in-page panel like spend experiences.

## Notes

- New activations are created in **draft** status (server default).
- Campaign wallet is provisioned server-side via Privy (not entered in the form).
- Base USDC contract defaults to mainnet USDC (`0x833589…`); venue wallet and checkpoint IDs must be filled in.

## Testing

- `yarn test app/admin/sponsored-activations/form-state.test.ts`
- Pre-commit `yarn build` passes
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1064819c-8ba2-417b-920d-ece53065f1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1064819c-8ba2-417b-920d-ece53065f1f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

