### PR TITLE
Simplify sponsored activation admin create form

### DIFF
--- a/app/admin/sponsored-activations/form-state.test.ts
+++ b/app/admin/sponsored-activations/form-state.test.ts
@@ -3,41 +3,36 @@ import {
   emptySponsoredActivationForm,
   formStateToCreatePayload,
 } from './form-state';
+import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/activation-eligibility-config';
 
 describe('formStateToCreatePayload', () => {
-  it('builds a base rail create body with eligibility', () => {
+  it('builds a base rail create body with default eligibility', () => {
     const form = {
       ...emptySponsoredActivationForm(),
-      slug: 'pr-drink',
       title: 'Drink credit',
       sponsor_name: 'Public Records',
       venue_settlement_wallet_address:
         '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-      required_checkpoint_ids: 'cp-1, cp-2',
     };
     const payload = formStateToCreatePayload(form);
     expect(payload.settlement_rail).toBe('base');
-    expect(payload.slug).toBe('pr-drink');
-    expect(payload.eligibility_config.required_checkpoint_ids).toEqual([
-      'cp-1',
-      'cp-2',
-    ]);
+    expect(payload.eligibility_config).toEqual(
+      DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG
+    );
     if (payload.settlement_rail === 'base') {
-      expect(payload.usdc_asset_config.contract_address).toBeTruthy();
+      expect('usdc_asset_config' in payload).toBe(false);
     }
   });
 
   it('requires at least one cap', () => {
     const form = {
       ...emptySponsoredActivationForm(),
-      slug: 'x',
       title: 't',
       sponsor_name: 's',
       venue_settlement_wallet_address:
         '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
       max_redemptions: '',
       max_usdc_budget: '',
-      required_checkpoint_ids: 'cp-1',
     };
     expect(() => formStateToCreatePayload(form)).toThrow(/max redemptions/i);
   });

--- a/app/admin/sponsored-activations/form-state.test.ts
+++ b/app/admin/sponsored-activations/form-state.test.ts
@@ -5,23 +5,22 @@ import {
 } from './form-state';
 import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/activation-eligibility-config';
 
+const VENUE_WALLET = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as const;
+
 describe('formStateToCreatePayload', () => {
   it('builds a base rail create body with default eligibility', () => {
     const form = {
       ...emptySponsoredActivationForm(),
       title: 'Drink credit',
       sponsor_name: 'Public Records',
-      venue_settlement_wallet_address:
-        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      venue_settlement_wallet_address: VENUE_WALLET,
     };
     const payload = formStateToCreatePayload(form);
     expect(payload.settlement_rail).toBe('base');
     expect(payload.eligibility_config).toEqual(
       DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG
     );
-    if (payload.settlement_rail === 'base') {
-      expect('usdc_asset_config' in payload).toBe(false);
-    }
+    expect(payload).not.toHaveProperty('usdc_asset_config');
   });
 
   it('requires at least one cap', () => {
@@ -29,8 +28,7 @@ describe('formStateToCreatePayload', () => {
       ...emptySponsoredActivationForm(),
       title: 't',
       sponsor_name: 's',
-      venue_settlement_wallet_address:
-        '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+      venue_settlement_wallet_address: VENUE_WALLET,
       max_redemptions: '',
       max_usdc_budget: '',
     };

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -1,28 +1,19 @@
 import type { SettlementRail } from '@/lib/db/sponsored-activations';
 import type { AdminCreateSponsoredActivationRequest } from '@/lib/schemas/sponsored-activation';
-import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
-
-/** Default Base USDC mint (canonical `POSTER_CHECKOUT_USDC_ADDRESS_BASE`). */
-export const DEFAULT_BASE_USDC_CONTRACT = POSTER_CHECKOUT_USDC_ADDRESS_BASE;
+import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/activation-eligibility-config';
 
 export type SponsoredActivationFormState = {
-  slug: string;
   title: string;
   sponsor_name: string;
   event_id: string;
   settlement_rail: SettlementRail;
   venue_settlement_wallet_address: string;
-  base_usdc_contract: string;
   stellar_asset_code: string;
   stellar_usdc_issuer: string;
   max_redemptions: string;
   max_usdc_budget: string;
   starts_at_local: string;
   ends_at_local: string;
-  max_events_per_user: string;
-  max_events_per_user_per_day: string;
-  required_checkpoint_ids: string;
-  min_tier: string;
 };
 
 export function isoToDatetimeLocalValue(iso: string): string {
@@ -44,23 +35,17 @@ function defaultWindow(): { start: string; end: string } {
 export function emptySponsoredActivationForm(): SponsoredActivationFormState {
   const { start, end } = defaultWindow();
   return {
-    slug: '',
     title: '',
     sponsor_name: '',
     event_id: '',
     settlement_rail: 'base',
     venue_settlement_wallet_address: '',
-    base_usdc_contract: DEFAULT_BASE_USDC_CONTRACT,
     stellar_asset_code: 'USDC',
     stellar_usdc_issuer: '',
     max_redemptions: '100',
     max_usdc_budget: '',
     starts_at_local: isoToDatetimeLocalValue(start),
     ends_at_local: isoToDatetimeLocalValue(end),
-    max_events_per_user: '50',
-    max_events_per_user_per_day: '10',
-    required_checkpoint_ids: '',
-    min_tier: '',
   };
 }
 
@@ -94,10 +79,8 @@ function parseOptionalPositiveDecimal(
 export function formStateToCreatePayload(
   form: SponsoredActivationFormState
 ): AdminCreateSponsoredActivationRequest {
-  const slug = form.slug.trim();
   const title = form.title.trim();
   const sponsor_name = form.sponsor_name.trim();
-  if (!slug) throw new Error('Slug is required');
   if (!title) throw new Error('Title is required');
   if (!sponsor_name) throw new Error('Sponsor name is required');
 
@@ -116,45 +99,7 @@ export function formStateToCreatePayload(
     throw new Error('Set max redemptions and/or max USDC budget');
   }
 
-  const checkpointIds = form.required_checkpoint_ids
-    .split(/[,\n]/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-  if (checkpointIds.length === 0) {
-    throw new Error('At least one required checkpoint ID is needed');
-  }
-
-  const max_events_per_user = parsePositiveIntField(
-    form.max_events_per_user,
-    'Max events per user'
-  );
-  const max_events_per_user_per_day = parsePositiveIntField(
-    form.max_events_per_user_per_day,
-    'Max events per user per day'
-  );
-  if (max_events_per_user == null || max_events_per_user_per_day == null) {
-    throw new Error('Eligibility event caps are required');
-  }
-
-  const minTierRaw = form.min_tier.trim();
-  let min_tier: number | undefined;
-  if (minTierRaw) {
-    const n = Number(minTierRaw);
-    if (!Number.isInteger(n) || n <= 0) {
-      throw new Error('Min tier must be a positive whole number');
-    }
-    min_tier = n;
-  }
-
-  const eligibility_config = {
-    max_events_per_user,
-    max_events_per_user_per_day,
-    required_checkpoint_ids: checkpointIds,
-    ...(min_tier != null ? { min_tier } : {}),
-  };
-
   const common = {
-    slug,
     title,
     sponsor_name,
     event_id: form.event_id.trim() || null,
@@ -162,17 +107,14 @@ export function formStateToCreatePayload(
     max_usdc_budget,
     starts_at: datetimeLocalToIso(form.starts_at_local),
     ends_at: datetimeLocalToIso(form.ends_at_local),
-    eligibility_config,
+    eligibility_config: DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG,
   };
 
   if (form.settlement_rail === 'base') {
-    const contract = form.base_usdc_contract.trim();
-    if (!contract) throw new Error('Base USDC contract address is required');
     return {
       ...common,
       settlement_rail: 'base',
       venue_settlement_wallet_address: venue,
-      usdc_asset_config: { contract_address: contract },
     } as AdminCreateSponsoredActivationRequest;
   }
 

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -16,24 +16,19 @@ export type SponsoredActivationFormState = {
   ends_at_local: string;
 };
 
-export function isoToDatetimeLocalValue(iso: string): string {
+function isoToDatetimeLocalValue(iso: string): string {
   const d = new Date(iso);
   const pad = (n: number) => String(n).padStart(2, '0');
   return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
 }
 
-export function datetimeLocalToIso(value: string): string {
+function datetimeLocalToIso(value: string): string {
   return new Date(value).toISOString();
 }
 
-function defaultWindow(): { start: string; end: string } {
+export function emptySponsoredActivationForm(): SponsoredActivationFormState {
   const start = new Date();
   const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
-  return { start: start.toISOString(), end: end.toISOString() };
-}
-
-export function emptySponsoredActivationForm(): SponsoredActivationFormState {
-  const { start, end } = defaultWindow();
   return {
     title: '',
     sponsor_name: '',
@@ -44,8 +39,8 @@ export function emptySponsoredActivationForm(): SponsoredActivationFormState {
     stellar_usdc_issuer: '',
     max_redemptions: '100',
     max_usdc_budget: '',
-    starts_at_local: isoToDatetimeLocalValue(start),
-    ends_at_local: isoToDatetimeLocalValue(end),
+    starts_at_local: isoToDatetimeLocalValue(start.toISOString()),
+    ends_at_local: isoToDatetimeLocalValue(end.toISOString()),
   };
 }
 
@@ -75,7 +70,6 @@ function parseOptionalPositiveDecimal(
   return n;
 }
 
-/** Builds the admin POST body from panel form state. */
 export function formStateToCreatePayload(
   form: SponsoredActivationFormState
 ): AdminCreateSponsoredActivationRequest {
@@ -95,7 +89,7 @@ export function formStateToCreatePayload(
     form.max_usdc_budget,
     'Max USDC budget'
   );
-  if (max_redemptions == null && max_usdc_budget == null) {
+  if (max_redemptions === undefined && max_usdc_budget === null) {
     throw new Error('Set max redemptions and/or max USDC budget');
   }
 

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -18,6 +18,11 @@ import {
 } from './form-state';
 import { SponsoredActivationFormPanel } from './sponsored-activation-form-panel';
 
+function unwrapAdminJson<T>(responseData: unknown): T {
+  const body = responseData as { data?: T };
+  return (body.data ?? body) as T;
+}
+
 /** Mirrors `GET /api/admin/sponsored-activations` rows (avoid `lib/db` in client bundles). */
 type ActivationListRow = {
   id: string;
@@ -142,7 +147,7 @@ export default function AdminSponsoredActivationsListPage() {
         body: JSON.stringify({}),
       });
       const responseData = await response.json();
-      const data = responseData.data || responseData;
+      const data = unwrapAdminJson<{ isAdmin: boolean }>(responseData);
       return data.isAdmin;
     } catch {
       return false;
@@ -171,17 +176,15 @@ export default function AdminSponsoredActivationsListPage() {
       });
       if (!response.ok) throw new Error('Failed to load activations');
       const responseData = await response.json();
-      const data = responseData.data || responseData;
-      return (data.activations ?? []) as ActivationListRow[];
+      const data = unwrapAdminJson<{ activations?: ActivationListRow[] }>(
+        responseData
+      );
+      return data.activations ?? [];
     },
     enabled: !!isAdmin && !!user?.email?.address,
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });
-
-  const closePanel = useCallback(() => {
-    setPanelOpen(false);
-  }, []);
 
   const openCreate = useCallback(() => {
     setForm(emptySponsoredActivationForm());
@@ -211,8 +214,8 @@ export default function AdminSponsoredActivationsListPage() {
       if (!response.ok) {
         throw new Error(readApiErrorMessage(j, 'Create failed'));
       }
-      const dataObj = j.data as { activation?: { id: string } } | undefined;
-      const activation = dataObj?.activation;
+      const dataObj = unwrapAdminJson<{ activation?: { id: string } }>(j);
+      const activation = dataObj.activation;
       if (!activation?.id) {
         throw new Error(readApiErrorMessage(j, 'Create failed'));
       }
@@ -227,7 +230,7 @@ export default function AdminSponsoredActivationsListPage() {
         `/admin/sponsored-activations/${encodeURIComponent(activation.id)}`
       );
     },
-    onError: (e: Error) => toast.error(e.message),
+    onError: (e) => toast.error(e.message),
   });
 
   const handleCreate = useCallback(() => {
@@ -316,7 +319,7 @@ export default function AdminSponsoredActivationsListPage() {
         form={form}
         setForm={setForm}
         isSaving={createMutation.isPending}
-        onClose={closePanel}
+        onClose={() => setPanelOpen(false)}
         onSubmit={handleCreate}
       />
     </div>

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -21,7 +21,6 @@ import { SponsoredActivationFormPanel } from './sponsored-activation-form-panel'
 /** Mirrors `GET /api/admin/sponsored-activations` rows (avoid `lib/db` in client bundles). */
 type ActivationListRow = {
   id: string;
-  slug: string;
   title: string;
   sponsor_name: string;
   status: string;
@@ -81,7 +80,7 @@ const SponsoredActivationsListBody = memo(
                 Rail
               </th>
               <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
-                Slug
+                Activation ID
               </th>
             </tr>
           </thead>
@@ -109,7 +108,7 @@ const SponsoredActivationsListBody = memo(
                   {a.settlement_rail}
                 </td>
                 <td className="px-4 py-3 font-mono text-xs text-neutral-600 dark:text-neutral-400">
-                  {a.slug}
+                  {a.id}
                 </td>
               </tr>
             ))}

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -10,7 +10,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import type { SettlementRail } from '@/lib/db/sponsored-activations';
 import type { SponsoredActivationFormState } from './form-state';
 
 export type SponsoredActivationFormPanelProps = {
@@ -33,6 +32,11 @@ export function SponsoredActivationFormPanel({
   if (!open) return null;
 
   const isBase = form.settlement_rail === 'base';
+
+  const setField =
+    <K extends keyof SponsoredActivationFormState>(key: K) =>
+    (value: SponsoredActivationFormState[K]) =>
+      setForm((f) => ({ ...f, [key]: value }));
 
   return (
     <div className="fixed inset-0 z-50 flex justify-end">
@@ -61,9 +65,7 @@ export function SponsoredActivationFormPanel({
             <Input
               id="sa-title"
               value={form.title}
-              onChange={(ev) =>
-                setForm((f) => ({ ...f, title: ev.target.value }))
-              }
+              onChange={(ev) => setField('title')(ev.target.value)}
               placeholder="e.g. Public Records drink credit"
             />
           </div>
@@ -72,9 +74,7 @@ export function SponsoredActivationFormPanel({
             <Input
               id="sa-sponsor"
               value={form.sponsor_name}
-              onChange={(ev) =>
-                setForm((f) => ({ ...f, sponsor_name: ev.target.value }))
-              }
+              onChange={(ev) => setField('sponsor_name')(ev.target.value)}
               placeholder="e.g. Public Records"
             />
           </div>
@@ -83,21 +83,18 @@ export function SponsoredActivationFormPanel({
             <Input
               id="sa-event"
               value={form.event_id}
-              onChange={(ev) =>
-                setForm((f) => ({ ...f, event_id: ev.target.value }))
-              }
+              onChange={(ev) => setField('event_id')(ev.target.value)}
             />
           </div>
           <div className="space-y-2">
             <Label>Settlement rail</Label>
             <Select
               value={form.settlement_rail}
-              onValueChange={(v) =>
-                setForm((f) => ({
-                  ...f,
-                  settlement_rail: v as SettlementRail,
-                }))
-              }
+              onValueChange={(v) => {
+                if (v === 'base' || v === 'stellar') {
+                  setField('settlement_rail')(v);
+                }
+              }}
             >
               <SelectTrigger>
                 <SelectValue placeholder="Select rail" />
@@ -117,16 +114,13 @@ export function SponsoredActivationFormPanel({
               id="sa-venue"
               value={form.venue_settlement_wallet_address}
               onChange={(ev) =>
-                setForm((f) => ({
-                  ...f,
-                  venue_settlement_wallet_address: ev.target.value,
-                }))
+                setField('venue_settlement_wallet_address')(ev.target.value)
               }
               placeholder={isBase ? '0x…' : 'G…'}
               className="font-mono text-sm"
             />
           </div>
-          {!isBase ? (
+          {!isBase && (
             <>
               <div className="space-y-2">
                 <Label htmlFor="sa-stellar-code">Stellar asset code</Label>
@@ -134,10 +128,7 @@ export function SponsoredActivationFormPanel({
                   id="sa-stellar-code"
                   value={form.stellar_asset_code}
                   onChange={(ev) =>
-                    setForm((f) => ({
-                      ...f,
-                      stellar_asset_code: ev.target.value,
-                    }))
+                    setField('stellar_asset_code')(ev.target.value)
                   }
                 />
               </div>
@@ -147,17 +138,14 @@ export function SponsoredActivationFormPanel({
                   id="sa-stellar-issuer"
                   value={form.stellar_usdc_issuer}
                   onChange={(ev) =>
-                    setForm((f) => ({
-                      ...f,
-                      stellar_usdc_issuer: ev.target.value,
-                    }))
+                    setField('stellar_usdc_issuer')(ev.target.value)
                   }
                   placeholder="G…"
                   className="font-mono text-sm"
                 />
               </div>
             </>
-          ) : null}
+          )}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-2">
               <Label htmlFor="sa-max-redemptions">Max redemptions</Label>
@@ -166,9 +154,7 @@ export function SponsoredActivationFormPanel({
                 type="number"
                 min={1}
                 value={form.max_redemptions}
-                onChange={(ev) =>
-                  setForm((f) => ({ ...f, max_redemptions: ev.target.value }))
-                }
+                onChange={(ev) => setField('max_redemptions')(ev.target.value)}
               />
             </div>
             <div className="space-y-2">
@@ -179,9 +165,7 @@ export function SponsoredActivationFormPanel({
                 min={0}
                 step="any"
                 value={form.max_usdc_budget}
-                onChange={(ev) =>
-                  setForm((f) => ({ ...f, max_usdc_budget: ev.target.value }))
-                }
+                onChange={(ev) => setField('max_usdc_budget')(ev.target.value)}
                 placeholder="Optional"
               />
             </div>
@@ -196,9 +180,7 @@ export function SponsoredActivationFormPanel({
                 id="sa-starts"
                 type="datetime-local"
                 value={form.starts_at_local}
-                onChange={(ev) =>
-                  setForm((f) => ({ ...f, starts_at_local: ev.target.value }))
-                }
+                onChange={(ev) => setField('starts_at_local')(ev.target.value)}
               />
             </div>
             <div className="space-y-2">
@@ -207,9 +189,7 @@ export function SponsoredActivationFormPanel({
                 id="sa-ends"
                 type="datetime-local"
                 value={form.ends_at_local}
-                onChange={(ev) =>
-                  setForm((f) => ({ ...f, ends_at_local: ev.target.value }))
-                }
+                onChange={(ev) => setField('ends_at_local')(ev.target.value)}
               />
             </div>
           </div>

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -3,7 +3,6 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -69,21 +68,6 @@ export function SponsoredActivationFormPanel({
             />
           </div>
           <div className="space-y-2">
-            <Label htmlFor="sa-slug">Slug</Label>
-            <Input
-              id="sa-slug"
-              value={form.slug}
-              onChange={(ev) =>
-                setForm((f) => ({ ...f, slug: ev.target.value }))
-              }
-              placeholder="public-records-drink"
-              className="font-mono text-sm"
-            />
-            <p className="text-xs text-neutral-500">
-              Public path: /activation/{'{slug}'}
-            </p>
-          </div>
-          <div className="space-y-2">
             <Label htmlFor="sa-sponsor">Sponsor name</Label>
             <Input
               id="sa-sponsor"
@@ -142,22 +126,7 @@ export function SponsoredActivationFormPanel({
               className="font-mono text-sm"
             />
           </div>
-          {isBase ? (
-            <div className="space-y-2">
-              <Label htmlFor="sa-base-contract">Base USDC contract</Label>
-              <Input
-                id="sa-base-contract"
-                value={form.base_usdc_contract}
-                onChange={(ev) =>
-                  setForm((f) => ({
-                    ...f,
-                    base_usdc_contract: ev.target.value,
-                  }))
-                }
-                className="font-mono text-sm"
-              />
-            </div>
-          ) : (
+          {!isBase ? (
             <>
               <div className="space-y-2">
                 <Label htmlFor="sa-stellar-code">Stellar asset code</Label>
@@ -188,7 +157,7 @@ export function SponsoredActivationFormPanel({
                 />
               </div>
             </>
-          )}
+          ) : null}
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-2">
               <Label htmlFor="sa-max-redemptions">Max redemptions</Label>
@@ -242,74 +211,6 @@ export function SponsoredActivationFormPanel({
                   setForm((f) => ({ ...f, ends_at_local: ev.target.value }))
                 }
               />
-            </div>
-          </div>
-          <div className="rounded-lg border border-neutral-200 p-3 dark:border-neutral-700">
-            <p className="mb-3 text-sm font-medium text-neutral-800 dark:text-neutral-200">
-              Eligibility
-            </p>
-            <div className="space-y-3">
-              <div className="grid grid-cols-2 gap-3">
-                <div className="space-y-2">
-                  <Label htmlFor="sa-max-events">Max events / user</Label>
-                  <Input
-                    id="sa-max-events"
-                    type="number"
-                    min={1}
-                    value={form.max_events_per_user}
-                    onChange={(ev) =>
-                      setForm((f) => ({
-                        ...f,
-                        max_events_per_user: ev.target.value,
-                      }))
-                    }
-                  />
-                </div>
-                <div className="space-y-2">
-                  <Label htmlFor="sa-max-events-day">
-                    Max events / user / day
-                  </Label>
-                  <Input
-                    id="sa-max-events-day"
-                    type="number"
-                    min={1}
-                    value={form.max_events_per_user_per_day}
-                    onChange={(ev) =>
-                      setForm((f) => ({
-                        ...f,
-                        max_events_per_user_per_day: ev.target.value,
-                      }))
-                    }
-                  />
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="sa-checkpoints">Required checkpoint IDs</Label>
-                <Textarea
-                  id="sa-checkpoints"
-                  className="min-h-[72px] font-mono text-sm"
-                  value={form.required_checkpoint_ids}
-                  onChange={(ev) =>
-                    setForm((f) => ({
-                      ...f,
-                      required_checkpoint_ids: ev.target.value,
-                    }))
-                  }
-                  placeholder="cp-abc, cp-def (comma or newline separated)"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label htmlFor="sa-min-tier">Min tier (optional)</Label>
-                <Input
-                  id="sa-min-tier"
-                  type="number"
-                  min={1}
-                  value={form.min_tier}
-                  onChange={(ev) =>
-                    setForm((f) => ({ ...f, min_tier: ev.target.value }))
-                  }
-                />
-              </div>
             </div>
           </div>
         </div>

--- a/app/api/admin/sponsored-activations/__tests__/admin-sponsored-activations.routes.test.ts
+++ b/app/api/admin/sponsored-activations/__tests__/admin-sponsored-activations.routes.test.ts
@@ -58,6 +58,8 @@ vi.mock('@/lib/activation/explorer-url', () => ({
   }),
 }));
 
+import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
+import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/activation-eligibility-config';
 import { GET as listGET, POST as listPOST } from '../route';
 import { GET as oneGET, PATCH as onePATCH } from '../[activationId]/route';
 import {
@@ -76,12 +78,6 @@ const validWindow = {
   ends_at: '2026-06-30T12:00:00.000Z',
 };
 
-const testEligibilityConfig = {
-  max_events_per_user: 50,
-  max_events_per_user_per_day: 10,
-  required_checkpoint_ids: ['cp-1'],
-};
-
 const baseFixture = {
   id: 'act-1',
   slug: 's1',
@@ -98,7 +94,7 @@ const baseFixture = {
   usdc_settled_total: 0,
   redemption_count_confirmed: 0,
   ...validWindow,
-  eligibility_config: testEligibilityConfig,
+  eligibility_config: DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG,
   created_by: 'a@b.com',
   created_at: '2026-01-01T00:00:00.000Z',
   updated_at: '2026-01-01T00:00:00.000Z',
@@ -168,15 +164,12 @@ describe('POST /api/admin/sponsored-activations', () => {
     const res = await listPOST(
       jsonReq('POST', 'http://localhost/api/admin/sponsored-activations', {
         settlement_rail: 'base',
-        slug: 'x',
         title: 't',
         sponsor_name: 's',
         max_redemptions: 1,
         ...validWindow,
-        eligibility_config: testEligibilityConfig,
         venue_settlement_wallet_address:
           '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-        usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
       })
     );
     expect(res.status).toBe(403);
@@ -186,14 +179,11 @@ describe('POST /api/admin/sponsored-activations', () => {
     const res = await listPOST(
       jsonReq('POST', 'http://localhost/api/admin/sponsored-activations', {
         settlement_rail: 'base',
-        slug: 'x',
         title: 't',
         sponsor_name: 's',
         max_redemptions: 1,
         ...validWindow,
-        eligibility_config: testEligibilityConfig,
         venue_settlement_wallet_address: STELLAR,
-        usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
       })
     );
     expect(res.status).toBe(400);
@@ -208,15 +198,12 @@ describe('POST /api/admin/sponsored-activations', () => {
         'http://localhost/api/admin/sponsored-activations',
         {
           settlement_rail: 'base',
-          slug: 'new-slug',
           title: 't',
           sponsor_name: 's',
           max_redemptions: 1,
           ...validWindow,
-          eligibility_config: testEligibilityConfig,
           venue_settlement_wallet_address:
             '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
-          usdc_asset_config: { contract_address: SAMPLE_CONTRACT },
         },
         'idem-xyz'
       )
@@ -227,8 +214,21 @@ describe('POST /api/admin/sponsored-activations', () => {
       settlementRail: 'base',
     });
     expect(mockCreate).toHaveBeenCalled();
-    const createArg = mockCreate.mock.calls[0][0] as { status: string };
+    const createArg = mockCreate.mock.calls[0][0] as {
+      status: string;
+      id: string;
+      slug: string;
+      usdc_asset_config: { contract_address: string };
+      eligibility_config: typeof DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG;
+    };
     expect(createArg.status).toBe('draft');
+    expect(createArg.id).toBe(createArg.slug);
+    expect(createArg.usdc_asset_config.contract_address).toBe(
+      POSTER_CHECKOUT_USDC_ADDRESS_BASE
+    );
+    expect(createArg.eligibility_config).toEqual(
+      DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG
+    );
   });
 });
 

--- a/app/api/admin/sponsored-activations/route.ts
+++ b/app/api/admin/sponsored-activations/route.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'crypto';
 import { NextRequest } from 'next/server';
 import { z } from 'zod';
 import {
@@ -5,7 +6,10 @@ import {
   getSponsoredActivationByCreateIdempotencyKey,
   listSponsoredActivations,
 } from '@/lib/db/sponsored-activations';
-import { adminCreateSponsoredActivationRequestSchema } from '@/lib/schemas/sponsored-activation';
+import {
+  adminCreateSponsoredActivationRequestSchema,
+  DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT,
+} from '@/lib/schemas/sponsored-activation';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
 import { createSponsoredActivationPrivyCampaignWallet } from '@/lib/api/privy';
@@ -86,8 +90,15 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    const activationId = randomUUID();
+    const usdc_asset_config =
+      data.settlement_rail === 'base'
+        ? { contract_address: DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT }
+        : (data.usdc_asset_config as Record<string, unknown>);
+
     const row = await createSponsoredActivation({
-      slug: data.slug,
+      id: activationId,
+      slug: activationId,
       title: data.title,
       sponsor_name: data.sponsor_name,
       event_id: data.event_id ?? null,
@@ -95,10 +106,7 @@ export async function POST(request: NextRequest) {
       settlement_rail: data.settlement_rail,
       campaign_wallet_address: wallet.campaign_wallet_address,
       venue_settlement_wallet_address: data.venue_settlement_wallet_address,
-      usdc_asset_config: data.usdc_asset_config as unknown as Record<
-        string,
-        unknown
-      >,
+      usdc_asset_config,
       max_redemptions: data.max_redemptions ?? null,
       max_usdc_budget: data.max_usdc_budget ?? null,
       starts_at: data.starts_at,

--- a/lib/db/sponsored-activations.ts
+++ b/lib/db/sponsored-activations.ts
@@ -209,6 +209,7 @@ export async function countActiveRewardItemsForActivation(
 }
 
 export type CreateSponsoredActivationDbInput = {
+  id?: string;
   slug: string;
   title: string;
   sponsor_name: string;
@@ -234,6 +235,7 @@ export async function createSponsoredActivation(
   const { data, error } = await supabase
     .from(TABLE)
     .insert({
+      ...(input.id != null ? { id: input.id } : {}),
       slug: input.slug,
       title: input.title,
       sponsor_name: input.sponsor_name,

--- a/lib/schemas/__tests__/sponsored-activation.test.ts
+++ b/lib/schemas/__tests__/sponsored-activation.test.ts
@@ -219,34 +219,45 @@ describe('createSponsoredActivationSchema', () => {
 });
 
 describe('adminCreateSponsoredActivationRequestSchema', () => {
-  it('accepts Base create without campaign_wallet_address', () => {
+  it('accepts Base create without campaign_wallet_address, slug, or usdc_asset_config', () => {
     const r = adminCreateSponsoredActivationRequestSchema.safeParse({
       settlement_rail: 'base',
-      slug: 'pr-admin',
       title: 'Public Records',
       sponsor_name: 'Acme',
       max_redemptions: 100,
       ...validTime,
-      eligibility_config: { ...sampleEligibilityConfig, min_tier: 1 },
       venue_settlement_wallet_address:
         '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
     });
     expect(r.success).toBe(true);
+    if (r.success) {
+      expect(r.data.eligibility_config.required_checkpoint_ids).toEqual([]);
+    }
+  });
+
+  it('rejects slug on admin create (strict)', () => {
+    const r = adminCreateSponsoredActivationRequestSchema.safeParse({
+      settlement_rail: 'base',
+      slug: 'pr-admin',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+    });
+    expect(r.success).toBe(false);
   });
 
   it('rejects extra campaign_wallet_address (strict)', () => {
     const r = adminCreateSponsoredActivationRequestSchema.safeParse({
       settlement_rail: 'base',
-      slug: 'x',
       title: 't',
       sponsor_name: 's',
       max_redemptions: 1,
       ...validTime,
-      eligibility_config: sampleEligibilityConfig,
       venue_settlement_wallet_address:
         '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
-      usdc_asset_config: { contract_address: SAMPLE_EVM_CONTRACT },
       campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
     });
     expect(r.success).toBe(false);

--- a/lib/schemas/activation-eligibility-config.ts
+++ b/lib/schemas/activation-eligibility-config.ts
@@ -17,6 +17,14 @@ export type ActivationEligibilityRulesConfig = z.infer<
   typeof activationEligibilityRulesConfigSchema
 >;
 
+/** Default eligibility rules for new sponsored activations (admin create). */
+export const DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG: ActivationEligibilityRulesConfig =
+  {
+    max_events_per_user: 50,
+    max_events_per_user_per_day: 10,
+    required_checkpoint_ids: [],
+  };
+
 export function parseActivationEligibilityRulesConfig(
   raw: unknown
 ): ActivationEligibilityRulesConfig {

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -1,6 +1,10 @@
 import { z } from 'zod';
 import { getAddress, isAddress } from 'viem';
-import { activationEligibilityRulesConfigSchema } from '@/lib/schemas/activation-eligibility-config';
+import {
+  activationEligibilityRulesConfigSchema,
+  DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG,
+} from '@/lib/schemas/activation-eligibility-config';
+import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 
@@ -180,11 +184,29 @@ export const createSponsoredActivationSchema =
   });
 
 const adminCreateSponsoredActivationBaseObject =
-  createSponsoredActivationBaseObject.omit({ campaign_wallet_address: true });
+  createSponsoredActivationBaseObject
+    .omit({
+      campaign_wallet_address: true,
+      slug: true,
+      usdc_asset_config: true,
+    })
+    .extend({
+      eligibility_config: activationEligibilityRulesConfigSchema
+        .optional()
+        .default(DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG),
+    });
 const adminCreateSponsoredActivationStellarObject =
-  createSponsoredActivationStellarObject.omit({
-    campaign_wallet_address: true,
-  });
+  createSponsoredActivationStellarObject
+    .omit({ campaign_wallet_address: true, slug: true })
+    .extend({
+      eligibility_config: activationEligibilityRulesConfigSchema
+        .optional()
+        .default(DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG),
+    });
+
+/** Canonical Base USDC contract for sponsored activations (admin create default). */
+export const DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT =
+  POSTER_CHECKOUT_USDC_ADDRESS_BASE;
 
 /**
  * Admin POST body: `campaign_wallet_address` is provisioned server-side (Privy), not supplied by the client.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Streamlines the **New sponsored activation** admin panel by removing fields that should not be configured manually at create time.

## Changes

- **Removed slug field** — new activations get a server-generated UUID used as both `id` and `slug`. Public links use `/activation/{activationId}` (already supported).
- **Removed Base USDC contract field** — server applies the canonical Base USDC contract (`POSTER_CHECKOUT_USDC_ADDRESS_BASE`).
- **Removed Eligibility section** — create uses `DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG` (50 events/user, 10/day, no required checkpoints).
- **Admin list table** — shows Activation ID instead of Slug.

## Testing

- `yarn test` on form-state, admin sponsored-activations routes, and sponsored-activation schema tests (33 passing)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b3ba9525-8972-4958-acd4-1b795fbacd8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b3ba9525-8972-4958-acd4-1b795fbacd8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

