### PR TITLE
Align sponsored activation UI with production mock

### DIFF
--- a/app/activation/[activationId]/page.tsx
+++ b/app/activation/[activationId]/page.tsx
@@ -14,7 +14,7 @@ function ActivationRouteInner() {
   if (!activationId) {
     return (
       <SponsoredActivationPageShell>
-        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+        <p className="body-medium font-grotesk p-6 text-center text-[#757575]">
           This activation link is not valid.
         </p>
       </SponsoredActivationPageShell>
@@ -34,10 +34,10 @@ export default function ActivationRoutePage() {
   return (
     <Suspense
       fallback={
-        <SponsoredActivationPageShell showCard={false}>
-          <div className="flex min-h-[40vh] items-center justify-center">
+        <SponsoredActivationPageShell>
+          <div className="flex min-h-[40vh] items-center justify-center px-4">
             <Loader2
-              className="size-8 animate-spin text-white/60"
+              className="size-8 animate-spin text-[#757575]"
               aria-hidden
             />
           </div>

--- a/components/sponsored-activation/sponsored-activation-cancelled.tsx
+++ b/components/sponsored-activation/sponsored-activation-cancelled.tsx
@@ -2,9 +2,9 @@
 
 export function SponsoredActivationCancelled() {
   return (
-    <div className="flex flex-col gap-3 p-6 text-center md:p-8">
-      <h1 className="title2 text-white">This redemption was cancelled</h1>
-      <p className="body-medium font-grotesk text-white/70">
+    <div className="flex flex-col gap-3 px-4 py-8 text-center md:px-6">
+      <h1 className="title2 text-[#171717]">This redemption was cancelled</h1>
+      <p className="body-medium font-grotesk text-[#757575]">
         This perk is no longer available on your account for this activation.
       </p>
     </div>

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import Image from 'next/image';
-import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
+import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
+import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
+import { SponsoredActivationCtaButton } from '@/components/sponsored-activation/sponsored-activation-cta-button';
 import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
 
 type SponsoredActivationConfirmProps = {
@@ -19,76 +20,45 @@ export function SponsoredActivationConfirm({
   pending,
   onConfirm,
 }: SponsoredActivationConfirmProps) {
-  const { rewardItem, activation } = read;
+  const { rewardItem } = read;
+  const pointsCost = rewardItem.points_cost;
 
   return (
-    <div className="flex min-h-[70vh] flex-col">
-      <div className="flex flex-1 flex-col gap-5 p-4 pb-36 md:p-6">
-        <p className="body-small font-grotesk uppercase tracking-wide text-white/50">
-          {activation.sponsor_name}
-        </p>
-        <h1 className="title2 text-white">{activation.title}</h1>
+    <div className="flex min-h-[calc(100vh-5rem)] flex-col bg-white">
+      <SponsoredActivationHero
+        heroImageUrl={rewardItem.hero_image_url}
+        itemName={rewardItem.name}
+      />
 
-        <div className="relative aspect-[4/5] w-full overflow-hidden rounded-md bg-white/5">
-          {rewardItem.hero_image_url ? (
-            <Image
-              src={rewardItem.hero_image_url}
-              alt={rewardItem.name}
-              fill
-              className="object-cover"
-              sizes="(max-width: 768px) 100vw, 400px"
-              unoptimized
-            />
-          ) : (
-            <div className="flex h-full min-h-[200px] items-center justify-center body-medium font-grotesk text-white/35">
-              {rewardItem.name}
-            </div>
-          )}
-        </div>
+      <div className="flex flex-1 flex-col px-4 pb-28 pt-6">
+        <h1 className="title2 text-[#171717]">Confirm Your Purchase</h1>
 
-        <div className="space-y-3 rounded-md border border-white/10 bg-white/5 p-4">
-          <div className="flex justify-between gap-3">
-            <span className="body-small font-grotesk uppercase tracking-wide text-white/50">
-              You send
-            </span>
-            <span className="body-medium font-grotesk font-semibold text-white">
-              {rewardItem.points_cost.toLocaleString()} PTS
-            </span>
-          </div>
-          <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
-            <span className="body-small font-grotesk uppercase tracking-wide text-white/50">
-              You receive
-            </span>
-            <span className="body-medium font-grotesk font-semibold text-right text-white">
-              {rewardItem.name}
-            </span>
-          </div>
-          {accountEmail ? (
-            <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
-              <span className="body-small font-grotesk text-white/50">
-                Account
-              </span>
-              <span className="body-medium font-grotesk text-right text-white/90">
-                {accountEmail}
-              </span>
-            </div>
-          ) : null}
-          <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
-            <span className="body-small font-grotesk text-white/50">
-              Current points
-            </span>
-            <span className="body-medium font-grotesk text-white">
-              {currentPoints.toLocaleString()}
-            </span>
-          </div>
+        <div className="mt-6">
+          <SponsoredActivationDetailRow
+            label="You send"
+            value={`${pointsCost.toLocaleString()} PTS`}
+          />
+          <SponsoredActivationDetailRow
+            label="Your account"
+            value={accountEmail ?? 'Signed in'}
+          />
+          <SponsoredActivationDetailRow
+            label="Current points"
+            value={`${currentPoints.toLocaleString()} PTS`}
+            subValue={`-${pointsCost.toLocaleString()}`}
+          />
         </div>
       </div>
 
-      <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-white/10 bg-[#0a0a0a]/95 px-4 py-4 backdrop-blur-md md:px-8">
+      <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-[#171717]/10 bg-white/95 px-4 py-4 backdrop-blur-sm">
         <div className="mx-auto w-full max-w-[420px] md:max-w-lg">
-          <SpendPrimaryButton pending={pending} onClick={onConfirm}>
+          <SponsoredActivationCtaButton
+            variant="confirm"
+            pending={pending}
+            onClick={onConfirm}
+          >
             Confirm Purchase
-          </SpendPrimaryButton>
+          </SponsoredActivationCtaButton>
         </div>
       </div>
     </div>

--- a/components/sponsored-activation/sponsored-activation-cta-button.tsx
+++ b/components/sponsored-activation/sponsored-activation-cta-button.tsx
@@ -1,0 +1,58 @@
+'use client';
+
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+import { Check, Loader2, Trophy } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type SponsoredActivationCtaButtonProps =
+  ButtonHTMLAttributes<HTMLButtonElement> & {
+    children: ReactNode;
+    variant: 'confirm' | 'redeemed';
+    pending?: boolean;
+  };
+
+/** Primary CTAs for activation purchase / redeemed states (Figma prod flow). */
+export function SponsoredActivationCtaButton({
+  children,
+  variant,
+  pending,
+  disabled,
+  className,
+  ...props
+}: SponsoredActivationCtaButtonProps) {
+  const isBusy = Boolean(pending);
+  const isRedeemed = variant === 'redeemed';
+
+  return (
+    <button
+      type="button"
+      className={cn(
+        'label-large flex h-12 w-full items-center justify-between gap-2 rounded-md px-4 font-grotesk uppercase tracking-wide transition-opacity disabled:cursor-not-allowed',
+        isRedeemed
+          ? 'bg-[#22c55e] text-white disabled:opacity-100'
+          : 'bg-[#171717] text-white hover:opacity-95 disabled:opacity-50',
+        className
+      )}
+      disabled={disabled || isBusy || isRedeemed}
+      {...props}
+    >
+      <span className="flex min-w-0 flex-1 items-center gap-2">
+        {isBusy ? (
+          <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+        ) : null}
+        <span className="min-w-0 truncate whitespace-nowrap text-left">
+          {children}
+        </span>
+      </span>
+      {!isBusy ? (
+        isRedeemed ? (
+          <Check className="size-5 shrink-0" strokeWidth={2.5} aria-hidden />
+        ) : (
+          <Trophy className="size-5 shrink-0" strokeWidth={2} aria-hidden />
+        )
+      ) : (
+        <span className="size-5 shrink-0" aria-hidden />
+      )}
+    </button>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-cta-button.tsx
+++ b/components/sponsored-activation/sponsored-activation-cta-button.tsx
@@ -11,7 +11,6 @@ type SponsoredActivationCtaButtonProps =
     pending?: boolean;
   };
 
-/** Primary CTAs for activation purchase / redeemed states (Figma prod flow). */
 export function SponsoredActivationCtaButton({
   children,
   variant,
@@ -22,6 +21,19 @@ export function SponsoredActivationCtaButton({
 }: SponsoredActivationCtaButtonProps) {
   const isBusy = Boolean(pending);
   const isRedeemed = variant === 'redeemed';
+
+  let trailingIcon: ReactNode;
+  if (isBusy) {
+    trailingIcon = <span className="size-5 shrink-0" aria-hidden />;
+  } else if (isRedeemed) {
+    trailingIcon = (
+      <Check className="size-5 shrink-0" strokeWidth={2.5} aria-hidden />
+    );
+  } else {
+    trailingIcon = (
+      <Trophy className="size-5 shrink-0" strokeWidth={2} aria-hidden />
+    );
+  }
 
   return (
     <button
@@ -44,15 +56,7 @@ export function SponsoredActivationCtaButton({
           {children}
         </span>
       </span>
-      {!isBusy ? (
-        isRedeemed ? (
-          <Check className="size-5 shrink-0" strokeWidth={2.5} aria-hidden />
-        ) : (
-          <Trophy className="size-5 shrink-0" strokeWidth={2} aria-hidden />
-        )
-      ) : (
-        <span className="size-5 shrink-0" aria-hidden />
-      )}
+      {trailingIcon}
     </button>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-detail-row.tsx
+++ b/components/sponsored-activation/sponsored-activation-detail-row.tsx
@@ -8,6 +8,8 @@ type SponsoredActivationDetailRowProps = {
   value: ReactNode;
   subValue?: ReactNode;
   className?: string;
+  /** Skip default value typography (e.g. bordered badge). */
+  bareValue?: boolean;
 };
 
 export function SponsoredActivationDetailRow({
@@ -15,6 +17,7 @@ export function SponsoredActivationDetailRow({
   value,
   subValue,
   className,
+  bareValue,
 }: SponsoredActivationDetailRowProps) {
   return (
     <div
@@ -27,9 +30,13 @@ export function SponsoredActivationDetailRow({
         {label}
       </span>
       <div className="min-w-0 text-right">
-        <div className="body-medium font-grotesk font-semibold text-[#171717]">
-          {value}
-        </div>
+        {bareValue ? (
+          <div className="flex justify-end">{value}</div>
+        ) : (
+          <div className="body-medium font-grotesk font-semibold text-[#171717]">
+            {value}
+          </div>
+        )}
         {subValue ? (
           <div className="mt-0.5 body-small font-grotesk font-semibold text-[#e53935]">
             {subValue}

--- a/components/sponsored-activation/sponsored-activation-detail-row.tsx
+++ b/components/sponsored-activation/sponsored-activation-detail-row.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import { cn } from '@/lib/utils';
+
+type SponsoredActivationDetailRowProps = {
+  label: string;
+  value: ReactNode;
+  subValue?: ReactNode;
+  className?: string;
+};
+
+export function SponsoredActivationDetailRow({
+  label,
+  value,
+  subValue,
+  className,
+}: SponsoredActivationDetailRowProps) {
+  return (
+    <div
+      className={cn(
+        'flex items-start justify-between gap-4 border-b border-[#171717]/10 py-3 last:border-b-0',
+        className
+      )}
+    >
+      <span className="label-small shrink-0 font-grotesk uppercase tracking-wide text-[#757575]">
+        {label}
+      </span>
+      <div className="min-w-0 text-right">
+        <div className="body-medium font-grotesk font-semibold text-[#171717]">
+          {value}
+        </div>
+        {subValue ? (
+          <div className="mt-0.5 body-small font-grotesk font-semibold text-[#e53935]">
+            {subValue}
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-expired.tsx
+++ b/components/sponsored-activation/sponsored-activation-expired.tsx
@@ -2,9 +2,9 @@
 
 export function SponsoredActivationExpired() {
   return (
-    <div className="flex flex-col gap-3 p-6 text-center md:p-8">
-      <h1 className="title2 text-white">This offer has expired</h1>
-      <p className="body-medium font-grotesk text-white/70">
+    <div className="flex flex-col gap-3 px-4 py-8 text-center md:px-6">
+      <h1 className="title2 text-[#171717]">This offer has expired</h1>
+      <p className="body-medium font-grotesk text-[#757575]">
         This redemption is no longer valid. If you think this is a mistake, ask
         staff at the venue.
       </p>

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -8,7 +8,6 @@ import { toast } from 'sonner';
 import { SponsoredActivationPageShell } from '@/components/sponsored-activation/sponsored-activation-page-shell';
 import { SponsoredActivationConfirm } from '@/components/sponsored-activation/sponsored-activation-confirm';
 import { SponsoredActivationSuccess } from '@/components/sponsored-activation/sponsored-activation-success';
-import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
 import { SponsoredActivationRedeemed } from '@/components/sponsored-activation/sponsored-activation-redeemed';
 import { SponsoredActivationExpired } from '@/components/sponsored-activation/sponsored-activation-expired';
 import { SponsoredActivationCancelled } from '@/components/sponsored-activation/sponsored-activation-cancelled';
@@ -29,7 +28,7 @@ import {
   resolveSponsoredActivationBaseScreen,
 } from '@/lib/sponsored-activation/flow-routing';
 import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
-import { resolveTierTitleForPoints } from '@/lib/sponsored-activation/tier-label';
+import { resolveTierForPoints } from '@/lib/tier-for-points';
 import {
   isInitialized,
   trackSponsoredActivationViewed,
@@ -83,7 +82,6 @@ export function SponsoredActivationFlow({
   const { data: player, isFetched: playerDetailsFetched } = useCurrentPlayer();
   const { data: tiers } = useTiers();
 
-  const [venueStep, setVenueStep] = useState<'success' | 'swipe'>('success');
   const [redemptionOverride, setRedemptionOverride] =
     useState<ActivationRedemptionRow | null>(null);
   const [swipeSliderKey, setSwipeSliderKey] = useState(0);
@@ -98,7 +96,6 @@ export function SponsoredActivationFlow({
   );
 
   useEffect(() => {
-    setVenueStep('success');
     setRedemptionOverride(null);
     activationViewEmittedRef.current = false;
     confirmScreenEmittedRef.current = false;
@@ -265,7 +262,6 @@ export function SponsoredActivationFlow({
     },
     onSuccess: (data) => {
       setRedemptionOverride(data.redemption);
-      setVenueStep('success');
       void queryClient.invalidateQueries({
         queryKey: ['sponsored-activation-eligibility-get', activationKey],
       });
@@ -339,7 +335,10 @@ export function SponsoredActivationFlow({
     confirmMutation.data?.player.total_points ?? player?.total_points ?? 0;
   const pointsSpent =
     redemption?.points_spent ?? readQuery.data?.rewardItem.points_cost ?? 0;
-  const tierTitle = resolveTierTitleForPoints(tiers, balanceAfterPoints);
+  const currentTier =
+    tiers?.length && balanceAfterPoints >= 0
+      ? resolveTierForPoints(tiers, balanceAfterPoints)
+      : null;
 
   const recordFlowLoading =
     Boolean(deeplink) &&
@@ -356,9 +355,9 @@ export function SponsoredActivationFlow({
 
   if (readQuery.isLoading) {
     return (
-      <SponsoredActivationPageShell showCard={false}>
-        <div className="flex min-h-[40vh] items-center justify-center">
-          <Loader2 className="size-8 animate-spin text-white/60" aria-hidden />
+      <SponsoredActivationPageShell>
+        <div className="flex min-h-[40vh] items-center justify-center px-4">
+          <Loader2 className="size-8 animate-spin text-[#757575]" aria-hidden />
         </div>
       </SponsoredActivationPageShell>
     );
@@ -367,7 +366,7 @@ export function SponsoredActivationFlow({
   if (readQuery.error || !readQuery.data) {
     return (
       <SponsoredActivationPageShell>
-        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+        <p className="body-medium font-grotesk p-6 text-center text-[#757575]">
           This activation link is not available.
         </p>
       </SponsoredActivationPageShell>
@@ -380,8 +379,8 @@ export function SponsoredActivationFlow({
     return (
       <SponsoredActivationPageShell>
         <div className="flex flex-col gap-6 p-6">
-          <h1 className="title2 text-white">{read.activation.title}</h1>
-          <p className="body-medium font-grotesk text-white/70">
+          <h1 className="title2 text-[#171717]">{read.activation.title}</h1>
+          <p className="body-medium font-grotesk text-[#757575]">
             Log in to continue with this activation.
           </p>
           <SpendPrimaryButton onClick={login}>
@@ -395,7 +394,7 @@ export function SponsoredActivationFlow({
   if (!walletAddress) {
     return (
       <SponsoredActivationPageShell>
-        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+        <p className="body-medium font-grotesk p-6 text-center text-[#757575]">
           A wallet is required on your IRL account to use this activation.
         </p>
       </SponsoredActivationPageShell>
@@ -404,10 +403,10 @@ export function SponsoredActivationFlow({
 
   if (eligibilityLoading) {
     return (
-      <SponsoredActivationPageShell showCard={false}>
+      <SponsoredActivationPageShell>
         <div className="flex min-h-[40vh] flex-col items-center justify-center gap-3 px-4">
-          <Loader2 className="size-8 animate-spin text-white/60" aria-hidden />
-          <p className="body-small font-grotesk text-white/50">
+          <Loader2 className="size-8 animate-spin text-[#757575]" aria-hidden />
+          <p className="body-small font-grotesk text-[#757575]">
             Checking your activation…
           </p>
         </div>
@@ -422,7 +421,7 @@ export function SponsoredActivationFlow({
         : null;
     return (
       <SponsoredActivationPageShell>
-        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+        <p className="body-medium font-grotesk p-6 text-center text-[#757575]">
           {apiMsg ??
             'We could not verify eligibility from this link. Please scan again or check with staff.'}
         </p>
@@ -433,7 +432,7 @@ export function SponsoredActivationFlow({
   if (resumeEligibility.isError) {
     return (
       <SponsoredActivationPageShell>
-        <p className="body-medium font-grotesk p-6 text-center text-white/80">
+        <p className="body-medium font-grotesk p-6 text-center text-[#757575]">
           We could not load your activation status. Please try again.
         </p>
       </SponsoredActivationPageShell>
@@ -444,8 +443,8 @@ export function SponsoredActivationFlow({
     return (
       <SponsoredActivationPageShell>
         <div className="flex flex-col gap-4 p-6 text-center">
-          <h1 className="title2 text-white">{read.activation.title}</h1>
-          <p className="body-medium font-grotesk text-white/75">
+          <h1 className="title2 text-[#171717]">{read.activation.title}</h1>
+          <p className="body-medium font-grotesk text-[#757575]">
             {deeplink
               ? 'You do not have an available redemption for this perk yet.'
               : 'No redemption is on file for this activation. Open the link from your QR code or checkpoint to continue.'}
@@ -474,7 +473,11 @@ export function SponsoredActivationFlow({
   if (baseScreen === 'redeemed') {
     return (
       <SponsoredActivationPageShell>
-        <SponsoredActivationRedeemed perkName={read.rewardItem.name} />
+        <SponsoredActivationRedeemed
+          heroImageUrl={read.rewardItem.hero_image_url}
+          perkName={read.rewardItem.name}
+          pointsSpent={pointsSpent}
+        />
       </SponsoredActivationPageShell>
     );
   }
@@ -497,7 +500,6 @@ export function SponsoredActivationFlow({
   }
 
   if (baseScreen === 'success_swipe') {
-    const showSwipe = venueStep === 'swipe';
     const swipeDisabled =
       swipeMutation.isPending ||
       isRedeemedLikeStatus(redemption.status) ||
@@ -505,34 +507,17 @@ export function SponsoredActivationFlow({
 
     return (
       <SponsoredActivationPageShell>
-        {!showSwipe ? (
-          <SponsoredActivationSuccess
-            pointsSpent={pointsSpent}
-            balanceAfter={balanceAfterPoints}
-            tierTitle={tierTitle}
-            perkName={read.rewardItem.name}
-            onContinueToSwipe={() => setVenueStep('swipe')}
-          />
-        ) : (
-          <div className="flex flex-col gap-6 p-4 md:p-6">
-            <div>
-              <h1 className="title2 text-white">Swipe to redeem</h1>
-              <p className="mt-2 body-medium font-grotesk text-white/70">
-                Complete the swipe when staff asks you to redeem{' '}
-                <span className="font-semibold text-white">
-                  {read.rewardItem.name}
-                </span>
-                .
-              </p>
-            </div>
-            <SponsoredActivationSwipeSlider
-              key={swipeSliderKey}
-              disabled={swipeDisabled}
-              onSwipeGestureStart={handleSwipeGestureStart}
-              onComplete={handleSwipeComplete}
-            />
-          </div>
-        )}
+        <SponsoredActivationSuccess
+          heroImageUrl={read.rewardItem.hero_image_url}
+          perkName={read.rewardItem.name}
+          pointsSpent={pointsSpent}
+          balanceAfter={balanceAfterPoints}
+          tier={currentTier}
+          swipeDisabled={swipeDisabled}
+          swipeSliderKey={swipeSliderKey}
+          onSwipeGestureStart={handleSwipeGestureStart}
+          onSwipeComplete={handleSwipeComplete}
+        />
       </SponsoredActivationPageShell>
     );
   }
@@ -540,7 +525,7 @@ export function SponsoredActivationFlow({
   return (
     <SponsoredActivationPageShell>
       <div className="p-6 text-center">
-        <p className="body-medium font-grotesk text-white/80">
+        <p className="body-medium font-grotesk text-[#757575]">
           This activation is not available for your account right now.
         </p>
       </div>

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -310,11 +310,14 @@ export function SponsoredActivationFlow({
     },
   });
 
+  const { mutate: mutateSwipeRedeem, isPending: swipeRedeemPending } =
+    swipeMutation;
+
   const handleSwipeComplete = useCallback(() => {
-    if (!redemption?.id || swipeMutation.isPending) return;
+    if (!redemption?.id || swipeRedeemPending) return;
     if (!isSwipeAllowedForStatus(redemption.status)) return;
-    swipeMutation.mutate(redemption.id);
-  }, [redemption, swipeMutation]);
+    mutateSwipeRedeem(redemption.id);
+  }, [redemption, swipeRedeemPending, mutateSwipeRedeem]);
 
   const handleSwipeGestureStart = useCallback(() => {
     if (!readQuery.data || swipeGestureReportedRef.current) return;
@@ -335,10 +338,10 @@ export function SponsoredActivationFlow({
     confirmMutation.data?.player.total_points ?? player?.total_points ?? 0;
   const pointsSpent =
     redemption?.points_spent ?? readQuery.data?.rewardItem.points_cost ?? 0;
-  const currentTier =
-    tiers?.length && balanceAfterPoints >= 0
-      ? resolveTierForPoints(tiers, balanceAfterPoints)
-      : null;
+  const currentTier = useMemo(() => {
+    if (!tiers?.length || balanceAfterPoints < 0) return null;
+    return resolveTierForPoints(tiers, balanceAfterPoints);
+  }, [tiers, balanceAfterPoints]);
 
   const recordFlowLoading =
     Boolean(deeplink) &&
@@ -501,7 +504,7 @@ export function SponsoredActivationFlow({
 
   if (baseScreen === 'success_swipe') {
     const swipeDisabled =
-      swipeMutation.isPending ||
+      swipeRedeemPending ||
       isRedeemedLikeStatus(redemption.status) ||
       !isSwipeAllowedForStatus(redemption.status);
 

--- a/components/sponsored-activation/sponsored-activation-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type SponsoredActivationHeroProps = {
+  heroImageUrl: string | null;
+  itemName: string;
+  className?: string;
+};
+
+/** Full-bleed hero with back control and “You receive” strip (Figma / prod mock). */
+export function SponsoredActivationHero({
+  heroImageUrl,
+  itemName,
+  className,
+}: SponsoredActivationHeroProps) {
+  const router = useRouter();
+
+  return (
+    <div className={cn('relative w-full', className)}>
+      <div className="relative aspect-[4/5] w-full overflow-hidden bg-neutral-100">
+        {heroImageUrl ? (
+          <Image
+            src={heroImageUrl}
+            alt={itemName}
+            fill
+            className="object-cover"
+            sizes="(max-width: 768px) 100vw, 420px"
+            priority
+            unoptimized
+          />
+        ) : (
+          <div className="flex h-full min-h-[240px] items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
+            {itemName}
+          </div>
+        )}
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="absolute left-4 top-4 flex size-10 items-center justify-center rounded-full bg-white shadow-sm transition-opacity hover:opacity-90"
+          aria-label="Go back"
+        >
+          <ArrowLeft className="size-5 text-[#171717]" strokeWidth={2} />
+        </button>
+      </div>
+      <div className="flex items-center justify-between gap-3 border-y border-[#171717]/10 bg-white px-4 py-2.5">
+        <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
+          You receive
+        </span>
+        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
+          {itemName}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero.tsx
@@ -11,7 +11,6 @@ type SponsoredActivationHeroProps = {
   className?: string;
 };
 
-/** Full-bleed hero with back control and “You receive” strip (Figma / prod mock). */
 export function SponsoredActivationHero({
   heroImageUrl,
   itemName,

--- a/components/sponsored-activation/sponsored-activation-page-shell.tsx
+++ b/components/sponsored-activation/sponsored-activation-page-shell.tsx
@@ -6,34 +6,26 @@ import { cn } from '@/lib/utils';
 
 type SponsoredActivationPageShellProps = {
   children: ReactNode;
-  showCard?: boolean;
   className?: string;
 };
 
 /**
- * Mobile-first shell for `/activation/:id` — dark canvas + header; inner card optional.
+ * Mobile-first shell for `/activation/:id` — light canvas aligned with Figma prod flow.
  */
 export function SponsoredActivationPageShell({
   children,
-  showCard = true,
   className,
 }: SponsoredActivationPageShellProps) {
   return (
     <div
       className={cn(
-        'relative min-h-screen w-full overflow-x-hidden bg-[#0a0a0a]',
+        'relative min-h-screen w-full overflow-x-hidden bg-white',
         className
       )}
     >
       <Header />
-      <main className="relative z-0 mx-auto w-full max-w-[420px] px-4 pb-28 pt-24 md:max-w-lg md:px-6 md:pb-32 md:pt-28">
-        {showCard ? (
-          <div className="overflow-hidden rounded-md border border-white/10 bg-[#141414] shadow-lg">
-            {children}
-          </div>
-        ) : (
-          children
-        )}
+      <main className="relative z-0 mx-auto w-full max-w-[420px] pb-8 pt-20 md:max-w-lg md:pt-24">
+        {children}
       </main>
     </div>
   );

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -1,23 +1,49 @@
 'use client';
 
+import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
+import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
+import { SponsoredActivationCtaButton } from '@/components/sponsored-activation/sponsored-activation-cta-button';
+
 type SponsoredActivationRedeemedProps = {
+  heroImageUrl: string | null;
   perkName: string;
+  pointsSpent: number;
 };
 
 export function SponsoredActivationRedeemed({
+  heroImageUrl,
   perkName,
+  pointsSpent,
 }: SponsoredActivationRedeemedProps) {
   return (
-    <div className="flex flex-col gap-4 p-4 md:p-6">
-      <div className="rounded-md border border-emerald-500/40 bg-emerald-500/15 p-6 text-center">
-        <p className="body-small font-grotesk uppercase tracking-wide text-emerald-200/90">
-          Redeemed
-        </p>
-        <h1 className="mt-2 title2 text-white">Enjoy your perk</h1>
-        <p className="mt-3 body-medium font-grotesk text-white/85">
-          {perkName} is redeemed. Show this screen if staff asks for
+    <div className="flex min-h-[calc(100vh-5rem)] flex-col bg-white">
+      <SponsoredActivationHero
+        heroImageUrl={heroImageUrl}
+        itemName={perkName}
+      />
+
+      <div className="flex flex-1 flex-col px-4 pb-28 pt-6">
+        <h1 className="title2 text-[#171717]">All set</h1>
+        <p className="mt-2 body-medium font-grotesk text-[#757575]">
+          Your perk is redeemed. Show this screen if staff asks for
           confirmation.
         </p>
+
+        <div className="mt-6">
+          <SponsoredActivationDetailRow
+            label="You spent"
+            value={`${pointsSpent.toLocaleString()} PTS`}
+          />
+          <SponsoredActivationDetailRow label="Status" value="Redeemed" />
+        </div>
+      </div>
+
+      <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-[#171717]/10 bg-white/95 px-4 py-4 backdrop-blur-sm">
+        <div className="mx-auto w-full max-w-[420px] md:max-w-lg">
+          <SponsoredActivationCtaButton variant="redeemed" disabled>
+            Redeemed
+          </SponsoredActivationCtaButton>
+        </div>
       </div>
     </div>
   );

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -1,69 +1,90 @@
 'use client';
 
-import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
+import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
+import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
+import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
+import type { Tier } from '@/lib/types';
 
 type SponsoredActivationSuccessProps = {
+  heroImageUrl: string | null;
+  perkName: string;
   pointsSpent: number;
   balanceAfter: number;
-  tierTitle: string | null;
-  perkName: string;
-  onContinueToSwipe: () => void;
+  tier: Tier | null;
+  swipeDisabled: boolean;
+  swipeSliderKey: number;
+  onSwipeGestureStart?: () => void;
+  onSwipeComplete: () => void;
 };
 
+function formatTierBadge(tier: Tier): string {
+  const title = tier.title.trim().toUpperCase();
+  const floor = tier.min_points.toLocaleString();
+  return `${title} • ${floor}+`;
+}
+
 export function SponsoredActivationSuccess({
+  heroImageUrl,
+  perkName,
   pointsSpent,
   balanceAfter,
-  tierTitle,
-  perkName,
-  onContinueToSwipe,
+  tier,
+  swipeDisabled,
+  swipeSliderKey,
+  onSwipeGestureStart,
+  onSwipeComplete,
 }: SponsoredActivationSuccessProps) {
   return (
-    <div className="flex flex-col gap-6 p-4 md:p-6">
-      <div>
-        <p className="body-small font-grotesk uppercase tracking-wide text-emerald-400/90">
-          Success!
-        </p>
-        <h1 className="mt-2 title2 text-white">You&apos;re almost there</h1>
-      </div>
+    <div className="flex min-h-[calc(100vh-5rem)] flex-col bg-white">
+      <SponsoredActivationHero
+        heroImageUrl={heroImageUrl}
+        itemName={perkName}
+      />
 
-      <div className="space-y-3 rounded-md border border-white/10 bg-white/5 p-4">
-        <div className="flex justify-between gap-3">
-          <span className="body-small font-grotesk uppercase tracking-wide text-white/50">
-            You spent
-          </span>
-          <span className="body-medium font-grotesk font-semibold text-white">
-            {pointsSpent.toLocaleString()} PTS
-          </span>
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-8 pt-6">
+        <div>
+          <h1 className="title2 text-[#171717]">Success!</h1>
         </div>
-        <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
-          <span className="body-small font-grotesk text-white/50">Balance</span>
-          <span className="body-medium font-grotesk text-white">
-            {balanceAfter.toLocaleString()} PTS
-          </span>
+
+        <div>
+          <SponsoredActivationDetailRow
+            label="You spent"
+            value={`${pointsSpent.toLocaleString()} PTS`}
+          />
+          <SponsoredActivationDetailRow
+            label="Balance"
+            value={`${balanceAfter.toLocaleString()} PTS`}
+          />
+          {tier ? (
+            <div className="flex items-start justify-between gap-4 border-b border-[#171717]/10 py-3">
+              <span className="label-small shrink-0 font-grotesk uppercase tracking-wide text-[#757575]">
+                Current tier
+              </span>
+              <span className="inline-block border border-[#171717] px-2.5 py-1 label-small font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
+                {formatTierBadge(tier)}
+              </span>
+            </div>
+          ) : null}
         </div>
-        {tierTitle ? (
-          <div className="flex justify-between gap-3 border-t border-white/10 pt-3">
-            <span className="body-small font-grotesk text-white/50">Tier</span>
-            <span className="body-medium font-grotesk text-white">
-              {tierTitle}
-            </span>
-          </div>
-        ) : null}
-      </div>
 
-      <div className="rounded-md border border-emerald-500/25 bg-emerald-500/10 p-4">
-        <h2 className="body-medium font-grotesk font-semibold text-white">
-          How to collect
-        </h2>
-        <p className="mt-2 body-medium font-grotesk text-white/80">
-          Show this screen on your phone at the venue to pick up{' '}
-          <span className="font-semibold text-white">{perkName}</span>.
-        </p>
-      </div>
+        <section>
+          <h2 className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
+            How to collect
+          </h2>
+          <p className="mt-2 body-medium font-grotesk leading-relaxed text-[#171717]">
+            When you&apos;re ready, swipe below to redeem with staff. Show this
+            screen at the venue to pick up{' '}
+            <span className="font-semibold">{perkName}</span>.
+          </p>
+        </section>
 
-      <SpendPrimaryButton type="button" onClick={onContinueToSwipe}>
-        Swipe to redeem at venue
-      </SpendPrimaryButton>
+        <SponsoredActivationSwipeSlider
+          key={swipeSliderKey}
+          disabled={swipeDisabled}
+          onSwipeGestureStart={onSwipeGestureStart}
+          onComplete={onSwipeComplete}
+        />
+      </div>
     </div>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -3,6 +3,7 @@
 import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
 import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
 import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
+import { formatActivationTierBadge } from '@/lib/sponsored-activation/tier-label';
 import type { Tier } from '@/lib/types';
 
 type SponsoredActivationSuccessProps = {
@@ -16,12 +17,6 @@ type SponsoredActivationSuccessProps = {
   onSwipeGestureStart?: () => void;
   onSwipeComplete: () => void;
 };
-
-function formatTierBadge(tier: Tier): string {
-  const title = tier.title.trim().toUpperCase();
-  const floor = tier.min_points.toLocaleString();
-  return `${title} • ${floor}+`;
-}
 
 export function SponsoredActivationSuccess({
   heroImageUrl,
@@ -56,14 +51,15 @@ export function SponsoredActivationSuccess({
             value={`${balanceAfter.toLocaleString()} PTS`}
           />
           {tier ? (
-            <div className="flex items-start justify-between gap-4 border-b border-[#171717]/10 py-3">
-              <span className="label-small shrink-0 font-grotesk uppercase tracking-wide text-[#757575]">
-                Current tier
-              </span>
-              <span className="inline-block border border-[#171717] px-2.5 py-1 label-small font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
-                {formatTierBadge(tier)}
-              </span>
-            </div>
+            <SponsoredActivationDetailRow
+              label="Current tier"
+              bareValue
+              value={
+                <span className="inline-block border border-[#171717] px-2.5 py-1 label-small font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
+                  {formatActivationTierBadge(tier)}
+                </span>
+              }
+            />
           ) : null}
         </div>
 

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 const COMPLETE_RATIO = 0.82;
@@ -109,6 +110,8 @@ export function SponsoredActivationSwipeSlider({
     }
   };
 
+  const displayLabel = completed ? 'Redeeming…' : label;
+
   return (
     <div className="w-full">
       <div
@@ -126,13 +129,13 @@ export function SponsoredActivationSwipeSlider({
         tabIndex={disabled || completed ? -1 : 0}
         onKeyDown={onKeyDown}
         className={cn(
-          'relative flex h-14 w-full select-none items-center rounded-full border border-white/15 bg-black/40 px-1',
-          disabled || completed ? 'opacity-50' : 'cursor-pointer'
+          'relative flex h-14 w-full select-none items-center rounded-md border border-[#171717] bg-white px-1',
+          disabled || completed ? 'opacity-60' : 'cursor-pointer'
         )}
       >
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <span className="label-small font-grotesk text-white/50">
-            {completed ? 'Redeemed' : label}
+          <span className="label-small font-grotesk uppercase tracking-wide text-[#171717]">
+            {displayLabel}
           </span>
         </div>
         <div
@@ -143,18 +146,16 @@ export function SponsoredActivationSwipeSlider({
           onPointerCancel={onPointerUp}
           style={{ transform: `translateX(${dragPx}px)` }}
           className={cn(
-            'relative z-10 flex h-12 w-[4.5rem] shrink-0 items-center justify-center rounded-full bg-[#FFF200] text-[#0a0a0a] shadow-md',
+            'relative z-10 flex h-12 w-12 shrink-0 items-center justify-center rounded-sm bg-[#171717] text-white',
             disabled || completed ? 'pointer-events-none' : 'touch-none'
           )}
         >
-          <span className="text-lg" aria-hidden>
-            →
-          </span>
+          <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden />
         </div>
       </div>
-      <p className="mt-2 body-small font-grotesk text-white/40">
-        Slide the button all the way right. Keyboard: focus the track, then
-        press Enter.
+      <p className="sr-only">
+        Slide the control all the way right to redeem. Keyboard: focus the
+        track, then press Enter.
       </p>
     </div>
   );

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -1,6 +1,12 @@
 'use client';
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} from 'react';
 import { ArrowRight } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -14,9 +20,6 @@ type SponsoredActivationSwipeSliderProps = {
   label?: string;
 };
 
-/**
- * Drag-to-complete slider — requires deliberate swipe (not a single tap).
- */
 export function SponsoredActivationSwipeSlider({
   disabled,
   onComplete,
@@ -30,6 +33,8 @@ export function SponsoredActivationSwipeSlider({
   const [completed, setCompleted] = useState(false);
   const completionSentRef = useRef(false);
   const activePointerId = useRef<number | null>(null);
+  /** Cached max travel for a11y ratio; avoids reading layout in render. */
+  const maxTravelForAriaRef = useRef(1);
 
   const maxTravel = useCallback(() => {
     const track = trackRef.current;
@@ -42,6 +47,7 @@ export function SponsoredActivationSwipeSlider({
     (px: number) => {
       if (completionSentRef.current) return;
       const max = maxTravel();
+      maxTravelForAriaRef.current = Math.max(1, max);
       if (max <= 0) return;
       if (px >= max * COMPLETE_RATIO) {
         completionSentRef.current = true;
@@ -61,11 +67,21 @@ export function SponsoredActivationSwipeSlider({
     dragPxRef.current = 0;
   }, [disabled, completed]);
 
-  const onPointerDown = (e: React.PointerEvent) => {
+  const syncMaxTravelForAria = useCallback(() => {
+    maxTravelForAriaRef.current = Math.max(1, maxTravel());
+  }, [maxTravel]);
+
+  useLayoutEffect(() => {
+    syncMaxTravelForAria();
+    window.addEventListener('resize', syncMaxTravelForAria);
+    return () => window.removeEventListener('resize', syncMaxTravelForAria);
+  }, [syncMaxTravelForAria, disabled, completed]);
+
+  const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
     if (disabled || completed) return;
     onSwipeGestureStart?.();
     activePointerId.current = e.pointerId;
-    (e.target as HTMLElement).setPointerCapture(e.pointerId);
+    e.currentTarget.setPointerCapture(e.pointerId);
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
@@ -77,6 +93,7 @@ export function SponsoredActivationSwipeSlider({
     const rect = track.getBoundingClientRect();
     const knobW = knob.offsetWidth;
     const max = Math.max(0, rect.width - knobW - 8);
+    maxTravelForAriaRef.current = Math.max(1, max);
     const x = e.clientX - rect.left - knobW / 2;
     const clamped = Math.min(max, Math.max(0, x));
     dragPxRef.current = clamped;
@@ -103,6 +120,7 @@ export function SponsoredActivationSwipeSlider({
       onSwipeGestureStart?.();
       completionSentRef.current = true;
       const max = maxTravel();
+      maxTravelForAriaRef.current = Math.max(1, max);
       dragPxRef.current = max;
       setDragPx(max);
       setCompleted(true);
@@ -122,7 +140,7 @@ export function SponsoredActivationSwipeSlider({
         aria-valuenow={
           completed
             ? 100
-            : Math.round((dragPx / Math.max(1, maxTravel())) * 100)
+            : Math.round((dragPx / maxTravelForAriaRef.current) * 100)
         }
         aria-disabled={disabled || completed}
         aria-label={label}

--- a/lib/sponsored-activation/tier-label.ts
+++ b/lib/sponsored-activation/tier-label.ts
@@ -9,3 +9,10 @@ export function resolveTierTitleForPoints(
   if (!tiers?.length) return null;
   return resolveTierForPoints(tiers, totalPoints)?.title ?? null;
 }
+
+/** Compact tier badge for activation success (uppercase title + floor). */
+export function formatActivationTierBadge(tier: Tier): string {
+  const title = tier.title.trim().toUpperCase();
+  const floor = tier.min_points.toLocaleString();
+  return `${title} • ${floor}+`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the `/activation/:id` purchase and redemption flow to match the light production mock (screenshot / Figma intent):

- **Light layout** — white canvas, full-bleed hero image, no dark frosted card
- **Hero** — back control, “You receive” strip with item name
- **Confirm** — “Confirm Your Purchase” with uppercase detail rows, red point deduction, black **Confirm Purchase** CTA with trophy icon
- **Success** — same hero, tier badge in bordered pill (`TITLE • MIN+`), “How to collect” copy, and **Swipe to redeem** on the same screen (no extra step)
- **Swipe slider** — white track, black border, square black knob with arrow (replaces yellow pill)
- **Redeemed** — green disabled **Redeemed** CTA with checkmark

## Notes

- Figma API was unavailable in this environment (token expired); layout follows the shared screenshot and existing design tokens (`#171717`, `#757575`, Gal Gothic / Monument Grotesk).
- Swipe slider unit tests pass.

## Test plan

- [x] `yarn test components/sponsored-activation/swipe-slider.test.tsx`
- [x] `yarn lint` on changed activation components
- [x] Pre-commit `yarn build`
- [ ] Manual: open `/activation/:id` through confirm → success → swipe → redeemed on mobile viewport
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2da85219-6dea-4e7e-909a-27ac5bf67bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2da85219-6dea-4e7e-909a-27ac5bf67bd8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

