### PR TITLE
fix: spend activation success hero overlay and collect copy

### DIFF
--- a/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
+++ b/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
@@ -1,23 +1,14 @@
-'use client';
-
 import { cn } from '@/lib/utils';
 
 const COLLECT_INSTRUCTIONS =
-  'Swipe below and show this screen to the event staff. Swipe only when you\u2019re ready to purchase \u2014 once you\u2019ve redeemed you can\u2019t redeem again!';
+  "Swipe below and show this screen to the event staff. Swipe only when you're ready to purchase — once you've redeemed you can't redeem again!";
 
 const collectSectionClass =
   'text-[13px] font-grotesk leading-[1.25rem] text-[#171717]';
 
-type SponsoredActivationCollectInstructionsProps = {
-  className?: string;
-};
-
-/** "How to collect" block — 13px title and body per Figma. */
-export function SponsoredActivationCollectInstructions({
-  className,
-}: SponsoredActivationCollectInstructionsProps) {
+export function SponsoredActivationCollectInstructions() {
   return (
-    <section className={className}>
+    <section>
       <h2
         className={cn(
           collectSectionClass,

--- a/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
+++ b/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+const COLLECT_INSTRUCTIONS =
+  'Swipe below and show this screen to the event staff. Swipe only when you\u2019re ready to purchase \u2014 once you\u2019ve redeemed you can\u2019t redeem again!';
+
+const collectSectionClass =
+  'text-[13px] font-grotesk leading-[1.25rem] text-[#171717]';
+
+type SponsoredActivationCollectInstructionsProps = {
+  className?: string;
+};
+
+/** "How to collect" block — 13px title and body per Figma. */
+export function SponsoredActivationCollectInstructions({
+  className,
+}: SponsoredActivationCollectInstructionsProps) {
+  return (
+    <section className={className}>
+      <h2
+        className={cn(
+          collectSectionClass,
+          'font-semibold uppercase tracking-wide text-[#757575]'
+        )}
+      >
+        How to collect
+      </h2>
+      <p className={cn(collectSectionClass, 'mt-2')}>{COLLECT_INSTRUCTIONS}</p>
+    </section>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero.tsx
@@ -3,30 +3,21 @@
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
-import { cn } from '@/lib/utils';
-
-/** Hero image height — half of a 640px mobile viewport per Figma. */
-export const SPONSORED_ACTIVATION_HERO_HEIGHT_PX = 320;
 
 type SponsoredActivationHeroProps = {
   heroImageUrl: string | null;
   itemName: string;
-  className?: string;
 };
 
 export function SponsoredActivationHero({
   heroImageUrl,
   itemName,
-  className,
 }: SponsoredActivationHeroProps) {
   const router = useRouter();
 
   return (
-    <div className={cn('relative w-full', className)}>
-      <div
-        className="relative w-full overflow-hidden bg-neutral-100"
-        style={{ height: SPONSORED_ACTIVATION_HERO_HEIGHT_PX }}
-      >
+    <div className="relative w-full">
+      <div className="relative h-[320px] w-full overflow-hidden bg-neutral-100">
         {heroImageUrl ? (
           <Image
             src={heroImageUrl}

--- a/components/sponsored-activation/sponsored-activation-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero.tsx
@@ -5,6 +5,9 @@ import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
+/** Hero image height — half of a 640px mobile viewport per Figma. */
+export const SPONSORED_ACTIVATION_HERO_HEIGHT_PX = 320;
+
 type SponsoredActivationHeroProps = {
   heroImageUrl: string | null;
   itemName: string;
@@ -20,7 +23,10 @@ export function SponsoredActivationHero({
 
   return (
     <div className={cn('relative w-full', className)}>
-      <div className="relative aspect-[4/5] w-full overflow-hidden bg-neutral-100">
+      <div
+        className="relative w-full overflow-hidden bg-neutral-100"
+        style={{ height: SPONSORED_ACTIVATION_HERO_HEIGHT_PX }}
+      >
         {heroImageUrl ? (
           <Image
             src={heroImageUrl}
@@ -32,26 +38,26 @@ export function SponsoredActivationHero({
             unoptimized
           />
         ) : (
-          <div className="flex h-full min-h-[240px] items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
+          <div className="flex h-full items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
             {itemName}
           </div>
         )}
         <button
           type="button"
           onClick={() => router.back()}
-          className="absolute left-4 top-4 flex size-10 items-center justify-center rounded-full bg-white shadow-sm transition-opacity hover:opacity-90"
+          className="absolute left-4 top-4 z-10 flex size-10 items-center justify-center rounded-full bg-white shadow-sm transition-opacity hover:opacity-90"
           aria-label="Go back"
         >
           <ArrowLeft className="size-5 text-[#171717]" strokeWidth={2} />
         </button>
-      </div>
-      <div className="flex items-center justify-between gap-3 border-y border-[#171717]/10 bg-white px-4 py-4">
-        <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
-          You receive
-        </span>
-        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
-          {itemName}
-        </span>
+        <div className="absolute bottom-0 left-0 right-0 z-10 flex items-center justify-between gap-3 bg-white px-4 py-4">
+          <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
+            You receive
+          </span>
+          <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
+            {itemName}
+          </span>
+        </div>
       </div>
     </div>
   );

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
+import { SponsoredActivationCollectInstructions } from '@/components/sponsored-activation/sponsored-activation-collect-instructions';
 import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
 import { SponsoredActivationCtaButton } from '@/components/sponsored-activation/sponsored-activation-cta-button';
 
@@ -38,14 +39,7 @@ export function SponsoredActivationRedeemed({
           />
         </div>
 
-        <section>
-          <h2 className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
-            How to collect
-          </h2>
-          <p className="mt-2 body-medium font-grotesk leading-relaxed text-[#171717]">
-            Show this screen to the event staff if they ask for confirmation.
-          </p>
-        </section>
+        <SponsoredActivationCollectInstructions />
       </div>
 
       <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-[#171717]/10 bg-white/95 px-4 py-4 backdrop-blur-sm">

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
+import { SponsoredActivationCollectInstructions } from '@/components/sponsored-activation/sponsored-activation-collect-instructions';
 import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
 import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
 
@@ -46,16 +47,7 @@ export function SponsoredActivationSuccess({
           />
         </div>
 
-        <section>
-          <h2 className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
-            How to collect
-          </h2>
-          <p className="mt-2 body-medium font-grotesk leading-relaxed text-[#171717]">
-            Swipe below and show this screen to the event staff. Swipe only when
-            you&apos;re ready to purchase – once you&apos;ve redeemed you
-            can&apos;t redeem again!
-          </p>
-        </section>
+        <SponsoredActivationCollectInstructions />
 
         <SponsoredActivationSwipeSlider
           key={swipeSliderKey}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the sponsored activation success/redeemed screens with Figma: hero image at half viewport height, "You receive" bar overlaid on the image, and consistent 13px "How to collect" typography and copy.

## Changes

- **Hero (`sponsored-activation-hero.tsx`)**
  - Fixed hero height to **320px** (half of 640px mobile viewport)
  - Moved **You receive** row to an **absolute overlay** at the bottom of the image (white bar on top of the photo)
  - Back button stays above the overlay (`z-10`)

- **Collect instructions**
  - New shared `SponsoredActivationCollectInstructions` component
  - Title and body both use **13px** (`text-[13px]`)
  - Copy on redeemed screen updated to match success/swipe: *"Swipe below and show this screen to the event staff. Swipe only when you're ready to purchase — once you've redeemed you can't redeem again!"*

## Screens affected

- Success (swipe to redeem)
- Redeemed (terminal state)
- Confirm purchase (hero layout only — same overlay treatment)

## Testing

- `yarn lint` on changed files — pass
- Pre-commit `yarn build` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7b1bfa80-880c-4047-8368-3617fe8731f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7b1bfa80-880c-4047-8368-3617fe8731f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

