### PR TITLE
feat: Figma spend activation screen for sponsored activations

### DIFF
--- a/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
@@ -91,6 +91,8 @@ describe('GET /api/sponsored-activations/[activationId]', () => {
       hero_image_url: activeItem.hero_image_url,
       description: activeItem.description,
       points_cost: activeItem.points_cost,
+      perk_value_usd: 7,
+      perk_value_label: '$7 USD value',
     });
     expect(json.data.rewardItem).not.toHaveProperty('usdc_amount');
   });

--- a/app/api/sponsored-activations/[activationId]/route.ts
+++ b/app/api/sponsored-activations/[activationId]/route.ts
@@ -2,6 +2,10 @@ import { NextRequest } from 'next/server';
 import { listActivationRewardItems } from '@/lib/db/activation-reward-items';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { apiError, apiSuccess } from '@/lib/api/response';
+import {
+  formatPerkValueUsdLabel,
+  perkValueUsdFromUsdcAmount,
+} from '@/lib/sponsored-activation/format-perk-value';
 
 export const dynamic = 'force-dynamic';
 
@@ -55,6 +59,8 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
       hero_image_url: reward.hero_image_url,
       description: reward.description,
       points_cost: reward.points_cost,
+      perk_value_usd: perkValueUsdFromUsdcAmount(reward.usdc_amount),
+      perk_value_label: formatPerkValueUsdLabel(reward.usdc_amount),
     },
   });
 }

--- a/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
+++ b/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
@@ -15,7 +15,7 @@ export function SponsoredActivationCollectInstructions() {
           'font-semibold uppercase tracking-wide text-[#757575]'
         )}
       >
-        How to collect
+        How to Collect
       </h2>
       <p className={cn(collectSectionClass, 'mt-2')}>{COLLECT_INSTRUCTIONS}</p>
     </section>

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -1,65 +1,64 @@
 'use client';
 
-import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
-import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
-import { SponsoredActivationCtaButton } from '@/components/sponsored-activation/sponsored-activation-cta-button';
+import { ArrowRight, Loader2 } from 'lucide-react';
+import { SponsoredActivationLandingHero } from '@/components/sponsored-activation/sponsored-activation-landing-hero';
+import { cn } from '@/lib/utils';
 import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
 
 type SponsoredActivationConfirmProps = {
   read: SponsoredActivationPublicReadResponse;
-  accountEmail: string | null;
-  currentPoints: number;
   pending: boolean;
   onConfirm: () => void;
 };
 
 export function SponsoredActivationConfirm({
   read,
-  accountEmail,
-  currentPoints,
   pending,
   onConfirm,
 }: SponsoredActivationConfirmProps) {
-  const { rewardItem } = read;
-  const pointsCost = rewardItem.points_cost;
+  const { activation, rewardItem } = read;
+  const description = rewardItem.description?.trim() || activation.sponsor_name;
 
   return (
     <div className="flex min-h-[calc(100vh-5rem)] flex-col bg-white">
-      <SponsoredActivationHero
+      <SponsoredActivationLandingHero
         heroImageUrl={rewardItem.hero_image_url}
         itemName={rewardItem.name}
+        pointsCost={rewardItem.points_cost}
+        perkValueLabel={rewardItem.perk_value_label}
       />
 
-      <div className="flex flex-1 flex-col px-4 pb-28 pt-6">
-        <h1 className="title2 text-[#171717]">Confirm Your Purchase</h1>
-
-        <div className="mt-6">
-          <SponsoredActivationDetailRow
-            label="You send"
-            value={`${pointsCost.toLocaleString()} PTS`}
-          />
-          <SponsoredActivationDetailRow
-            label="Your account"
-            value={accountEmail ?? 'Signed in'}
-          />
-          <SponsoredActivationDetailRow
-            label="Current points"
-            value={`${currentPoints.toLocaleString()} PTS`}
-            subValue={`-${pointsCost.toLocaleString()}`}
-          />
+      <div className="flex flex-1 flex-col gap-6 px-4 pb-10 pt-4">
+        <div className="flex flex-col gap-2">
+          <h1 className="title3 font-medium text-[#171717]">
+            {activation.title}
+          </h1>
+          {description ? (
+            <p className="body-small font-grotesk text-[#757575]">
+              {description}
+            </p>
+          ) : null}
         </div>
-      </div>
 
-      <div className="fixed bottom-0 left-0 right-0 z-20 border-t border-[#171717]/10 bg-white/95 px-4 py-4 backdrop-blur-sm">
-        <div className="mx-auto w-full max-w-[420px] md:max-w-lg">
-          <SponsoredActivationCtaButton
-            variant="confirm"
-            pending={pending}
-            onClick={onConfirm}
-          >
-            Confirm Purchase
-          </SponsoredActivationCtaButton>
-        </div>
+        <button
+          type="button"
+          onClick={onConfirm}
+          disabled={pending}
+          className={cn(
+            'label-large flex h-11 w-full items-center justify-between gap-2 rounded-md bg-[#171717] px-4 font-grotesk uppercase tracking-[0.0625em] text-white transition-opacity',
+            'hover:opacity-95 disabled:cursor-not-allowed disabled:opacity-50'
+          )}
+        >
+          <span className="flex min-w-0 flex-1 items-center gap-2">
+            {pending ? (
+              <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
+            ) : null}
+            <span className="truncate text-left">
+              {pending ? 'Processing…' : 'Pay With Points'}
+            </span>
+          </span>
+          <ArrowRight className="size-6 shrink-0" strokeWidth={2} aria-hidden />
+        </button>
       </div>
     </div>
   );

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -9,12 +9,15 @@ type SponsoredActivationConfirmProps = {
   read: SponsoredActivationPublicReadResponse;
   pending: boolean;
   onConfirm: () => void;
+  /** Replaces the idle primary action label (default: "Pay With Points"). */
+  primaryActionLabel?: string;
 };
 
 export function SponsoredActivationConfirm({
   read,
   pending,
   onConfirm,
+  primaryActionLabel,
 }: SponsoredActivationConfirmProps) {
   const { activation, rewardItem } = read;
   const description = rewardItem.description?.trim() || activation.sponsor_name;
@@ -54,7 +57,9 @@ export function SponsoredActivationConfirm({
               <Loader2 className="size-4 shrink-0 animate-spin" aria-hidden />
             ) : null}
             <span className="truncate text-left">
-              {pending ? 'Processing…' : 'Pay With Points'}
+              {pending
+                ? 'Processing…'
+                : (primaryActionLabel ?? 'Pay With Points')}
             </span>
           </span>
           <ArrowRight className="size-6 shrink-0" strokeWidth={2} aria-hidden />

--- a/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import Image from 'next/image';
+
+type SponsoredActivationDrawerHeroProps = {
+  heroImageUrl: string | null;
+  itemName: string;
+};
+
+/** Figma Generic Drawer hero: image with "You receive" strip overlay. */
+export function SponsoredActivationDrawerHero({
+  heroImageUrl,
+  itemName,
+}: SponsoredActivationDrawerHeroProps) {
+  return (
+    <div className="relative -mx-4 h-[323px] w-[calc(100%+2rem)] overflow-hidden bg-neutral-100">
+      {heroImageUrl ? (
+        <Image
+          src={heroImageUrl}
+          alt=""
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, 420px"
+          priority
+          unoptimized
+        />
+      ) : (
+        <div className="absolute inset-0 bg-neutral-200" aria-hidden />
+      )}
+      <div
+        className="absolute inset-x-4 bottom-0 flex items-center justify-between gap-3 border-t border-[#454545]/20 bg-white px-2 py-2"
+        role="group"
+        aria-label="You receive"
+      >
+        <span className="label-small font-grotesk font-bold uppercase tracking-wide text-[#757575]">
+          You receive
+        </span>
+        <span className="title5 max-w-[60%] truncate text-right font-grotesk font-semibold text-[#171717]">
+          {itemName}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 
 type SponsoredActivationDrawerHeroProps = {
@@ -7,7 +5,6 @@ type SponsoredActivationDrawerHeroProps = {
   itemName: string;
 };
 
-/** Figma Generic Drawer hero: image with "You receive" strip overlay. */
 export function SponsoredActivationDrawerHero({
   heroImageUrl,
   itemName,

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -74,7 +74,6 @@ export function SponsoredActivationFlow({
 }: SponsoredActivationFlowProps) {
   const { user, login, getAccessToken } = usePrivy();
   const walletAddress = user?.wallet?.address ?? null;
-  const accountEmail = user?.email?.address ?? null;
   const queryClient = useQueryClient();
 
   const { data: player, isFetched: playerDetailsFetched } = useCurrentPlayer();
@@ -481,11 +480,9 @@ export function SponsoredActivationFlow({
 
   if (baseScreen === 'confirm') {
     return (
-      <SponsoredActivationPageShell>
+      <SponsoredActivationPageShell flush>
         <SponsoredActivationConfirm
           read={read}
-          accountEmail={accountEmail}
-          currentPoints={player?.total_points ?? 0}
           pending={confirmMutation.isPending}
           onConfirm={() => {
             if (!redemption.id) return;
@@ -503,7 +500,7 @@ export function SponsoredActivationFlow({
       !isSwipeAllowedForStatus(redemption.status);
 
     return (
-      <SponsoredActivationPageShell>
+      <SponsoredActivationPageShell flush>
         <SponsoredActivationSuccess
           heroImageUrl={read.rewardItem.hero_image_url}
           perkName={read.rewardItem.name}

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -81,6 +81,7 @@ export function SponsoredActivationFlow({
   const [redemptionOverride, setRedemptionOverride] =
     useState<ActivationRedemptionRow | null>(null);
   const [swipeSliderKey, setSwipeSliderKey] = useState(0);
+  const [successOverlayDismissed, setSuccessOverlayDismissed] = useState(false);
 
   const activationViewEmittedRef = useRef(false);
   const confirmScreenEmittedRef = useRef(false);
@@ -96,6 +97,7 @@ export function SponsoredActivationFlow({
     activationViewEmittedRef.current = false;
     confirmScreenEmittedRef.current = false;
     swipeGestureReportedRef.current = false;
+    setSuccessOverlayDismissed(false);
   }, [activationKey]);
 
   useEffect(() => {
@@ -306,8 +308,14 @@ export function SponsoredActivationFlow({
     },
   });
 
-  const { mutate: mutateSwipeRedeem, isPending: swipeRedeemPending } =
-    swipeMutation;
+  const {
+    mutate: mutateSwipeRedeem,
+    isPending: swipeRedeemPending,
+    isSuccess: swipeRedeemMutationSuccess,
+  } = swipeMutation;
+
+  const swipeRedeemSucceeded =
+    swipeRedeemMutationSuccess && !swipeRedeemPending;
 
   const handleSwipeComplete = useCallback(() => {
     if (!redemption?.id || swipeRedeemPending) return;
@@ -499,6 +507,19 @@ export function SponsoredActivationFlow({
       isRedeemedLikeStatus(redemption.status) ||
       !isSwipeAllowedForStatus(redemption.status);
 
+    if (successOverlayDismissed) {
+      return (
+        <SponsoredActivationPageShell flush>
+          <SponsoredActivationConfirm
+            read={read}
+            pending={false}
+            onConfirm={() => setSuccessOverlayDismissed(false)}
+            primaryActionLabel="Swipe to redeem"
+          />
+        </SponsoredActivationPageShell>
+      );
+    }
+
     return (
       <SponsoredActivationPageShell flush>
         <SponsoredActivationSuccess
@@ -508,8 +529,10 @@ export function SponsoredActivationFlow({
           balanceAfter={balanceAfterPoints}
           swipeDisabled={swipeDisabled}
           swipeSliderKey={swipeSliderKey}
+          redeemRequestSucceeded={swipeRedeemSucceeded}
           onSwipeGestureStart={handleSwipeGestureStart}
           onSwipeComplete={handleSwipeComplete}
+          onBack={() => setSuccessOverlayDismissed(true)}
         />
       </SponsoredActivationPageShell>
     );

--- a/components/sponsored-activation/sponsored-activation-landing-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-landing-hero.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import Image from 'next/image';
 import { SponsoredActivationPointsValue } from '@/components/sponsored-activation/sponsored-activation-points-value';
 
@@ -10,9 +8,6 @@ type SponsoredActivationLandingHeroProps = {
   perkValueLabel: string;
 };
 
-/**
- * Figma spend activation landing: full-bleed hero with white perk card anchored at bottom.
- */
 export function SponsoredActivationLandingHero({
   heroImageUrl,
   itemName,

--- a/components/sponsored-activation/sponsored-activation-landing-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-landing-hero.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import Image from 'next/image';
+import { SponsoredActivationPointsValue } from '@/components/sponsored-activation/sponsored-activation-points-value';
+
+type SponsoredActivationLandingHeroProps = {
+  heroImageUrl: string | null;
+  itemName: string;
+  pointsCost: number;
+  perkValueLabel: string;
+};
+
+/**
+ * Figma spend activation landing: full-bleed hero with white perk card anchored at bottom.
+ */
+export function SponsoredActivationLandingHero({
+  heroImageUrl,
+  itemName,
+  pointsCost,
+  perkValueLabel,
+}: SponsoredActivationLandingHeroProps) {
+  return (
+    <section className="relative min-h-[470px] w-full overflow-hidden bg-neutral-200">
+      {heroImageUrl ? (
+        <Image
+          src={heroImageUrl}
+          alt=""
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, 420px"
+          priority
+          unoptimized
+        />
+      ) : (
+        <div className="absolute inset-0 bg-neutral-300" aria-hidden />
+      )}
+
+      <div className="absolute inset-x-0 bottom-0 flex justify-center px-4 pb-5 pt-[156px]">
+        <div className="w-full max-w-[361px] rounded-sm bg-white p-4 shadow-[0_4px_16px_rgba(0,0,0,0.12)]">
+          <div className="flex items-start justify-between gap-3">
+            <h2 className="title4 min-w-0 flex-1 text-[#171717]">{itemName}</h2>
+            <SponsoredActivationPointsValue points={pointsCost} />
+          </div>
+          <p className="label-small mt-2 text-right font-grotesk font-semibold uppercase tracking-wide text-[#a9a9a9]">
+            {perkValueLabel}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-page-shell.tsx
+++ b/components/sponsored-activation/sponsored-activation-page-shell.tsx
@@ -11,9 +11,6 @@ type SponsoredActivationPageShellProps = {
   flush?: boolean;
 };
 
-/**
- * Mobile-first shell for `/activation/:id` — light canvas aligned with Figma prod flow.
- */
 export function SponsoredActivationPageShell({
   children,
   className,

--- a/components/sponsored-activation/sponsored-activation-page-shell.tsx
+++ b/components/sponsored-activation/sponsored-activation-page-shell.tsx
@@ -7,6 +7,8 @@ import { cn } from '@/lib/utils';
 type SponsoredActivationPageShellProps = {
   children: ReactNode;
   className?: string;
+  /** Full-bleed activation screens (hero edge-to-edge). */
+  flush?: boolean;
 };
 
 /**
@@ -15,6 +17,7 @@ type SponsoredActivationPageShellProps = {
 export function SponsoredActivationPageShell({
   children,
   className,
+  flush = false,
 }: SponsoredActivationPageShellProps) {
   return (
     <div
@@ -24,7 +27,12 @@ export function SponsoredActivationPageShell({
       )}
     >
       <Header />
-      <main className="relative z-0 mx-auto w-full max-w-[420px] pb-8 pt-20 md:max-w-lg md:pt-24">
+      <main
+        className={cn(
+          'relative z-0 mx-auto w-full max-w-[420px] md:max-w-lg',
+          flush ? 'px-0 pb-0 pt-20 md:pt-24' : 'px-0 pb-8 pt-20 md:pt-24'
+        )}
+      >
         {children}
       </main>
     </div>

--- a/components/sponsored-activation/sponsored-activation-points-value.tsx
+++ b/components/sponsored-activation/sponsored-activation-points-value.tsx
@@ -6,7 +6,6 @@ type SponsoredActivationPointsValueProps = {
   className?: string;
 };
 
-/** Figma Data Line: bold number + muted suffix (PTS or $IRL). */
 export function SponsoredActivationPointsValue({
   points,
   suffix = 'PTS',

--- a/components/sponsored-activation/sponsored-activation-points-value.tsx
+++ b/components/sponsored-activation/sponsored-activation-points-value.tsx
@@ -1,0 +1,30 @@
+import { cn } from '@/lib/utils';
+
+type SponsoredActivationPointsValueProps = {
+  points: number;
+  suffix?: 'PTS' | '$IRL';
+  className?: string;
+};
+
+/** Figma Data Line: bold number + muted suffix (PTS or $IRL). */
+export function SponsoredActivationPointsValue({
+  points,
+  suffix = 'PTS',
+  className,
+}: SponsoredActivationPointsValueProps) {
+  return (
+    <span
+      className={cn(
+        'inline-flex items-baseline justify-end gap-1 font-grotesk',
+        className
+      )}
+    >
+      <span className="title5 font-semibold text-[#171717]">
+        {points.toLocaleString()}
+      </span>
+      <span className="title5 font-semibold uppercase text-[#757575]">
+        {suffix}
+      </span>
+    </span>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -3,6 +3,7 @@
 import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
 import { SponsoredActivationCollectInstructions } from '@/components/sponsored-activation/sponsored-activation-collect-instructions';
 import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
+import { SponsoredActivationPointsValue } from '@/components/sponsored-activation/sponsored-activation-points-value';
 import { SponsoredActivationCtaButton } from '@/components/sponsored-activation/sponsored-activation-cta-button';
 
 type SponsoredActivationRedeemedProps = {
@@ -30,12 +31,24 @@ export function SponsoredActivationRedeemed({
 
         <div>
           <SponsoredActivationDetailRow
-            label="You spent"
-            value={`${pointsSpent.toLocaleString()} PTS`}
+            label="You Spent"
+            value={
+              <SponsoredActivationPointsValue
+                points={pointsSpent}
+                suffix="PTS"
+              />
+            }
+            bareValue
           />
           <SponsoredActivationDetailRow
-            label="Your points balance"
-            value={`${balanceAfter.toLocaleString()} $IRL`}
+            label="Your Points Balance"
+            value={
+              <SponsoredActivationPointsValue
+                points={balanceAfter}
+                suffix="$IRL"
+              />
+            }
+            bareValue
           />
         </div>
 

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
 import { ArrowLeft } from 'lucide-react';
 import { SponsoredActivationDrawerHero } from '@/components/sponsored-activation/sponsored-activation-drawer-hero';
 import { SponsoredActivationCollectInstructions } from '@/components/sponsored-activation/sponsored-activation-collect-instructions';
@@ -15,8 +14,10 @@ type SponsoredActivationSuccessProps = {
   balanceAfter: number;
   swipeDisabled: boolean;
   swipeSliderKey: number;
+  redeemRequestSucceeded: boolean;
   onSwipeGestureStart?: () => void;
   onSwipeComplete: () => void;
+  onBack: () => void;
 };
 
 export function SponsoredActivationSuccess({
@@ -26,11 +27,11 @@ export function SponsoredActivationSuccess({
   balanceAfter,
   swipeDisabled,
   swipeSliderKey,
+  redeemRequestSucceeded,
   onSwipeGestureStart,
   onSwipeComplete,
+  onBack,
 }: SponsoredActivationSuccessProps) {
-  const router = useRouter();
-
   return (
     <div className="fixed inset-0 top-20 z-30 flex justify-center">
       <div
@@ -50,7 +51,7 @@ export function SponsoredActivationSuccess({
 
         <button
           type="button"
-          onClick={() => router.back()}
+          onClick={onBack}
           className="absolute left-3 top-3 z-20 flex size-10 items-center justify-center rounded-full border border-[#dbdbdb] bg-white shadow-sm transition-opacity hover:opacity-90"
           aria-label="Go back"
         >
@@ -100,6 +101,7 @@ export function SponsoredActivationSuccess({
           <SponsoredActivationSwipeSlider
             key={swipeSliderKey}
             disabled={swipeDisabled}
+            redeemRequestSucceeded={redeemRequestSucceeded}
             onSwipeGestureStart={onSwipeGestureStart}
             onComplete={onSwipeComplete}
           />

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -1,8 +1,11 @@
 'use client';
 
-import { SponsoredActivationHero } from '@/components/sponsored-activation/sponsored-activation-hero';
+import { useRouter } from 'next/navigation';
+import { ArrowLeft } from 'lucide-react';
+import { SponsoredActivationDrawerHero } from '@/components/sponsored-activation/sponsored-activation-drawer-hero';
 import { SponsoredActivationCollectInstructions } from '@/components/sponsored-activation/sponsored-activation-collect-instructions';
 import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
+import { SponsoredActivationPointsValue } from '@/components/sponsored-activation/sponsored-activation-points-value';
 import { SponsoredActivationSwipeSlider } from '@/components/sponsored-activation/sponsored-activation-swipe-slider';
 
 type SponsoredActivationSuccessProps = {
@@ -16,6 +19,9 @@ type SponsoredActivationSuccessProps = {
   onSwipeComplete: () => void;
 };
 
+/**
+ * Figma Generic Drawer — post-purchase success with swipe-to-redeem (no current tier row).
+ */
 export function SponsoredActivationSuccess({
   heroImageUrl,
   perkName,
@@ -26,35 +32,81 @@ export function SponsoredActivationSuccess({
   onSwipeGestureStart,
   onSwipeComplete,
 }: SponsoredActivationSuccessProps) {
+  const router = useRouter();
+
   return (
-    <div className="flex min-h-[calc(100vh-5rem)] flex-col bg-white">
-      <SponsoredActivationHero
-        heroImageUrl={heroImageUrl}
-        itemName={perkName}
+    <div className="fixed inset-0 top-20 z-30 flex justify-center">
+      <div
+        className="absolute inset-0 bg-[#171717]/70 backdrop-blur-[16px]"
+        aria-hidden
       />
 
-      <div className="flex flex-1 flex-col gap-6 px-4 pb-8 pt-6">
-        <h1 className="title2 text-[#171717]">Success</h1>
+      <div
+        className="relative z-10 flex h-full w-full max-w-[420px] flex-col overflow-y-auto rounded-t-2xl bg-white shadow-[0_4px_16px_rgba(0,0,0,0.25)] md:max-w-lg"
+        role="dialog"
+        aria-labelledby="sponsored-activation-success-title"
+      >
+        <div
+          className="mx-auto mt-2 h-[3px] w-8 shrink-0 rounded-full bg-[#a9a9a9]"
+          aria-hidden
+        />
 
-        <div>
-          <SponsoredActivationDetailRow
-            label="You spent"
-            value={`${pointsSpent.toLocaleString()} PTS`}
-          />
-          <SponsoredActivationDetailRow
-            label="Your points balance"
-            value={`${balanceAfter.toLocaleString()} $IRL`}
+        <button
+          type="button"
+          onClick={() => router.back()}
+          className="absolute left-3 top-3 z-20 flex size-10 items-center justify-center rounded-full border border-[#dbdbdb] bg-white shadow-sm transition-opacity hover:opacity-90"
+          aria-label="Go back"
+        >
+          <ArrowLeft className="size-5 text-[#171717]" strokeWidth={2} />
+        </button>
+
+        <SponsoredActivationDrawerHero
+          heroImageUrl={heroImageUrl}
+          itemName={perkName}
+        />
+
+        <div className="flex flex-col gap-4 px-4 pb-8 pt-6">
+          <h1
+            id="sponsored-activation-success-title"
+            className="title2 text-[#171717]"
+          >
+            Success!
+          </h1>
+
+          <div className="w-full">
+            <SponsoredActivationDetailRow
+              label="You Spent"
+              value={
+                <SponsoredActivationPointsValue
+                  points={pointsSpent}
+                  suffix="PTS"
+                />
+              }
+              bareValue
+            />
+            <SponsoredActivationDetailRow
+              label="Your Points Balance"
+              value={
+                <SponsoredActivationPointsValue
+                  points={balanceAfter}
+                  suffix="$IRL"
+                />
+              }
+              bareValue
+            />
+          </div>
+
+          <div className="border-t border-[#dbdbdb] pt-4">
+            <SponsoredActivationCollectInstructions />
+          </div>
+
+          <SponsoredActivationSwipeSlider
+            key={swipeSliderKey}
+            disabled={swipeDisabled}
+            onSwipeGestureStart={onSwipeGestureStart}
+            onComplete={onSwipeComplete}
           />
         </div>
-
-        <SponsoredActivationCollectInstructions />
-
-        <SponsoredActivationSwipeSlider
-          key={swipeSliderKey}
-          disabled={swipeDisabled}
-          onSwipeGestureStart={onSwipeGestureStart}
-          onComplete={onSwipeComplete}
-        />
       </div>
     </div>
   );

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -19,9 +19,6 @@ type SponsoredActivationSuccessProps = {
   onSwipeComplete: () => void;
 };
 
-/**
- * Figma Generic Drawer — post-purchase success with swipe-to-redeem (no current tier row).
- */
 export function SponsoredActivationSuccess({
   heroImageUrl,
   perkName,

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -24,7 +24,7 @@ export function SponsoredActivationSwipeSlider({
   disabled,
   onComplete,
   onSwipeGestureStart,
-  label = 'Swipe to redeem',
+  label = 'Swipe to Redeem',
 }: SponsoredActivationSwipeSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
   const knobRef = useRef<HTMLDivElement>(null);
@@ -128,7 +128,7 @@ export function SponsoredActivationSwipeSlider({
     }
   };
 
-  const displayLabel = completed ? 'Redeeming…' : label;
+  const displayLabel = completed ? 'Redeemed' : label;
 
   return (
     <div className="w-full">
@@ -147,12 +147,18 @@ export function SponsoredActivationSwipeSlider({
         tabIndex={disabled || completed ? -1 : 0}
         onKeyDown={onKeyDown}
         className={cn(
-          'relative flex h-14 w-full select-none items-center rounded-md border border-[#171717] bg-white px-1',
-          disabled || completed ? 'opacity-60' : 'cursor-pointer'
+          'relative flex h-[52px] w-full select-none items-center rounded-md border-2 border-[#171717] bg-white px-0',
+          disabled ? 'opacity-60' : 'cursor-pointer',
+          completed && 'border-[#14a64a]'
         )}
       >
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <span className="label-small font-grotesk uppercase tracking-wide text-[#171717]">
+          <span
+            className={cn(
+              'label-large font-grotesk uppercase tracking-[0.0625em]',
+              completed ? 'text-[#a9a9a9]' : 'text-[#a9a9a9]'
+            )}
+          >
             {displayLabel}
           </span>
         </div>
@@ -164,11 +170,14 @@ export function SponsoredActivationSwipeSlider({
           onPointerCancel={onPointerUp}
           style={{ transform: `translateX(${dragPx}px)` }}
           className={cn(
-            'relative z-10 flex h-12 w-12 shrink-0 items-center justify-center rounded-sm bg-[#171717] text-white',
+            'relative z-10 flex h-[52px] min-w-[52px] shrink-0 items-center justify-center rounded-sm px-4 text-white',
+            completed ? 'bg-[#14a64a]' : 'bg-[#171717]',
             disabled || completed ? 'pointer-events-none' : 'touch-none'
           )}
         >
-          <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden />
+          {!completed ? (
+            <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden />
+          ) : null}
         </div>
       </div>
       <p className="sr-only">

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -18,6 +18,8 @@ type SponsoredActivationSwipeSliderProps = {
   /** Fires when the user begins a swipe (pointer down on knob). */
   onSwipeGestureStart?: () => void;
   label?: string;
+  /** True after swipe-redeem has completed successfully. */
+  redeemRequestSucceeded?: boolean;
 };
 
 export function SponsoredActivationSwipeSlider({
@@ -25,12 +27,13 @@ export function SponsoredActivationSwipeSlider({
   onComplete,
   onSwipeGestureStart,
   label = 'Swipe to Redeem',
+  redeemRequestSucceeded = false,
 }: SponsoredActivationSwipeSliderProps) {
   const trackRef = useRef<HTMLDivElement>(null);
   const knobRef = useRef<HTMLDivElement>(null);
   const [dragPx, setDragPx] = useState(0);
   const dragPxRef = useRef(0);
-  const [completed, setCompleted] = useState(false);
+  const [swipeCommitted, setSwipeCommitted] = useState(false);
   const completionSentRef = useRef(false);
   const activePointerId = useRef<number | null>(null);
   /** Cached max travel for a11y ratio; avoids reading layout in render. */
@@ -51,7 +54,7 @@ export function SponsoredActivationSwipeSlider({
       if (max <= 0) return;
       if (px >= max * COMPLETE_RATIO) {
         completionSentRef.current = true;
-        setCompleted(true);
+        setSwipeCommitted(true);
         setDragPx(max);
         dragPxRef.current = max;
         onComplete();
@@ -61,11 +64,11 @@ export function SponsoredActivationSwipeSlider({
   );
 
   useEffect(() => {
-    if (disabled || completed) return;
+    if (disabled || swipeCommitted) return;
     completionSentRef.current = false;
     setDragPx(0);
     dragPxRef.current = 0;
-  }, [disabled, completed]);
+  }, [disabled, swipeCommitted]);
 
   const syncMaxTravelForAria = useCallback(() => {
     maxTravelForAriaRef.current = Math.max(1, maxTravel());
@@ -75,17 +78,17 @@ export function SponsoredActivationSwipeSlider({
     syncMaxTravelForAria();
     window.addEventListener('resize', syncMaxTravelForAria);
     return () => window.removeEventListener('resize', syncMaxTravelForAria);
-  }, [syncMaxTravelForAria, disabled, completed]);
+  }, [syncMaxTravelForAria, disabled, swipeCommitted]);
 
   const onPointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
-    if (disabled || completed) return;
+    if (disabled || swipeCommitted) return;
     onSwipeGestureStart?.();
     activePointerId.current = e.pointerId;
     e.currentTarget.setPointerCapture(e.pointerId);
   };
 
   const onPointerMove = (e: React.PointerEvent) => {
-    if (disabled || completed) return;
+    if (disabled || swipeCommitted) return;
     if (activePointerId.current !== e.pointerId) return;
     const track = trackRef.current;
     const knob = knobRef.current;
@@ -104,7 +107,7 @@ export function SponsoredActivationSwipeSlider({
   const onPointerUp = (e: React.PointerEvent) => {
     if (activePointerId.current !== e.pointerId) return;
     activePointerId.current = null;
-    if (disabled || completed) return;
+    if (disabled || swipeCommitted) return;
     const max = maxTravel();
     const px = dragPxRef.current;
     if (max > 0 && px < max * COMPLETE_RATIO) {
@@ -114,7 +117,7 @@ export function SponsoredActivationSwipeSlider({
   };
 
   const onKeyDown = (e: React.KeyboardEvent) => {
-    if (disabled || completed || completionSentRef.current) return;
+    if (disabled || swipeCommitted || completionSentRef.current) return;
     if (e.key === 'Enter' || e.key === ' ') {
       e.preventDefault();
       onSwipeGestureStart?.();
@@ -123,12 +126,16 @@ export function SponsoredActivationSwipeSlider({
       maxTravelForAriaRef.current = Math.max(1, max);
       dragPxRef.current = max;
       setDragPx(max);
-      setCompleted(true);
+      setSwipeCommitted(true);
       onComplete();
     }
   };
 
-  const displayLabel = completed ? 'Redeemed' : label;
+  const displayLabel = redeemRequestSucceeded
+    ? 'Redeemed'
+    : swipeCommitted
+      ? 'Redeeming…'
+      : label;
 
   return (
     <div className="w-full">
@@ -138,18 +145,18 @@ export function SponsoredActivationSwipeSlider({
         aria-valuemin={0}
         aria-valuemax={100}
         aria-valuenow={
-          completed
+          swipeCommitted
             ? 100
             : Math.round((dragPx / maxTravelForAriaRef.current) * 100)
         }
-        aria-disabled={disabled || completed}
-        aria-label={label}
-        tabIndex={disabled || completed ? -1 : 0}
+        aria-disabled={disabled || swipeCommitted}
+        aria-label={displayLabel}
+        tabIndex={disabled || swipeCommitted ? -1 : 0}
         onKeyDown={onKeyDown}
         className={cn(
           'relative flex h-[52px] w-full select-none items-center rounded-md border-2 border-[#171717] bg-white px-0',
           disabled ? 'opacity-60' : 'cursor-pointer',
-          completed && 'border-[#14a64a]'
+          redeemRequestSucceeded && 'border-[#14a64a]'
         )}
       >
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
@@ -166,11 +173,11 @@ export function SponsoredActivationSwipeSlider({
           style={{ transform: `translateX(${dragPx}px)` }}
           className={cn(
             'relative z-10 flex h-[52px] min-w-[52px] shrink-0 items-center justify-center rounded-sm px-4 text-white',
-            completed ? 'bg-[#14a64a]' : 'bg-[#171717]',
-            disabled || completed ? 'pointer-events-none' : 'touch-none'
+            redeemRequestSucceeded ? 'bg-[#14a64a]' : 'bg-[#171717]',
+            disabled || swipeCommitted ? 'pointer-events-none' : 'touch-none'
           )}
         >
-          {!completed && (
+          {!swipeCommitted && (
             <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden />
           )}
         </div>

--- a/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
+++ b/components/sponsored-activation/sponsored-activation-swipe-slider.tsx
@@ -153,12 +153,7 @@ export function SponsoredActivationSwipeSlider({
         )}
       >
         <div className="pointer-events-none absolute inset-0 flex items-center justify-center">
-          <span
-            className={cn(
-              'label-large font-grotesk uppercase tracking-[0.0625em]',
-              completed ? 'text-[#a9a9a9]' : 'text-[#a9a9a9]'
-            )}
-          >
+          <span className="label-large font-grotesk uppercase tracking-[0.0625em] text-[#a9a9a9]">
             {displayLabel}
           </span>
         </div>
@@ -175,9 +170,9 @@ export function SponsoredActivationSwipeSlider({
             disabled || completed ? 'pointer-events-none' : 'touch-none'
           )}
         >
-          {!completed ? (
+          {!completed && (
             <ArrowRight className="size-5" strokeWidth={2.5} aria-hidden />
-          ) : null}
+          )}
         </div>
       </div>
       <p className="sr-only">

--- a/lib/sponsored-activation/__tests__/format-perk-value.test.ts
+++ b/lib/sponsored-activation/__tests__/format-perk-value.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatPerkValueUsdLabel,
+  perkValueUsdFromUsdcAmount,
+} from '@/lib/sponsored-activation/format-perk-value';
+
+describe('formatPerkValueUsdLabel', () => {
+  it('formats whole dollars', () => {
+    expect(formatPerkValueUsdLabel(9)).toBe('$9 USD value');
+  });
+
+  it('formats fractional dollars without trailing zeros', () => {
+    expect(formatPerkValueUsdLabel(9.5)).toBe('$9.5 USD value');
+  });
+});
+
+describe('perkValueUsdFromUsdcAmount', () => {
+  it('rounds to two decimal places', () => {
+    expect(perkValueUsdFromUsdcAmount(7.125)).toBe(7.13);
+  });
+});

--- a/lib/sponsored-activation/format-perk-value.ts
+++ b/lib/sponsored-activation/format-perk-value.ts
@@ -1,0 +1,18 @@
+/**
+ * User-facing retail value label for sponsored activation reward items (Figma: "$9 USD value").
+ * Derived from backend `usdc_amount`; not shown as crypto or settlement copy.
+ */
+export function formatPerkValueUsdLabel(usdcAmount: number): string {
+  const dollars = Number.isFinite(usdcAmount) ? usdcAmount : 0;
+  const rounded =
+    dollars % 1 === 0
+      ? dollars.toFixed(0)
+      : dollars.toFixed(2).replace(/\.?0+$/, '');
+  return `$${rounded} USD value`;
+}
+
+/** Whole-dollar display amount for public read (no chain/settlement semantics). */
+export function perkValueUsdFromUsdcAmount(usdcAmount: number): number {
+  if (!Number.isFinite(usdcAmount) || usdcAmount <= 0) return 0;
+  return Math.round(usdcAmount * 100) / 100;
+}

--- a/lib/sponsored-activation/format-perk-value.ts
+++ b/lib/sponsored-activation/format-perk-value.ts
@@ -1,15 +1,15 @@
+/** Numeric USD for public read; non-finite or non-positive values become 0 (two decimal places max). */
+export function perkValueUsdFromUsdcAmount(usdcAmount: number): number {
+  if (!Number.isFinite(usdcAmount) || usdcAmount <= 0) return 0;
+  return Math.round(usdcAmount * 100) / 100;
+}
+
 /** Retail-style label from reward `usdc_amount` (not settlement/onchain copy). */
 export function formatPerkValueUsdLabel(usdcAmount: number): string {
-  const dollars = Number.isFinite(usdcAmount) ? usdcAmount : 0;
+  const dollars = perkValueUsdFromUsdcAmount(usdcAmount);
   const rounded =
     dollars % 1 === 0
       ? dollars.toFixed(0)
       : dollars.toFixed(2).replace(/\.?0+$/, '');
   return `$${rounded} USD value`;
-}
-
-/** Numeric USD for public read; non-finite or non-positive values become 0 (two decimal places max). */
-export function perkValueUsdFromUsdcAmount(usdcAmount: number): number {
-  if (!Number.isFinite(usdcAmount) || usdcAmount <= 0) return 0;
-  return Math.round(usdcAmount * 100) / 100;
 }

--- a/lib/sponsored-activation/format-perk-value.ts
+++ b/lib/sponsored-activation/format-perk-value.ts
@@ -1,7 +1,4 @@
-/**
- * User-facing retail value label for sponsored activation reward items (Figma: "$9 USD value").
- * Derived from backend `usdc_amount`; not shown as crypto or settlement copy.
- */
+/** Retail-style label from reward `usdc_amount` (not settlement/onchain copy). */
 export function formatPerkValueUsdLabel(usdcAmount: number): string {
   const dollars = Number.isFinite(usdcAmount) ? usdcAmount : 0;
   const rounded =
@@ -11,7 +8,7 @@ export function formatPerkValueUsdLabel(usdcAmount: number): string {
   return `$${rounded} USD value`;
 }
 
-/** Whole-dollar display amount for public read (no chain/settlement semantics). */
+/** Numeric USD for public read; non-finite or non-positive values become 0 (two decimal places max). */
 export function perkValueUsdFromUsdcAmount(usdcAmount: number): number {
   if (!Number.isFinite(usdcAmount) || usdcAmount <= 0) return 0;
   return Math.round(usdcAmount * 100) / 100;

--- a/lib/sponsored-activation/public-read.ts
+++ b/lib/sponsored-activation/public-read.ts
@@ -20,5 +20,8 @@ export type SponsoredActivationPublicReadResponse = {
     hero_image_url: string | null;
     description: string | null;
     points_cost: number;
+    /** Retail-style USD value for UI (from reward `usdc_amount`, not onchain copy). */
+    perk_value_usd: number;
+    perk_value_label: string;
   };
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the Figma spend activation experience for sponsored activations (`/activation/:id`):

- **Landing / confirm:** Full-bleed hero with white perk card (name, points, USD value label), activation title + description, and **Pay With Points** CTA.
- **Success:** Bottom drawer overlay with blurred backdrop, hero strip (“You receive”), **Success!** headline, **You Spent** / **Your Points Balance** rows (no current tier), **How to Collect**, and updated **Swipe to Redeem** control.
- **API:** Public read now includes `perk_value_usd` and `perk_value_label` (retail-style copy derived from reward `usdc_amount`; raw settlement fields stay server-only).

## Test plan

- [x] `yarn test` for format-perk-value, read-route, swipe-slider
- [ ] Manual: open an activation with `available` redemption → confirm layout + Pay With Points
- [ ] Manual: after confirm → success drawer, swipe to redeem
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-39c45ca1-0539-4c37-9b1f-82f49ec5c155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-39c45ca1-0539-4c37-9b1f-82f49ec5c155"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

