### PR TITLE
fix: success screen You receive overlay and detail separator

### DIFF
--- a/components/sponsored-activation/sponsored-activation-detail-row.tsx
+++ b/components/sponsored-activation/sponsored-activation-detail-row.tsx
@@ -22,7 +22,7 @@ export function SponsoredActivationDetailRow({
   return (
     <div
       className={cn(
-        'flex items-start justify-between gap-4 border-b border-[#171717]/10 py-3 last:border-b-0',
+        'flex items-start justify-between gap-4 border-b border-[#171717]/10 py-3',
         className
       )}
     >

--- a/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
@@ -10,7 +10,7 @@ export function SponsoredActivationDrawerHero({
   itemName,
 }: SponsoredActivationDrawerHeroProps) {
   return (
-    <div className="relative -mx-4 h-[323px] w-[calc(100%+2rem)] overflow-hidden bg-neutral-100">
+    <div className="relative -mx-4 h-[320px] w-[calc(100%+2rem)] overflow-hidden bg-neutral-100">
       {heroImageUrl ? (
         <Image
           src={heroImageUrl}
@@ -25,14 +25,14 @@ export function SponsoredActivationDrawerHero({
         <div className="absolute inset-0 bg-neutral-200" aria-hidden />
       )}
       <div
-        className="absolute inset-x-4 bottom-0 flex items-center justify-between gap-3 border-t border-[#454545]/20 bg-white px-2 py-2"
+        className="absolute bottom-0 left-0 right-0 z-10 flex items-center justify-between gap-3 bg-white px-4 py-4"
         role="group"
         aria-label="You receive"
       >
-        <span className="label-small font-grotesk font-bold uppercase tracking-wide text-[#757575]">
+        <span className="label-small font-grotesk tracking-wide text-[#757575]">
           You receive
         </span>
-        <span className="title5 max-w-[60%] truncate text-right font-grotesk font-semibold text-[#171717]">
+        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold tracking-wide text-[#171717]">
           {itemName}
         </span>
       </div>

--- a/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
@@ -29,10 +29,10 @@ export function SponsoredActivationDrawerHero({
         role="group"
         aria-label="You receive"
       >
-        <span className="label-small font-grotesk tracking-wide text-[#757575]">
+        <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
           You receive
         </span>
-        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold tracking-wide text-[#171717]">
+        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
           {itemName}
         </span>
       </div>

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -27,7 +27,7 @@ export function SponsoredActivationRedeemed({
       />
 
       <div className="flex flex-1 flex-col gap-6 px-4 pb-28 pt-6">
-        <h1 className="title2 text-[#171717]">Success</h1>
+        <h1 className="title2 text-[#171717]">Success!</h1>
 
         <div>
           <SponsoredActivationDetailRow
@@ -39,6 +39,7 @@ export function SponsoredActivationRedeemed({
               />
             }
             bareValue
+            className="border-b-0"
           />
           <SponsoredActivationDetailRow
             label="Your Points Balance"
@@ -49,6 +50,7 @@ export function SponsoredActivationRedeemed({
               />
             }
             bareValue
+            className="!border-b"
           />
         </div>
 

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -50,7 +50,6 @@ export function SponsoredActivationRedeemed({
               />
             }
             bareValue
-            className="!border-b"
           />
         </div>
 

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -92,7 +92,6 @@ export function SponsoredActivationSuccess({
                 />
               }
               bareValue
-              className="!border-b"
             />
           </div>
 

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -81,6 +81,7 @@ export function SponsoredActivationSuccess({
                 />
               }
               bareValue
+              className="border-b-0"
             />
             <SponsoredActivationDetailRow
               label="Your Points Balance"
@@ -91,10 +92,11 @@ export function SponsoredActivationSuccess({
                 />
               }
               bareValue
+              className="!border-b"
             />
           </div>
 
-          <div className="border-t border-[#dbdbdb] pt-4">
+          <div className="pt-4">
             <SponsoredActivationCollectInstructions />
           </div>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the sponsored activation success screen with the production design for the hero overlay and transaction detail layout.

## Changes

- **You receive hero** (`sponsored-activation-drawer-hero.tsx`): Full-width white overlay bar at the bottom of the hero image (edge-to-edge, `px-4 py-4`), matching the main activation hero. Removed inset margins and top border on the overlay.
- **Success heading**: `SponsoredActivationRedeemed` now uses `Success!` (success overlay already did).
- **Detail separator**: Divider sits below **Your Points Balance** instead of **You Spent** by removing the first row border and keeping the border on the balance row. Removed duplicate `border-t` above “How to collect”.

## Notes

Figma node `240-4050` was not reachable via the API; overlay styling was matched to the existing `SponsoredActivationHero` component, which implements the same pattern.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dffa876-be82-461d-8a05-bd4a158a0bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dffa876-be82-461d-8a05-bd4a158a0bea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

