### PR TITLE
refactor(sponsored-activation): dedupe hero overlays and tighten shel…

### DIFF
--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -24,7 +24,7 @@ export function SponsoredActivationConfirm({
   const { activation, rewardItem } = read;
   const description = rewardItem.description?.trim() || activation.sponsor_name;
 
-  const perkValueLabel = rewardItem.perk_value_label?.trim();
+  const perkValueLabel = rewardItem.perk_value_label.trim();
 
   return (
     <div className="flex min-h-screen flex-col bg-white">
@@ -50,18 +50,16 @@ export function SponsoredActivationConfirm({
           ) : null}
         </div>
 
-        <div className="w-full">
-          <SponsoredActivationDetailRow
-            label="You send"
-            value={
-              <SponsoredActivationPointsValue
-                points={rewardItem.points_cost}
-                suffix="PTS"
-              />
-            }
-            bareValue
-          />
-        </div>
+        <SponsoredActivationDetailRow
+          label="You send"
+          value={
+            <SponsoredActivationPointsValue
+              points={rewardItem.points_cost}
+              suffix="PTS"
+            />
+          }
+          bareValue
+        />
 
         <button
           type="button"

--- a/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
@@ -1,4 +1,5 @@
 import Image from 'next/image';
+import { SponsoredActivationHeroReceiveBar } from '@/components/sponsored-activation/sponsored-activation-hero-receive-bar';
 
 type SponsoredActivationDrawerHeroProps = {
   heroImageUrl: string | null;
@@ -24,18 +25,7 @@ export function SponsoredActivationDrawerHero({
       ) : (
         <div className="absolute inset-0 bg-neutral-200" aria-hidden />
       )}
-      <div
-        className="absolute bottom-0 left-0 right-0 z-10 flex items-center justify-between gap-3 bg-white px-4 py-4"
-        role="group"
-        aria-label="You receive"
-      >
-        <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
-          You receive
-        </span>
-        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
-          {itemName}
-        </span>
-      </div>
+      <SponsoredActivationHeroReceiveBar itemName={itemName} />
     </div>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-exit-back-link.tsx
+++ b/components/sponsored-activation/sponsored-activation-exit-back-link.tsx
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { SPONSORED_ACTIVATION_EXIT_URL } from '@/lib/sponsored-activation/exit-url';
+
+export function SponsoredActivationExitBackLink() {
+  return (
+    <Link
+      href={SPONSORED_ACTIVATION_EXIT_URL}
+      className="absolute left-4 top-[max(1rem,env(safe-area-inset-top))] z-10 flex size-10 items-center justify-center rounded-full bg-white shadow-sm transition-opacity hover:opacity-90"
+      aria-label="Back to IRL"
+    >
+      <ArrowLeft className="size-5 text-[#171717]" strokeWidth={2} />
+    </Link>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-hero-receive-bar.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero-receive-bar.tsx
@@ -1,0 +1,23 @@
+type SponsoredActivationHeroReceiveBarProps = {
+  itemName: string;
+};
+
+/** Bottom "You receive" strip shared by page and drawer activation heroes. */
+export function SponsoredActivationHeroReceiveBar({
+  itemName,
+}: SponsoredActivationHeroReceiveBarProps) {
+  return (
+    <div
+      className="absolute inset-x-0 bottom-0 z-10 flex items-center justify-between gap-3 bg-white px-4 py-4"
+      role="group"
+      aria-label="You receive"
+    >
+      <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
+        You receive
+      </span>
+      <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
+        {itemName}
+      </span>
+    </div>
+  );
+}

--- a/components/sponsored-activation/sponsored-activation-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
-import { SPONSORED_ACTIVATION_EXIT_URL } from '@/lib/sponsored-activation/exit-url';
+import { SponsoredActivationExitBackLink } from '@/components/sponsored-activation/sponsored-activation-exit-back-link';
+import { SponsoredActivationHeroReceiveBar } from '@/components/sponsored-activation/sponsored-activation-hero-receive-bar';
 
 type SponsoredActivationHeroProps = {
   heroImageUrl: string | null;
@@ -15,43 +14,24 @@ export function SponsoredActivationHero({
   itemName,
 }: SponsoredActivationHeroProps) {
   return (
-    <div className="relative w-full">
-      <div className="relative min-h-[470px] w-full overflow-hidden bg-neutral-100">
-        {heroImageUrl ? (
-          <Image
-            src={heroImageUrl}
-            alt={itemName}
-            fill
-            className="object-cover"
-            sizes="(max-width: 768px) 100vw, 420px"
-            priority
-            unoptimized
-          />
-        ) : (
-          <div className="flex h-full min-h-[470px] items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
-            {itemName}
-          </div>
-        )}
-        <Link
-          href={SPONSORED_ACTIVATION_EXIT_URL}
-          className="absolute left-4 top-[max(1rem,env(safe-area-inset-top))] z-10 flex size-10 items-center justify-center rounded-full bg-white shadow-sm transition-opacity hover:opacity-90"
-          aria-label="Back to IRL"
-        >
-          <ArrowLeft className="size-5 text-[#171717]" strokeWidth={2} />
-        </Link>
-        <div
-          className="absolute inset-x-0 bottom-0 z-10 flex items-center justify-between gap-3 bg-white px-4 py-4"
-          role="group"
-          aria-label="You receive"
-        >
-          <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
-            You receive
-          </span>
-          <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
-            {itemName}
-          </span>
+    <div className="relative min-h-[470px] w-full overflow-hidden bg-neutral-100">
+      {heroImageUrl ? (
+        <Image
+          src={heroImageUrl}
+          alt={itemName}
+          fill
+          className="object-cover"
+          sizes="(max-width: 768px) 100vw, 420px"
+          priority
+          unoptimized
+        />
+      ) : (
+        <div className="flex h-full min-h-[470px] items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
+          {itemName}
         </div>
-      </div>
+      )}
+      <SponsoredActivationExitBackLink />
+      <SponsoredActivationHeroReceiveBar itemName={itemName} />
     </div>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-landing-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-landing-hero.tsx
@@ -1,7 +1,6 @@
 import Image from 'next/image';
-import Link from 'next/link';
-import { ArrowLeft } from 'lucide-react';
-import { SPONSORED_ACTIVATION_EXIT_URL } from '@/lib/sponsored-activation/exit-url';
+import { SponsoredActivationExitBackLink } from '@/components/sponsored-activation/sponsored-activation-exit-back-link';
+import { SponsoredActivationHeroReceiveBar } from '@/components/sponsored-activation/sponsored-activation-hero-receive-bar';
 
 type SponsoredActivationLandingHeroProps = {
   heroImageUrl: string | null;
@@ -28,26 +27,8 @@ export function SponsoredActivationLandingHero({
         <div className="absolute inset-0 bg-neutral-300" aria-hidden />
       )}
 
-      <Link
-        href={SPONSORED_ACTIVATION_EXIT_URL}
-        className="absolute left-4 top-[max(1rem,env(safe-area-inset-top))] z-10 flex size-10 items-center justify-center rounded-full bg-white shadow-sm transition-opacity hover:opacity-90"
-        aria-label="Back to IRL"
-      >
-        <ArrowLeft className="size-5 text-[#171717]" strokeWidth={2} />
-      </Link>
-
-      <div
-        className="absolute inset-x-0 bottom-0 z-10 flex items-center justify-between gap-3 bg-white px-4 py-4"
-        role="group"
-        aria-label="You receive"
-      >
-        <span className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
-          You receive
-        </span>
-        <span className="label-small max-w-[55%] truncate text-right font-grotesk font-semibold uppercase tracking-wide text-[#171717]">
-          {itemName}
-        </span>
-      </div>
+      <SponsoredActivationExitBackLink />
+      <SponsoredActivationHeroReceiveBar itemName={itemName} />
     </section>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-page-shell.tsx
+++ b/components/sponsored-activation/sponsored-activation-page-shell.tsx
@@ -6,7 +6,6 @@ import { cn } from '@/lib/utils';
 type SponsoredActivationPageShellProps = {
   children: ReactNode;
   className?: string;
-  /** Full-bleed activation screens (hero edge-to-edge, no top inset). */
   flush?: boolean;
 };
 
@@ -24,8 +23,8 @@ export function SponsoredActivationPageShell({
     >
       <main
         className={cn(
-          'relative z-0 mx-auto w-full max-w-[420px] md:max-w-lg',
-          flush ? 'px-0 pb-0 pt-0' : 'px-0 pb-8 pt-4'
+          'relative z-0 mx-auto w-full max-w-[420px] px-0 md:max-w-lg',
+          flush ? 'pb-0 pt-0' : 'pb-8 pt-4'
         )}
       >
         {children}


### PR DESCRIPTION
…l markup

Extract shared exit back link and You receive bar for page and drawer heroes. Hoist shared padding in the page shell, drop a redundant wrapper in confirm, and align perk_value_label with the public-read type.