### PR TITLE
fix: improve activation page layout to match Figma design

### DIFF
--- a/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
+++ b/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
@@ -1,23 +1,15 @@
-import { cn } from '@/lib/utils';
-
 const COLLECT_INSTRUCTIONS =
   "Swipe below and show this screen to the event staff. Swipe only when you're ready to purchase — once you've redeemed you can't redeem again!";
 
-const collectSectionClass =
-  'text-[13px] font-grotesk leading-[1.25rem] text-[#171717]';
-
 export function SponsoredActivationCollectInstructions() {
   return (
-    <section>
-      <h2
-        className={cn(
-          collectSectionClass,
-          'font-semibold uppercase tracking-wide text-[#757575]'
-        )}
-      >
+    <section className="border-t border-[#171717]/10 pt-4">
+      <h2 className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
         How to Collect
       </h2>
-      <p className={cn(collectSectionClass, 'mt-2')}>{COLLECT_INSTRUCTIONS}</p>
+      <p className="mt-2 text-[13px] font-grotesk leading-5 text-[#171717]">
+        {COLLECT_INSTRUCTIONS}
+      </p>
     </section>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
+++ b/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
@@ -7,7 +7,7 @@ export function SponsoredActivationCollectInstructions() {
       <h2 className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
         How to Collect
       </h2>
-      <p className="mt-2 text-[13px] font-grotesk leading-5 text-[#171717]">
+      <p className="mt-2 body-small font-grotesk text-[#171717]">
         {COLLECT_INSTRUCTIONS}
       </p>
     </section>

--- a/components/sponsored-activation/sponsored-activation-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero.tsx
@@ -14,7 +14,7 @@ export function SponsoredActivationHero({
   itemName,
 }: SponsoredActivationHeroProps) {
   return (
-    <div className="relative min-h-[470px] w-full overflow-hidden bg-neutral-100">
+    <div className="relative h-[320px] w-full shrink-0 overflow-hidden bg-neutral-100">
       {heroImageUrl ? (
         <Image
           src={heroImageUrl}
@@ -26,7 +26,7 @@ export function SponsoredActivationHero({
           unoptimized
         />
       ) : (
-        <div className="flex h-full min-h-[470px] items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
+        <div className="flex h-full items-center justify-center px-6 text-center body-medium font-grotesk text-[#757575]">
           {itemName}
         </div>
       )}

--- a/components/sponsored-activation/sponsored-activation-redeemed.tsx
+++ b/components/sponsored-activation/sponsored-activation-redeemed.tsx
@@ -26,7 +26,7 @@ export function SponsoredActivationRedeemed({
         itemName={perkName}
       />
 
-      <div className="flex flex-1 flex-col gap-6 px-4 pb-28 pt-6">
+      <div className="flex flex-1 flex-col gap-4 px-4 pb-28 pt-4">
         <h1 className="title2 text-[#171717]">Success!</h1>
 
         <div>

--- a/components/sponsored-activation/sponsored-activation-success.tsx
+++ b/components/sponsored-activation/sponsored-activation-success.tsx
@@ -95,9 +95,7 @@ export function SponsoredActivationSuccess({
             />
           </div>
 
-          <div className="pt-4">
-            <SponsoredActivationCollectInstructions />
-          </div>
+          <SponsoredActivationCollectInstructions />
 
           <SponsoredActivationSwipeSlider
             key={swipeSliderKey}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the `/activation/` page layout based on user feedback and Figma reference (`2:106876`):

- **Hero image too tall**: Reduced from `min-h-[470px]` to `h-[320px]` (matching Figma's 323px drawer hero), so content below is visible without excessive scrolling
- **"You Receive" bar not overlaying image**: The bar was already absolutely positioned, but the oversized hero pushed it too far down visually. With the reduced height it now properly overlays the bottom of the image area
- **"Success!" not right under image**: Reduced top padding from `pt-6` to `pt-4` and gap from `gap-6` to `gap-4` so the title sits tight against the hero
- **"How to Collect" sizing mismatch**: Changed heading from `text-[13px] font-semibold` to `label-small` class to match the typography of "Your Points Balance" label. Also added a top border separator per Figma
- **Success drawer cleanup**: Removed redundant wrapper `div` around collect instructions to reduce spacing

## Files Changed

| File | Change |
|------|--------|
| `components/sponsored-activation/sponsored-activation-hero.tsx` | Fixed height from `min-h-[470px]` to `h-[320px]`, removed duplicate min-height on fallback |
| `components/sponsored-activation/sponsored-activation-redeemed.tsx` | Tighter spacing (`pt-4`, `gap-4`) for "Success!" placement |
| `components/sponsored-activation/sponsored-activation-collect-instructions.tsx` | Use `label-small` for heading, add border-top separator, remove unused `cn` import |
| `components/sponsored-activation/sponsored-activation-success.tsx` | Remove extra wrapper div around collect instructions |

## Testing

- Lint passes (only pre-existing warnings)
- Build succeeds
- All tests pass except pre-existing known failures (`location-search`, `user-menu`, `admin`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-136fac0c-bbd5-4a55-9ab9-3f76a7082cf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-136fac0c-bbd5-4a55-9ab9-3f76a7082cf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

