### PR TITLE
fix: remove duplicate separator above sponsored collect instructions

### DIFF
--- a/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
+++ b/components/sponsored-activation/sponsored-activation-collect-instructions.tsx
@@ -3,7 +3,7 @@ const COLLECT_INSTRUCTIONS =
 
 export function SponsoredActivationCollectInstructions() {
   return (
-    <section className="border-t border-[#171717]/10 pt-4">
+    <section>
       <h2 className="label-small font-grotesk uppercase tracking-wide text-[#757575]">
         How to Collect
       </h2>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The "How to Collect" block in sponsored activation success/redeemed flows used a top border on `SponsoredActivationCollectInstructions`, while the last detail row (`Your Points Balance`) already has a bottom border from `SponsoredActivationDetailRow`. Those two borders stacked and read as a double line.

## Changes

- Removed `border-t border-[#171717]/10 pt-4` from the collect instructions `<section>` so only the detail row’s `border-b` remains as the separator.

## Testing

- Pre-commit `yarn build` passed on commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e6ecb215-f10a-4517-bd8a-f86c3a616343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6ecb215-f10a-4517-bd8a-f86c3a616343"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

