### PR TITLE
feat: add description to sponsored_activation and update unauthenticated activation UI

### DIFF
--- a/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/__tests__/read-route.test.ts
@@ -19,6 +19,7 @@ const activation = {
   id: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
   slug: 'pr-drink',
   title: 'Public Records Drink',
+  description: 'A complimentary drink at Public Records.',
   sponsor_name: 'Public Records',
   event_id: null,
   status: 'active' as const,
@@ -76,6 +77,7 @@ describe('GET /api/sponsored-activations/[activationId]', () => {
     expect(json.data.activation).toEqual({
       id: activation.id,
       title: activation.title,
+      description: activation.description,
       sponsor_name: activation.sponsor_name,
       slug: activation.slug,
       status: activation.status,

--- a/app/api/sponsored-activations/[activationId]/route.ts
+++ b/app/api/sponsored-activations/[activationId]/route.ts
@@ -44,6 +44,7 @@ export async function GET(_request: NextRequest, { params }: RouteParams) {
     activation: {
       id: activation.id,
       title: activation.title,
+      description: activation.description,
       sponsor_name: activation.sponsor_name,
       slug: activation.slug,
       status: activation.status,

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -22,7 +22,10 @@ export function SponsoredActivationConfirm({
   primaryActionLabel,
 }: SponsoredActivationConfirmProps) {
   const { activation, rewardItem } = read;
-  const description = rewardItem.description?.trim() || activation.sponsor_name;
+  const description =
+    activation.description?.trim() ||
+    rewardItem.description?.trim() ||
+    activation.sponsor_name;
 
   const perkValueLabel = rewardItem.perk_value_label.trim();
 

--- a/components/sponsored-activation/sponsored-activation-confirm.tsx
+++ b/components/sponsored-activation/sponsored-activation-confirm.tsx
@@ -5,6 +5,7 @@ import { SponsoredActivationLandingHero } from '@/components/sponsored-activatio
 import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
 import { SponsoredActivationPointsValue } from '@/components/sponsored-activation/sponsored-activation-points-value';
 import { cn } from '@/lib/utils';
+import { resolveSponsoredActivationDescription } from '@/lib/sponsored-activation/public-read-display';
 import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
 
 type SponsoredActivationConfirmProps = {
@@ -22,10 +23,7 @@ export function SponsoredActivationConfirm({
   primaryActionLabel,
 }: SponsoredActivationConfirmProps) {
   const { activation, rewardItem } = read;
-  const description =
-    activation.description?.trim() ||
-    rewardItem.description?.trim() ||
-    activation.sponsor_name;
+  const description = resolveSponsoredActivationDescription(read);
 
   const perkValueLabel = rewardItem.perk_value_label.trim();
 

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -3,15 +3,17 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy } from '@privy-io/react-auth';
-import { Loader2 } from 'lucide-react';
+import { ArrowRight, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { SponsoredActivationPageShell } from '@/components/sponsored-activation/sponsored-activation-page-shell';
 import { SponsoredActivationConfirm } from '@/components/sponsored-activation/sponsored-activation-confirm';
+import { SponsoredActivationDetailRow } from '@/components/sponsored-activation/sponsored-activation-detail-row';
+import { SponsoredActivationLandingHero } from '@/components/sponsored-activation/sponsored-activation-landing-hero';
+import { SponsoredActivationPointsValue } from '@/components/sponsored-activation/sponsored-activation-points-value';
 import { SponsoredActivationSuccess } from '@/components/sponsored-activation/sponsored-activation-success';
 import { SponsoredActivationRedeemed } from '@/components/sponsored-activation/sponsored-activation-redeemed';
 import { SponsoredActivationExpired } from '@/components/sponsored-activation/sponsored-activation-expired';
 import { SponsoredActivationCancelled } from '@/components/sponsored-activation/sponsored-activation-cancelled';
-import { SpendPrimaryButton } from '@/components/spend/spend-primary-button';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
 import { apiClient, ApiError } from '@/lib/api/client';
@@ -379,16 +381,60 @@ export function SponsoredActivationFlow({
   const read = readQuery.data;
 
   if (!user) {
+    const unauthDescription =
+      read.activation.description?.trim() ||
+      read.rewardItem.description?.trim() ||
+      read.activation.sponsor_name;
+
     return (
-      <SponsoredActivationPageShell>
-        <div className="flex flex-col gap-6 p-6">
-          <h1 className="title2 text-[#171717]">{read.activation.title}</h1>
-          <p className="body-medium font-grotesk text-[#757575]">
-            Log in to continue with this activation.
-          </p>
-          <SpendPrimaryButton onClick={login}>
-            Log in to continue
-          </SpendPrimaryButton>
+      <SponsoredActivationPageShell flush>
+        <div className="flex min-h-screen flex-col bg-white">
+          <SponsoredActivationLandingHero
+            heroImageUrl={read.rewardItem.hero_image_url}
+            itemName={read.rewardItem.name}
+          />
+
+          <div className="flex flex-1 flex-col gap-6 px-4 pb-10 pt-4">
+            <div className="flex flex-col gap-2">
+              <h1 className="title3 font-medium text-[#171717]">
+                {read.activation.title}
+              </h1>
+              {unauthDescription ? (
+                <p className="body-small font-grotesk text-[#757575]">
+                  {unauthDescription}
+                </p>
+              ) : null}
+              {read.rewardItem.perk_value_label.trim() ? (
+                <p className="label-small font-grotesk font-semibold uppercase tracking-wide text-[#a9a9a9]">
+                  {read.rewardItem.perk_value_label.trim()}
+                </p>
+              ) : null}
+            </div>
+
+            <SponsoredActivationDetailRow
+              label="You send"
+              value={
+                <SponsoredActivationPointsValue
+                  points={read.rewardItem.points_cost}
+                  suffix="PTS"
+                />
+              }
+              bareValue
+            />
+
+            <button
+              type="button"
+              onClick={login}
+              className="label-large flex h-11 w-full items-center justify-between gap-2 rounded-md bg-[#171717] px-4 font-grotesk uppercase tracking-[0.0625em] text-white transition-opacity hover:opacity-95"
+            >
+              <span className="truncate text-left">Sign Up</span>
+              <ArrowRight
+                className="size-6 shrink-0"
+                strokeWidth={2}
+                aria-hidden
+              />
+            </button>
+          </div>
         </div>
       </SponsoredActivationPageShell>
     );

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -28,6 +28,7 @@ import {
   pickPrimaryActivationRedemption,
   resolveSponsoredActivationBaseScreen,
 } from '@/lib/sponsored-activation/flow-routing';
+import { resolveSponsoredActivationDescription } from '@/lib/sponsored-activation/public-read-display';
 import type { SponsoredActivationPublicReadResponse } from '@/lib/sponsored-activation/public-read';
 import {
   isInitialized,
@@ -381,10 +382,8 @@ export function SponsoredActivationFlow({
   const read = readQuery.data;
 
   if (!user) {
-    const unauthDescription =
-      read.activation.description?.trim() ||
-      read.rewardItem.description?.trim() ||
-      read.activation.sponsor_name;
+    const description = resolveSponsoredActivationDescription(read);
+    const perkValueLabel = read.rewardItem.perk_value_label.trim();
 
     return (
       <SponsoredActivationPageShell flush>
@@ -399,14 +398,14 @@ export function SponsoredActivationFlow({
               <h1 className="title3 font-medium text-[#171717]">
                 {read.activation.title}
               </h1>
-              {unauthDescription ? (
+              {description ? (
                 <p className="body-small font-grotesk text-[#757575]">
-                  {unauthDescription}
+                  {description}
                 </p>
               ) : null}
-              {read.rewardItem.perk_value_label.trim() ? (
+              {perkValueLabel ? (
                 <p className="label-small font-grotesk font-semibold uppercase tracking-wide text-[#a9a9a9]">
-                  {read.rewardItem.perk_value_label.trim()}
+                  {perkValueLabel}
                 </p>
               ) : null}
             </div>

--- a/database/add-description-to-sponsored-activations.sql
+++ b/database/add-description-to-sponsored-activations.sql
@@ -1,7 +1,3 @@
--- Add optional description column to sponsored_activation table.
--- Allows admins to set a human-readable description displayed on the public
--- activation landing page (both authenticated and unauthenticated views).
-
 ALTER TABLE sponsored_activation
     ADD COLUMN IF NOT EXISTS description TEXT;
 

--- a/database/add-description-to-sponsored-activations.sql
+++ b/database/add-description-to-sponsored-activations.sql
@@ -1,0 +1,9 @@
+-- Add optional description column to sponsored_activation table.
+-- Allows admins to set a human-readable description displayed on the public
+-- activation landing page (both authenticated and unauthenticated views).
+
+ALTER TABLE sponsored_activation
+    ADD COLUMN IF NOT EXISTS description TEXT;
+
+COMMENT ON COLUMN sponsored_activation.description IS
+    'Optional public-facing description shown on the activation landing page.';

--- a/lib/activation/settlement-worker-stellar.test.ts
+++ b/lib/activation/settlement-worker-stellar.test.ts
@@ -57,6 +57,7 @@ const activationFixture: SponsoredActivationRow = {
   id: 'act-1',
   slug: 'test',
   title: 't',
+  description: null,
   sponsor_name: 's',
   event_id: null,
   status: 'active',

--- a/lib/db/sponsored-activations.ts
+++ b/lib/db/sponsored-activations.ts
@@ -8,6 +8,7 @@ export type SponsoredActivationRow = {
   id: string;
   slug: string;
   title: string;
+  description: string | null;
   sponsor_name: string;
   event_id: string | null;
   status: SponsoredActivationStatus;
@@ -51,6 +52,7 @@ function normalizeRow(row: Record<string, unknown>): SponsoredActivationRow {
     id: String(row.id),
     slug: String(row.slug),
     title: String(row.title),
+    description: row.description == null ? null : String(row.description),
     sponsor_name: String(row.sponsor_name),
     event_id: row.event_id == null ? null : String(row.event_id),
     status: row.status as SponsoredActivationStatus,
@@ -212,6 +214,7 @@ export type CreateSponsoredActivationDbInput = {
   id?: string;
   slug: string;
   title: string;
+  description?: string | null;
   sponsor_name: string;
   event_id?: string | null;
   status: SponsoredActivationStatus;
@@ -238,6 +241,7 @@ export async function createSponsoredActivation(
       ...(input.id != null ? { id: input.id } : {}),
       slug: input.slug,
       title: input.title,
+      description: input.description ?? null,
       sponsor_name: input.sponsor_name,
       event_id: input.event_id ?? null,
       status: input.status,

--- a/lib/sponsored-activation/__tests__/public-read-display.test.ts
+++ b/lib/sponsored-activation/__tests__/public-read-display.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { resolveSponsoredActivationDescription } from '@/lib/sponsored-activation/public-read-display';
+
+describe('resolveSponsoredActivationDescription', () => {
+  it('prefers activation.description when set', () => {
+    expect(
+      resolveSponsoredActivationDescription({
+        activation: {
+          description: '  From activation ',
+          sponsor_name: 'Sponsor',
+        },
+        rewardItem: { description: 'From reward' },
+      })
+    ).toBe('From activation');
+  });
+
+  it('falls back to reward item description', () => {
+    expect(
+      resolveSponsoredActivationDescription({
+        activation: { description: null, sponsor_name: 'Sponsor' },
+        rewardItem: { description: '  Reward copy  ' },
+      })
+    ).toBe('Reward copy');
+  });
+
+  it('falls back to sponsor_name', () => {
+    expect(
+      resolveSponsoredActivationDescription({
+        activation: { description: null, sponsor_name: 'Acme Co' },
+        rewardItem: { description: null },
+      })
+    ).toBe('Acme Co');
+  });
+});

--- a/lib/sponsored-activation/public-read-display.ts
+++ b/lib/sponsored-activation/public-read-display.ts
@@ -1,0 +1,24 @@
+type SponsoredActivationDescriptionRead = {
+  activation: {
+    description: string | null;
+    sponsor_name: string;
+  };
+  rewardItem: {
+    description: string | null;
+  };
+};
+
+/**
+ * Public landing copy: prefer activation description, then reward item
+ * description, then sponsor name (always non-empty for valid reads).
+ */
+export function resolveSponsoredActivationDescription(
+  read: SponsoredActivationDescriptionRead
+): string {
+  const { activation, rewardItem } = read;
+  return (
+    activation.description?.trim() ||
+    rewardItem.description?.trim() ||
+    activation.sponsor_name
+  );
+}

--- a/lib/sponsored-activation/public-read.ts
+++ b/lib/sponsored-activation/public-read.ts
@@ -8,6 +8,7 @@ export type SponsoredActivationPublicReadResponse = {
   activation: {
     id: string;
     title: string;
+    description: string | null;
     sponsor_name: string;
     slug: string;
     status: SponsoredActivationStatus;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Updates the unauthenticated `/activation/[id]` page to match the Figma design, making it consistent with the authenticated confirm view. Also adds a `description` column to the `sponsored_activation` database table.

## Changes

### Database
- New migration `database/add-description-to-sponsored-activations.sql` adds an optional `description TEXT` column to `sponsored_activation`

### Backend
- `lib/db/sponsored-activations.ts`: Updated `SponsoredActivationRow` type + `normalizeRow` + `CreateSponsoredActivationDbInput` to include `description`
- `app/api/sponsored-activations/[activationId]/route.ts`: Exposes `activation.description` in the public read API response
- `lib/sponsored-activation/public-read.ts`: Updated `SponsoredActivationPublicReadResponse` type

### Frontend (Unauthenticated UI)
- `components/sponsored-activation/sponsored-activation-flow.tsx`: Replaced the minimal "Log in to continue" prompt with a full layout matching the authenticated confirm view:
  - Hero image with "You receive" bar
  - Activation title + description + perk value label
  - "You send" points detail row
  - Styled "Sign Up" CTA button (dark, with arrow icon)
- `components/sponsored-activation/sponsored-activation-confirm.tsx`: Updated description resolution to prefer `activation.description` over `rewardItem.description`

### Tests
- Updated `read-route.test.ts` to include `description` in mock data and assertions
- Updated `settlement-worker-stellar.test.ts` fixture to include `description` field

## Testing

- All 48 sponsored-activation tests pass
- Build completes successfully
- Lint passes (only pre-existing warnings)
- Dev server starts and activation page renders without crashes

[Activation page renders correctly](https://cursor.com/agents/bc-152d5b6b-262e-4bee-aea0-8bed1b8b3d95/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Factivation_page_renders.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-152d5b6b-262e-4bee-aea0-8bed1b8b3d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-152d5b6b-262e-4bee-aea0-8bed1b8b3d95"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

