### PR TITLE
Admin sponsored activations: optional description on create; remove list subtitle

### DIFF
--- a/app/admin/sponsored-activations/form-state.test.ts
+++ b/app/admin/sponsored-activations/form-state.test.ts
@@ -23,6 +23,30 @@ describe('formStateToCreatePayload', () => {
     expect(payload).not.toHaveProperty('usdc_asset_config');
   });
 
+  it('includes trimmed description when set', () => {
+    const form = {
+      ...emptySponsoredActivationForm(),
+      title: 'Drink credit',
+      sponsor_name: 'Public Records',
+      venue_settlement_wallet_address: VENUE_WALLET,
+      description: '  Free drink with check-in  ',
+    };
+    const payload = formStateToCreatePayload(form);
+    expect(payload.description).toBe('Free drink with check-in');
+  });
+
+  it('sends null description when empty', () => {
+    const form = {
+      ...emptySponsoredActivationForm(),
+      title: 'Drink credit',
+      sponsor_name: 'Public Records',
+      venue_settlement_wallet_address: VENUE_WALLET,
+      description: '   ',
+    };
+    const payload = formStateToCreatePayload(form);
+    expect(payload.description).toBeNull();
+  });
+
   it('requires at least one cap', () => {
     const form = {
       ...emptySponsoredActivationForm(),

--- a/app/admin/sponsored-activations/form-state.test.ts
+++ b/app/admin/sponsored-activations/form-state.test.ts
@@ -7,14 +7,21 @@ import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/a
 
 const VENUE_WALLET = '0x70997970C51812dc3A010C7d01b50e0d17dc79C8' as const;
 
+function minimalBaseCreateForm(
+  overrides: Partial<ReturnType<typeof emptySponsoredActivationForm>> = {}
+) {
+  return {
+    ...emptySponsoredActivationForm(),
+    title: 'Drink credit',
+    sponsor_name: 'Public Records',
+    venue_settlement_wallet_address: VENUE_WALLET,
+    ...overrides,
+  };
+}
+
 describe('formStateToCreatePayload', () => {
   it('builds a base rail create body with default eligibility', () => {
-    const form = {
-      ...emptySponsoredActivationForm(),
-      title: 'Drink credit',
-      sponsor_name: 'Public Records',
-      venue_settlement_wallet_address: VENUE_WALLET,
-    };
+    const form = minimalBaseCreateForm();
     const payload = formStateToCreatePayload(form);
     expect(payload.settlement_rail).toBe('base');
     expect(payload.eligibility_config).toEqual(
@@ -24,26 +31,16 @@ describe('formStateToCreatePayload', () => {
   });
 
   it('includes trimmed description when set', () => {
-    const form = {
-      ...emptySponsoredActivationForm(),
-      title: 'Drink credit',
-      sponsor_name: 'Public Records',
-      venue_settlement_wallet_address: VENUE_WALLET,
-      description: '  Free drink with check-in  ',
-    };
-    const payload = formStateToCreatePayload(form);
+    const payload = formStateToCreatePayload(
+      minimalBaseCreateForm({ description: '  Free drink with check-in  ' })
+    );
     expect(payload.description).toBe('Free drink with check-in');
   });
 
   it('sends null description when empty', () => {
-    const form = {
-      ...emptySponsoredActivationForm(),
-      title: 'Drink credit',
-      sponsor_name: 'Public Records',
-      venue_settlement_wallet_address: VENUE_WALLET,
-      description: '   ',
-    };
-    const payload = formStateToCreatePayload(form);
+    const payload = formStateToCreatePayload(
+      minimalBaseCreateForm({ description: '   ' })
+    );
     expect(payload.description).toBeNull();
   });
 

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -99,9 +99,7 @@ export function formStateToCreatePayload(
 
   const common = {
     title,
-    ...(descriptionTrimmed
-      ? { description: descriptionTrimmed }
-      : { description: null }),
+    description: descriptionTrimmed || null,
     sponsor_name,
     event_id: form.event_id.trim() || null,
     max_redemptions: max_redemptions ?? null,

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -4,6 +4,7 @@ import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/a
 
 export type SponsoredActivationFormState = {
   title: string;
+  description: string;
   sponsor_name: string;
   event_id: string;
   settlement_rail: SettlementRail;
@@ -31,6 +32,7 @@ export function emptySponsoredActivationForm(): SponsoredActivationFormState {
   const end = new Date(start.getTime() + 7 * 24 * 60 * 60 * 1000);
   return {
     title: '',
+    description: '',
     sponsor_name: '',
     event_id: '',
     settlement_rail: 'base',
@@ -93,8 +95,13 @@ export function formStateToCreatePayload(
     throw new Error('Set max redemptions and/or max USDC budget');
   }
 
+  const descriptionTrimmed = form.description.trim();
+
   const common = {
     title,
+    ...(descriptionTrimmed
+      ? { description: descriptionTrimmed }
+      : { description: null }),
     sponsor_name,
     event_id: form.event_id.trim() || null,
     max_redemptions: max_redemptions ?? null,

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -287,9 +287,6 @@ export default function AdminSponsoredActivationsListPage() {
                 <h1 className="text-2xl font-bold text-gray-900 dark:text-neutral-100">
                   Sponsored activations
                 </h1>
-                <p className="text-sm text-gray-500 dark:text-neutral-400">
-                  Public Records activation health and settlement ops.
-                </p>
               </div>
             </div>
             <Button

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -78,6 +78,7 @@ export function SponsoredActivationFormPanel({
               onChange={(ev) => setField('description')(ev.target.value)}
               placeholder="Shown on the activation landing page"
               rows={4}
+              maxLength={10000}
               className="resize-y"
             />
           </div>

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -3,6 +3,7 @@ import { Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
 import {
   Select,
   SelectContent,
@@ -67,6 +68,17 @@ export function SponsoredActivationFormPanel({
               value={form.title}
               onChange={(ev) => setField('title')(ev.target.value)}
               placeholder="e.g. Public Records drink credit"
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="sa-description">Description (optional)</Label>
+            <Textarea
+              id="sa-description"
+              value={form.description}
+              onChange={(ev) => setField('description')(ev.target.value)}
+              placeholder="Shown on the activation landing page"
+              rows={4}
+              className="resize-y"
             />
           </div>
           <div className="space-y-2">

--- a/app/api/admin/sponsored-activations/route.ts
+++ b/app/api/admin/sponsored-activations/route.ts
@@ -96,10 +96,14 @@ export async function POST(request: NextRequest) {
         ? { contract_address: DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT }
         : (data.usdc_asset_config as Record<string, unknown>);
 
+    const description =
+      data.description == null ? null : String(data.description).trim() || null;
+
     const row = await createSponsoredActivation({
       id: activationId,
       slug: activationId,
       title: data.title,
+      description,
       sponsor_name: data.sponsor_name,
       event_id: data.event_id ?? null,
       status: 'draft',

--- a/app/api/admin/sponsored-activations/route.ts
+++ b/app/api/admin/sponsored-activations/route.ts
@@ -97,7 +97,7 @@ export async function POST(request: NextRequest) {
         : (data.usdc_asset_config as Record<string, unknown>);
 
     const description =
-      data.description == null ? null : String(data.description).trim() || null;
+      data.description == null ? null : data.description.trim() || null;
 
     const row = await createSponsoredActivation({
       id: activationId,

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -107,6 +107,7 @@ const positiveDecimalOrNullSchema = z.union([
 const sponsoredActivationCommonCreateFields = {
   slug: z.string().min(1).max(256),
   title: z.string().min(1).max(512),
+  description: z.string().max(10000).optional().nullable(),
   sponsor_name: z.string().min(1).max(512),
   event_id: z.string().min(1).max(512).optional().nullable(),
   status: sponsoredActivationStatusSchema.default('draft'),

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -107,7 +107,7 @@ const positiveDecimalOrNullSchema = z.union([
 const sponsoredActivationCommonCreateFields = {
   slug: z.string().min(1).max(256),
   title: z.string().min(1).max(512),
-  description: z.string().max(10000).optional().nullable(),
+  description: z.string().trim().max(10000).optional().nullable(),
   sponsor_name: z.string().min(1).max(512),
   event_id: z.string().min(1).max(512).optional().nullable(),
   status: sponsoredActivationStatusSchema.default('draft'),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Removed the subtitle under **Sponsored activations** on the admin list page (the Public Records–specific line).
- Added an optional **Description** field to the **New sponsored activation** side panel (multi-line textarea after Title), aligned with the existing `sponsored_activation.description` column and DB comment (landing-page copy).
- Extended `adminCreateSponsoredActivationRequestSchema` / shared create fields with optional nullable `description` (max 10k chars). The admin POST handler trims the value and passes it through to `createSponsoredActivation`.
- Added Vitest coverage for description trimming and null when blank.

## Testing

- `yarn test app/admin/sponsored-activations/form-state.test.ts lib/schemas/__tests__/sponsored-activation.test.ts`
- Pre-commit `yarn build` (via Husky) completed successfully on commit.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-248136da-ccc4-434a-9d3e-694cfadfb46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-248136da-ccc4-434a-9d3e-694cfadfb46b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

