### PR TITLE
feat(admin): QR params on sponsored activation guest share link

### DIFF
--- a/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
+++ b/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
@@ -27,6 +27,7 @@ import type {
 } from '@/lib/db/sponsored-activations';
 import {
   sponsoredActivationQrGuestSharePath,
+  sponsoredActivationQrGuestShareSourceRefId,
   sponsoredActivationQrGuestShareUrl,
 } from '@/lib/sponsored-activation/admin-public-url';
 
@@ -263,20 +264,6 @@ export function ActivationLaunchPanel({
 
   const activeRewardCount = rewardItems.filter((i) => i.is_active).length;
 
-  /** `source_ref_id` for QR deeplinks: activation display name, then slug, then id. */
-  const activationNameForGuestRef = activation
-    ? activation.title.trim() || activation.slug.trim() || activation.id
-    : '';
-
-  const guestShareUrl =
-    typeof window !== 'undefined' && activation && activationNameForGuestRef
-      ? sponsoredActivationQrGuestShareUrl(
-          activation.slug || activation.id,
-          window.location.origin,
-          activationNameForGuestRef
-        )
-      : '';
-
   const invalidateAll = async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: activationQueryKey }),
@@ -409,6 +396,18 @@ export function ActivationLaunchPanel({
       </section>
     );
   }
+
+  const activationKey = activation.slug || activation.id;
+  const qrGuestShareSourceRefId =
+    sponsoredActivationQrGuestShareSourceRefId(activation);
+  const guestShareUrl =
+    typeof window !== 'undefined'
+      ? sponsoredActivationQrGuestShareUrl(
+          activationKey,
+          window.location.origin,
+          qrGuestShareSourceRefId
+        )
+      : '';
 
   const hasActiveReward = activeRewardCount > 0;
   const isDraft = activation.status === 'draft';
@@ -756,8 +755,8 @@ export function ActivationLaunchPanel({
                   <Button type="button" size="sm" variant="outline" asChild>
                     <Link
                       href={sponsoredActivationQrGuestSharePath(
-                        activation.slug || activation.id,
-                        activationNameForGuestRef
+                        activationKey,
+                        qrGuestShareSourceRefId
                       )}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
+++ b/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
@@ -26,8 +26,8 @@ import type {
   SponsoredActivationStatus,
 } from '@/lib/db/sponsored-activations';
 import {
-  sponsoredActivationPublicPath,
-  sponsoredActivationPublicUrl,
+  sponsoredActivationQrGuestSharePath,
+  sponsoredActivationQrGuestShareUrl,
 } from '@/lib/sponsored-activation/admin-public-url';
 
 type ActivationAdminRow = {
@@ -263,11 +263,17 @@ export function ActivationLaunchPanel({
 
   const activeRewardCount = rewardItems.filter((i) => i.is_active).length;
 
-  const publicUrl =
-    typeof window !== 'undefined' && activation
-      ? sponsoredActivationPublicUrl(
+  /** `source_ref_id` for QR deeplinks: activation display name, then slug, then id. */
+  const activationNameForGuestRef = activation
+    ? activation.title.trim() || activation.slug.trim() || activation.id
+    : '';
+
+  const guestShareUrl =
+    typeof window !== 'undefined' && activation && activationNameForGuestRef
+      ? sponsoredActivationQrGuestShareUrl(
           activation.slug || activation.id,
-          window.location.origin
+          window.location.origin,
+          activationNameForGuestRef
         )
       : '';
 
@@ -445,7 +451,7 @@ export function ActivationLaunchPanel({
       id: 'share',
       done: isLive,
       title: 'Share the guest link',
-      body: 'Send this URL (not the admin dashboard URL). Optional QR check-in params: ?source=qr_scan&source_ref_id=YOUR_REF',
+      body: 'Send this URL (not the admin dashboard URL). It includes QR check-in params (?source=qr_scan&source_ref_id); source_ref_id is this activation’s name (title), or slug/id if the title is blank.',
     },
   ];
 
@@ -500,12 +506,12 @@ export function ActivationLaunchPanel({
               Resume
             </Button>
           )}
-          {publicUrl && (
+          {guestShareUrl && (
             <Button
               type="button"
               variant="outline"
               className="gap-1"
-              onClick={() => void copyText(publicUrl, 'Guest link copied')}
+              onClick={() => void copyText(guestShareUrl, 'Guest link copied')}
             >
               <Copy className="size-3.5" />
               Copy guest link
@@ -730,10 +736,10 @@ export function ActivationLaunchPanel({
                 </div>
               )}
 
-              {step.id === 'share' && publicUrl && (
+              {step.id === 'share' && guestShareUrl && (
                 <div className="mt-3 flex flex-wrap items-center gap-2">
                   <code className="block max-w-full flex-1 break-all rounded-lg bg-neutral-50 p-2 text-xs text-blue-800 dark:bg-neutral-950 dark:text-blue-300">
-                    {publicUrl}
+                    {guestShareUrl}
                   </code>
                   <Button
                     type="button"
@@ -741,7 +747,7 @@ export function ActivationLaunchPanel({
                     variant="outline"
                     className="gap-1"
                     onClick={() =>
-                      void copyText(publicUrl, 'Guest link copied')
+                      void copyText(guestShareUrl, 'Guest link copied')
                     }
                   >
                     <Copy className="size-3.5" />
@@ -749,8 +755,9 @@ export function ActivationLaunchPanel({
                   </Button>
                   <Button type="button" size="sm" variant="outline" asChild>
                     <Link
-                      href={sponsoredActivationPublicPath(
-                        activation.slug || activation.id
+                      href={sponsoredActivationQrGuestSharePath(
+                        activation.slug || activation.id,
+                        activationNameForGuestRef
                       )}
                       target="_blank"
                       rel="noopener noreferrer"

--- a/lib/sponsored-activation/__tests__/admin-public-url.test.ts
+++ b/lib/sponsored-activation/__tests__/admin-public-url.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect } from 'vitest';
 import {
   sponsoredActivationPublicPath,
   sponsoredActivationPublicUrl,
+  sponsoredActivationQrGuestSharePath,
+  sponsoredActivationQrGuestShareUrl,
 } from '@/lib/sponsored-activation/admin-public-url';
 
 describe('sponsoredActivationPublicPath', () => {
@@ -27,6 +29,40 @@ describe('sponsoredActivationPublicUrl', () => {
     );
     expect(sponsoredActivationPublicUrl('abc', 'https://irl.energy/')).toBe(
       'https://irl.energy/activation/abc'
+    );
+  });
+});
+
+describe('sponsoredActivationQrGuestSharePath', () => {
+  it('appends qr_scan and source_ref_id', () => {
+    expect(sponsoredActivationQrGuestSharePath('my-slug', 'Launch Party')).toBe(
+      '/activation/my-slug?source=qr_scan&source_ref_id=Launch+Party'
+    );
+  });
+
+  it('trims source_ref_id', () => {
+    expect(sponsoredActivationQrGuestSharePath('x', '  ref  ')).toBe(
+      '/activation/x?source=qr_scan&source_ref_id=ref'
+    );
+  });
+
+  it('omits query when ref is blank after trim', () => {
+    expect(sponsoredActivationQrGuestSharePath('x', '   ')).toBe(
+      '/activation/x'
+    );
+  });
+});
+
+describe('sponsoredActivationQrGuestShareUrl', () => {
+  it('joins origin, path, and QR params', () => {
+    expect(
+      sponsoredActivationQrGuestShareUrl(
+        'my-slug',
+        'https://example.test',
+        'Launch Party'
+      )
+    ).toBe(
+      'https://example.test/activation/my-slug?source=qr_scan&source_ref_id=Launch+Party'
     );
   });
 });

--- a/lib/sponsored-activation/__tests__/admin-public-url.test.ts
+++ b/lib/sponsored-activation/__tests__/admin-public-url.test.ts
@@ -3,6 +3,7 @@ import {
   sponsoredActivationPublicPath,
   sponsoredActivationPublicUrl,
   sponsoredActivationQrGuestSharePath,
+  sponsoredActivationQrGuestShareSourceRefId,
   sponsoredActivationQrGuestShareUrl,
 } from '@/lib/sponsored-activation/admin-public-url';
 
@@ -30,6 +31,35 @@ describe('sponsoredActivationPublicUrl', () => {
     expect(sponsoredActivationPublicUrl('abc', 'https://irl.energy/')).toBe(
       'https://irl.energy/activation/abc'
     );
+  });
+});
+
+describe('sponsoredActivationQrGuestShareSourceRefId', () => {
+  it('prefers trimmed title over slug and id', () => {
+    expect(
+      sponsoredActivationQrGuestShareSourceRefId({
+        id: 'id-1',
+        slug: 'slug-1',
+        title: '  Launch  ',
+      })
+    ).toBe('Launch');
+  });
+
+  it('falls back to trimmed slug then id when title is blank', () => {
+    expect(
+      sponsoredActivationQrGuestShareSourceRefId({
+        id: 'id-1',
+        slug: '  slug-1  ',
+        title: '   ',
+      })
+    ).toBe('slug-1');
+    expect(
+      sponsoredActivationQrGuestShareSourceRefId({
+        id: 'id-1',
+        slug: '   ',
+        title: '   ',
+      })
+    ).toBe('id-1');
   });
 });
 

--- a/lib/sponsored-activation/admin-public-url.ts
+++ b/lib/sponsored-activation/admin-public-url.ts
@@ -5,13 +5,29 @@ export function sponsoredActivationPublicPath(activationKey: string): string {
   return `/activation/${encodeURIComponent(key)}`;
 }
 
+function joinOriginAndPath(origin: string, path: string): string {
+  const base = origin.replace(/\/$/, '');
+  return `${base}${path}`;
+}
+
 /** Joins normalized `origin` with the public activation path. */
 export function sponsoredActivationPublicUrl(
   activationKey: string,
   origin: string
 ): string {
-  const base = origin.replace(/\/$/, '');
-  return `${base}${sponsoredActivationPublicPath(activationKey)}`;
+  return joinOriginAndPath(
+    origin,
+    sponsoredActivationPublicPath(activationKey)
+  );
+}
+
+/** Value for `source_ref_id` on guest QR share links: title, else trimmed slug, else id. */
+export function sponsoredActivationQrGuestShareSourceRefId(row: {
+  id: string;
+  slug: string;
+  title: string;
+}): string {
+  return row.title.trim() || row.slug.trim() || row.id;
 }
 
 const QR_GUEST_SOURCE = 'qr_scan' as const;
@@ -40,6 +56,8 @@ export function sponsoredActivationQrGuestShareUrl(
   origin: string,
   sourceRefId: string
 ): string {
-  const base = origin.replace(/\/$/, '');
-  return `${base}${sponsoredActivationQrGuestSharePath(activationKey, sourceRefId)}`;
+  return joinOriginAndPath(
+    origin,
+    sponsoredActivationQrGuestSharePath(activationKey, sourceRefId)
+  );
 }

--- a/lib/sponsored-activation/admin-public-url.ts
+++ b/lib/sponsored-activation/admin-public-url.ts
@@ -13,3 +13,33 @@ export function sponsoredActivationPublicUrl(
   const base = origin.replace(/\/$/, '');
   return `${base}${sponsoredActivationPublicPath(activationKey)}`;
 }
+
+const QR_GUEST_SOURCE = 'qr_scan' as const;
+
+/**
+ * `/activation/{key}` with `source=qr_scan` and `source_ref_id` for guest QR
+ * eligibility deeplinks (see `parseSponsoredActivationEligibilityDeeplink`).
+ */
+export function sponsoredActivationQrGuestSharePath(
+  activationKey: string,
+  sourceRefId: string
+): string {
+  const path = sponsoredActivationPublicPath(activationKey);
+  const ref = sourceRefId.trim();
+  if (!ref) return path;
+  const q = new URLSearchParams({
+    source: QR_GUEST_SOURCE,
+    source_ref_id: ref,
+  });
+  return `${path}?${q.toString()}`;
+}
+
+/** Same as {@link sponsoredActivationQrGuestSharePath} with an absolute origin. */
+export function sponsoredActivationQrGuestShareUrl(
+  activationKey: string,
+  origin: string,
+  sourceRefId: string
+): string {
+  const base = origin.replace(/\/$/, '');
+  return `${base}${sponsoredActivationQrGuestSharePath(activationKey, sourceRefId)}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The admin launch checklist "Share the guest link" step now shows the full activation URL with `source=qr_scan` and `source_ref_id` query parameters so QR eligibility deeplinks work out of the box.

## Details

- **`source_ref_id`** is derived from the activation display name: trimmed `title`, then trimmed `slug`, then `id` (so it is always non-empty when an activation row exists).
- **Copy** (header and step) and the monospace display use this full URL.
- **Preview** opens `Link` to the same path and query string in a new tab.

## Tests

- Extended `lib/sponsored-activation/__tests__/admin-public-url.test.ts` for the new URL helpers.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f0a5062e-1d6e-4a99-be27-d19be78945a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f0a5062e-1d6e-4a99-be27-d19be78945a9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

