### PR TITLE
fix(sponsored-activation): solid white receive bar and drawer text alignment

### DIFF
--- a/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
+++ b/components/sponsored-activation/sponsored-activation-drawer-hero.tsx
@@ -25,7 +25,7 @@ export function SponsoredActivationDrawerHero({
       ) : (
         <div className="absolute inset-0 bg-neutral-200" aria-hidden />
       )}
-      <SponsoredActivationHeroReceiveBar itemName={itemName} />
+      <SponsoredActivationHeroReceiveBar itemName={itemName} className="px-8" />
     </div>
   );
 }

--- a/components/sponsored-activation/sponsored-activation-hero-receive-bar.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero-receive-bar.tsx
@@ -1,14 +1,22 @@
+import { cn } from '@/lib/utils';
+
 type SponsoredActivationHeroReceiveBarProps = {
   itemName: string;
+  /** Extra horizontal inset when the hero uses full-bleed negative margins (e.g. drawer). */
+  className?: string;
 };
 
 /** Bottom "You receive" strip shared by page and drawer activation heroes. */
 export function SponsoredActivationHeroReceiveBar({
   itemName,
+  className,
 }: SponsoredActivationHeroReceiveBarProps) {
   return (
     <div
-      className="absolute inset-x-0 bottom-0 z-10 flex items-center justify-between gap-3 border-t border-white/40 bg-white/85 px-4 py-4 backdrop-blur-md supports-[backdrop-filter]:bg-white/75"
+      className={cn(
+        'absolute inset-x-0 bottom-0 z-10 flex items-center justify-between gap-3 border-t border-[#171717]/10 bg-white px-4 py-4',
+        className
+      )}
       role="group"
       aria-label="You receive"
     >

--- a/components/sponsored-activation/sponsored-activation-hero-receive-bar.tsx
+++ b/components/sponsored-activation/sponsored-activation-hero-receive-bar.tsx
@@ -6,7 +6,6 @@ type SponsoredActivationHeroReceiveBarProps = {
   className?: string;
 };
 
-/** Bottom "You receive" strip shared by page and drawer activation heroes. */
 export function SponsoredActivationHeroReceiveBar({
   itemName,
   className,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The sponsored activation hero strip that shows "You receive" used a semi-transparent white background with backdrop blur, which read as grey over the image. The success drawer also full-bleeds the hero with negative horizontal margins (`-mx-4`), so the strip's default `px-4` padding no longer lined up with the `px-4` body below (e.g. "Success!").

## Changes

- **`SponsoredActivationHeroReceiveBar`**: Solid `bg-white`, subtle top border aligned with other rows (`border-[#171717]/10`), removed translucent/blur styling. Optional `className` prop merged with `cn()` for layout-specific padding.
- **`SponsoredActivationDrawerHero`**: Passes `className="px-8"` so horizontal inset matches the padded content column (offsets the 1rem bleed on each side).

Full-page heroes (`SponsoredActivationHero`, `SponsoredActivationLandingHero`) keep the default `px-4`, which already matches their page gutters.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c8e29368-48f4-49ed-8481-0a8d0cba824a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c8e29368-48f4-49ed-8481-0a8d0cba824a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

