### PR TITLE
fix: unblock username creation during player signup

### DIFF
--- a/app/api/player/route.ts
+++ b/app/api/player/route.ts
@@ -48,14 +48,14 @@ export async function POST(request: NextRequest) {
     // Create or update player
     const playerData: Omit<Player, 'id' | 'created_at' | 'updated_at'> = {
       wallet_address: walletAddress,
-      email: email || undefined,
+      email,
       username: normalizedUsername,
       total_points: 0,
     };
 
     let player;
     try {
-      player = await createOrUpdatePlayer(playerData);
+      player = await createOrUpdatePlayer(playerData, existingPlayer);
     } catch (err: unknown) {
       if (isPostgresUniqueUsernameViolation(err)) {
         return apiError('Username is already taken', 409);
@@ -203,7 +203,7 @@ export async function PATCH(request: NextRequest) {
 
     let updatedPlayer;
     try {
-      updatedPlayer = await createOrUpdatePlayer(playerData);
+      updatedPlayer = await createOrUpdatePlayer(playerData, existingPlayer);
     } catch (err: unknown) {
       if (isPostgresUniqueUsernameViolation(err)) {
         return apiError('Username is already taken', 409);

--- a/app/api/player/route.ts
+++ b/app/api/player/route.ts
@@ -93,33 +93,31 @@ export async function POST(request: NextRequest) {
       });
     }
 
-    // === Sync the player data to Airtable via internal API ===
-    try {
-      // Derive the base URL (e.g., https://example.com) from the incoming request
+    // Fire-and-forget downstream syncs so signup UI is not blocked on third parties.
+    if (player.email) {
       const baseUrl = new URL(request.url).origin;
-      await fetch(`${baseUrl}/api/add-user`, {
+      void fetch(`${baseUrl}/api/add-user`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           createdAt: player.created_at,
-          email: player.email ?? '',
+          email: player.email,
         }),
+      }).catch((airtableSyncError) => {
+        console.error('Failed to sync user to Airtable:', airtableSyncError);
+        captureHandledException(airtableSyncError, {
+          route: '/api/player',
+          operation: 'sync_user_to_airtable',
+          statusCode: 500,
+          extra: {
+            hasEmail: true,
+          },
+        });
       });
-    } catch (airtableSyncError) {
-      console.error('Failed to sync user to Airtable:', airtableSyncError);
-      captureHandledException(airtableSyncError, {
-        route: '/api/player',
-        operation: 'sync_user_to_airtable',
-        statusCode: 500,
-        extra: {
-          hasEmail: Boolean(player.email),
-        },
-      });
-      // We log the error but do NOT block the main response
     }
 
     if (isNewPlayer && email) {
-      await syncCampaignMonitorOnboarding({
+      void syncCampaignMonitorOnboarding({
         email,
         username: normalizedUsername,
         source: '/api/player',

--- a/components/auth/auth-wrapper.tsx
+++ b/components/auth/auth-wrapper.tsx
@@ -2,10 +2,10 @@
 
 import { usePrivy } from '@privy-io/react-auth';
 import { Button } from '@/components/ui/button';
-import { useState, useEffect } from 'react';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
-import { getSignupAttributionBodyFields } from '@/lib/analytics/attribution';
+import { useUsernameSignup } from '@/hooks/use-username-signup';
+import { UsernameSignupForm } from '@/components/auth/username-signup-form';
 
 export interface CheckpointCustomization {
   partnerImageUrl?: string;
@@ -70,83 +70,19 @@ export default function AuthWrapper({
     ? `Choose your username to check in at ${authContextName.trim()}`
     : DEFAULT_USERNAME_HEADING;
   const { user, ready, linkEmail, login } = usePrivy();
-  const [username, setUsername] = useState('');
-  const [isCreatingPlayer, setIsCreatingPlayer] = useState(false);
-  const [needsUsername, setNeedsUsername] = useState(false);
-  const [createPlayerError, setCreatePlayerError] = useState<string | null>(
-    null
-  );
-
-  useEffect(() => {
-    if (!requireUsername || !ready || !user?.wallet?.address) return;
-
-    const walletAddress = user.wallet.address;
-    const checkPlayerData = async () => {
-      try {
-        const response = await fetch(
-          `/api/player?walletAddress=${encodeURIComponent(walletAddress)}`
-        );
-
-        if (response.ok) {
-          const responseData = await response.json();
-          const result = responseData.data || responseData;
-          const existingPlayer = result.player;
-
-          if (existingPlayer && !existingPlayer.username) {
-            setNeedsUsername(true);
-          }
-        } else if (response.status === 404) {
-          setNeedsUsername(true);
-        }
-      } catch (error) {
-        console.error('Error checking player data:', error);
-        setNeedsUsername(true);
-      }
-    };
-
-    checkPlayerData();
-  }, [ready, user?.wallet?.address, requireUsername]);
-
-  const handleCreatePlayer = async () => {
-    if (!username.trim() || !user?.wallet?.address) return;
-
-    const walletAddress = user.wallet.address;
-    setIsCreatingPlayer(true);
-    setCreatePlayerError(null);
-    try {
-      const email = user.email?.address?.trim();
-      const response = await fetch('/api/player', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          walletAddress,
-          ...(email ? { email } : {}),
-          username: username.trim(),
-          ...getSignupAttributionBodyFields(),
-        }),
-      });
-
-      const responseData = await response.json();
-
-      if (responseData.success) {
-        setNeedsUsername(false);
-      } else {
-        const message =
-          responseData.error ||
-          'Unable to create your profile. Please try again.';
-        setCreatePlayerError(message);
-        console.error('Failed to create player:', message);
-      }
-    } catch (error) {
-      const message = 'Something went wrong. Please try again.';
-      setCreatePlayerError(message);
-      console.error('Error creating player:', error);
-    } finally {
-      setIsCreatingPlayer(false);
-    }
-  };
+  const walletAddress = user?.wallet?.address;
+  const {
+    username,
+    setUsername,
+    isCreatingPlayer,
+    needsUsername,
+    createPlayerError,
+    handleCreatePlayer,
+  } = useUsernameSignup({
+    checkEnabled: !!(requireUsername && ready && walletAddress),
+    walletAddress,
+    emailAddress: user?.email?.address,
+  });
 
   // Loading state
   if (!ready) {
@@ -207,70 +143,19 @@ export default function AuthWrapper({
                 }
         }
       >
-        <div className="flex w-full max-w-md flex-col gap-6">
-          <p
-            className={cn(
-              'text-center text-lg font-semibold tracking-tight font-inktrap md:text-xl',
-              !cp && unauthenticatedUI === 'map-onboarding' && 'text-[#171717]',
-              !cp && unauthenticatedUI !== 'map-onboarding' && 'text-foreground'
-            )}
-            style={cp ? { color: checkpointText } : undefined}
-          >
-            {usernameHeading}
-          </p>
-
-          <div className="rounded-2xl border border-white/30 bg-white/20 p-4 backdrop-blur-sm">
-            <p className="mb-3 text-sm font-inktrap uppercase text-foreground">
-              ENTER YOUR USERNAME
-            </p>
-            <input
-              type="text"
-              placeholder="Enter your username"
-              value={username}
-              onChange={(e) => {
-                setUsername(e.target.value);
-                if (createPlayerError) setCreatePlayerError(null);
-              }}
-              className="w-full rounded-full border border-border/60 bg-white py-3 pl-4 pr-4 font-inktrap text-foreground placeholder:text-muted-foreground shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
-              maxLength={20}
-              disabled={isCreatingPlayer}
-              autoComplete="username"
-            />
-          </div>
-
-          {createPlayerError ? (
-            <p
-              className="text-center text-sm font-medium text-red-700"
-              role="alert"
-            >
-              {createPlayerError}
-            </p>
-          ) : null}
-
-          <Button
-            className="flex w-full items-center justify-center rounded-full bg-white px-6 py-6 text-base font-inktrap uppercase text-black hover:bg-white/90 disabled:opacity-50"
-            onClick={handleCreatePlayer}
-            disabled={!username.trim() || isCreatingPlayer}
-          >
-            {isCreatingPlayer ? 'CREATING PLAYER...' : 'START EARNING'}
-            {!isCreatingPlayer && (
-              <svg
-                className="ml-2 h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            )}
-          </Button>
-        </div>
+        <UsernameSignupForm
+          heading={usernameHeading}
+          headingClassName={cn(
+            !cp && unauthenticatedUI === 'map-onboarding' && 'text-[#171717]',
+            !cp && unauthenticatedUI !== 'map-onboarding' && 'text-foreground'
+          )}
+          headingStyle={cp ? { color: checkpointText } : undefined}
+          username={username}
+          onUsernameChange={setUsername}
+          createPlayerError={createPlayerError}
+          isCreatingPlayer={isCreatingPlayer}
+          onSubmit={handleCreatePlayer}
+        />
       </div>
     );
   }

--- a/components/auth/auth-wrapper.tsx
+++ b/components/auth/auth-wrapper.tsx
@@ -73,6 +73,9 @@ export default function AuthWrapper({
   const [username, setUsername] = useState('');
   const [isCreatingPlayer, setIsCreatingPlayer] = useState(false);
   const [needsUsername, setNeedsUsername] = useState(false);
+  const [createPlayerError, setCreatePlayerError] = useState<string | null>(
+    null
+  );
 
   useEffect(() => {
     if (!requireUsername || !ready || !user?.wallet?.address) return;
@@ -109,7 +112,9 @@ export default function AuthWrapper({
 
     const walletAddress = user.wallet.address;
     setIsCreatingPlayer(true);
+    setCreatePlayerError(null);
     try {
+      const email = user.email?.address?.trim();
       const response = await fetch('/api/player', {
         method: 'POST',
         headers: {
@@ -117,7 +122,7 @@ export default function AuthWrapper({
         },
         body: JSON.stringify({
           walletAddress,
-          email: user.email?.address || '',
+          ...(email ? { email } : {}),
           username: username.trim(),
           ...getSignupAttributionBodyFields(),
         }),
@@ -128,9 +133,15 @@ export default function AuthWrapper({
       if (responseData.success) {
         setNeedsUsername(false);
       } else {
-        console.error('Failed to create player:', responseData.error);
+        const message =
+          responseData.error ||
+          'Unable to create your profile. Please try again.';
+        setCreatePlayerError(message);
+        console.error('Failed to create player:', message);
       }
     } catch (error) {
+      const message = 'Something went wrong. Please try again.';
+      setCreatePlayerError(message);
       console.error('Error creating player:', error);
     } finally {
       setIsCreatingPlayer(false);
@@ -216,13 +227,25 @@ export default function AuthWrapper({
               type="text"
               placeholder="Enter your username"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => {
+                setUsername(e.target.value);
+                if (createPlayerError) setCreatePlayerError(null);
+              }}
               className="w-full rounded-full border border-border/60 bg-white py-3 pl-4 pr-4 font-inktrap text-foreground placeholder:text-muted-foreground shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
               maxLength={20}
               disabled={isCreatingPlayer}
               autoComplete="username"
             />
           </div>
+
+          {createPlayerError ? (
+            <p
+              className="text-center text-sm font-medium text-red-700"
+              role="alert"
+            >
+              {createPlayerError}
+            </p>
+          ) : null}
 
           <Button
             className="flex w-full items-center justify-center rounded-full bg-white px-6 py-6 text-base font-inktrap uppercase text-black hover:bg-white/90 disabled:opacity-50"

--- a/components/auth/auth.tsx
+++ b/components/auth/auth.tsx
@@ -2,9 +2,9 @@
 
 import { usePrivy } from '@privy-io/react-auth';
 import { Button } from '@/components/ui/button';
-import { useState, useEffect } from 'react';
 import Image from 'next/image';
-import { getSignupAttributionBodyFields } from '@/lib/analytics/attribution';
+import { useUsernameSignup } from '@/hooks/use-username-signup';
+import { UsernameSignupForm } from '@/components/auth/username-signup-form';
 
 interface AuthProps {
   children: React.ReactNode;
@@ -12,89 +12,19 @@ interface AuthProps {
 
 export default function Auth({ children }: AuthProps) {
   const { user, ready, linkEmail, login } = usePrivy();
-  const [username, setUsername] = useState('');
-  const [isCreatingPlayer, setIsCreatingPlayer] = useState(false);
-  const [needsUsername, setNeedsUsername] = useState(false);
-  const [createPlayerError, setCreatePlayerError] = useState<string | null>(
-    null
-  );
-
-  useEffect(() => {
-    const checkPlayerData = async () => {
-      if (user?.wallet?.address) {
-        try {
-          const response = await fetch(
-            `/api/player?walletAddress=${encodeURIComponent(
-              user.wallet.address
-            )}`
-          );
-
-          if (response.ok) {
-            const responseData = await response.json();
-            // Unwrap the apiSuccess wrapper
-            const result = responseData.data || responseData;
-            const existingPlayer = result.player;
-
-            // If player exists but has no username, prompt for username
-            if (existingPlayer && !existingPlayer.username) {
-              setNeedsUsername(true);
-            }
-          } else if (response.status === 404) {
-            // New player, needs username
-            setNeedsUsername(true);
-          }
-        } catch (error) {
-          console.error('Error checking player data:', error);
-          // Assume new player if error occurs
-          setNeedsUsername(true);
-        }
-      }
-    };
-
-    if (ready && user?.wallet?.address) {
-      checkPlayerData();
-    }
-  }, [ready, user?.wallet?.address]);
-
-  const handleCreatePlayer = async () => {
-    if (!username.trim() || !user?.wallet?.address) return;
-
-    setIsCreatingPlayer(true);
-    setCreatePlayerError(null);
-    try {
-      const email = user.email?.address?.trim();
-      const response = await fetch('/api/player', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({
-          walletAddress: user.wallet.address,
-          ...(email ? { email } : {}),
-          username: username.trim(),
-          ...getSignupAttributionBodyFields(),
-        }),
-      });
-
-      const responseData = await response.json();
-
-      if (responseData.success) {
-        setNeedsUsername(false);
-      } else {
-        const message =
-          responseData.error ||
-          'Unable to create your profile. Please try again.';
-        setCreatePlayerError(message);
-        console.error('Failed to create player:', message);
-      }
-    } catch (error) {
-      const message = 'Something went wrong. Please try again.';
-      setCreatePlayerError(message);
-      console.error('Error creating player:', error);
-    } finally {
-      setIsCreatingPlayer(false);
-    }
-  };
+  const walletAddress = user?.wallet?.address;
+  const {
+    username,
+    setUsername,
+    isCreatingPlayer,
+    needsUsername,
+    createPlayerError,
+    handleCreatePlayer,
+  } = useUsernameSignup({
+    checkEnabled: !!(ready && walletAddress),
+    walletAddress,
+    emailAddress: user?.email?.address,
+  });
 
   if (!ready) {
     return (
@@ -133,63 +63,15 @@ export default function Auth({ children }: AuthProps) {
           backgroundSize: 'cover',
         }}
       >
-        <div className="flex w-full max-w-md flex-col gap-6">
-          <p className="text-center text-lg font-semibold tracking-tight text-foreground font-inktrap md:text-xl">
-            Choose your username to start earning points
-          </p>
-
-          <div className="rounded-2xl border border-white/30 bg-white/20 p-4 backdrop-blur-sm">
-            <p className="mb-3 text-sm font-inktrap uppercase text-foreground">
-              ENTER YOUR USERNAME
-            </p>
-            <input
-              type="text"
-              placeholder="Enter your username"
-              value={username}
-              onChange={(e) => {
-                setUsername(e.target.value);
-                if (createPlayerError) setCreatePlayerError(null);
-              }}
-              className="w-full rounded-full border border-border/60 bg-white py-3 pl-4 pr-4 font-inktrap text-foreground placeholder:text-muted-foreground shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
-              maxLength={20}
-              disabled={isCreatingPlayer}
-              autoComplete="username"
-            />
-          </div>
-
-          {createPlayerError ? (
-            <p
-              className="text-center text-sm font-medium text-red-700"
-              role="alert"
-            >
-              {createPlayerError}
-            </p>
-          ) : null}
-
-          <Button
-            className="flex w-full items-center justify-center rounded-full bg-white px-6 py-6 text-base font-inktrap uppercase text-black hover:bg-white/90 disabled:opacity-50"
-            onClick={handleCreatePlayer}
-            disabled={!username.trim() || isCreatingPlayer}
-          >
-            {isCreatingPlayer ? 'CREATING PLAYER...' : 'START EARNING'}
-            {!isCreatingPlayer && (
-              <svg
-                className="ml-2 h-4 w-4"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-                aria-hidden
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M9 5l7 7-7 7"
-                />
-              </svg>
-            )}
-          </Button>
-        </div>
+        <UsernameSignupForm
+          heading="Choose your username to start earning points"
+          headingClassName="text-foreground"
+          username={username}
+          onUsernameChange={setUsername}
+          createPlayerError={createPlayerError}
+          isCreatingPlayer={isCreatingPlayer}
+          onSubmit={handleCreatePlayer}
+        />
       </div>
     );
   }

--- a/components/auth/auth.tsx
+++ b/components/auth/auth.tsx
@@ -15,6 +15,9 @@ export default function Auth({ children }: AuthProps) {
   const [username, setUsername] = useState('');
   const [isCreatingPlayer, setIsCreatingPlayer] = useState(false);
   const [needsUsername, setNeedsUsername] = useState(false);
+  const [createPlayerError, setCreatePlayerError] = useState<string | null>(
+    null
+  );
 
   useEffect(() => {
     const checkPlayerData = async () => {
@@ -57,7 +60,9 @@ export default function Auth({ children }: AuthProps) {
     if (!username.trim() || !user?.wallet?.address) return;
 
     setIsCreatingPlayer(true);
+    setCreatePlayerError(null);
     try {
+      const email = user.email?.address?.trim();
       const response = await fetch('/api/player', {
         method: 'POST',
         headers: {
@@ -65,7 +70,7 @@ export default function Auth({ children }: AuthProps) {
         },
         body: JSON.stringify({
           walletAddress: user.wallet.address,
-          email: user.email?.address || '',
+          ...(email ? { email } : {}),
           username: username.trim(),
           ...getSignupAttributionBodyFields(),
         }),
@@ -74,15 +79,18 @@ export default function Auth({ children }: AuthProps) {
       const responseData = await response.json();
 
       if (responseData.success) {
-        // Player created successfully
         setNeedsUsername(false);
       } else {
-        console.error('Failed to create player:', responseData.error);
-        // TODO: Show error message to user
+        const message =
+          responseData.error ||
+          'Unable to create your profile. Please try again.';
+        setCreatePlayerError(message);
+        console.error('Failed to create player:', message);
       }
     } catch (error) {
+      const message = 'Something went wrong. Please try again.';
+      setCreatePlayerError(message);
       console.error('Error creating player:', error);
-      // TODO: Show error message to user
     } finally {
       setIsCreatingPlayer(false);
     }
@@ -138,13 +146,25 @@ export default function Auth({ children }: AuthProps) {
               type="text"
               placeholder="Enter your username"
               value={username}
-              onChange={(e) => setUsername(e.target.value)}
+              onChange={(e) => {
+                setUsername(e.target.value);
+                if (createPlayerError) setCreatePlayerError(null);
+              }}
               className="w-full rounded-full border border-border/60 bg-white py-3 pl-4 pr-4 font-inktrap text-foreground placeholder:text-muted-foreground shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
               maxLength={20}
               disabled={isCreatingPlayer}
               autoComplete="username"
             />
           </div>
+
+          {createPlayerError ? (
+            <p
+              className="text-center text-sm font-medium text-red-700"
+              role="alert"
+            >
+              {createPlayerError}
+            </p>
+          ) : null}
 
           <Button
             className="flex w-full items-center justify-center rounded-full bg-white px-6 py-6 text-base font-inktrap uppercase text-black hover:bg-white/90 disabled:opacity-50"

--- a/components/auth/username-signup-form.tsx
+++ b/components/auth/username-signup-form.tsx
@@ -1,0 +1,90 @@
+'use client';
+
+import type { CSSProperties } from 'react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+
+interface UsernameSignupFormProps {
+  heading: string;
+  headingClassName?: string;
+  headingStyle?: CSSProperties;
+  username: string;
+  onUsernameChange: (value: string) => void;
+  createPlayerError: string | null;
+  isCreatingPlayer: boolean;
+  onSubmit: () => void;
+}
+
+export function UsernameSignupForm({
+  heading,
+  headingClassName,
+  headingStyle,
+  username,
+  onUsernameChange,
+  createPlayerError,
+  isCreatingPlayer,
+  onSubmit,
+}: UsernameSignupFormProps) {
+  return (
+    <div className="flex w-full max-w-md flex-col gap-6">
+      <p
+        className={cn(
+          'text-center text-lg font-semibold tracking-tight font-inktrap md:text-xl',
+          headingClassName
+        )}
+        style={headingStyle}
+      >
+        {heading}
+      </p>
+
+      <div className="rounded-2xl border border-white/30 bg-white/20 p-4 backdrop-blur-sm">
+        <p className="mb-3 text-sm font-inktrap uppercase text-foreground">
+          ENTER YOUR USERNAME
+        </p>
+        <input
+          type="text"
+          placeholder="Enter your username"
+          value={username}
+          onChange={(e) => onUsernameChange(e.target.value)}
+          className="w-full rounded-full border border-border/60 bg-white py-3 pl-4 pr-4 font-inktrap text-foreground placeholder:text-muted-foreground shadow-sm focus:border-ring focus:outline-none focus:ring-2 focus:ring-ring/30"
+          maxLength={20}
+          disabled={isCreatingPlayer}
+          autoComplete="username"
+        />
+      </div>
+
+      {createPlayerError && (
+        <p
+          className="text-center text-sm font-medium text-red-700"
+          role="alert"
+        >
+          {createPlayerError}
+        </p>
+      )}
+
+      <Button
+        className="flex w-full items-center justify-center rounded-full bg-white px-6 py-6 text-base font-inktrap uppercase text-black hover:bg-white/90 disabled:opacity-50"
+        onClick={onSubmit}
+        disabled={!username.trim() || isCreatingPlayer}
+      >
+        {isCreatingPlayer ? 'CREATING PLAYER...' : 'START EARNING'}
+        {!isCreatingPlayer && (
+          <svg
+            className="ml-2 h-4 w-4"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+            aria-hidden
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M9 5l7 7-7 7"
+            />
+          </svg>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/hooks/use-username-signup.ts
+++ b/hooks/use-username-signup.ts
@@ -1,0 +1,105 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { getSignupAttributionBodyFields } from '@/lib/analytics/attribution';
+import { optionalPrivyEmailBody } from '@/lib/api/privy-email';
+
+const DEFAULT_CREATE_ERROR = 'Unable to create your profile. Please try again.';
+const NETWORK_ERROR = 'Something went wrong. Please try again.';
+
+interface UseUsernameSignupOptions {
+  /** When false, skip the GET /api/player probe (e.g. AuthWrapper when requireUsername is off). */
+  checkEnabled: boolean;
+  walletAddress?: string;
+  emailAddress?: string;
+}
+
+export function useUsernameSignup({
+  checkEnabled,
+  walletAddress,
+  emailAddress,
+}: UseUsernameSignupOptions) {
+  const [username, setUsername] = useState('');
+  const [isCreatingPlayer, setIsCreatingPlayer] = useState(false);
+  const [needsUsername, setNeedsUsername] = useState(false);
+  const [createPlayerError, setCreatePlayerError] = useState<string | null>(
+    null
+  );
+
+  useEffect(() => {
+    if (!checkEnabled || !walletAddress) return;
+
+    const checkPlayerData = async () => {
+      try {
+        const response = await fetch(
+          `/api/player?walletAddress=${encodeURIComponent(walletAddress)}`
+        );
+
+        if (response.ok) {
+          const responseData = await response.json();
+          const result = responseData.data || responseData;
+          const existingPlayer = result.player;
+
+          if (existingPlayer && !existingPlayer.username) {
+            setNeedsUsername(true);
+          }
+        } else if (response.status === 404) {
+          setNeedsUsername(true);
+        }
+      } catch (error) {
+        console.error('Error checking player data:', error);
+        setNeedsUsername(true);
+      }
+    };
+
+    checkPlayerData();
+  }, [checkEnabled, walletAddress]);
+
+  const handleCreatePlayer = useCallback(async () => {
+    if (!username.trim() || !walletAddress) return;
+
+    setIsCreatingPlayer(true);
+    setCreatePlayerError(null);
+    try {
+      const response = await fetch('/api/player', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          walletAddress,
+          ...optionalPrivyEmailBody(emailAddress),
+          username: username.trim(),
+          ...getSignupAttributionBodyFields(),
+        }),
+      });
+
+      const responseData = await response.json();
+
+      if (responseData.success) {
+        setNeedsUsername(false);
+      } else {
+        const message = responseData.error || DEFAULT_CREATE_ERROR;
+        setCreatePlayerError(message);
+        console.error('Failed to create player:', message);
+      }
+    } catch (error) {
+      setCreatePlayerError(NETWORK_ERROR);
+      console.error('Error creating player:', error);
+    } finally {
+      setIsCreatingPlayer(false);
+    }
+  }, [username, walletAddress, emailAddress]);
+
+  const handleUsernameChange = useCallback((value: string) => {
+    setUsername(value);
+    setCreatePlayerError(null);
+  }, []);
+
+  return {
+    username,
+    setUsername: handleUsernameChange,
+    isCreatingPlayer,
+    needsUsername,
+    createPlayerError,
+    handleCreatePlayer,
+  };
+}

--- a/lib/api/privy-email.ts
+++ b/lib/api/privy-email.ts
@@ -1,0 +1,7 @@
+/** Omit blank Privy email strings from API request bodies (matches optionalEmailSchema). */
+export function optionalPrivyEmailBody(emailAddress: string | undefined): {
+  email?: string;
+} {
+  const email = emailAddress?.trim();
+  return email ? { email } : {};
+}

--- a/lib/db/__tests__/players.test.ts
+++ b/lib/db/__tests__/players.test.ts
@@ -305,6 +305,36 @@ describe('Players Database Module', () => {
       expect(result).toEqual(updatedPlayer);
     });
 
+    it('should skip wallet lookup when existing player hint is provided', async () => {
+      const existingPlayer: Player = {
+        id: 1,
+        wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+        username: 'olduser',
+        email: 'old@example.com',
+        total_points: 100,
+      };
+
+      const updatedPlayer: Player = {
+        ...existingPlayer,
+        username: 'newuser',
+      };
+
+      mockSingle.mockResolvedValueOnce({ data: updatedPlayer, error: null });
+
+      const result = await createOrUpdatePlayer(
+        {
+          wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+          username: 'newuser',
+          email: 'new@example.com',
+          total_points: 100,
+        },
+        existingPlayer
+      );
+
+      expect(result).toEqual(updatedPlayer);
+      expect(mockMaybeSingle).not.toHaveBeenCalled();
+    });
+
     it('should create new player when not exists', async () => {
       const newPlayer: Player = {
         id: 1,

--- a/lib/db/__tests__/players.test.ts
+++ b/lib/db/__tests__/players.test.ts
@@ -289,9 +289,10 @@ describe('Players Database Module', () => {
         email: 'new@example.com',
       };
 
-      // First call finds existing player
-      mockSingle.mockResolvedValueOnce({ data: existingPlayer, error: null });
-      // Second call updates player
+      mockMaybeSingle.mockResolvedValueOnce({
+        data: existingPlayer,
+        error: null,
+      });
       mockSingle.mockResolvedValueOnce({ data: updatedPlayer, error: null });
 
       const result = await createOrUpdatePlayer({
@@ -313,9 +314,7 @@ describe('Players Database Module', () => {
         total_points: 0,
       };
 
-      // First call returns no existing player
-      mockSingle.mockResolvedValueOnce({ data: null, error: null });
-      // Second call creates new player
+      mockMaybeSingle.mockResolvedValue({ data: null, error: null });
       mockSingle.mockResolvedValueOnce({ data: newPlayer, error: null });
 
       const result = await createOrUpdatePlayer({
@@ -335,9 +334,10 @@ describe('Players Database Module', () => {
         total_points: 100,
       };
 
-      // First call finds existing player
-      mockSingle.mockResolvedValueOnce({ data: existingPlayer, error: null });
-      // Second call fails
+      mockMaybeSingle.mockResolvedValueOnce({
+        data: existingPlayer,
+        error: null,
+      });
       mockSingle.mockResolvedValueOnce({
         data: null,
         error: { code: 'PGRST500', message: 'Update failed' },
@@ -353,9 +353,7 @@ describe('Players Database Module', () => {
     });
 
     it('should throw error on insert failure', async () => {
-      // First call returns no existing player
-      mockSingle.mockResolvedValueOnce({ data: null, error: null });
-      // Second call fails
+      mockMaybeSingle.mockResolvedValue({ data: null, error: null });
       mockSingle.mockResolvedValueOnce({
         data: null,
         error: { code: 'PGRST500', message: 'Insert failed' },

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -58,9 +58,7 @@ export const createOrUpdatePlayer = async (
     tryNormalizeEvmAddress(player.wallet_address) ??
     player.wallet_address.trim();
   const existingPlayer =
-    existingPlayerHint !== undefined
-      ? existingPlayerHint
-      : await getPlayerByWallet(normalizedWallet);
+    existingPlayerHint ?? (await getPlayerByWallet(normalizedWallet));
 
   if (existingPlayer) {
     const { data, error } = await supabase

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -53,11 +53,10 @@ async function getPlayerByField(
 export const createOrUpdatePlayer = async (
   player: Omit<Player, 'id' | 'created_at' | 'updated_at'>
 ) => {
-  const { data: existingPlayer } = await supabase
-    .from('players')
-    .select(PLAYER_COLUMNS)
-    .eq('wallet_address', player.wallet_address)
-    .single();
+  const normalizedWallet =
+    tryNormalizeEvmAddress(player.wallet_address) ??
+    player.wallet_address.trim();
+  const existingPlayer = await getPlayerByWallet(normalizedWallet);
 
   if (existingPlayer) {
     const { data, error } = await supabase
@@ -67,22 +66,25 @@ export const createOrUpdatePlayer = async (
         username: player.username || existingPlayer.username,
         updated_at: new Date().toISOString(),
       })
-      .eq('wallet_address', player.wallet_address)
-      .select(PLAYER_COLUMNS)
-      .single();
-
-    if (error) throw error;
-    return data;
-  } else {
-    const { data, error } = await supabase
-      .from('players')
-      .insert(player)
+      .eq('id', existingPlayer.id)
       .select(PLAYER_COLUMNS)
       .single();
 
     if (error) throw error;
     return data;
   }
+
+  const { data, error } = await supabase
+    .from('players')
+    .insert({
+      ...player,
+      wallet_address: normalizedWallet,
+    })
+    .select(PLAYER_COLUMNS)
+    .single();
+
+  if (error) throw error;
+  return data;
 };
 
 /**

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -51,12 +51,16 @@ async function getPlayerByField(
  * If player exists, updates email and username if provided.
  */
 export const createOrUpdatePlayer = async (
-  player: Omit<Player, 'id' | 'created_at' | 'updated_at'>
+  player: Omit<Player, 'id' | 'created_at' | 'updated_at'>,
+  existingPlayerHint?: Player | null
 ) => {
   const normalizedWallet =
     tryNormalizeEvmAddress(player.wallet_address) ??
     player.wallet_address.trim();
-  const existingPlayer = await getPlayerByWallet(normalizedWallet);
+  const existingPlayer =
+    existingPlayerHint !== undefined
+      ? existingPlayerHint
+      : await getPlayerByWallet(normalizedWallet);
 
   if (existingPlayer) {
     const { data, error } = await supabase

--- a/lib/db/profiles.ts
+++ b/lib/db/profiles.ts
@@ -1,5 +1,6 @@
 import { supabase } from './client';
 import type { UserProfile } from '../types';
+import { sameWalletAddress } from '../utils/wallets';
 
 // Select specific columns for profile queries (from players table)
 const PROFILE_COLUMNS = `
@@ -110,11 +111,12 @@ export const isUsernameTakenByOther = async (
     .from('players')
     .select('wallet_address')
     .eq('username', key)
-    .neq('wallet_address', excludeWalletAddress)
     .maybeSingle();
 
   if (error && error.code !== 'PGRST116') throw error;
-  return data != null;
+  if (!data?.wallet_address) return false;
+
+  return !sameWalletAddress(data.wallet_address, excludeWalletAddress);
 };
 
 /**

--- a/lib/schemas/__tests__/api.test.ts
+++ b/lib/schemas/__tests__/api.test.ts
@@ -322,6 +322,18 @@ describe('API Schemas', () => {
       expect(result.success).toBe(true);
     });
 
+    it('should treat empty email string as omitted', () => {
+      const result = createPlayerRequestSchema.safeParse({
+        walletAddress: '0x1234567890abcdef1234567890abcdef12345678',
+        username: 'testuser',
+        email: '',
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data.email).toBeUndefined();
+      }
+    });
+
     it('should reject empty username', () => {
       const result = createPlayerRequestSchema.safeParse({
         walletAddress: '0x1234567890abcdef1234567890abcdef12345678',

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -7,6 +7,12 @@ import {
 } from './player';
 import { signupAttributionSchema } from './signup-attribution';
 
+/** Treat blank client email strings as omitted (Privy often sends `''`). */
+export const optionalEmailSchema = z.preprocess(
+  (val) => (typeof val === 'string' && val.trim() === '' ? undefined : val),
+  z.string().email().optional()
+);
+
 /**
  * Common query parameter schemas for pagination and filtering
  */
@@ -21,7 +27,7 @@ export const paginationSchema = z.object({
  */
 export const checkinRequestSchema = z.object({
   walletAddress: walletAddressSchema,
-  email: z.string().email().optional(),
+  email: optionalEmailSchema,
   checkpoint: z.string().min(1),
 });
 
@@ -30,7 +36,7 @@ export const checkinRequestSchema = z.object({
  */
 export const createPlayerRequestSchema = z.object({
   walletAddress: walletAddressSchema,
-  email: z.string().email().optional(),
+  email: optionalEmailSchema,
   username: z.string().min(1).max(30),
   signup_attribution: signupAttributionSchema.optional(),
 });

--- a/lib/schemas/api.ts
+++ b/lib/schemas/api.ts
@@ -134,7 +134,7 @@ export const unifiedCheckinRequestSchema = z
   .object({
     chain: chainTypeSchema,
     walletAddress: z.string().min(1),
-    email: z.string().email().optional(),
+    email: optionalEmailSchema,
     checkpoint: z.string().min(1),
   })
   .superRefine((data, ctx) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users on checkpoint and map onboarding flows could tap **START EARNING**, see **CREATING PLAYER...**, and then get stuck with no progress and no error message.

## Root causes

1. **Empty email rejected by API validation** — the client always sent `email: ''` when no email was linked. Zod's `z.string().email().optional()` treats `''` as present but invalid, so `POST /api/player` returned 400 while the UI swallowed the error.
2. **Wallet address casing mismatch** — `createOrUpdatePlayer` looked up players with an exact `wallet_address` match. Users created via check-in with a different casing could fail to update and attempt a duplicate insert.
3. **Blocking downstream syncs** — Airtable and Campaign Monitor syncs were awaited before returning the API response, which could leave the button spinning if third-party calls were slow.
4. **No user-visible errors** — failures were only logged to the console.

## Fix

- Treat blank email strings as omitted in `createPlayerRequestSchema` (and check-in schema).
- Omit `email` from the client request body when absent.
- Resolve existing players via case-insensitive `getPlayerByWallet` and update by `id`.
- Compare username ownership case-insensitively when checking duplicates.
- Return the signup response immediately; run Airtable / Campaign Monitor syncs in the background.
- Show API error messages inline on the username form.

## Test plan

- [x] `yarn test lib/schemas/__tests__/api.test.ts app/api/player/__tests__/route.test.ts lib/db/__tests__/players.test.ts components/auth/auth.test.tsx`
- [ ] Manual: create username on `/c/[id]` checkpoint without linked email path
- [ ] Manual: verify taken username shows "Username is already taken"
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1779e148-b305-47c6-b4e8-0787c3f6e658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1779e148-b305-47c6-b4e8-0787c3f6e658"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

