### PR TITLE
feat: admin withdraw from sponsored activation campaign wallet

### DIFF
--- a/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
+++ b/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
@@ -355,8 +355,10 @@ export function ActivationLaunchPanel({
       }
       return body;
     },
-    onSuccess: async () => {
-      toast.success('Campaign wallet withdrawal submitted');
+    onSuccess: async (body) => {
+      const message =
+        (body as { message?: string }).message ?? 'Withdrawal confirmed.';
+      toast.success(message);
       setWithdrawDestination('');
       await invalidateAll();
     },

--- a/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
+++ b/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
@@ -43,6 +43,9 @@ type ActivationAdminRow = {
   venue_settlement_wallet_explorer_url: string | null;
   max_usdc_budget: number | null;
   max_redemptions: number | null;
+  campaign_wallet_usdc_balance?: number | null;
+  campaign_wallet_withdrawable_usdc?: number | null;
+  campaign_wallet_reserved_usdc?: number;
 };
 
 type RewardItemRow = {
@@ -188,6 +191,7 @@ export function ActivationLaunchPanel({
   const [rewardPoints, setRewardPoints] = useState('0');
   const [rewardUsdc, setRewardUsdc] = useState('1');
   const [rewardHeroFile, setRewardHeroFile] = useState<File | null>(null);
+  const [withdrawDestination, setWithdrawDestination] = useState('');
   const rewardHeroPreviewUrl = useMemo(
     () => (rewardHeroFile ? URL.createObjectURL(rewardHeroFile) : null),
     [rewardHeroFile]
@@ -324,6 +328,36 @@ export function ActivationLaunchPanel({
     },
     onSuccess: async () => {
       toast.success('Hero image updated');
+      await invalidateAll();
+    },
+    onError: (e: unknown) => toast.error(mutationErrorMessage(e)),
+  });
+
+  const withdrawMutation = useMutation({
+    mutationFn: async () => {
+      const trimmed = withdrawDestination.trim();
+      if (!trimmed) throw new Error('Refund address is required');
+      const auth = await adminApiAuthHeaders(getAccessToken);
+      const response = await fetch(
+        `/api/admin/sponsored-activations/${encodeURIComponent(activationId)}/campaign-wallet/withdraw`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...auth },
+          body: JSON.stringify({ destinationAddress: trimmed }),
+        }
+      );
+      const body = (await response.json().catch(() => ({}))) as Record<
+        string,
+        unknown
+      >;
+      if (!response.ok) {
+        throw new Error(readApiErrorMessage(body, 'Withdrawal failed'));
+      }
+      return body;
+    },
+    onSuccess: async () => {
+      toast.success('Campaign wallet withdrawal submitted');
+      setWithdrawDestination('');
       await invalidateAll();
     },
     onError: (e: unknown) => toast.error(mutationErrorMessage(e)),
@@ -673,70 +707,167 @@ export function ActivationLaunchPanel({
               )}
 
               {step.id === 'fund' && (
-                <div className="mt-3 flex flex-wrap items-start justify-between gap-3">
-                  <code className="block max-w-full break-all rounded-lg bg-neutral-50 p-2 font-mono text-xs text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
-                    {activation.campaign_wallet_address}
-                  </code>
-                  <div className="flex flex-wrap gap-2">
-                    <Button
-                      type="button"
-                      size="sm"
-                      variant="outline"
-                      className="gap-1"
-                      onClick={() =>
-                        void copyText(
-                          activation.campaign_wallet_address,
-                          'Campaign wallet copied'
-                        )
-                      }
-                    >
-                      <Copy className="size-3.5" />
-                      Copy wallet
-                    </Button>
-                    {activation.campaign_wallet_explorer_url && (
+                <div className="mt-3 space-y-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <code className="block max-w-full break-all rounded-lg bg-neutral-50 p-2 font-mono text-xs text-neutral-800 dark:bg-neutral-950 dark:text-neutral-200">
+                      {activation.campaign_wallet_address}
+                    </code>
+                    <div className="flex flex-wrap gap-2">
                       <Button
                         type="button"
                         size="sm"
                         variant="outline"
                         className="gap-1"
-                        asChild
+                        onClick={() =>
+                          void copyText(
+                            activation.campaign_wallet_address,
+                            'Campaign wallet copied'
+                          )
+                        }
                       >
-                        <a
-                          href={activation.campaign_wallet_explorer_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                        >
-                          View on {railLabel(activation.settlement_rail)}
-                          <ExternalLink className="size-3.5" />
-                        </a>
+                        <Copy className="size-3.5" />
+                        Copy wallet
                       </Button>
-                    )}
-                  </div>
-                  <p className="w-full text-xs text-neutral-500">
-                    {activation.settlement_rail === 'stellar'
-                      ? 'Shared Stellar campaign wallet (server-configured). Fund with USDC before redemptions settle.'
-                      : 'Send funds here (campaign wallet, provisioned via Privy).'}{' '}
-                    Redemptions settle USDC to the venue wallet{' '}
-                    <span className="font-mono text-[11px]">
-                      {activation.venue_settlement_wallet_address}
-                    </span>
-                    {activation.venue_settlement_wallet_explorer_url ? (
-                      <>
-                        {' '}
-                        (
-                        <a
-                          href={activation.venue_settlement_wallet_explorer_url}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="text-blue-700 hover:underline dark:text-blue-400"
+                      {activation.campaign_wallet_explorer_url && (
+                        <Button
+                          type="button"
+                          size="sm"
+                          variant="outline"
+                          className="gap-1"
+                          asChild
                         >
-                          venue explorer
-                        </a>
-                        )
-                      </>
-                    ) : null}
-                    .
-                  </p>
+                          <a
+                            href={activation.campaign_wallet_explorer_url}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                          >
+                            View on {railLabel(activation.settlement_rail)}
+                            <ExternalLink className="size-3.5" />
+                          </a>
+                        </Button>
+                      )}
+                    </div>
+                    <p className="w-full text-xs text-neutral-500">
+                      {activation.settlement_rail === 'stellar'
+                        ? 'Shared Stellar campaign wallet (server-configured). Fund with USDC before redemptions settle.'
+                        : 'Send funds here (campaign wallet, provisioned via Privy).'}{' '}
+                      Redemptions settle USDC to the venue wallet{' '}
+                      <span className="font-mono text-[11px]">
+                        {activation.venue_settlement_wallet_address}
+                      </span>
+                      {activation.venue_settlement_wallet_explorer_url ? (
+                        <>
+                          {' '}
+                          (
+                          <a
+                            href={
+                              activation.venue_settlement_wallet_explorer_url
+                            }
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-blue-700 hover:underline dark:text-blue-400"
+                          >
+                            venue explorer
+                          </a>
+                          )
+                        </>
+                      ) : null}
+                      .
+                    </p>
+                  </div>
+
+                  <div className="rounded-lg border border-neutral-200 p-4 dark:border-neutral-700">
+                    <div className="grid gap-3 text-sm sm:grid-cols-2">
+                      <div>
+                        <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+                          USDC balance
+                        </div>
+                        <div className="mt-1 font-medium text-neutral-900 dark:text-neutral-100">
+                          {activation.campaign_wallet_usdc_balance == null
+                            ? '—'
+                            : fmtUsdcHint(
+                                activation.campaign_wallet_usdc_balance
+                              )}
+                        </div>
+                      </div>
+                      <div>
+                        <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
+                          Withdrawable
+                        </div>
+                        <div className="mt-1 font-medium text-neutral-900 dark:text-neutral-100">
+                          {activation.campaign_wallet_withdrawable_usdc == null
+                            ? '—'
+                            : fmtUsdcHint(
+                                activation.campaign_wallet_withdrawable_usdc
+                              )}
+                        </div>
+                        {(activation.campaign_wallet_reserved_usdc ?? 0) >
+                          0 && (
+                          <p className="mt-1 text-xs text-amber-700 dark:text-amber-300">
+                            {fmtUsdcHint(
+                              activation.campaign_wallet_reserved_usdc ?? 0
+                            )}{' '}
+                            reserved for pending redemptions or settlements.
+                          </p>
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="mt-4 border-t border-neutral-100 pt-4 dark:border-neutral-800">
+                      <div className="flex flex-col gap-3 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-x-3 sm:gap-y-1.5">
+                        <Label
+                          htmlFor="campaign-withdraw-destination"
+                          className="order-1 text-neutral-500 sm:col-start-1 sm:row-start-1"
+                        >
+                          Refund to address
+                        </Label>
+                        <Input
+                          id="campaign-withdraw-destination"
+                          type="text"
+                          placeholder={
+                            activation.settlement_rail === 'base' ? '0x…' : 'G…'
+                          }
+                          autoComplete="off"
+                          spellCheck={false}
+                          value={withdrawDestination}
+                          onChange={(e) =>
+                            setWithdrawDestination(e.target.value)
+                          }
+                          disabled={withdrawMutation.isPending}
+                          className="order-2 w-full font-mono text-xs sm:col-start-1 sm:row-start-2"
+                        />
+                        <p className="order-3 text-xs text-neutral-500 sm:col-start-1 sm:row-start-3">
+                          Withdraws the full withdrawable USDC balance to the
+                          address above.
+                          {activation.settlement_rail === 'base'
+                            ? ' Gas is sponsored on Base.'
+                            : ' Stellar uses the shared campaign wallet; confirm the destination before sending.'}
+                        </p>
+                        <Button
+                          type="button"
+                          variant="outline"
+                          className="order-4 w-full shrink-0 whitespace-nowrap sm:order-none sm:col-start-2 sm:row-start-2 sm:w-auto sm:self-end"
+                          disabled={
+                            withdrawMutation.isPending ||
+                            !withdrawDestination.trim() ||
+                            activation.campaign_wallet_withdrawable_usdc ==
+                              null ||
+                            activation.campaign_wallet_withdrawable_usdc <= 0
+                          }
+                          onClick={() => withdrawMutation.mutate()}
+                        >
+                          {withdrawMutation.isPending ? (
+                            <>
+                              <Loader2 className="mr-2 size-4 animate-spin" />
+                              Withdrawing…
+                            </>
+                          ) : (
+                            'Withdraw USDC'
+                          )}
+                        </Button>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               )}
 

--- a/app/api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw/__tests__/route.test.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw/__tests__/route.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockRequireAdmin = vi.fn();
+const mockGetSponsoredActivationById = vi.fn();
+const mockWithdraw = vi.fn();
+
+vi.mock('@/lib/auth', () => ({
+  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+}));
+
+vi.mock('@/lib/db/sponsored-activations', () => ({
+  getSponsoredActivationById: (...args: unknown[]) =>
+    mockGetSponsoredActivationById(...args),
+}));
+
+vi.mock('@/lib/activation/campaign-wallet-withdraw', () => ({
+  withdrawSponsoredActivationCampaignWallet: (...args: unknown[]) =>
+    mockWithdraw(...args),
+}));
+
+import { POST } from '../route';
+
+const activation = {
+  id: 'act-1',
+  slug: 'act-1',
+  title: 'Pilot',
+  description: null,
+  sponsor_name: 'Sponsor',
+  event_id: null,
+  status: 'active' as const,
+  settlement_rail: 'base' as const,
+  campaign_wallet_address: '0x1111111111111111111111111111111111111111',
+  venue_settlement_wallet_address: '0x2222222222222222222222222222222222222222',
+  usdc_asset_config: {
+    contract_address: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+  },
+  max_redemptions: 10,
+  max_usdc_budget: 100,
+  usdc_settled_total: 5,
+  redemption_count_confirmed: 2,
+  starts_at: '2026-01-01T00:00:00.000Z',
+  ends_at: '2026-02-01T00:00:00.000Z',
+  eligibility_config: {},
+  created_by: null,
+  created_at: '2026-01-01T00:00:00.000Z',
+  updated_at: '2026-01-01T00:00:00.000Z',
+  activation_create_idempotency_key: null,
+  privy_campaign_wallet_id: 'pw-1',
+};
+
+describe('POST /api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAdmin.mockResolvedValue({
+      isValid: true,
+      user: { email: 'admin@example.com' },
+    });
+    mockGetSponsoredActivationById.mockResolvedValue(activation);
+    mockWithdraw.mockResolvedValue({
+      ok: true,
+      status: 'confirmed',
+      txHash: '0xabc',
+      amountUsdc: 1.5,
+      destinationAddress: '0x3333333333333333333333333333333333333333',
+      privyTransactionId: 'ptx-1',
+    });
+  });
+
+  it('returns 403 when admin auth fails', async () => {
+    mockRequireAdmin.mockResolvedValue({ isValid: false });
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/sponsored-activations/act-1/campaign-wallet/withdraw',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          destinationAddress: '0x3333333333333333333333333333333333333333',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { activationId: 'act-1' } });
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 404 when activation is missing', async () => {
+    mockGetSponsoredActivationById.mockResolvedValue(null);
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/sponsored-activations/act-1/campaign-wallet/withdraw',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          destinationAddress: '0x3333333333333333333333333333333333333333',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { activationId: 'act-1' } });
+    expect(res.status).toBe(404);
+  });
+
+  it('returns 400 for invalid body', async () => {
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/sponsored-activations/act-1/campaign-wallet/withdraw',
+      {
+        method: 'POST',
+        body: JSON.stringify({ destinationAddress: '' }),
+      }
+    );
+    const res = await POST(req, { params: { activationId: 'act-1' } });
+    expect(res.status).toBe(400);
+    expect(mockWithdraw).not.toHaveBeenCalled();
+  });
+
+  it('confirms withdrawal on success', async () => {
+    const destination = '0x3333333333333333333333333333333333333333';
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/sponsored-activations/act-1/campaign-wallet/withdraw',
+      {
+        method: 'POST',
+        body: JSON.stringify({ destinationAddress: destination }),
+      }
+    );
+    const res = await POST(req, { params: { activationId: 'act-1' } });
+    expect(res.status).toBe(200);
+    expect(mockWithdraw).toHaveBeenCalledWith({
+      activation,
+      destinationAddress: destination,
+      amountUsdc: undefined,
+    });
+    const json = await res.json();
+    expect(json.data.status).toBe('confirmed');
+    expect(json.data.txHash).toBe('0xabc');
+  });
+
+  it('returns 202 when withdrawal is submitted but pending', async () => {
+    mockWithdraw.mockResolvedValue({
+      ok: true,
+      status: 'submitted',
+      amountUsdc: 1.5,
+      destinationAddress: '0x3333333333333333333333333333333333333333',
+      message: 'pending',
+    });
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/sponsored-activations/act-1/campaign-wallet/withdraw',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          destinationAddress: '0x3333333333333333333333333333333333333333',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { activationId: 'act-1' } });
+    expect(res.status).toBe(202);
+  });
+
+  it('returns business error from withdraw helper', async () => {
+    mockWithdraw.mockResolvedValue({
+      ok: false,
+      error: 'No USDC available to withdraw.',
+      statusCode: 400,
+    });
+    const req = new NextRequest(
+      'http://localhost:3000/api/admin/sponsored-activations/act-1/campaign-wallet/withdraw',
+      {
+        method: 'POST',
+        body: JSON.stringify({
+          destinationAddress: '0x3333333333333333333333333333333333333333',
+        }),
+      }
+    );
+    const res = await POST(req, { params: { activationId: 'act-1' } });
+    expect(res.status).toBe(400);
+  });
+});

--- a/app/api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw/route.ts
@@ -45,37 +45,24 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
     });
 
     if (!result.ok) {
-      return apiError(result.error, result.statusCode === 400 ? 400 : 500);
+      return apiError(result.error, result.statusCode ?? 500);
     }
 
-    if (result.status === 'submitted') {
-      return apiSuccess(
-        {
-          status: result.status,
-          amountUsdc: result.amountUsdc,
-          destinationAddress: result.destinationAddress,
-          txHash: result.txHash,
-          privyTransactionId: result.privyTransactionId,
-          userOperationHash: result.userOperationHash,
-          referenceId: result.referenceId,
-          message: result.message,
-        },
-        result.message,
-        202
-      );
-    }
+    const payload = {
+      status: result.status,
+      amountUsdc: result.amountUsdc,
+      destinationAddress: result.destinationAddress,
+      txHash: result.txHash,
+      privyTransactionId: result.privyTransactionId,
+      userOperationHash: result.userOperationHash,
+      referenceId: result.referenceId,
+      ...(result.status === 'submitted' ? { message: result.message } : {}),
+    };
 
     return apiSuccess(
-      {
-        status: result.status,
-        txHash: result.txHash,
-        amountUsdc: result.amountUsdc,
-        destinationAddress: result.destinationAddress,
-        privyTransactionId: result.privyTransactionId,
-        userOperationHash: result.userOperationHash,
-        referenceId: result.referenceId,
-      },
-      'Withdrawal confirmed.'
+      payload,
+      result.status === 'submitted' ? result.message : 'Withdrawal confirmed.',
+      result.status === 'submitted' ? 202 : 200
     );
   } catch (error) {
     console.error(

--- a/app/api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw/route.ts
@@ -1,0 +1,87 @@
+import { NextRequest } from 'next/server';
+import { withdrawSponsoredActivationCampaignWallet } from '@/lib/activation/campaign-wallet-withdraw';
+import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
+import { requireAdmin } from '@/lib/auth';
+import { getSponsoredActivationById } from '@/lib/db/sponsored-activations';
+import { sponsoredActivationCampaignWithdrawRequestSchema } from '@/lib/schemas/sponsored-activation-withdraw';
+
+interface RouteParams {
+  params: { activationId: string };
+}
+
+/**
+ * POST /api/admin/sponsored-activations/{activationId}/campaign-wallet/withdraw
+ * Sends withdrawable USDC from the activation campaign wallet to an admin-provided address.
+ */
+export async function POST(request: NextRequest, { params }: RouteParams) {
+  try {
+    const adminCheck = await requireAdmin(request);
+    if (!adminCheck.isValid) {
+      return apiError('Unauthorized - Admin access required', 403);
+    }
+
+    const activation = await getSponsoredActivationById(params.activationId);
+    if (!activation) {
+      return apiError('Sponsored activation not found', 404);
+    }
+
+    let raw: unknown;
+    try {
+      raw = await request.json();
+    } catch {
+      return apiError('Invalid JSON body', 400);
+    }
+
+    const validation =
+      sponsoredActivationCampaignWithdrawRequestSchema.safeParse(raw);
+    if (!validation.success) {
+      return apiValidationError(validation.error);
+    }
+
+    const result = await withdrawSponsoredActivationCampaignWallet({
+      activation,
+      destinationAddress: validation.data.destinationAddress,
+      amountUsdc: validation.data.amountUsdc,
+    });
+
+    if (!result.ok) {
+      return apiError(result.error, result.statusCode === 400 ? 400 : 500);
+    }
+
+    if (result.status === 'submitted') {
+      return apiSuccess(
+        {
+          status: result.status,
+          amountUsdc: result.amountUsdc,
+          destinationAddress: result.destinationAddress,
+          txHash: result.txHash,
+          privyTransactionId: result.privyTransactionId,
+          userOperationHash: result.userOperationHash,
+          referenceId: result.referenceId,
+          message: result.message,
+        },
+        result.message,
+        202
+      );
+    }
+
+    return apiSuccess(
+      {
+        status: result.status,
+        txHash: result.txHash,
+        amountUsdc: result.amountUsdc,
+        destinationAddress: result.destinationAddress,
+        privyTransactionId: result.privyTransactionId,
+        userOperationHash: result.userOperationHash,
+        referenceId: result.referenceId,
+      },
+      'Withdrawal confirmed.'
+    );
+  } catch (error) {
+    console.error(
+      'POST /api/admin/sponsored-activations/[activationId]/campaign-wallet/withdraw:',
+      error
+    );
+    return apiError('Failed to withdraw campaign wallet USDC', 500);
+  }
+}

--- a/app/api/admin/sponsored-activations/[activationId]/route.ts
+++ b/app/api/admin/sponsored-activations/[activationId]/route.ts
@@ -12,6 +12,7 @@ import {
 } from '@/lib/schemas/sponsored-activation';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
+import { loadSponsoredActivationCampaignWalletBalancePack } from '@/lib/activation/campaign-wallet-withdraw';
 import { sponsoredActivationAdminEnvelope } from '@/lib/activation/explorer-url';
 
 interface RouteParams {
@@ -57,8 +58,14 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return apiError('Sponsored activation not found', 404);
     }
 
+    const walletBalance =
+      await loadSponsoredActivationCampaignWalletBalancePack(row);
+
     return apiSuccess({
-      activation: sponsoredActivationAdminEnvelope(row),
+      activation: {
+        ...sponsoredActivationAdminEnvelope(row),
+        ...walletBalance,
+      },
     });
   } catch (error) {
     console.error(

--- a/lib/activation/campaign-wallet-withdraw.test.ts
+++ b/lib/activation/campaign-wallet-withdraw.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect } from 'vitest';
-import { computeWithdrawableUsdc } from '@/lib/activation/campaign-wallet-withdraw';
+import {
+  computeStellarSharedWalletActivationWithdrawableUsdc,
+  computeWithdrawableUsdc,
+} from '@/lib/activation/campaign-wallet-withdraw';
 
 describe('computeWithdrawableUsdc', () => {
   it('subtracts reserved USDC from balance', () => {
@@ -12,5 +15,40 @@ describe('computeWithdrawableUsdc', () => {
 
   it('returns full balance when nothing is reserved', () => {
     expect(computeWithdrawableUsdc(4.5, 0)).toBe(4.5);
+  });
+});
+
+describe('computeStellarSharedWalletActivationWithdrawableUsdc', () => {
+  it('subtracts reservations from all activations on the shared wallet', () => {
+    expect(
+      computeStellarSharedWalletActivationWithdrawableUsdc({
+        walletBalanceUsdc: 100,
+        sharedWalletReservedUsdc: 25,
+        activationBudgetRemainingUsdc: 80,
+        otherActivationsBudgetRemainingUsdc: 0,
+      })
+    ).toBe(75);
+  });
+
+  it('caps withdrawable by this activation budget remaining and peer allocations', () => {
+    expect(
+      computeStellarSharedWalletActivationWithdrawableUsdc({
+        walletBalanceUsdc: 100,
+        sharedWalletReservedUsdc: 0,
+        activationBudgetRemainingUsdc: 60,
+        otherActivationsBudgetRemainingUsdc: 60,
+      })
+    ).toBe(40);
+  });
+
+  it('never returns negative withdrawable amounts', () => {
+    expect(
+      computeStellarSharedWalletActivationWithdrawableUsdc({
+        walletBalanceUsdc: 50,
+        sharedWalletReservedUsdc: 60,
+        activationBudgetRemainingUsdc: 10,
+        otherActivationsBudgetRemainingUsdc: 0,
+      })
+    ).toBe(0);
   });
 });

--- a/lib/activation/campaign-wallet-withdraw.test.ts
+++ b/lib/activation/campaign-wallet-withdraw.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { computeWithdrawableUsdc } from '@/lib/activation/campaign-wallet-withdraw';
+
+describe('computeWithdrawableUsdc', () => {
+  it('subtracts reserved USDC from balance', () => {
+    expect(computeWithdrawableUsdc(10, 3.25)).toBe(6.75);
+  });
+
+  it('never returns negative withdrawable amounts', () => {
+    expect(computeWithdrawableUsdc(2, 5)).toBe(0);
+  });
+
+  it('returns full balance when nothing is reserved', () => {
+    expect(computeWithdrawableUsdc(4.5, 0)).toBe(4.5);
+  });
+});

--- a/lib/activation/campaign-wallet-withdraw.ts
+++ b/lib/activation/campaign-wallet-withdraw.ts
@@ -2,8 +2,14 @@ import {
   parseStellarSettlementAssetConfig,
   submitStellarCampaignUsdcPayment,
 } from '@/lib/activation/stellar-settlement-submit';
-import { loadActivationReservedUsdc } from '@/lib/db/sponsored-activation-admin';
-import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
+import {
+  computeBudgetRemainingUsdc,
+  loadActivationReservedUsdc,
+} from '@/lib/db/sponsored-activation-admin';
+import {
+  listStellarActivationsSharingCampaignWallet,
+  type SponsoredActivationRow,
+} from '@/lib/db/sponsored-activations';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { baseUsdcAssetConfigSchema } from '@/lib/schemas/sponsored-activation';
 import { parseUsdcBalanceLine } from '@/lib/spend/stellar-treasury-funding';
@@ -68,6 +74,87 @@ export function computeWithdrawableUsdc(
   return computeWithdrawableMicro(balanceUsdc, reservedUsdc) / 1e6;
 }
 
+/** Withdrawable USDC for one Stellar activation on the shared campaign wallet. */
+export function computeStellarSharedWalletActivationWithdrawableUsdc(input: {
+  walletBalanceUsdc: number;
+  sharedWalletReservedUsdc: number;
+  activationBudgetRemainingUsdc: number | null;
+  otherActivationsBudgetRemainingUsdc: number;
+}): number {
+  const poolWithdrawable = computeWithdrawableUsdc(
+    input.walletBalanceUsdc,
+    input.sharedWalletReservedUsdc
+  );
+  const afterOtherClaims = Math.max(
+    0,
+    poolWithdrawable - input.otherActivationsBudgetRemainingUsdc
+  );
+  if (input.activationBudgetRemainingUsdc == null) {
+    return afterOtherClaims;
+  }
+  return Math.min(
+    Math.max(0, input.activationBudgetRemainingUsdc),
+    afterOtherClaims
+  );
+}
+
+function sumOtherStellarActivationsBudgetRemainingUsdc(
+  peers: Array<{ activation: SponsoredActivationRow; reservedUsdc: number }>,
+  currentActivationId: string
+): number {
+  let total = 0;
+  for (const peer of peers) {
+    if (peer.activation.id === currentActivationId) continue;
+    const remaining = computeBudgetRemainingUsdc({
+      maxUsdcBudget: peer.activation.max_usdc_budget,
+      usdcSettledTotal: peer.activation.usdc_settled_total,
+      reservedUsdc: peer.reservedUsdc,
+    });
+    if (remaining != null && remaining > 0) {
+      total += remaining;
+    }
+  }
+  return total;
+}
+
+async function loadStellarSharedWalletWithdrawContext(
+  activation: SponsoredActivationRow
+): Promise<{
+  activationReservedUsdc: number;
+  sharedWalletReservedUsdc: number;
+  activationBudgetRemainingUsdc: number | null;
+  otherActivationsBudgetRemainingUsdc: number;
+}> {
+  const peerActivations = await listStellarActivationsSharingCampaignWallet(
+    activation.campaign_wallet_address
+  );
+  const peers = await Promise.all(
+    peerActivations.map(async (peer) => ({
+      activation: peer,
+      reservedUsdc: await loadActivationReservedUsdc(peer.id),
+    }))
+  );
+  const activationPeer = peers.find(
+    (peer) => peer.activation.id === activation.id
+  );
+  const activationReservedUsdc = activationPeer?.reservedUsdc ?? 0;
+  const sharedWalletReservedUsdc = peers.reduce(
+    (sum, peer) => sum + peer.reservedUsdc,
+    0
+  );
+  return {
+    activationReservedUsdc,
+    sharedWalletReservedUsdc,
+    activationBudgetRemainingUsdc: computeBudgetRemainingUsdc({
+      maxUsdcBudget: activation.max_usdc_budget,
+      usdcSettledTotal: activation.usdc_settled_total,
+      reservedUsdc: activationReservedUsdc,
+    }),
+    otherActivationsBudgetRemainingUsdc:
+      sumOtherStellarActivationsBudgetRemainingUsdc(peers, activation.id),
+  };
+}
+
 async function readBaseCampaignWalletBalance(
   activation: SponsoredActivationRow
 ): Promise<number | null> {
@@ -118,18 +205,38 @@ async function readStellarCampaignWalletBalance(
 export async function loadSponsoredActivationCampaignWalletBalancePack(
   activation: SponsoredActivationRow
 ): Promise<SponsoredActivationCampaignWalletBalancePack> {
-  const [reservedUsdc, balance] = await Promise.all([
-    loadActivationReservedUsdc(activation.id),
-    activation.settlement_rail === 'base'
-      ? readBaseCampaignWalletBalance(activation)
-      : readStellarCampaignWalletBalance(activation),
+  if (activation.settlement_rail === 'base') {
+    const [reservedUsdc, balance] = await Promise.all([
+      loadActivationReservedUsdc(activation.id),
+      readBaseCampaignWalletBalance(activation),
+    ]);
+    return {
+      campaign_wallet_usdc_balance: balance,
+      campaign_wallet_withdrawable_usdc:
+        balance == null ? null : computeWithdrawableUsdc(balance, reservedUsdc),
+      campaign_wallet_reserved_usdc: reservedUsdc,
+    };
+  }
+
+  const [balance, stellarContext] = await Promise.all([
+    readStellarCampaignWalletBalance(activation),
+    loadStellarSharedWalletWithdrawContext(activation),
   ]);
 
   return {
     campaign_wallet_usdc_balance: balance,
     campaign_wallet_withdrawable_usdc:
-      balance == null ? null : computeWithdrawableUsdc(balance, reservedUsdc),
-    campaign_wallet_reserved_usdc: reservedUsdc,
+      balance == null
+        ? null
+        : computeStellarSharedWalletActivationWithdrawableUsdc({
+            walletBalanceUsdc: balance,
+            sharedWalletReservedUsdc: stellarContext.sharedWalletReservedUsdc,
+            activationBudgetRemainingUsdc:
+              stellarContext.activationBudgetRemainingUsdc,
+            otherActivationsBudgetRemainingUsdc:
+              stellarContext.otherActivationsBudgetRemainingUsdc,
+          }),
+    campaign_wallet_reserved_usdc: stellarContext.activationReservedUsdc,
   };
 }
 

--- a/lib/activation/campaign-wallet-withdraw.ts
+++ b/lib/activation/campaign-wallet-withdraw.ts
@@ -1,0 +1,484 @@
+import {
+  Asset,
+  Horizon,
+  Operation,
+  TransactionBuilder,
+} from '@stellar/stellar-sdk';
+import { parseStellarSponsoredCampaignKeypair } from '@/lib/activation/stellar-campaign-wallet-config';
+import { parseStellarSettlementAssetConfig } from '@/lib/activation/stellar-settlement-submit';
+import { loadActivationReservedUsdc } from '@/lib/db/sponsored-activation-admin';
+import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
+import { stellarWalletAddressSchema } from '@/lib/schemas/player';
+import { baseUsdcAssetConfigSchema } from '@/lib/schemas/sponsored-activation';
+import {
+  classifyStellarHorizonSubmitError,
+  formatUsdcAmountForStellar,
+  loadAccountOrThrow,
+  readHorizonHttpErrorData,
+} from '@/lib/stellar/horizon-submit-helpers';
+import {
+  createStellarSpendHorizonServer,
+  getStellarSpendNetworkPassphrase,
+} from '@/lib/spend/stellar-wallet-readiness-config';
+import { getSpendRailBaseRpcUrl } from '@/lib/spend-rail-config';
+import {
+  submitTreasuryUsdcTransfer,
+  waitForTreasuryTxReceipt,
+} from '@/lib/spend-treasury-usdc-transfer';
+import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+import {
+  fetchUsdcBalanceOnBase,
+  isEvmAddress,
+} from '@/lib/walletconnect-poster-direct-usdc';
+
+export type SponsoredActivationCampaignWalletBalancePack = {
+  campaign_wallet_usdc_balance: number | null;
+  campaign_wallet_withdrawable_usdc: number | null;
+  campaign_wallet_reserved_usdc: number;
+};
+
+export type SponsoredActivationCampaignWithdrawResult =
+  | {
+      ok: true;
+      status: 'confirmed';
+      txHash: string;
+      amountUsdc: number;
+      destinationAddress: string;
+      privyTransactionId?: string;
+      userOperationHash?: string | null;
+      referenceId?: string;
+    }
+  | {
+      ok: true;
+      status: 'submitted';
+      amountUsdc: number;
+      destinationAddress: string;
+      txHash?: string;
+      privyTransactionId?: string;
+      userOperationHash?: string | null;
+      referenceId?: string;
+      message: string;
+    }
+  | { ok: false; error: string; statusCode?: 400 | 500 };
+
+function computeWithdrawableMicro(
+  balanceUsdc: number,
+  reservedUsdc: number
+): number {
+  const balanceMicro = Math.floor(balanceUsdc * 1e6);
+  const reservedMicro = Math.ceil(Math.max(0, reservedUsdc) * 1e6);
+  return Math.max(0, balanceMicro - reservedMicro);
+}
+
+export function computeWithdrawableUsdc(
+  balanceUsdc: number,
+  reservedUsdc: number
+): number {
+  return computeWithdrawableMicro(balanceUsdc, reservedUsdc) / 1e6;
+}
+
+async function readBaseCampaignWalletBalance(
+  activation: SponsoredActivationRow
+): Promise<number | null> {
+  const cfg = baseUsdcAssetConfigSchema.safeParse(activation.usdc_asset_config);
+  if (!cfg.success) return null;
+  const normalized = tryNormalizeEvmAddress(activation.campaign_wallet_address);
+  if (!normalized || !isEvmAddress(normalized)) return null;
+  try {
+    return await fetchUsdcBalanceOnBase(normalized as `0x${string}`, {
+      rpcUrl: getSpendRailBaseRpcUrl() || undefined,
+      usdcContract: cfg.data.contract_address as `0x${string}`,
+    });
+  } catch (e) {
+    console.error('readBaseCampaignWalletBalance:', e);
+    return null;
+  }
+}
+
+async function readStellarCampaignWalletBalance(
+  activation: SponsoredActivationRow
+): Promise<number | null> {
+  const assetParsed = parseStellarSettlementAssetConfig(
+    activation.usdc_asset_config
+  );
+  if (!assetParsed.ok) return null;
+
+  const campaignParse = stellarWalletAddressSchema.safeParse(
+    activation.campaign_wallet_address.trim().toUpperCase()
+  );
+  if (!campaignParse.success) return null;
+
+  const server = createStellarSpendHorizonServer();
+  try {
+    const account = await server.loadAccount(campaignParse.data);
+    for (const b of account.balances) {
+      if (
+        b.asset_type !== 'credit_alphanum4' &&
+        b.asset_type !== 'credit_alphanum12'
+      ) {
+        continue;
+      }
+      if (
+        b.asset_code === assetParsed.config.asset_code &&
+        b.asset_issuer === assetParsed.config.issuer
+      ) {
+        const n = Number(b.balance);
+        return Number.isFinite(n) ? n : null;
+      }
+    }
+    return 0;
+  } catch (e) {
+    console.error('readStellarCampaignWalletBalance:', e);
+    return null;
+  }
+}
+
+export async function loadSponsoredActivationCampaignWalletBalancePack(
+  activation: SponsoredActivationRow
+): Promise<SponsoredActivationCampaignWalletBalancePack> {
+  const reservedUsdc = await loadActivationReservedUsdc(activation.id);
+  const balance =
+    activation.settlement_rail === 'base'
+      ? await readBaseCampaignWalletBalance(activation)
+      : await readStellarCampaignWalletBalance(activation);
+
+  return {
+    campaign_wallet_usdc_balance: balance,
+    campaign_wallet_withdrawable_usdc:
+      balance == null ? null : computeWithdrawableUsdc(balance, reservedUsdc),
+    campaign_wallet_reserved_usdc: reservedUsdc,
+  };
+}
+
+function validateDestinationForRail(
+  activation: SponsoredActivationRow,
+  destinationAddress: string
+): { ok: true; normalized: string } | { ok: false; error: string } {
+  if (activation.settlement_rail === 'base') {
+    const normalized = tryNormalizeEvmAddress(destinationAddress);
+    if (!normalized || !isEvmAddress(normalized)) {
+      return { ok: false, error: 'Invalid Ethereum address' };
+    }
+    if (
+      sameWalletAddress(normalized, activation.campaign_wallet_address) ||
+      sameWalletAddress(normalized, activation.venue_settlement_wallet_address)
+    ) {
+      return {
+        ok: false,
+        error:
+          'Destination must differ from the campaign and venue settlement wallets.',
+      };
+    }
+    return { ok: true, normalized };
+  }
+
+  const parsed = stellarWalletAddressSchema.safeParse(
+    destinationAddress.trim().toUpperCase()
+  );
+  if (!parsed.success) {
+    return { ok: false, error: 'Invalid Stellar address' };
+  }
+  if (
+    sameWalletAddress(parsed.data, activation.campaign_wallet_address) ||
+    sameWalletAddress(parsed.data, activation.venue_settlement_wallet_address)
+  ) {
+    return {
+      ok: false,
+      error:
+        'Destination must differ from the campaign and venue settlement wallets.',
+    };
+  }
+  return { ok: true, normalized: parsed.data };
+}
+
+async function submitStellarCampaignWalletWithdraw(input: {
+  activation: SponsoredActivationRow;
+  destinationAddress: string;
+  usdcAmount: number;
+}): Promise<
+  | { ok: true; txHash: string }
+  | { ok: false; error: string; statusCode?: 400 | 500 }
+> {
+  const assetParsed = parseStellarSettlementAssetConfig(
+    input.activation.usdc_asset_config
+  );
+  if (!assetParsed.ok) {
+    return { ok: false, error: 'Stellar USDC asset is misconfigured.' };
+  }
+
+  let campaignKp;
+  try {
+    campaignKp = parseStellarSponsoredCampaignKeypair();
+  } catch {
+    return {
+      ok: false,
+      error: 'Stellar campaign wallet is not configured on the server.',
+      statusCode: 500,
+    };
+  }
+
+  const campaignPub = input.activation.campaign_wallet_address
+    .trim()
+    .toUpperCase();
+  if (campaignKp.publicKey() !== campaignPub) {
+    return {
+      ok: false,
+      error: 'Stellar campaign wallet key does not match this activation.',
+      statusCode: 500,
+    };
+  }
+
+  const passphrase = getStellarSpendNetworkPassphrase();
+  const server = createStellarSpendHorizonServer();
+  const { asset_code: usdcCode, issuer: usdcIssuer } = assetParsed.config;
+  const usdcAsset = new Asset(usdcCode, usdcIssuer);
+  const payAmount = formatUsdcAmountForStellar(input.usdcAmount);
+
+  let campaignAccount: Horizon.AccountResponse;
+  try {
+    campaignAccount = await loadAccountOrThrow(server, campaignPub);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const { resultCodes } = readHorizonHttpErrorData(e);
+    return {
+      ok: false,
+      error: classifyStellarHorizonSubmitError(msg, resultCodes),
+      statusCode: 500,
+    };
+  }
+
+  let baseFee: string;
+  try {
+    baseFee = (await server.fetchBaseFee()).toString();
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return {
+      ok: false,
+      error: classifyStellarHorizonSubmitError(msg),
+      statusCode: 500,
+    };
+  }
+
+  const tx = new TransactionBuilder(campaignAccount, {
+    fee: baseFee,
+    networkPassphrase: passphrase,
+  })
+    .addOperation(
+      Operation.payment({
+        destination: input.destinationAddress,
+        asset: usdcAsset,
+        amount: payAmount,
+      })
+    )
+    .setTimeout(180)
+    .build();
+
+  tx.sign(campaignKp);
+
+  try {
+    const res = await server.submitTransaction(tx);
+    return { ok: true, txHash: res.hash };
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    const { resultCodes } = readHorizonHttpErrorData(e);
+    return {
+      ok: false,
+      error: classifyStellarHorizonSubmitError(msg, resultCodes),
+      statusCode: 500,
+    };
+  }
+}
+
+export async function withdrawSponsoredActivationCampaignWallet(input: {
+  activation: SponsoredActivationRow;
+  destinationAddress: string;
+  amountUsdc?: number | null;
+}): Promise<SponsoredActivationCampaignWithdrawResult> {
+  const destCheck = validateDestinationForRail(
+    input.activation,
+    input.destinationAddress
+  );
+  if (!destCheck.ok) {
+    return { ok: false, error: destCheck.error, statusCode: 400 };
+  }
+
+  const balancePack = await loadSponsoredActivationCampaignWalletBalancePack(
+    input.activation
+  );
+  if (balancePack.campaign_wallet_usdc_balance == null) {
+    return {
+      ok: false,
+      error: 'Could not read campaign wallet USDC balance.',
+      statusCode: 500,
+    };
+  }
+
+  const maxWithdrawableMicro = computeWithdrawableMicro(
+    balancePack.campaign_wallet_usdc_balance,
+    balancePack.campaign_wallet_reserved_usdc
+  );
+  if (maxWithdrawableMicro <= 0) {
+    return {
+      ok: false,
+      error:
+        balancePack.campaign_wallet_reserved_usdc > 0
+          ? 'No withdrawable USDC while funds are reserved for pending redemptions or settlements.'
+          : 'No USDC available to withdraw.',
+      statusCode: 400,
+    };
+  }
+
+  let withdrawMicro: number;
+  if (input.amountUsdc != null && input.amountUsdc > 0) {
+    withdrawMicro = Math.floor(input.amountUsdc * 1e6);
+    if (withdrawMicro <= 0) {
+      return {
+        ok: false,
+        error: 'Withdraw amount must be positive.',
+        statusCode: 400,
+      };
+    }
+    if (withdrawMicro > maxWithdrawableMicro) {
+      return {
+        ok: false,
+        error: `Amount exceeds withdrawable balance (${(maxWithdrawableMicro / 1e6).toFixed(6)} USDC).`,
+        statusCode: 400,
+      };
+    }
+  } else {
+    withdrawMicro = maxWithdrawableMicro;
+  }
+
+  const withdrawAmount = withdrawMicro / 1e6;
+  const destinationAddress = destCheck.normalized;
+
+  if (input.activation.settlement_rail === 'stellar') {
+    const submitted = await submitStellarCampaignWalletWithdraw({
+      activation: input.activation,
+      destinationAddress,
+      usdcAmount: withdrawAmount,
+    });
+    if (!submitted.ok) {
+      return {
+        ok: false,
+        error: submitted.error,
+        statusCode: submitted.statusCode === 400 ? 400 : 500,
+      };
+    }
+    return {
+      ok: true,
+      status: 'confirmed',
+      txHash: submitted.txHash,
+      amountUsdc: withdrawAmount,
+      destinationAddress,
+    };
+  }
+
+  const privyWalletId = input.activation.privy_campaign_wallet_id?.trim();
+  if (!privyWalletId) {
+    return {
+      ok: false,
+      error: 'Campaign wallet is not configured for this activation.',
+      statusCode: 400,
+    };
+  }
+
+  const campaignAddress = tryNormalizeEvmAddress(
+    input.activation.campaign_wallet_address
+  );
+  if (!campaignAddress || !isEvmAddress(campaignAddress)) {
+    return {
+      ok: false,
+      error: 'Campaign wallet address is invalid.',
+      statusCode: 500,
+    };
+  }
+
+  const cfg = baseUsdcAssetConfigSchema.safeParse(
+    input.activation.usdc_asset_config
+  );
+  if (!cfg.success) {
+    return {
+      ok: false,
+      error: 'USDC contract is misconfigured.',
+      statusCode: 500,
+    };
+  }
+
+  const submit = await submitTreasuryUsdcTransfer({
+    serverWalletId: privyWalletId,
+    serverWalletAddress: campaignAddress as `0x${string}`,
+    recipientAddress: destinationAddress as `0x${string}`,
+    usdcAmount: withdrawAmount,
+    usdcContractAddress: cfg.data.contract_address,
+    referenceId: `sponsored-activation-withdraw:${input.activation.id}:${Date.now()}`,
+    withdrawTelemetry: true,
+  });
+
+  if (!submit.ok) {
+    return {
+      ok: false,
+      error: submit.error || 'USDC transfer failed',
+      statusCode: 500,
+    };
+  }
+
+  if ('submittedPending' in submit && submit.submittedPending) {
+    return {
+      ok: true,
+      status: 'submitted',
+      amountUsdc: withdrawAmount,
+      destinationAddress,
+      privyTransactionId: submit.privyTransactionId,
+      userOperationHash: submit.userOperationHash,
+      referenceId: submit.referenceId,
+      message:
+        'Withdrawal was accepted by Privy; on-chain hash is not available yet. Re-check shortly or use the block explorer with this transaction id.',
+    };
+  }
+
+  if (!('txHash' in submit)) {
+    return {
+      ok: false,
+      error: 'Unexpected treasury submit response.',
+      statusCode: 500,
+    };
+  }
+
+  try {
+    await waitForTreasuryTxReceipt(submit.txHash);
+  } catch (waitErr) {
+    const msg =
+      waitErr instanceof Error ? waitErr.message : 'Confirmation failed';
+    console.warn(
+      'sponsored activation withdraw receipt_wait_timeout_or_error',
+      {
+        txHash: submit.txHash,
+        error: msg,
+      }
+    );
+    return {
+      ok: true,
+      status: 'submitted',
+      txHash: submit.txHash,
+      amountUsdc: withdrawAmount,
+      destinationAddress,
+      privyTransactionId: submit.privyTransactionId,
+      userOperationHash: submit.userOperationHash,
+      referenceId: submit.referenceId,
+      message:
+        'Withdrawal was included on-chain; full receipt confirmation is still pending or timed out. Check the block explorer for this transaction hash.',
+    };
+  }
+
+  return {
+    ok: true,
+    status: 'confirmed',
+    txHash: submit.txHash,
+    amountUsdc: withdrawAmount,
+    destinationAddress,
+    privyTransactionId: submit.privyTransactionId,
+    userOperationHash: submit.userOperationHash,
+    referenceId: submit.referenceId,
+  };
+}

--- a/lib/activation/campaign-wallet-withdraw.ts
+++ b/lib/activation/campaign-wallet-withdraw.ts
@@ -1,25 +1,13 @@
 import {
-  Asset,
-  Horizon,
-  Operation,
-  TransactionBuilder,
-} from '@stellar/stellar-sdk';
-import { parseStellarSponsoredCampaignKeypair } from '@/lib/activation/stellar-campaign-wallet-config';
-import { parseStellarSettlementAssetConfig } from '@/lib/activation/stellar-settlement-submit';
+  parseStellarSettlementAssetConfig,
+  submitStellarCampaignUsdcPayment,
+} from '@/lib/activation/stellar-settlement-submit';
 import { loadActivationReservedUsdc } from '@/lib/db/sponsored-activation-admin';
 import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { baseUsdcAssetConfigSchema } from '@/lib/schemas/sponsored-activation';
-import {
-  classifyStellarHorizonSubmitError,
-  formatUsdcAmountForStellar,
-  loadAccountOrThrow,
-  readHorizonHttpErrorData,
-} from '@/lib/stellar/horizon-submit-helpers';
-import {
-  createStellarSpendHorizonServer,
-  getStellarSpendNetworkPassphrase,
-} from '@/lib/spend/stellar-wallet-readiness-config';
+import { parseUsdcBalanceLine } from '@/lib/spend/stellar-treasury-funding';
+import { createStellarSpendHorizonServer } from '@/lib/spend/stellar-wallet-readiness-config';
 import { getSpendRailBaseRpcUrl } from '@/lib/spend-rail-config';
 import {
   submitTreasuryUsdcTransfer,
@@ -60,6 +48,9 @@ export type SponsoredActivationCampaignWithdrawResult =
       message: string;
     }
   | { ok: false; error: string; statusCode?: 400 | 500 };
+
+const DESTINATION_WALLET_CONFLICT_ERROR =
+  'Destination must differ from the campaign and venue settlement wallets.';
 
 function computeWithdrawableMicro(
   balanceUsdc: number,
@@ -111,22 +102,13 @@ async function readStellarCampaignWalletBalance(
   const server = createStellarSpendHorizonServer();
   try {
     const account = await server.loadAccount(campaignParse.data);
-    for (const b of account.balances) {
-      if (
-        b.asset_type !== 'credit_alphanum4' &&
-        b.asset_type !== 'credit_alphanum12'
-      ) {
-        continue;
-      }
-      if (
-        b.asset_code === assetParsed.config.asset_code &&
-        b.asset_issuer === assetParsed.config.issuer
-      ) {
-        const n = Number(b.balance);
-        return Number.isFinite(n) ? n : null;
-      }
-    }
-    return 0;
+    return (
+      parseUsdcBalanceLine(
+        account,
+        assetParsed.config.asset_code,
+        assetParsed.config.issuer
+      ) ?? 0
+    );
   } catch (e) {
     console.error('readStellarCampaignWalletBalance:', e);
     return null;
@@ -136,11 +118,12 @@ async function readStellarCampaignWalletBalance(
 export async function loadSponsoredActivationCampaignWalletBalancePack(
   activation: SponsoredActivationRow
 ): Promise<SponsoredActivationCampaignWalletBalancePack> {
-  const reservedUsdc = await loadActivationReservedUsdc(activation.id);
-  const balance =
+  const [reservedUsdc, balance] = await Promise.all([
+    loadActivationReservedUsdc(activation.id),
     activation.settlement_rail === 'base'
-      ? await readBaseCampaignWalletBalance(activation)
-      : await readStellarCampaignWalletBalance(activation);
+      ? readBaseCampaignWalletBalance(activation)
+      : readStellarCampaignWalletBalance(activation),
+  ]);
 
   return {
     campaign_wallet_usdc_balance: balance,
@@ -148,6 +131,19 @@ export async function loadSponsoredActivationCampaignWalletBalancePack(
       balance == null ? null : computeWithdrawableUsdc(balance, reservedUsdc),
     campaign_wallet_reserved_usdc: reservedUsdc,
   };
+}
+
+function assertDestinationNotCampaignOrVenue(
+  normalized: string,
+  activation: SponsoredActivationRow
+): { ok: true } | { ok: false; error: string } {
+  if (
+    sameWalletAddress(normalized, activation.campaign_wallet_address) ||
+    sameWalletAddress(normalized, activation.venue_settlement_wallet_address)
+  ) {
+    return { ok: false, error: DESTINATION_WALLET_CONFLICT_ERROR };
+  }
+  return { ok: true };
 }
 
 function validateDestinationForRail(
@@ -159,16 +155,11 @@ function validateDestinationForRail(
     if (!normalized || !isEvmAddress(normalized)) {
       return { ok: false, error: 'Invalid Ethereum address' };
     }
-    if (
-      sameWalletAddress(normalized, activation.campaign_wallet_address) ||
-      sameWalletAddress(normalized, activation.venue_settlement_wallet_address)
-    ) {
-      return {
-        ok: false,
-        error:
-          'Destination must differ from the campaign and venue settlement wallets.',
-      };
-    }
+    const walletCheck = assertDestinationNotCampaignOrVenue(
+      normalized,
+      activation
+    );
+    if (!walletCheck.ok) return walletCheck;
     return { ok: true, normalized };
   }
 
@@ -178,18 +169,21 @@ function validateDestinationForRail(
   if (!parsed.success) {
     return { ok: false, error: 'Invalid Stellar address' };
   }
-  if (
-    sameWalletAddress(parsed.data, activation.campaign_wallet_address) ||
-    sameWalletAddress(parsed.data, activation.venue_settlement_wallet_address)
-  ) {
-    return {
-      ok: false,
-      error:
-        'Destination must differ from the campaign and venue settlement wallets.',
-    };
-  }
+  const walletCheck = assertDestinationNotCampaignOrVenue(
+    parsed.data,
+    activation
+  );
+  if (!walletCheck.ok) return walletCheck;
   return { ok: true, normalized: parsed.data };
 }
+
+const STELLAR_WITHDRAW_REASON_MESSAGES: Record<string, string> = {
+  stellar_usdc_asset_misconfigured: 'Stellar USDC asset is misconfigured.',
+  stellar_campaign_wallet_not_configured:
+    'Stellar campaign wallet is not configured on the server.',
+  stellar_campaign_wallet_mismatch:
+    'Stellar campaign wallet key does not match this activation.',
+};
 
 async function submitStellarCampaignWalletWithdraw(input: {
   activation: SponsoredActivationRow;
@@ -199,94 +193,23 @@ async function submitStellarCampaignWalletWithdraw(input: {
   | { ok: true; txHash: string }
   | { ok: false; error: string; statusCode?: 400 | 500 }
 > {
-  const assetParsed = parseStellarSettlementAssetConfig(
-    input.activation.usdc_asset_config
-  );
-  if (!assetParsed.ok) {
-    return { ok: false, error: 'Stellar USDC asset is misconfigured.' };
-  }
+  const submitted = await submitStellarCampaignUsdcPayment({
+    campaignPublicKey: input.activation.campaign_wallet_address,
+    destinationPublicKey: input.destinationAddress,
+    usdcAmount: input.usdcAmount,
+    usdcAssetConfig: input.activation.usdc_asset_config,
+  });
 
-  let campaignKp;
-  try {
-    campaignKp = parseStellarSponsoredCampaignKeypair();
-  } catch {
+  if (!submitted.ok) {
     return {
       ok: false,
-      error: 'Stellar campaign wallet is not configured on the server.',
+      error:
+        STELLAR_WITHDRAW_REASON_MESSAGES[submitted.reason] ?? submitted.reason,
       statusCode: 500,
     };
   }
 
-  const campaignPub = input.activation.campaign_wallet_address
-    .trim()
-    .toUpperCase();
-  if (campaignKp.publicKey() !== campaignPub) {
-    return {
-      ok: false,
-      error: 'Stellar campaign wallet key does not match this activation.',
-      statusCode: 500,
-    };
-  }
-
-  const passphrase = getStellarSpendNetworkPassphrase();
-  const server = createStellarSpendHorizonServer();
-  const { asset_code: usdcCode, issuer: usdcIssuer } = assetParsed.config;
-  const usdcAsset = new Asset(usdcCode, usdcIssuer);
-  const payAmount = formatUsdcAmountForStellar(input.usdcAmount);
-
-  let campaignAccount: Horizon.AccountResponse;
-  try {
-    campaignAccount = await loadAccountOrThrow(server, campaignPub);
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    const { resultCodes } = readHorizonHttpErrorData(e);
-    return {
-      ok: false,
-      error: classifyStellarHorizonSubmitError(msg, resultCodes),
-      statusCode: 500,
-    };
-  }
-
-  let baseFee: string;
-  try {
-    baseFee = (await server.fetchBaseFee()).toString();
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    return {
-      ok: false,
-      error: classifyStellarHorizonSubmitError(msg),
-      statusCode: 500,
-    };
-  }
-
-  const tx = new TransactionBuilder(campaignAccount, {
-    fee: baseFee,
-    networkPassphrase: passphrase,
-  })
-    .addOperation(
-      Operation.payment({
-        destination: input.destinationAddress,
-        asset: usdcAsset,
-        amount: payAmount,
-      })
-    )
-    .setTimeout(180)
-    .build();
-
-  tx.sign(campaignKp);
-
-  try {
-    const res = await server.submitTransaction(tx);
-    return { ok: true, txHash: res.hash };
-  } catch (e) {
-    const msg = e instanceof Error ? e.message : String(e);
-    const { resultCodes } = readHorizonHttpErrorData(e);
-    return {
-      ok: false,
-      error: classifyStellarHorizonSubmitError(msg, resultCodes),
-      statusCode: 500,
-    };
-  }
+  return { ok: true, txHash: submitted.txHash };
 }
 
 export async function withdrawSponsoredActivationCampaignWallet(input: {
@@ -362,7 +285,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
       return {
         ok: false,
         error: submitted.error,
-        statusCode: submitted.statusCode === 400 ? 400 : 500,
+        statusCode: submitted.statusCode ?? 500,
       };
     }
     return {

--- a/lib/activation/stellar-settlement-submit.ts
+++ b/lib/activation/stellar-settlement-submit.ts
@@ -36,9 +36,9 @@ export function parseStellarSettlementAssetConfig(
 }
 
 /** USDC asset comes from activation `usdc_asset_config`, not spend-rail env. */
-export async function submitStellarActivationSettlementFromCampaign(input: {
+export async function submitStellarCampaignUsdcPayment(input: {
   campaignPublicKey: string;
-  venueSettlementPublicKey: string;
+  destinationPublicKey: string;
   usdcAmount: number;
   usdcAssetConfig: Record<string, unknown>;
 }): Promise<
@@ -53,10 +53,10 @@ export async function submitStellarActivationSettlementFromCampaign(input: {
   const campaignParse = stellarWalletAddressSchema.safeParse(
     input.campaignPublicKey.trim().toUpperCase()
   );
-  const venueParse = stellarWalletAddressSchema.safeParse(
-    input.venueSettlementPublicKey.trim().toUpperCase()
+  const destinationParse = stellarWalletAddressSchema.safeParse(
+    input.destinationPublicKey.trim().toUpperCase()
   );
-  if (!campaignParse.success || !venueParse.success) {
+  if (!campaignParse.success || !destinationParse.success) {
     return { ok: false, reason: 'stellar_address_invalid' };
   }
 
@@ -74,7 +74,7 @@ export async function submitStellarActivationSettlementFromCampaign(input: {
 
   const passphrase = getStellarSpendNetworkPassphrase();
   const server = createStellarSpendHorizonServer();
-  const dest = venueParse.data;
+  const dest = destinationParse.data;
   const { asset_code: usdcCode, issuer: usdcIssuer } = assetParsed.config;
   const usdcAsset = new Asset(usdcCode, usdcIssuer);
   const payAmount = formatUsdcAmountForStellar(input.usdcAmount);
@@ -136,4 +136,21 @@ export async function submitStellarActivationSettlementFromCampaign(input: {
       }).slice(0, 1200),
     };
   }
+}
+
+export async function submitStellarActivationSettlementFromCampaign(input: {
+  campaignPublicKey: string;
+  venueSettlementPublicKey: string;
+  usdcAmount: number;
+  usdcAssetConfig: Record<string, unknown>;
+}): Promise<
+  | { ok: true; txHash: string }
+  | { ok: false; reason: string; internalMessage?: string }
+> {
+  return submitStellarCampaignUsdcPayment({
+    campaignPublicKey: input.campaignPublicKey,
+    destinationPublicKey: input.venueSettlementPublicKey,
+    usdcAmount: input.usdcAmount,
+    usdcAssetConfig: input.usdcAssetConfig,
+  });
 }

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -415,6 +415,20 @@ async function fetchSettlementsByRedemptionIds(
  * Aggregated read model for the admin sponsored activation ops dashboard (IRL-62).
  * Returns `null` when the activation id/slug does not exist.
  */
+/** Reserved USDC for inflight settlements and committed redemptions on one activation. */
+export async function loadActivationReservedUsdc(
+  activationId: string
+): Promise<number> {
+  const [inflightRows, committedRows] = await Promise.all([
+    fetchInflightSettlementAmountRows(activationId),
+    fetchCommittedRedemptionSnapshotRows(activationId),
+  ]);
+  return computeReservedUsdcFromRaw({
+    inflightSettlementRows: inflightRows,
+    committedRedemptionRows: committedRows,
+  });
+}
+
 export async function loadSponsoredActivationAdminDashboard(
   activationIdOrSlug: string
 ): Promise<

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -411,10 +411,6 @@ async function fetchSettlementsByRedemptionIds(
   return map;
 }
 
-/**
- * Aggregated read model for the admin sponsored activation ops dashboard (IRL-62).
- * Returns `null` when the activation id/slug does not exist.
- */
 /** Reserved USDC for inflight settlements and committed redemptions on one activation. */
 export async function loadActivationReservedUsdc(
   activationId: string
@@ -429,6 +425,10 @@ export async function loadActivationReservedUsdc(
   });
 }
 
+/**
+ * Aggregated read model for the admin sponsored activation ops dashboard (IRL-62).
+ * Returns `null` when the activation id/slug does not exist.
+ */
 export async function loadSponsoredActivationAdminDashboard(
   activationIdOrSlug: string
 ): Promise<

--- a/lib/db/sponsored-activations.ts
+++ b/lib/db/sponsored-activations.ts
@@ -1,4 +1,5 @@
 import { supabase } from '@/lib/db/client';
+import { sameWalletAddress } from '@/lib/utils/wallets';
 
 export type SponsoredActivationStatus = 'draft' | 'active' | 'paused' | 'ended';
 
@@ -107,6 +108,27 @@ export async function listSponsoredActivations(): Promise<
     throw new Error(error.message || 'Failed to list sponsored activations');
   }
   return (data ?? []).map((r) => normalizeRow(r as Record<string, unknown>));
+}
+
+/** Stellar sponsored activations that share the same on-chain campaign wallet. */
+export async function listStellarActivationsSharingCampaignWallet(
+  campaignWalletAddress: string
+): Promise<SponsoredActivationRow[]> {
+  const { data, error } = await supabase
+    .from(TABLE)
+    .select('*')
+    .eq('settlement_rail', 'stellar');
+  if (error) {
+    console.error('listStellarActivationsSharingCampaignWallet:', error);
+    throw new Error(
+      error.message || 'Failed to list Stellar sponsored activations'
+    );
+  }
+  return (data ?? [])
+    .map((r) => normalizeRow(r as Record<string, unknown>))
+    .filter((row) =>
+      sameWalletAddress(row.campaign_wallet_address, campaignWalletAddress)
+    );
 }
 
 export async function getSponsoredActivationById(

--- a/lib/schemas/sponsored-activation-withdraw.ts
+++ b/lib/schemas/sponsored-activation-withdraw.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod';
+
+export const sponsoredActivationCampaignWithdrawRequestSchema = z.object({
+  destinationAddress: z
+    .string()
+    .trim()
+    .min(1, 'Destination address is required'),
+  /** Omit or null to withdraw the full withdrawable USDC balance (6 decimals on Base). */
+  amountUsdc: z.number().positive().finite().optional().nullable(),
+});
+
+export type SponsoredActivationCampaignWithdrawRequest = z.infer<
+  typeof sponsoredActivationCampaignWithdrawRequestSchema
+>;

--- a/lib/spend/stellar-treasury-funding.ts
+++ b/lib/spend/stellar-treasury-funding.ts
@@ -110,7 +110,7 @@ async function loadAccountOrThrow(
   }
 }
 
-function parseUsdcBalanceLine(
+export function parseUsdcBalanceLine(
   account: Horizon.AccountResponse,
   code: string,
   issuer: string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds admin tooling to withdraw (refund) USDC from a sponsored activation's campaign wallet to an arbitrary destination address.

- New API: `POST /api/admin/sponsored-activations/{activationId}/campaign-wallet/withdraw`
- Activation detail page launch checklist now shows campaign wallet balance, withdrawable amount, and a **Refund to address** input with **Withdraw USDC**
- Supports **Base** activations (per-activation Privy campaign wallet) and **Stellar** activations (shared server campaign wallet)
- Withdrawable balance excludes USDC reserved for inflight settlements and committed redemptions

## How to use

1. Open `/admin/sponsored-activations` and click into an activation
2. In the launch checklist **Fund the campaign wallet** step, enter a refund address (`0x…` on Base, `G…` on Stellar)
3. Click **Withdraw USDC** to send the full withdrawable balance

## Notes

- Destination cannot be the campaign or venue settlement wallet
- Stellar uses a shared campaign wallet across activations; the UI warns admins to confirm the destination before sending
- Base withdrawals use sponsored gas via Privy, matching the spend-experience treasury withdraw pattern
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2a294b5d-6179-4898-83c2-f01e701cbfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2a294b5d-6179-4898-83c2-f01e701cbfa4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

