### PR TITLE
fix: resolve EVM wallet for spend when Privy primary is non-EVM

### DIFF
--- a/app/api/checkpoints/[id]/spend/__tests__/route.test.ts
+++ b/app/api/checkpoints/[id]/spend/__tests__/route.test.ts
@@ -13,6 +13,11 @@ vi.mock('@/lib/db/spend', () => ({
 
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: vi.fn(),
+  getPrivyUserFromRequest: vi.fn(),
+}));
+
+vi.mock('@/lib/privy/resolve-player-for-privy-user', () => ({
+  resolvePlayerForPrivyUser: vi.fn(),
 }));
 
 import { GET, POST } from '../route';
@@ -22,7 +27,11 @@ import {
   getUserRedemptionForSpendItem,
   redeemSpendItemOnce,
 } from '@/lib/db/spend';
-import { verifyWalletOwnership } from '@/lib/api/privy';
+import {
+  getPrivyUserFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import { resolvePlayerForPrivyUser } from '@/lib/privy/resolve-player-for-privy-user';
 
 const checkpointId = 'abc123def4';
 const walletAddress = '0x1234567890abcdef1234567890abcdef12345678';
@@ -34,6 +43,15 @@ describe('checkpoint spend route', () => {
       authorized: true,
       userId: 'did:privy:123',
     });
+    vi.mocked(getPrivyUserFromRequest).mockResolvedValue({
+      id: 'did:privy:123',
+      linkedAccounts: [],
+    } as never);
+    vi.mocked(resolvePlayerForPrivyUser).mockResolvedValue({
+      id: 1,
+      wallet_address: walletAddress,
+      total_points: 200,
+    } as never);
   });
 
   it('GET returns checkpoint spend data', async () => {

--- a/app/api/checkpoints/[id]/spend/route.ts
+++ b/app/api/checkpoints/[id]/spend/route.ts
@@ -1,7 +1,12 @@
 import { NextRequest } from 'next/server';
 import { apiError, apiSuccess, apiValidationError } from '@/lib/api/response';
 import { walletAddressSchema } from '@/lib/schemas/player';
-import { verifyWalletOwnership } from '@/lib/api/privy';
+import {
+  getPrivyUserFromRequest,
+  verifyWalletOwnership,
+} from '@/lib/api/privy';
+import { resolvePlayerForPrivyUser } from '@/lib/privy/resolve-player-for-privy-user';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 import { getActiveCheckpointById } from '@/lib/db/checkpoints';
 import {
   getSpendItemByCheckpointId,
@@ -29,7 +34,9 @@ export async function GET(
       return apiError('Spend item unavailable', 404);
     }
 
-    const walletAddress = new URL(request.url).searchParams.get('walletAddress');
+    const walletAddress = new URL(request.url).searchParams.get(
+      'walletAddress'
+    );
     if (!walletAddress) {
       return apiSuccess({ checkpoint, spendItem, redemption: null });
     }
@@ -44,9 +51,18 @@ export async function GET(
       return apiError(auth.error ?? 'Unauthorized', 401);
     }
 
+    const normalizedWallet =
+      tryNormalizeEvmAddress(walletResult.data.trim()) ??
+      walletResult.data.trim();
+    const privyUser = await getPrivyUserFromRequest(request);
+    const player = privyUser
+      ? await resolvePlayerForPrivyUser(normalizedWallet, privyUser)
+      : null;
+    const lookupWallet = player?.wallet_address ?? normalizedWallet;
+
     const redemption = await getUserRedemptionForSpendItem(
       spendItem.id!,
-      walletResult.data
+      lookupWallet
     );
 
     return apiSuccess({ checkpoint, spendItem, redemption });
@@ -85,10 +101,16 @@ export async function POST(
       return apiError(auth.error ?? 'Unauthorized', 401);
     }
 
-    const result = await redeemSpendItemOnce(
-      spendItem.id!,
-      validationResult.data.walletAddress
-    );
+    const normalizedWallet =
+      tryNormalizeEvmAddress(validationResult.data.walletAddress.trim()) ??
+      validationResult.data.walletAddress.trim();
+    const privyUser = await getPrivyUserFromRequest(request);
+    const player = privyUser
+      ? await resolvePlayerForPrivyUser(normalizedWallet, privyUser)
+      : null;
+    const spendWallet = player?.wallet_address ?? normalizedWallet;
+
+    const result = await redeemSpendItemOnce(spendItem.id!, spendWallet);
 
     return apiSuccess(
       {

--- a/app/api/checkpoints/[id]/spend/route.ts
+++ b/app/api/checkpoints/[id]/spend/route.ts
@@ -55,10 +55,10 @@ export async function GET(
       tryNormalizeEvmAddress(walletResult.data.trim()) ??
       walletResult.data.trim();
     const privyUser = await getPrivyUserFromRequest(request);
-    const player = privyUser
-      ? await resolvePlayerForPrivyUser(normalizedWallet, privyUser)
-      : null;
-    const lookupWallet = player?.wallet_address ?? normalizedWallet;
+    if (privyUser) {
+      await resolvePlayerForPrivyUser(normalizedWallet, privyUser);
+    }
+    const lookupWallet = normalizedWallet;
 
     const redemption = await getUserRedemptionForSpendItem(
       spendItem.id!,
@@ -105,10 +105,10 @@ export async function POST(
       tryNormalizeEvmAddress(validationResult.data.walletAddress.trim()) ??
       validationResult.data.walletAddress.trim();
     const privyUser = await getPrivyUserFromRequest(request);
-    const player = privyUser
-      ? await resolvePlayerForPrivyUser(normalizedWallet, privyUser)
-      : null;
-    const spendWallet = player?.wallet_address ?? normalizedWallet;
+    if (privyUser) {
+      await resolvePlayerForPrivyUser(normalizedWallet, privyUser);
+    }
+    const spendWallet = normalizedWallet;
 
     const result = await redeemSpendItemOnce(spendItem.id!, spendWallet);
 

--- a/app/api/sponsored-activations/[activationId]/eligibility/route.ts
+++ b/app/api/sponsored-activations/[activationId]/eligibility/route.ts
@@ -24,7 +24,9 @@ import {
   type ActivationRedemptionRow,
 } from '@/lib/db/activation-redemptions';
 import { listActivationRewardItems } from '@/lib/db/activation-reward-items';
+import { getPrivyUserFromRequest } from '@/lib/api/privy';
 import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+import { resolvePlayerForPrivyUser } from '@/lib/privy/resolve-player-for-privy-user';
 import { getSponsoredActivationByIdOrSlug } from '@/lib/db/sponsored-activations';
 import { getTiers } from '@/lib/db/tiers';
 import { safeParseActivationEligibilityRulesConfig } from '@/lib/schemas/activation-eligibility-config';
@@ -49,19 +51,28 @@ const eligibilityWalletQuerySchema = z
 
 const ELIGIBILITY_RULES_NOT_MET = 'Eligibility requirements were not met';
 
-async function resolvePlayerForEligibility(walletAddress: string): Promise<{
+async function resolvePlayerForEligibility(
+  request: NextRequest,
+  walletAddress: string
+): Promise<{
   playerId: number;
   totalPoints: number;
 }> {
   const trimmed = walletAddress.trim();
   const normalized = tryNormalizeEvmAddress(trimmed) ?? trimmed;
-  let player = await getPlayerByWallet(normalized);
-  if (!player?.id) {
-    player = await createOrUpdatePlayer({
-      wallet_address: normalized,
-      total_points: 0,
-    });
-  }
+  const privyUser = await getPrivyUserFromRequest(request);
+  const player = privyUser
+    ? await resolvePlayerForPrivyUser(normalized, privyUser)
+    : await (async () => {
+        let row = await getPlayerByWallet(normalized);
+        if (!row?.id) {
+          row = await createOrUpdatePlayer({
+            wallet_address: normalized,
+            total_points: 0,
+          });
+        }
+        return row;
+      })();
   if (!player?.id) {
     throw new Error('Failed to resolve player for wallet');
   }
@@ -124,7 +135,7 @@ export async function POST(request: NextRequest, { params }: RouteParams) {
   let playerId: number;
   let totalPoints: number;
   try {
-    const resolved = await resolvePlayerForEligibility(walletAddress);
+    const resolved = await resolvePlayerForEligibility(request, walletAddress);
     playerId = resolved.playerId;
     totalPoints = resolved.totalPoints;
   } catch (e) {
@@ -295,7 +306,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
 
   let playerId: number;
   try {
-    const resolved = await resolvePlayerForEligibility(walletAddress);
+    const resolved = await resolvePlayerForEligibility(request, walletAddress);
     playerId = resolved.playerId;
   } catch (e) {
     const msg = e instanceof Error ? e.message : 'Failed to resolve player';

--- a/components/checkpoint/spend-checkpoint.tsx
+++ b/components/checkpoint/spend-checkpoint.tsx
@@ -4,6 +4,7 @@ import { useMemo, useState } from 'react';
 import Image from 'next/image';
 import { usePrivy } from '@privy-io/react-auth';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import type {
   Checkpoint,
@@ -65,7 +66,7 @@ function extractBaseColor(gradient?: string | null): string {
 export default function SpendCheckpoint({ checkpoint }: SpendCheckpointProps) {
   const { user, login, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   const { data: player } = useCurrentPlayer();

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { usePrivy, useSendTransaction, useWallets } from '@privy-io/react-auth';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { SpendPageShell } from '@/components/spend/spend-page-shell';
@@ -187,7 +188,7 @@ export function SpendExperiencePage({
   const { sendTransaction } = useSendTransaction();
   const { wallets } = useWallets();
   const queryClient = useQueryClient();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
   const [trackedScan, setTrackedScan] = useState(false);
 
   const evmWallet = useMemo(() => {

--- a/components/spend/spend-item-page.tsx
+++ b/components/spend/spend-item-page.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/hooks/useSpend';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import { usePrivy } from '@privy-io/react-auth';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import type { SpendRedemption } from '@/lib/types';
 
 type SpendItemPageProps = {
@@ -25,7 +26,7 @@ type SpendItemPageProps = {
  */
 export function SpendItemPage({ itemId }: SpendItemPageProps) {
   const { user, login, getAccessToken } = usePrivy();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
 
   const { data: item, isLoading: itemLoading } = useSpendItem(itemId);
   const { data: player } = useCurrentPlayer();

--- a/components/sponsored-activation/sponsored-activation-flow.tsx
+++ b/components/sponsored-activation/sponsored-activation-flow.tsx
@@ -13,6 +13,7 @@ import { SponsoredActivationSuccess } from '@/components/sponsored-activation/sp
 import { SponsoredActivationRedeemed } from '@/components/sponsored-activation/sponsored-activation-redeemed';
 import { SponsoredActivationExpired } from '@/components/sponsored-activation/sponsored-activation-expired';
 import { SponsoredActivationCancelled } from '@/components/sponsored-activation/sponsored-activation-cancelled';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import type { ActivationRedemptionRow } from '@/lib/db/activation-redemptions';
 import { apiClient, ApiError } from '@/lib/api/client';
@@ -75,7 +76,7 @@ export function SponsoredActivationFlow({
   sourceRefId,
 }: SponsoredActivationFlowProps) {
   const { user, login, getAccessToken } = usePrivy();
-  const walletAddress = user?.wallet?.address ?? null;
+  const walletAddress = useEvmWalletAddress() ?? null;
   const queryClient = useQueryClient();
 
   const { data: player, isFetched: playerDetailsFetched } = useCurrentPlayer();

--- a/hooks/use-evm-wallet-address.ts
+++ b/hooks/use-evm-wallet-address.ts
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+import { usePrivy, useWallets } from '@privy-io/react-auth';
+import { resolvePrivyEvmWalletAddress } from '@/lib/privy/resolve-evm-wallet-address';
+
+/** EVM `0x` address for the signed-in Privy user (spend / activation APIs). */
+export function useEvmWalletAddress(): string | undefined {
+  const { user } = usePrivy();
+  const { wallets } = useWallets();
+  return useMemo(
+    () => resolvePrivyEvmWalletAddress(user, wallets),
+    [user, wallets]
+  );
+}

--- a/hooks/usePlayer.ts
+++ b/hooks/usePlayer.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { usePrivy } from '@privy-io/react-auth';
 import { apiClient } from '@/lib/api/client';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import type { Player } from '@/lib/types';
 
 interface PlayerRankResponse {
@@ -22,8 +22,7 @@ interface Activity {
  * Hook to fetch current authenticated player's data
  */
 export function useCurrentPlayer() {
-  const { user } = usePrivy();
-  const address = user?.wallet?.address;
+  const address = useEvmWalletAddress();
 
   return useQuery({
     queryKey: ['player', address],
@@ -88,13 +87,13 @@ export interface UserStats {
 /**
  * Hook to fetch combined user stats (rank and points)
  * Returns a unified interface with loading state and default values for new users
- * 
+ *
  * @param address - Optional wallet address. If not provided, uses current authenticated user's address
  */
 export function useUserStats(address?: string) {
-  const { user } = usePrivy();
-  const walletAddress = address || user?.wallet?.address;
-  
+  const evmWalletAddress = useEvmWalletAddress();
+  const walletAddress = address || evmWalletAddress;
+
   // Fetch player data - use address if provided, otherwise use current player hook
   const playerQuery = useQuery({
     queryKey: ['player', walletAddress],
@@ -133,4 +132,3 @@ export function useUserStats(address?: string) {
     isLoading,
   };
 }
-

--- a/lib/activation/activation-wallet-gate.ts
+++ b/lib/activation/activation-wallet-gate.ts
@@ -5,6 +5,8 @@ import {
 } from '@/lib/api/privy';
 import { apiError, type ApiResponse } from '@/lib/api/response';
 import { createOrUpdatePlayer, getPlayerByWallet } from '@/lib/db/players';
+import { resolvePlayerForPrivyUser } from '@/lib/privy/resolve-player-for-privy-user';
+import type { User } from '@privy-io/server-auth';
 
 /**
  * Ensures the request has a valid Privy Bearer token and the token user matches
@@ -28,15 +30,21 @@ export async function assertPrivyWalletAuth(
 }
 
 export async function resolvePlayerForWallet(
-  normalizedWalletAddress: string
+  normalizedWalletAddress: string,
+  privyUser?: User | null
 ): Promise<{ playerId: number }> {
-  let player = await getPlayerByWallet(normalizedWalletAddress);
-  if (!player?.id) {
-    player = await createOrUpdatePlayer({
-      wallet_address: normalizedWalletAddress,
-      total_points: 0,
-    });
-  }
+  const player = privyUser
+    ? await resolvePlayerForPrivyUser(normalizedWalletAddress, privyUser)
+    : await (async () => {
+        let row = await getPlayerByWallet(normalizedWalletAddress);
+        if (!row?.id) {
+          row = await createOrUpdatePlayer({
+            wallet_address: normalizedWalletAddress,
+            total_points: 0,
+          });
+        }
+        return row;
+      })();
   if (!player?.id) {
     throw new Error('Failed to resolve player for wallet');
   }

--- a/lib/activation/cancel-redemption.ts
+++ b/lib/activation/cancel-redemption.ts
@@ -3,6 +3,7 @@ import {
   assertPrivyWalletAuth,
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
+import { getPrivyUserFromRequest } from '@/lib/api/privy';
 import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import { trackSponsoredRedemptionCancelled } from '@/lib/analytics/server';
 import { emitSponsoredAnalyticsForWalletRequest } from '@/lib/analytics/sponsored-wallet-request-tracking';
@@ -80,9 +81,11 @@ export async function runCancelActivationRedemption(input: {
     };
   }
 
+  const privyUser = await getPrivyUserFromRequest(input.request);
+
   let playerId: number;
   try {
-    const resolved = await resolvePlayerForWallet(walletKey);
+    const resolved = await resolvePlayerForWallet(walletKey, privyUser);
     playerId = resolved.playerId;
   } catch (e) {
     console.error('cancel redemption (resolve player):', e);

--- a/lib/activation/confirm-purchase.ts
+++ b/lib/activation/confirm-purchase.ts
@@ -3,6 +3,7 @@ import {
   assertPrivyWalletAuth,
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
+import { getPrivyUserFromRequest } from '@/lib/api/privy';
 import {
   trackSponsoredActivationCapReached,
   trackSponsoredRedemptionPurchaseConfirmed,
@@ -156,9 +157,11 @@ export async function runConfirmActivationPurchase(input: {
   }
   const rulesConfig = configParse.data;
 
+  const privyUser = await getPrivyUserFromRequest(input.request);
+
   let playerId: number;
   try {
-    const resolved = await resolvePlayerForWallet(walletKey);
+    const resolved = await resolvePlayerForWallet(walletKey, privyUser);
     playerId = resolved.playerId;
   } catch (e) {
     console.error('confirm purchase (resolve player):', e);

--- a/lib/activation/swipe-redeem.ts
+++ b/lib/activation/swipe-redeem.ts
@@ -3,6 +3,7 @@ import {
   assertPrivyWalletAuth,
   resolvePlayerForWallet,
 } from '@/lib/activation/activation-wallet-gate';
+import { getPrivyUserFromRequest } from '@/lib/api/privy';
 import { buildActivationRedemptionIdempotencyKey } from '@/lib/activation/eligibility';
 import {
   trackSponsoredRedemptionExpired,
@@ -132,9 +133,11 @@ export async function runSwipeActivationRedeem(input: {
   }
   const rulesConfig = configParse.data;
 
+  const privyUser = await getPrivyUserFromRequest(input.request);
+
   let playerId: number;
   try {
-    const resolved = await resolvePlayerForWallet(walletKey);
+    const resolved = await resolvePlayerForWallet(walletKey, privyUser);
     playerId = resolved.playerId;
   } catch (e) {
     console.error('swipe redeem (resolve player):', e);

--- a/lib/api/privy.ts
+++ b/lib/api/privy.ts
@@ -260,6 +260,21 @@ export async function getPrivyUserIdFromRequest(
   }
 }
 
+/** Full Privy user for the Bearer token, or null when missing/invalid. */
+export async function getPrivyUserFromRequest(req: NextRequest) {
+  const authHeader = req.headers.get('authorization');
+  if (!authHeader?.startsWith('Bearer ')) return null;
+  const token = authHeader.slice(7).trim();
+  if (!token) return null;
+  try {
+    const privy = getPrivyClient();
+    const verifiedClaims = await privy.verifyAuthToken(token);
+    return await privy.getUser(verifiedClaims.userId);
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Verified login email from a Privy access token (`Authorization: Bearer`).
  * Never trust client-supplied email headers for authorization.

--- a/lib/privy/__tests__/resolve-evm-wallet-address.test.ts
+++ b/lib/privy/__tests__/resolve-evm-wallet-address.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import { resolvePrivyEvmWalletAddress } from '@/lib/privy/resolve-evm-wallet-address';
+
+const EVM = '0x4D418f71c531465337b65127B207aa849Fa5a9e3';
+const STELLAR = 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+describe('resolvePrivyEvmWalletAddress', () => {
+  it('prefers ethereum linked account over user.wallet stellar address', () => {
+    const address = resolvePrivyEvmWalletAddress({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'ethereum',
+          address: EVM,
+        },
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: STELLAR,
+        },
+      ],
+      wallet: { address: STELLAR },
+    } as never);
+
+    expect(address).toBe('0x4D418f71c531465337b65127B207aa849Fa5a9e3');
+  });
+
+  it('returns undefined when only non-EVM wallets are linked', () => {
+    const address = resolvePrivyEvmWalletAddress({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: STELLAR,
+        },
+      ],
+      wallet: { address: STELLAR },
+    } as never);
+
+    expect(address).toBeUndefined();
+  });
+
+  it('uses connected wallets as fallback', () => {
+    const address = resolvePrivyEvmWalletAddress(
+      { linkedAccounts: [], wallet: { address: STELLAR } } as never,
+      [{ address: EVM } as never]
+    );
+
+    expect(address).toBe('0x4D418f71c531465337b65127B207aa849Fa5a9e3');
+  });
+});

--- a/lib/privy/__tests__/resolve-player-for-privy-user.test.ts
+++ b/lib/privy/__tests__/resolve-player-for-privy-user.test.ts
@@ -1,0 +1,83 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolvePlayerForPrivyUser } from '@/lib/privy/resolve-player-for-privy-user';
+
+const EVM = '0x4D418f71c531465337b65127B207aa849Fa5a9e3';
+const STELLAR = 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
+
+const mockGetPlayerByWallet = vi.fn();
+const mockGetPlayerByEmail = vi.fn();
+const mockGetPlayerByStellarWallet = vi.fn();
+const mockGetPlayerBySolanaWallet = vi.fn();
+const mockGetPlayerByAptosWallet = vi.fn();
+const mockCreateOrUpdatePlayer = vi.fn();
+
+vi.mock('@/lib/db/players', () => ({
+  getPlayerByWallet: (...args: unknown[]) => mockGetPlayerByWallet(...args),
+  getPlayerByEmail: (...args: unknown[]) => mockGetPlayerByEmail(...args),
+  getPlayerByStellarWallet: (...args: unknown[]) =>
+    mockGetPlayerByStellarWallet(...args),
+  getPlayerBySolanaWallet: (...args: unknown[]) =>
+    mockGetPlayerBySolanaWallet(...args),
+  getPlayerByAptosWallet: (...args: unknown[]) =>
+    mockGetPlayerByAptosWallet(...args),
+  createOrUpdatePlayer: (...args: unknown[]) =>
+    mockCreateOrUpdatePlayer(...args),
+}));
+
+describe('resolvePlayerForPrivyUser', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetPlayerBySolanaWallet.mockResolvedValue(null);
+    mockGetPlayerByAptosWallet.mockResolvedValue(null);
+  });
+
+  it('returns player matched by EVM wallet', async () => {
+    mockGetPlayerByWallet.mockResolvedValue({
+      id: 1,
+      wallet_address: EVM,
+      total_points: 200,
+    });
+
+    const player = await resolvePlayerForPrivyUser(EVM, {
+      id: 'privy-1',
+      linkedAccounts: [],
+    } as never);
+
+    expect(player.id).toBe(1);
+    expect(mockGetPlayerByStellarWallet).not.toHaveBeenCalled();
+  });
+
+  it('falls back to stellar-linked player and backfills EVM wallet', async () => {
+    mockGetPlayerByWallet.mockResolvedValue(null);
+    mockGetPlayerByEmail.mockResolvedValue(null);
+    mockGetPlayerByStellarWallet.mockResolvedValue({
+      id: 42,
+      wallet_address: null,
+      stellar_wallet_address: STELLAR,
+      total_points: 200,
+    });
+    mockCreateOrUpdatePlayer.mockResolvedValue({
+      id: 42,
+      wallet_address: EVM,
+      stellar_wallet_address: STELLAR,
+      total_points: 200,
+    });
+
+    const player = await resolvePlayerForPrivyUser(EVM, {
+      id: 'privy-1',
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'stellar',
+          address: STELLAR,
+        },
+      ],
+    } as never);
+
+    expect(player.id).toBe(42);
+    expect(mockCreateOrUpdatePlayer).toHaveBeenCalledWith(
+      { wallet_address: EVM },
+      expect.objectContaining({ id: 42 })
+    );
+  });
+});

--- a/lib/privy/resolve-evm-wallet-address.ts
+++ b/lib/privy/resolve-evm-wallet-address.ts
@@ -1,0 +1,52 @@
+import type { User } from '@privy-io/react-auth';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+type WalletAddressSource = { address?: string | null };
+
+function evmAddressFromLinkedAccount(account: unknown): string | null {
+  if (!account || typeof account !== 'object') return null;
+  const record = account as Record<string, unknown>;
+  if (record.type !== 'wallet' || typeof record.address !== 'string') {
+    return null;
+  }
+  const chainType = record.chainType;
+  if (
+    chainType === 'stellar' ||
+    chainType === 'solana' ||
+    chainType === 'aptos'
+  ) {
+    return null;
+  }
+  return tryNormalizeEvmAddress(record.address);
+}
+
+/**
+ * Resolves the user's EVM wallet for spend / activation APIs.
+ * Privy `user.wallet` may point at a Stellar or Solana linked account when that
+ * chain was used for check-in; spend flows require a `0x` address.
+ */
+export function resolvePrivyEvmWalletAddress(
+  user: User | null | undefined,
+  connectedWallets?: WalletAddressSource[]
+): string | undefined {
+  const candidates: string[] = [];
+
+  const push = (value: string | null | undefined) => {
+    const normalized = value ? tryNormalizeEvmAddress(value) : null;
+    if (normalized && !candidates.includes(normalized)) {
+      candidates.push(normalized);
+    }
+  };
+
+  for (const account of user?.linkedAccounts ?? []) {
+    push(evmAddressFromLinkedAccount(account));
+  }
+
+  push(user?.wallet?.address);
+
+  for (const wallet of connectedWallets ?? []) {
+    push(wallet.address);
+  }
+
+  return candidates[0];
+}

--- a/lib/privy/resolve-player-for-privy-user.ts
+++ b/lib/privy/resolve-player-for-privy-user.ts
@@ -33,7 +33,21 @@ async function backfillEvmWalletOnPlayer(
   evmWalletAddress: string
 ): Promise<Player> {
   if (player.wallet_address?.trim()) return player;
-  return createOrUpdatePlayer({ wallet_address: evmWalletAddress }, player);
+  const wallet =
+    tryNormalizeEvmAddress(evmWalletAddress.trim()) ?? evmWalletAddress.trim();
+  const { data, error } = await supabase
+    .from('players')
+    .update({
+      wallet_address: wallet,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', player.id)
+    .select(
+      'id, wallet_address, solana_wallet_address, stellar_wallet_address, stellar_wallet_id, aptos_wallet_address, aptos_wallet_id, email, username, total_points, created_at, updated_at'
+    )
+    .single();
+  if (error) throw error;
+  return data;
 }
 
 /**

--- a/lib/privy/resolve-player-for-privy-user.ts
+++ b/lib/privy/resolve-player-for-privy-user.ts
@@ -1,0 +1,90 @@
+import type { User } from '@privy-io/server-auth';
+import {
+  createOrUpdatePlayer,
+  getPlayerByAptosWallet,
+  getPlayerByEmail,
+  getPlayerBySolanaWallet,
+  getPlayerByStellarWallet,
+  getPlayerByWallet,
+} from '@/lib/db/players';
+import { supabase } from '@/lib/db/client';
+import type { Player } from '@/lib/types';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+function linkedWalletAddress(
+  user: User,
+  chainType: 'stellar' | 'solana' | 'aptos'
+): string | null {
+  for (const account of user.linkedAccounts ?? []) {
+    if (account.type !== 'wallet' || !('address' in account)) continue;
+    if (
+      'chainType' in account &&
+      (account as { chainType?: string }).chainType === chainType
+    ) {
+      const trimmed = String(account.address).trim();
+      if (trimmed) return trimmed;
+    }
+  }
+  return null;
+}
+
+async function backfillEvmWalletOnPlayer(
+  player: Player,
+  evmWalletAddress: string
+): Promise<Player> {
+  if (player.wallet_address?.trim()) return player;
+  return createOrUpdatePlayer({ wallet_address: evmWalletAddress }, player);
+}
+
+/**
+ * Finds the player row that owns points for this Privy session, even when the
+ * user checked in with Stellar/Solana and `players.wallet_address` was never set.
+ */
+export async function resolvePlayerForPrivyUser(
+  evmWalletAddress: string,
+  privyUser: User
+): Promise<Player> {
+  const normalized =
+    tryNormalizeEvmAddress(evmWalletAddress.trim()) ?? evmWalletAddress.trim();
+
+  const byEvm = await getPlayerByWallet(normalized);
+  if (byEvm?.id) return byEvm;
+
+  const email = privyUser.email?.address?.trim().toLowerCase();
+  if (email) {
+    const byEmail = await getPlayerByEmail(email);
+    if (byEmail?.id) {
+      return backfillEvmWalletOnPlayer(byEmail, normalized);
+    }
+  }
+
+  const stellarAddress = linkedWalletAddress(privyUser, 'stellar');
+  if (stellarAddress) {
+    const byStellar = await getPlayerByStellarWallet(stellarAddress);
+    if (byStellar?.id) {
+      return backfillEvmWalletOnPlayer(byStellar, normalized);
+    }
+  }
+
+  const solanaAddress = linkedWalletAddress(privyUser, 'solana');
+  if (solanaAddress) {
+    const bySolana = await getPlayerBySolanaWallet(solanaAddress);
+    if (bySolana?.id) {
+      return backfillEvmWalletOnPlayer(bySolana, normalized);
+    }
+  }
+
+  const aptosAddress = linkedWalletAddress(privyUser, 'aptos');
+  if (aptosAddress) {
+    const byAptos = await getPlayerByAptosWallet(aptosAddress);
+    if (byAptos?.id) {
+      return backfillEvmWalletOnPlayer(byAptos, normalized);
+    }
+  }
+
+  return createOrUpdatePlayer({
+    wallet_address: normalized,
+    email: email || undefined,
+    total_points: 0,
+  });
+}

--- a/lib/privy/resolve-player-for-privy-user.ts
+++ b/lib/privy/resolve-player-for-privy-user.ts
@@ -32,9 +32,14 @@ async function backfillEvmWalletOnPlayer(
   player: Player,
   evmWalletAddress: string
 ): Promise<Player> {
-  if (player.wallet_address?.trim()) return player;
   const wallet =
     tryNormalizeEvmAddress(evmWalletAddress.trim()) ?? evmWalletAddress.trim();
+  const storedWallet = player.wallet_address?.trim();
+  if (storedWallet) {
+    const normalizedStored =
+      tryNormalizeEvmAddress(storedWallet) ?? storedWallet;
+    if (normalizedStored === wallet) return player;
+  }
   const { data, error } = await supabase
     .from('players')
     .update({
@@ -65,12 +70,6 @@ export async function resolvePlayerForPrivyUser(
   if (byEvm?.id) return byEvm;
 
   const email = privyUser.email?.address?.trim().toLowerCase();
-  if (email) {
-    const byEmail = await getPlayerByEmail(email);
-    if (byEmail?.id) {
-      return backfillEvmWalletOnPlayer(byEmail, normalized);
-    }
-  }
 
   const stellarAddress = linkedWalletAddress(privyUser, 'stellar');
   if (stellarAddress) {
@@ -93,6 +92,13 @@ export async function resolvePlayerForPrivyUser(
     const byAptos = await getPlayerByAptosWallet(aptosAddress);
     if (byAptos?.id) {
       return backfillEvmWalletOnPlayer(byAptos, normalized);
+    }
+  }
+
+  if (email) {
+    const byEmail = await getPlayerByEmail(email);
+    if (byEmail?.id) {
+      return backfillEvmWalletOnPlayer(byEmail, normalized);
     }
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Users who checked in at event checkpoints (e.g. ENS tour at Public Records) with a **Stellar** wallet could earn points successfully, but hit this error when trying to spend:

```
walletAddress: walletAddress must be a valid EVM address
```

Spend and sponsored-activation APIs require a valid `0x…` EVM address. The client was sending `user.wallet.address` from Privy, which can point at the user's **primary non-EVM wallet** (Stellar/Solana) after a chain-specific check-in.

## Fix

### Client
- Added `resolvePrivyEvmWalletAddress()` and `useEvmWalletAddress()` hook to pick the embedded/ethereum linked account instead of the primary wallet when it is not EVM.
- Updated spend checkpoint, sponsored activation flow, spend experience/item pages, and `useCurrentPlayer` to use the hook.

### Server
- Added `resolvePlayerForPrivyUser()` to find the correct player row by email or alt-chain wallets (Stellar/Solana/Aptos) and backfill `wallet_address` when missing.
- Wired into checkpoint spend, sponsored activation eligibility, and activation purchase/redeem/cancel routes.

## Testing
- `lib/privy/__tests__/resolve-evm-wallet-address.test.ts`
- `lib/privy/__tests__/resolve-player-for-privy-user.test.ts`
- `app/api/checkpoints/[id]/spend/__tests__/route.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6796593f-6bf5-4e44-9e76-c442f32c9854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6796593f-6bf5-4e44-9e76-c442f32c9854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

