### PR TITLE
fix: keep Privy reference_id within 64-char limit for campaign withdraw

### DIFF
--- a/lib/activation/campaign-wallet-withdraw.ts
+++ b/lib/activation/campaign-wallet-withdraw.ts
@@ -390,7 +390,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     recipientAddress: destinationAddress as `0x${string}`,
     usdcAmount: withdrawAmount,
     usdcContractAddress: cfg.data.contract_address,
-    referenceId: `sponsored-activation-withdraw:${input.activation.id}:${Date.now()}`,
+    referenceId: `sa-wd:${input.activation.id}:${Date.now().toString(36)}`,
     withdrawTelemetry: true,
   });
 

--- a/lib/privy-server-rest.test.ts
+++ b/lib/privy-server-rest.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   normalizePrivyReferenceId,
-  PRIVY_REFERENCE_ID_MAX_LENGTH,
   PrivyRestApiError,
   signAndSendTransaction,
   waitForTransaction,
 } from './privy-server-rest';
+
+const PRIVY_REFERENCE_ID_MAX_LENGTH = 64;
+
+/** Legacy withdraw prefix; still over Privy's 64-char limit with a UUID + timestamp. */
+const LONG_REFERENCE_ID = `sponsored-activation-withdraw:66701108-f3d1-4b3a-bc23-84681e8472f4:${Date.now()}`;
 
 const fetchMock = vi.fn();
 
@@ -28,12 +32,13 @@ describe('normalizePrivyReferenceId', () => {
   });
 
   it('maps ids longer than 64 chars to a 64-char digest', () => {
-    const longId = `sponsored-activation-withdraw:66701108-f3d1-4b3a-bc23-84681e8472f4:${Date.now()}`;
-    expect(longId.length).toBeGreaterThan(PRIVY_REFERENCE_ID_MAX_LENGTH);
+    expect(LONG_REFERENCE_ID.length).toBeGreaterThan(
+      PRIVY_REFERENCE_ID_MAX_LENGTH
+    );
 
-    const normalized = normalizePrivyReferenceId(longId);
+    const normalized = normalizePrivyReferenceId(LONG_REFERENCE_ID);
     expect(normalized).toHaveLength(PRIVY_REFERENCE_ID_MAX_LENGTH);
-    expect(normalized).toBe(normalizePrivyReferenceId(longId));
+    expect(normalized).toBe(normalizePrivyReferenceId(LONG_REFERENCE_ID));
   });
 });
 
@@ -95,19 +100,18 @@ describe('signAndSendTransaction', () => {
       }),
     });
 
-    const longReferenceId = `sponsored-activation-withdraw:66701108-f3d1-4b3a-bc23-84681e8472f4:${Date.now()}`;
     await signAndSendTransaction({
       walletId: 'w1',
       to: '0x1',
       data: '0x',
-      referenceId: longReferenceId,
+      referenceId: LONG_REFERENCE_ID,
     });
 
     const body = JSON.parse(
       (fetchMock.mock.calls[0][1] as { body: string }).body
     );
     expect(body.reference_id).toHaveLength(PRIVY_REFERENCE_ID_MAX_LENGTH);
-    expect(body.reference_id).toBe(normalizePrivyReferenceId(longReferenceId));
+    expect(body.reference_id).not.toBe(LONG_REFERENCE_ID);
   });
 });
 

--- a/lib/privy-server-rest.test.ts
+++ b/lib/privy-server-rest.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  normalizePrivyReferenceId,
+  PRIVY_REFERENCE_ID_MAX_LENGTH,
   PrivyRestApiError,
   signAndSendTransaction,
   waitForTransaction,
@@ -16,6 +18,23 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.unstubAllGlobals();
+});
+
+describe('normalizePrivyReferenceId', () => {
+  it('returns short ids unchanged', () => {
+    expect(normalizePrivyReferenceId('activation-settlement:abc')).toBe(
+      'activation-settlement:abc'
+    );
+  });
+
+  it('maps ids longer than 64 chars to a 64-char digest', () => {
+    const longId = `sponsored-activation-withdraw:66701108-f3d1-4b3a-bc23-84681e8472f4:${Date.now()}`;
+    expect(longId.length).toBeGreaterThan(PRIVY_REFERENCE_ID_MAX_LENGTH);
+
+    const normalized = normalizePrivyReferenceId(longId);
+    expect(normalized).toHaveLength(PRIVY_REFERENCE_ID_MAX_LENGTH);
+    expect(normalized).toBe(normalizePrivyReferenceId(longId));
+  });
 });
 
 describe('signAndSendTransaction', () => {
@@ -62,6 +81,33 @@ describe('signAndSendTransaction', () => {
         data: '0x',
       })
     ).rejects.toBeInstanceOf(PrivyRestApiError);
+  });
+
+  it('normalizes reference_id longer than 64 characters before send', async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          transaction_id: 'tx-abc',
+          user_operation_hash: null,
+          hash: '',
+        },
+      }),
+    });
+
+    const longReferenceId = `sponsored-activation-withdraw:66701108-f3d1-4b3a-bc23-84681e8472f4:${Date.now()}`;
+    await signAndSendTransaction({
+      walletId: 'w1',
+      to: '0x1',
+      data: '0x',
+      referenceId: longReferenceId,
+    });
+
+    const body = JSON.parse(
+      (fetchMock.mock.calls[0][1] as { body: string }).body
+    );
+    expect(body.reference_id).toHaveLength(PRIVY_REFERENCE_ID_MAX_LENGTH);
+    expect(body.reference_id).toBe(normalizePrivyReferenceId(longReferenceId));
   });
 });
 

--- a/lib/privy-server-rest.ts
+++ b/lib/privy-server-rest.ts
@@ -8,12 +8,8 @@ import { createHash } from 'crypto';
 import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
 
 /** Privy REST rejects `reference_id` longer than this. */
-export const PRIVY_REFERENCE_ID_MAX_LENGTH = 64;
+const PRIVY_REFERENCE_ID_MAX_LENGTH = 64;
 
-/**
- * Ensures a Privy `reference_id` fits API limits. Values over 64 chars are mapped
- * deterministically to a 64-character SHA-256 hex digest.
- */
 export function normalizePrivyReferenceId(referenceId: string): string {
   const trimmed = referenceId.trim();
   if (!trimmed) {
@@ -22,7 +18,7 @@ export function normalizePrivyReferenceId(referenceId: string): string {
   if (trimmed.length <= PRIVY_REFERENCE_ID_MAX_LENGTH) {
     return trimmed;
   }
-  return createHash('sha256').update(trimmed).digest('hex');
+  return createHash('sha256').update(trimmed, 'utf8').digest('hex');
 }
 
 const PRIVY_API_BASE = 'https://api.privy.io/v1';
@@ -199,8 +195,9 @@ export async function signAndSendTransaction(
     },
   };
   if (sponsor) body.sponsor = true;
-  if (referenceId) {
-    body.reference_id = normalizePrivyReferenceId(referenceId);
+  const normalizedReferenceId = referenceId?.trim();
+  if (normalizedReferenceId) {
+    body.reference_id = normalizePrivyReferenceId(normalizedReferenceId);
   }
 
   const res = await privyRestFetch(

--- a/lib/privy-server-rest.ts
+++ b/lib/privy-server-rest.ts
@@ -4,7 +4,26 @@
  * @see https://docs.privy.io/api-reference/wallets/ethereum/eth-send-transaction
  * @see https://docs.privy.io/api-reference/transactions/get
  */
+import { createHash } from 'crypto';
 import { SPEND_SERVER_WALLET_CAIP2 } from '@/lib/spend-server-wallet';
+
+/** Privy REST rejects `reference_id` longer than this. */
+export const PRIVY_REFERENCE_ID_MAX_LENGTH = 64;
+
+/**
+ * Ensures a Privy `reference_id` fits API limits. Values over 64 chars are mapped
+ * deterministically to a 64-character SHA-256 hex digest.
+ */
+export function normalizePrivyReferenceId(referenceId: string): string {
+  const trimmed = referenceId.trim();
+  if (!trimmed) {
+    throw new Error('normalizePrivyReferenceId: referenceId must be non-empty');
+  }
+  if (trimmed.length <= PRIVY_REFERENCE_ID_MAX_LENGTH) {
+    return trimmed;
+  }
+  return createHash('sha256').update(trimmed).digest('hex');
+}
 
 const PRIVY_API_BASE = 'https://api.privy.io/v1';
 
@@ -180,7 +199,9 @@ export async function signAndSendTransaction(
     },
   };
   if (sponsor) body.sponsor = true;
-  if (referenceId) body.reference_id = referenceId;
+  if (referenceId) {
+    body.reference_id = normalizePrivyReferenceId(referenceId);
+  }
 
   const res = await privyRestFetch(
     `/wallets/${encodeURIComponent(walletId)}/rpc`,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Campaign wallet withdraws on `/api/admin/sponsored-activations/{id}/campaign-wallet/withdraw` failed with:

```
Privy REST error 400: reference_id: String must contain at most 64 character(s)
```

The withdraw flow built an 81-character `reference_id`:

```
sponsored-activation-withdraw:{activationUuid}:{Date.now()}
```

## Fix

1. **Shorten withdraw reference id** in `lib/activation/campaign-wallet-withdraw.ts` to `sa-wd:{activationId}:{base36Timestamp}` (~51 chars).
2. **Normalize at Privy REST boundary** in `lib/privy-server-rest.ts`: any `reference_id` longer than 64 chars is mapped deterministically to a 64-char SHA-256 hex digest before send.

## Tests

- Added `normalizePrivyReferenceId` unit tests
- Added `signAndSendTransaction` test verifying overlong ids are normalized before API call
- Existing treasury/withdraw route tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-557e11fb-72d7-422a-b780-f90d36273da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-557e11fb-72d7-422a-b780-f90d36273da4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

