### PR TITLE
Add CADD as a settlement token option for sponsored activations on Base

### DIFF
--- a/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
+++ b/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
@@ -18,7 +18,14 @@ import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { balanceUsdcToMicro } from '@/lib/activation/usdc-micro';
+import {
+  balanceToTokenMicro,
+  balanceUsdcToMicro,
+} from '@/lib/activation/usdc-micro';
+import {
+  describeSponsoredActivationPaymentTokenSymbol,
+  resolveBaseTokenDecimals,
+} from '@/lib/schemas/sponsored-activation-tokens';
 import { adminApiAuthHeaders } from '@/lib/admin-api-auth-headers';
 import { readApiErrorMessage } from '@/lib/admin/read-api-error-message';
 import { unwrapAdminJson } from '@/lib/admin/unwrap-admin-json';
@@ -26,7 +33,6 @@ import type {
   SettlementRail,
   SponsoredActivationStatus,
 } from '@/lib/db/sponsored-activations';
-import { describeSponsoredActivationPaymentTokenSymbol } from '@/lib/schemas/sponsored-activation-tokens';
 import {
   sponsoredActivationQrGuestSharePath,
   sponsoredActivationQrGuestShareSourceRefId,
@@ -111,12 +117,6 @@ function fmtUsdc(n: number | null | undefined, tokenSymbol: string): string {
 
 function railLabel(rail: SettlementRail): string {
   return rail === 'base' ? 'Base' : 'Stellar';
-}
-
-function usdcAssetHint(rail: SettlementRail, tokenSymbol: string): string {
-  return rail === 'base'
-    ? `${tokenSymbol} on Base`
-    : `${tokenSymbol} on Stellar`;
 }
 
 function statusUpdateToastLabel(status: SponsoredActivationStatus): string {
@@ -464,6 +464,14 @@ export function ActivationLaunchPanel({
   const isPaused = activation.status === 'paused';
   const canGoLive = isDraft && hasActiveReward;
   const tokenSymbol = describeSponsoredActivationPaymentTokenSymbol(activation);
+  const tokenDecimals =
+    activation.settlement_rail === 'base'
+      ? resolveBaseTokenDecimals(
+          typeof activation.usdc_asset_config?.contract_address === 'string'
+            ? activation.usdc_asset_config.contract_address
+            : ''
+        )
+      : 6;
 
   let liveStepBody: string;
   if (isDraft) {
@@ -487,7 +495,7 @@ export function ActivationLaunchPanel({
     {
       id: 'fund',
       done: false,
-      title: `Fund the campaign wallet (${usdcAssetHint(activation.settlement_rail, tokenSymbol)})`,
+      title: `Fund the campaign wallet (${activation.settlement_rail === 'base' ? `${tokenSymbol} on Base` : `${tokenSymbol} on Stellar`})`,
       body:
         activation.settlement_rail === 'stellar'
           ? `Fund the shared Stellar campaign wallet below with ${fmtUsdcHint(activation.max_usdc_budget, tokenSymbol)} or more ${tokenSymbol}. All Stellar activations settle from this wallet.`
@@ -859,9 +867,14 @@ export function ActivationLaunchPanel({
                             withdrawMutation.isPending ||
                             !withdrawDestination.trim() ||
                             activation.campaign_wallet_usdc_balance == null ||
-                            balanceUsdcToMicro(
-                              activation.campaign_wallet_usdc_balance
-                            ) <= 0
+                            (activation.settlement_rail === 'base'
+                              ? balanceToTokenMicro(
+                                  activation.campaign_wallet_usdc_balance,
+                                  tokenDecimals
+                                )
+                              : balanceUsdcToMicro(
+                                  activation.campaign_wallet_usdc_balance
+                                )) <= 0
                           }
                           onClick={() => withdrawMutation.mutate()}
                         >

--- a/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
+++ b/app/admin/sponsored-activations/[activationId]/activation-launch-panel.tsx
@@ -26,6 +26,7 @@ import type {
   SettlementRail,
   SponsoredActivationStatus,
 } from '@/lib/db/sponsored-activations';
+import { describeSponsoredActivationPaymentTokenSymbol } from '@/lib/schemas/sponsored-activation-tokens';
 import {
   sponsoredActivationQrGuestSharePath,
   sponsoredActivationQrGuestShareSourceRefId,
@@ -42,6 +43,7 @@ type ActivationAdminRow = {
   campaign_wallet_explorer_url: string | null;
   venue_settlement_wallet_address: string;
   venue_settlement_wallet_explorer_url: string | null;
+  usdc_asset_config: Record<string, unknown>;
   max_usdc_budget: number | null;
   max_redemptions: number | null;
   campaign_wallet_usdc_balance?: number | null;
@@ -90,29 +92,31 @@ type ActivationLaunchPanelProps = {
   dashboardQueryKey: readonly ['admin-sponsored-activation-dashboard', string];
 };
 
-function fmtUsdcHint(n: number | null): string {
-  if (n == null || Number.isNaN(n)) return 'your planned USDC budget';
-  return `$${n.toLocaleString(undefined, {
+function fmtUsdcHint(n: number | null, tokenSymbol: string): string {
+  if (n == null || Number.isNaN(n)) return `your planned ${tokenSymbol} budget`;
+  return `${n.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 2,
-  })}`;
+  })} ${tokenSymbol}`;
 }
 
-function fmtUsdc(n: number | null | undefined): string {
+function fmtUsdc(n: number | null | undefined, tokenSymbol: string): string {
   if (n == null || Number.isNaN(n)) return '—';
   const rounded = Math.round(n * 1e6) / 1e6;
-  return `$${rounded.toLocaleString(undefined, {
+  return `${rounded.toLocaleString(undefined, {
     minimumFractionDigits: 2,
     maximumFractionDigits: 6,
-  })}`;
+  })} ${tokenSymbol}`;
 }
 
 function railLabel(rail: SettlementRail): string {
   return rail === 'base' ? 'Base' : 'Stellar';
 }
 
-function usdcAssetHint(rail: SettlementRail): string {
-  return rail === 'base' ? 'USDC on Base' : 'USDC on Stellar';
+function usdcAssetHint(rail: SettlementRail, tokenSymbol: string): string {
+  return rail === 'base'
+    ? `${tokenSymbol} on Base`
+    : `${tokenSymbol} on Stellar`;
 }
 
 function statusUpdateToastLabel(status: SponsoredActivationStatus): string {
@@ -383,7 +387,7 @@ export function ActivationLaunchPanel({
         throw new Error('Points must be zero or greater');
       }
       if (!Number.isFinite(usdc) || usdc <= 0) {
-        throw new Error('USDC amount must be greater than zero');
+        throw new Error('Payout amount must be greater than zero');
       }
       const heroImageUrl = rewardHeroFile
         ? await uploadActivationHeroImage(rewardHeroFile)
@@ -459,6 +463,7 @@ export function ActivationLaunchPanel({
   const isLive = activation.status === 'active';
   const isPaused = activation.status === 'paused';
   const canGoLive = isDraft && hasActiveReward;
+  const tokenSymbol = describeSponsoredActivationPaymentTokenSymbol(activation);
 
   let liveStepBody: string;
   if (isDraft) {
@@ -477,16 +482,16 @@ export function ActivationLaunchPanel({
       title: 'Add at least one active reward',
       body: hasActiveReward
         ? `${activeRewardCount} active reward${activeRewardCount === 1 ? '' : 's'} configured.`
-        : 'Users need a reward (name, points cost, USDC payout) before the activation can go live.',
+        : `Users need a reward (name, points cost, ${tokenSymbol} payout) before the activation can go live.`,
     },
     {
       id: 'fund',
       done: false,
-      title: `Fund the campaign wallet (${usdcAssetHint(activation.settlement_rail)})`,
+      title: `Fund the campaign wallet (${usdcAssetHint(activation.settlement_rail, tokenSymbol)})`,
       body:
         activation.settlement_rail === 'stellar'
-          ? `Fund the shared Stellar campaign wallet below with ${fmtUsdcHint(activation.max_usdc_budget)} or more USDC. All Stellar activations settle from this wallet.`
-          : `Send ${fmtUsdcHint(activation.max_usdc_budget)} or more to the campaign wallet below. Settlements pull from this wallet when guests redeem.`,
+          ? `Fund the shared Stellar campaign wallet below with ${fmtUsdcHint(activation.max_usdc_budget, tokenSymbol)} or more ${tokenSymbol}. All Stellar activations settle from this wallet.`
+          : `Send ${fmtUsdcHint(activation.max_usdc_budget, tokenSymbol)} or more to the campaign wallet below. Settlements pull from this wallet when guests redeem.`,
     },
     {
       id: 'live',
@@ -573,7 +578,8 @@ export function ActivationLaunchPanel({
           {activation.max_usdc_budget != null && (
             <>
               {' '}
-              Planned budget cap: {fmtUsdcHint(activation.max_usdc_budget)} (
+              Planned budget cap:{' '}
+              {fmtUsdcHint(activation.max_usdc_budget, tokenSymbol)} (
               {activation.max_redemptions ?? '∞'} max redemptions).
             </>
           )}
@@ -613,7 +619,8 @@ export function ActivationLaunchPanel({
                           <div>
                             <span className="font-medium">{item.name}</span>
                             {' · '}
-                            {item.points_cost} pts · ${item.usdc_amount} USDC
+                            {item.points_cost} pts · {item.usdc_amount}{' '}
+                            {tokenSymbol}
                             {!item.is_active && (
                               <span className="text-amber-700">
                                 {' '}
@@ -663,7 +670,9 @@ export function ActivationLaunchPanel({
                         />
                       </div>
                       <div className="space-y-1">
-                        <Label htmlFor="launch-reward-usdc">USDC payout</Label>
+                        <Label htmlFor="launch-reward-usdc">
+                          {tokenSymbol} payout
+                        </Label>
                         <Input
                           id="launch-reward-usdc"
                           type="number"
@@ -760,9 +769,9 @@ export function ActivationLaunchPanel({
                     </div>
                     <p className="w-full text-xs text-neutral-500">
                       {activation.settlement_rail === 'stellar'
-                        ? 'Shared Stellar campaign wallet (server-configured). Fund with USDC before redemptions settle.'
+                        ? `Shared Stellar campaign wallet (server-configured). Fund with ${tokenSymbol} before redemptions settle.`
                         : 'Send funds here (campaign wallet, provisioned via Privy).'}{' '}
-                      Redemptions settle USDC to the venue wallet{' '}
+                      Redemptions settle {tokenSymbol} to the venue wallet{' '}
                       <span className="font-mono text-[11px]">
                         {activation.venue_settlement_wallet_address}
                       </span>
@@ -790,15 +799,21 @@ export function ActivationLaunchPanel({
                   <div className="rounded-lg border border-neutral-200 p-4 dark:border-neutral-700">
                     <div className="text-sm">
                       <div className="text-xs font-medium uppercase tracking-wide text-neutral-500">
-                        USDC balance
+                        {tokenSymbol} balance
                       </div>
                       <div className="mt-1 font-medium text-neutral-900 dark:text-neutral-100">
-                        {fmtUsdc(activation.campaign_wallet_usdc_balance)}
+                        {fmtUsdc(
+                          activation.campaign_wallet_usdc_balance,
+                          tokenSymbol
+                        )}
                       </div>
                       {(activation.campaign_wallet_reserved_usdc ?? 0) > 0 && (
                         <p className="mt-2 text-xs text-amber-700 dark:text-amber-300">
-                          {fmtUsdc(activation.campaign_wallet_reserved_usdc)} is
-                          earmarked for pending redemptions or settlements.
+                          {fmtUsdc(
+                            activation.campaign_wallet_reserved_usdc,
+                            tokenSymbol
+                          )}{' '}
+                          is earmarked for pending redemptions or settlements.
                           Withdrawal includes this balance; in-flight
                           settlements may fail afterward.
                         </p>
@@ -829,9 +844,9 @@ export function ActivationLaunchPanel({
                           className="order-2 w-full font-mono text-xs sm:col-start-1 sm:row-start-2"
                         />
                         <p className="order-3 text-xs text-neutral-500 sm:col-start-1 sm:row-start-3">
-                          Withdraws the full on-chain USDC balance to the
-                          address above, including funds earmarked for pending
-                          activity.
+                          Withdraws the full on-chain {tokenSymbol} balance to
+                          the address above, including funds earmarked for
+                          pending activity.
                           {activation.settlement_rail === 'base'
                             ? ' Gas is sponsored on Base.'
                             : ' Stellar uses the shared campaign wallet; confirm the destination before sending.'}
@@ -856,7 +871,7 @@ export function ActivationLaunchPanel({
                               Withdrawing…
                             </>
                           ) : (
-                            'Withdraw USDC'
+                            `Withdraw ${tokenSymbol}`
                           )}
                         </Button>
                       </div>

--- a/app/admin/sponsored-activations/[activationId]/page.tsx
+++ b/app/admin/sponsored-activations/[activationId]/page.tsx
@@ -22,6 +22,7 @@ import type {
   SettlementRail,
   SponsoredActivationStatus,
 } from '@/lib/db/sponsored-activations';
+import { describeSponsoredActivationPaymentTokenSymbol } from '@/lib/schemas/sponsored-activation-tokens';
 import { ActivationLaunchPanel } from './activation-launch-panel';
 
 type ActivationEnvelope = {
@@ -29,6 +30,7 @@ type ActivationEnvelope = {
   title: string;
   status: SponsoredActivationStatus;
   settlement_rail: SettlementRail;
+  usdc_asset_config: Record<string, unknown>;
   max_usdc_budget: number | null;
   max_redemptions: number | null;
 };
@@ -49,13 +51,13 @@ function formatIfNumber(
   return format(n);
 }
 
-function fmtUsdc(n: number | null | undefined): string {
+function fmtUsdc(n: number | null | undefined, tokenSymbol: string): string {
   return formatIfNumber(n, (v) => {
     const rounded = Math.round(v * 1e6) / 1e6;
-    return `$${rounded.toLocaleString(undefined, {
+    return `${rounded.toLocaleString(undefined, {
       minimumFractionDigits: 2,
       maximumFractionDigits: 6,
-    })}`;
+    })} ${tokenSymbol}`;
   });
 }
 
@@ -196,6 +198,10 @@ export default function AdminSponsoredActivationDetailPage() {
     staleTime: 60_000,
     refetchOnWindowFocus: false,
   });
+
+  const tokenSymbol = dashboard
+    ? describeSponsoredActivationPaymentTokenSymbol(dashboard.activation)
+    : 'USDC';
 
   useEffect(() => {
     if (!dashboard?.activation?.id) return;
@@ -339,24 +345,24 @@ export default function AdminSponsoredActivationDetailPage() {
                 value={fmtInt(dashboard.tiles.redemptionsConfirmed)}
               />
               <Tile
-                label="USDC settled"
-                value={fmtUsdc(dashboard.tiles.usdcSettledTotal)}
+                label={`${tokenSymbol} settled`}
+                value={fmtUsdc(dashboard.tiles.usdcSettledTotal, tokenSymbol)}
               />
               <Tile
                 label="Reserved (inflight + committed)"
-                value={fmtUsdc(dashboard.tiles.reservedUsdc)}
+                value={fmtUsdc(dashboard.tiles.reservedUsdc, tokenSymbol)}
               />
               <Tile
                 label="Budget remaining"
                 hint={
                   dashboard.activation.max_usdc_budget == null
-                    ? 'No USDC budget cap'
+                    ? `No ${tokenSymbol} budget cap`
                     : undefined
                 }
                 value={
                   dashboard.tiles.budgetRemainingUsdc == null
                     ? '—'
-                    : fmtUsdc(dashboard.tiles.budgetRemainingUsdc)
+                    : fmtUsdc(dashboard.tiles.budgetRemainingUsdc, tokenSymbol)
                 }
               />
               <Tile
@@ -415,7 +421,7 @@ export default function AdminSponsoredActivationDetailPage() {
                             {fmtLocalDateTime(row.confirmedAt)}
                           </td>
                           <td className="px-3 py-2 font-mono text-xs">
-                            {fmtUsdc(row.amount)}
+                            {fmtUsdc(row.amount, tokenSymbol)}
                           </td>
                           <td className="px-3 py-2">
                             <SettlementExplorerTxLink
@@ -474,7 +480,7 @@ export default function AdminSponsoredActivationDetailPage() {
                             {row.status}
                           </td>
                           <td className="px-3 py-2 font-mono text-xs">
-                            {fmtUsdc(row.amount)}
+                            {fmtUsdc(row.amount, tokenSymbol)}
                           </td>
                           <td className="px-3 py-2 text-xs">
                             {row.submissionAttempt}
@@ -659,7 +665,11 @@ export default function AdminSponsoredActivationDetailPage() {
                       Status: {selectedRedemption.settlement.status}
                     </li>
                     <li>
-                      Amount: {fmtUsdc(selectedRedemption.settlement.amount)}
+                      Amount:{' '}
+                      {fmtUsdc(
+                        selectedRedemption.settlement.amount,
+                        tokenSymbol
+                      )}
                     </li>
                     <li className="break-all">
                       Tx:{' '}

--- a/app/admin/sponsored-activations/form-state.test.ts
+++ b/app/admin/sponsored-activations/form-state.test.ts
@@ -30,6 +30,25 @@ describe('formStateToCreatePayload', () => {
     expect(payload).not.toHaveProperty('usdc_asset_config');
   });
 
+  it('defaults payment_token to USDC on base rail', () => {
+    const payload = formStateToCreatePayload(minimalBaseCreateForm());
+    expect(payload).toMatchObject({ payment_token: 'USDC' });
+  });
+
+  it('includes the selected payment_token (CADD) on base rail', () => {
+    const payload = formStateToCreatePayload(
+      minimalBaseCreateForm({ payment_token: 'CADD' })
+    );
+    expect(payload).toMatchObject({ payment_token: 'CADD' });
+  });
+
+  it('omits payment_token on stellar rail', () => {
+    const payload = formStateToCreatePayload(
+      minimalBaseCreateForm({ settlement_rail: 'stellar' })
+    );
+    expect(payload).not.toHaveProperty('payment_token');
+  });
+
   it('includes trimmed description when set', () => {
     const payload = formStateToCreatePayload(
       minimalBaseCreateForm({ description: '  Free drink with check-in  ' })

--- a/app/admin/sponsored-activations/form-state.ts
+++ b/app/admin/sponsored-activations/form-state.ts
@@ -1,5 +1,6 @@
 import type { SettlementRail } from '@/lib/db/sponsored-activations';
 import type { AdminCreateSponsoredActivationRequest } from '@/lib/schemas/sponsored-activation';
+import type { SponsoredActivationBaseTokenSymbol } from '@/lib/schemas/sponsored-activation-tokens';
 import { DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG } from '@/lib/schemas/activation-eligibility-config';
 
 export type SponsoredActivationFormState = {
@@ -8,6 +9,8 @@ export type SponsoredActivationFormState = {
   sponsor_name: string;
   event_id: string;
   settlement_rail: SettlementRail;
+  /** Base rail only; ignored (and omitted from the payload) for Stellar. */
+  payment_token: SponsoredActivationBaseTokenSymbol;
   venue_settlement_wallet_address: string;
   max_redemptions: string;
   max_usdc_budget: string;
@@ -34,6 +37,7 @@ export function emptySponsoredActivationForm(): SponsoredActivationFormState {
     sponsor_name: '',
     event_id: '',
     settlement_rail: 'base',
+    payment_token: 'USDC',
     venue_settlement_wallet_address: '',
     max_redemptions: '100',
     max_usdc_budget: '',
@@ -110,6 +114,7 @@ export function formStateToCreatePayload(
       ...common,
       settlement_rail: 'base',
       venue_settlement_wallet_address: venue,
+      payment_token: form.payment_token,
     } as AdminCreateSponsoredActivationRequest;
   }
 

--- a/app/admin/sponsored-activations/page.tsx
+++ b/app/admin/sponsored-activations/page.tsx
@@ -12,6 +12,7 @@ import { Loader2, ArrowLeft, CircleDollarSign, Plus } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import type { AdminCreateSponsoredActivationRequest } from '@/lib/schemas/sponsored-activation';
+import { describeSponsoredActivationPaymentTokenSymbol } from '@/lib/schemas/sponsored-activation-tokens';
 import {
   emptySponsoredActivationForm,
   formStateToCreatePayload,
@@ -26,6 +27,7 @@ type ActivationListRow = {
   sponsor_name: string;
   status: string;
   settlement_rail: string;
+  usdc_asset_config: Record<string, unknown>;
 };
 
 const LIST_QUERY_KEY = ['admin-sponsored-activations-list'] as const;
@@ -81,6 +83,9 @@ const SponsoredActivationsListBody = memo(
                 Rail
               </th>
               <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
+                Token
+              </th>
+              <th className="px-4 py-3 font-medium text-gray-700 dark:text-neutral-300">
                 Activation ID
               </th>
             </tr>
@@ -107,6 +112,9 @@ const SponsoredActivationsListBody = memo(
                 </td>
                 <td className="px-4 py-3 font-mono text-xs text-neutral-700 dark:text-neutral-300">
                   {a.settlement_rail}
+                </td>
+                <td className="px-4 py-3 font-mono text-xs text-neutral-700 dark:text-neutral-300">
+                  {describeSponsoredActivationPaymentTokenSymbol(a)}
                 </td>
                 <td className="px-4 py-3 font-mono text-xs text-neutral-600 dark:text-neutral-400">
                   {a.id}

--- a/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
+++ b/app/admin/sponsored-activations/sponsored-activation-form-panel.tsx
@@ -11,6 +11,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import {
+  isSponsoredActivationBaseTokenSymbol,
+  SPONSORED_ACTIVATION_BASE_TOKENS,
+} from '@/lib/schemas/sponsored-activation-tokens';
 import type { SponsoredActivationFormState } from './form-state';
 
 export type SponsoredActivationFormPanelProps = {
@@ -123,6 +127,36 @@ export function SponsoredActivationFormPanel({
                 : 'Settlements pay from the shared Stellar campaign wallet configured on the server. Fund that wallet with USDC before going live.'}
             </p>
           </div>
+          {isBase && (
+            <div className="space-y-2">
+              <Label>Payment token</Label>
+              <Select
+                value={form.payment_token}
+                onValueChange={(v) => {
+                  if (isSponsoredActivationBaseTokenSymbol(v)) {
+                    setField('payment_token')(v);
+                  }
+                }}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Select token" />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.values(SPONSORED_ACTIVATION_BASE_TOKENS).map(
+                    (token) => (
+                      <SelectItem key={token.symbol} value={token.symbol}>
+                        {token.label}
+                      </SelectItem>
+                    )
+                  )}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-neutral-500">
+                Settlements pay the venue in this token on Base. Fund the
+                campaign wallet with the same token before going live.
+              </p>
+            </div>
+          )}
           <div className="space-y-2">
             <Label htmlFor="sa-venue">Venue settlement wallet</Label>
             <Input
@@ -153,7 +187,9 @@ export function SponsoredActivationFormPanel({
               />
             </div>
             <div className="space-y-2">
-              <Label htmlFor="sa-max-budget">Max USDC budget</Label>
+              <Label htmlFor="sa-max-budget">
+                Max budget ({isBase ? form.payment_token : 'USDC'})
+              </Label>
               <Input
                 id="sa-max-budget"
                 type="number"

--- a/app/api/admin/sponsored-activations/__tests__/admin-sponsored-activations.routes.test.ts
+++ b/app/api/admin/sponsored-activations/__tests__/admin-sponsored-activations.routes.test.ts
@@ -244,6 +244,35 @@ describe('POST /api/admin/sponsored-activations', () => {
     expect(createArg.privy_campaign_wallet_id).toBe('pw-new');
   });
 
+  it('creates a Base activation with payment_token=CADD', async () => {
+    mockCreate.mockResolvedValue(baseFixture);
+    const res = await listPOST(
+      jsonReq(
+        'POST',
+        'http://localhost/api/admin/sponsored-activations',
+        {
+          settlement_rail: 'base',
+          title: 't',
+          sponsor_name: 's',
+          max_redemptions: 1,
+          ...validWindow,
+          venue_settlement_wallet_address:
+            '0x70997970C51812dc3A010C7d01b50e0d17dc79C8',
+          payment_token: 'CADD',
+        },
+        'idem-cadd'
+      )
+    );
+    expect(res.status).toBe(200);
+    const createArg = mockCreate.mock.calls[0][0] as {
+      usdc_asset_config: { contract_address: string; symbol: string };
+    };
+    expect(createArg.usdc_asset_config).toEqual({
+      contract_address: '0x16F93eBC5320C89EfC8701577efe49d14A276a06',
+      symbol: 'CADD',
+    });
+  });
+
   it('uses shared env Stellar campaign wallet without Privy', async () => {
     mockCreate.mockResolvedValue({
       ...baseFixture,

--- a/app/api/admin/sponsored-activations/route.ts
+++ b/app/api/admin/sponsored-activations/route.ts
@@ -8,7 +8,7 @@ import {
 } from '@/lib/db/sponsored-activations';
 import {
   adminCreateSponsoredActivationRequestSchema,
-  DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT,
+  resolveAdminBaseSponsoredActivationAssetConfig,
 } from '@/lib/schemas/sponsored-activation';
 import { apiSuccess, apiError, apiValidationError } from '@/lib/api/response';
 import { requireAdmin } from '@/lib/auth';
@@ -116,7 +116,7 @@ export async function POST(request: NextRequest) {
     const activationId = randomUUID();
     const usdc_asset_config =
       data.settlement_rail === 'base'
-        ? { contract_address: DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT }
+        ? resolveAdminBaseSponsoredActivationAssetConfig(data.payment_token)
         : getDefaultStellarSponsoredActivationUsdcAssetConfig();
 
     const description =

--- a/lib/activation/base-settlement-worker.test.ts
+++ b/lib/activation/base-settlement-worker.test.ts
@@ -413,6 +413,73 @@ describe('processBaseActivationSettlement', () => {
     });
   });
 
+  it('happy path: resolves 18-decimal CADD decimals for submit and chain scan', async () => {
+    const cadd = '0x16F93eBC5320C89EfC8701577efe49d14A276a06';
+    mockGetSettlementById
+      .mockResolvedValueOnce(baseSettlement())
+      .mockResolvedValue({
+        ...baseSettlement({
+          status: 'confirmed',
+          tx_hash: txHash,
+          privy_transaction_id: 'privy-tx-1',
+          submission_attempt: 1,
+        }),
+      });
+    mockGetActivationById.mockResolvedValue(
+      baseActivation({ usdc_asset_config: { contract_address: cadd } })
+    );
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockSubmitTreasury.mockResolvedValue({
+      ok: true,
+      txHash: txHash as `0x${string}`,
+      privyTransactionId: 'privy-tx-1',
+      privyStatus: 'finalized',
+    });
+
+    await processBaseActivationSettlement({ settlementId: 'settle-1' });
+
+    expect(mockSubmitTreasury).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usdcContractAddress: cadd,
+        decimals: 18,
+      })
+    );
+  });
+
+  it('idempotent replay on submitted: passes 18 decimals to chain scan for CADD', async () => {
+    const cadd = '0x16F93eBC5320C89EfC8701577efe49d14A276a06';
+    mockGetSettlementById
+      .mockResolvedValueOnce(
+        baseSettlement({
+          status: 'submitted',
+          privy_transaction_id: 'privy-tx-old',
+          submission_attempt: 1,
+        })
+      )
+      .mockResolvedValue({
+        ...baseSettlement({
+          status: 'confirmed',
+          tx_hash: txHash,
+          privy_transaction_id: 'privy-tx-old',
+          submission_attempt: 1,
+        }),
+      });
+    mockGetActivationById.mockResolvedValue(
+      baseActivation({ usdc_asset_config: { contract_address: cadd } })
+    );
+    mockGetRedemptionById.mockResolvedValue(baseRedemption());
+    mockWaitForTransaction.mockRejectedValue(
+      new PrivyRestTransactionTimeoutError('privy-tx-old')
+    );
+    mockFindRecent.mockResolvedValue(txHash as `0x${string}`);
+
+    await processBaseActivationSettlement({ settlementId: 'settle-1' });
+
+    expect(mockFindRecent).toHaveBeenCalledWith(
+      expect.objectContaining({ erc20ContractAddress: cadd, decimals: 18 })
+    );
+  });
+
   it('records retry when Privy REST is not configured', async () => {
     const { PrivyRestNotConfiguredError } =
       await import('@/lib/privy-server-rest');

--- a/lib/activation/base-settlement-worker.ts
+++ b/lib/activation/base-settlement-worker.ts
@@ -25,6 +25,7 @@ import {
   waitForTransaction,
 } from '@/lib/privy-server-rest';
 import { baseUsdcAssetConfigSchema } from '@/lib/schemas/sponsored-activation';
+import { resolveBaseTokenDecimals } from '@/lib/schemas/sponsored-activation-tokens';
 import {
   findRecentTreasuryUsdcTransfer,
   getTreasuryTxReceiptStatus,
@@ -306,6 +307,7 @@ export async function processBaseActivationSettlement(input: {
     );
   }
   const usdcContract = cfgParse.data.contract_address;
+  const tokenDecimals = resolveBaseTokenDecimals(usdcContract);
 
   const privyWalletId = activation.privy_campaign_wallet_id?.trim();
   if (!privyWalletId) {
@@ -394,6 +396,7 @@ export async function processBaseActivationSettlement(input: {
       recipientAddress: venueExpected as `0x${string}`,
       usdcAmount: settlementAmount,
       erc20ContractAddress: usdcContract,
+      decimals: tokenDecimals,
     });
   }
 
@@ -485,6 +488,7 @@ export async function processBaseActivationSettlement(input: {
       recipientAddress: venueExpected,
       usdcAmount: row.amount,
       usdcContractAddress: usdcContract,
+      decimals: tokenDecimals,
       referenceId,
     });
   } catch (e) {

--- a/lib/activation/campaign-wallet-withdraw.test.ts
+++ b/lib/activation/campaign-wallet-withdraw.test.ts
@@ -1,0 +1,125 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockLoadActivationReservedUsdc = vi.fn();
+const mockFetchUsdcBalanceOnBase = vi.fn();
+const mockSubmitTreasuryUsdcTransfer = vi.fn();
+const mockWaitForTreasuryTxReceipt = vi.fn();
+
+vi.mock('@/lib/db/sponsored-activation-admin', () => ({
+  loadActivationReservedUsdc: (...a: unknown[]) =>
+    mockLoadActivationReservedUsdc(...a),
+}));
+
+vi.mock('@/lib/walletconnect-poster-direct-usdc', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/lib/walletconnect-poster-direct-usdc')
+    >();
+  return {
+    ...actual,
+    fetchUsdcBalanceOnBase: (...a: unknown[]) =>
+      mockFetchUsdcBalanceOnBase(...a),
+  };
+});
+
+vi.mock('@/lib/spend-treasury-usdc-transfer', () => ({
+  submitTreasuryUsdcTransfer: (...a: unknown[]) =>
+    mockSubmitTreasuryUsdcTransfer(...a),
+  waitForTreasuryTxReceipt: (...a: unknown[]) =>
+    mockWaitForTreasuryTxReceipt(...a),
+}));
+
+import {
+  loadSponsoredActivationCampaignWalletBalancePack,
+  withdrawSponsoredActivationCampaignWallet,
+} from '@/lib/activation/campaign-wallet-withdraw';
+import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
+
+const CADD = '0x16F93eBC5320C89EfC8701577efe49d14A276a06';
+
+function baseActivation(
+  overrides: Partial<SponsoredActivationRow> = {}
+): SponsoredActivationRow {
+  return {
+    id: 'act-1',
+    slug: 'act-1',
+    title: 'T',
+    description: null,
+    sponsor_name: 'S',
+    event_id: null,
+    status: 'active',
+    settlement_rail: 'base',
+    campaign_wallet_address: '0x1111111111111111111111111111111111111111',
+    venue_settlement_wallet_address:
+      '0x2222222222222222222222222222222222222222',
+    usdc_asset_config: { contract_address: CADD, symbol: 'CADD' },
+    max_redemptions: null,
+    max_usdc_budget: null,
+    usdc_settled_total: 0,
+    redemption_count_confirmed: 0,
+    starts_at: '2026-01-01T00:00:00.000Z',
+    ends_at: '2026-02-01T00:00:00.000Z',
+    eligibility_config: {},
+    created_by: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+    activation_create_idempotency_key: null,
+    privy_campaign_wallet_id: 'pw-1',
+    ...overrides,
+  };
+}
+
+describe('campaign-wallet-withdraw (CADD / 18-decimal Base tokens)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoadActivationReservedUsdc.mockResolvedValue(0);
+  });
+
+  it('reads campaign wallet balance with 18 decimals for CADD', async () => {
+    mockFetchUsdcBalanceOnBase.mockResolvedValue(123.456);
+    const pack =
+      await loadSponsoredActivationCampaignWalletBalancePack(baseActivation());
+    expect(mockFetchUsdcBalanceOnBase).toHaveBeenCalledWith(
+      '0x1111111111111111111111111111111111111111',
+      expect.objectContaining({ usdcContract: CADD, decimals: 18 })
+    );
+    expect(pack.campaign_wallet_usdc_balance).toBe(123.456);
+  });
+
+  it('submits withdraw transfer with 18 decimals for CADD', async () => {
+    mockFetchUsdcBalanceOnBase.mockResolvedValue(10);
+    mockSubmitTreasuryUsdcTransfer.mockResolvedValue({
+      ok: true,
+      txHash: '0xabc',
+      privyTransactionId: 'ptx-1',
+    });
+    mockWaitForTreasuryTxReceipt.mockResolvedValue(undefined);
+
+    const result = await withdrawSponsoredActivationCampaignWallet({
+      activation: baseActivation(),
+      destinationAddress: '0x3333333333333333333333333333333333333333',
+    });
+
+    expect(mockSubmitTreasuryUsdcTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usdcContractAddress: CADD,
+        decimals: 18,
+      })
+    );
+    expect(result.ok).toBe(true);
+  });
+
+  it('falls back to 6 decimals for legacy/unrecognized contracts', async () => {
+    const legacyContract = '0x9999999999999999999999999999999999999999';
+    mockFetchUsdcBalanceOnBase.mockResolvedValue(5);
+    await loadSponsoredActivationCampaignWalletBalancePack(
+      baseActivation({
+        usdc_asset_config: { contract_address: legacyContract },
+      })
+    );
+    expect(mockFetchUsdcBalanceOnBase).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ decimals: 6 })
+    );
+  });
+});

--- a/lib/activation/campaign-wallet-withdraw.test.ts
+++ b/lib/activation/campaign-wallet-withdraw.test.ts
@@ -34,8 +34,9 @@ import {
   withdrawSponsoredActivationCampaignWallet,
 } from '@/lib/activation/campaign-wallet-withdraw';
 import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
+import { CADD_ADDRESS_BASE } from '@/lib/schemas/sponsored-activation-tokens';
 
-const CADD = '0x16F93eBC5320C89EfC8701577efe49d14A276a06';
+const CADD = CADD_ADDRESS_BASE;
 
 function baseActivation(
   overrides: Partial<SponsoredActivationRow> = {}
@@ -104,9 +105,33 @@ describe('campaign-wallet-withdraw (CADD / 18-decimal Base tokens)', () => {
       expect.objectContaining({
         usdcContractAddress: CADD,
         decimals: 18,
+        usdcAmount: 10,
       })
     );
     expect(result.ok).toBe(true);
+  });
+
+  it('withdraws full CADD balance using 18-decimal micro precision', async () => {
+    const preciseBalance = 10.123456789012345678;
+    mockFetchUsdcBalanceOnBase.mockResolvedValue(preciseBalance);
+    mockSubmitTreasuryUsdcTransfer.mockResolvedValue({
+      ok: true,
+      txHash: '0xabc',
+      privyTransactionId: 'ptx-1',
+    });
+    mockWaitForTreasuryTxReceipt.mockResolvedValue(undefined);
+
+    await withdrawSponsoredActivationCampaignWallet({
+      activation: baseActivation(),
+      destinationAddress: '0x3333333333333333333333333333333333333333',
+    });
+
+    expect(mockSubmitTreasuryUsdcTransfer).toHaveBeenCalledWith(
+      expect.objectContaining({
+        usdcAmount: 10.123456789012345678,
+        decimals: 18,
+      })
+    );
   });
 
   it('falls back to 6 decimals for legacy/unrecognized contracts', async () => {

--- a/lib/activation/campaign-wallet-withdraw.ts
+++ b/lib/activation/campaign-wallet-withdraw.ts
@@ -8,6 +8,10 @@ import { supabase } from '@/lib/db/client';
 import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { baseUsdcAssetConfigSchema } from '@/lib/schemas/sponsored-activation';
+import {
+  describeSponsoredActivationPaymentTokenSymbol,
+  resolveBaseTokenDecimals,
+} from '@/lib/schemas/sponsored-activation-tokens';
 import { parseUsdcBalanceLine } from '@/lib/spend/stellar-treasury-funding';
 import { createStellarSpendHorizonServer } from '@/lib/spend/stellar-wallet-readiness-config';
 import { getSpendRailBaseRpcUrl } from '@/lib/spend-rail-config';
@@ -149,6 +153,7 @@ async function readBaseCampaignWalletBalance(
     return await fetchUsdcBalanceOnBase(normalized as `0x${string}`, {
       rpcUrl: getSpendRailBaseRpcUrl() || undefined,
       usdcContract: cfg.data.contract_address as `0x${string}`,
+      decimals: resolveBaseTokenDecimals(cfg.data.contract_address),
     });
   } catch (e) {
     console.error('readBaseCampaignWalletBalance:', e);
@@ -283,11 +288,15 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     return { ok: false, error: destCheck.error, statusCode: 400 };
   }
 
+  const tokenSymbol = describeSponsoredActivationPaymentTokenSymbol(
+    input.activation
+  );
+
   const balance = await readCampaignWalletOnChainBalance(input.activation);
   if (balance == null) {
     return {
       ok: false,
-      error: 'Could not read campaign wallet USDC balance.',
+      error: `Could not read campaign wallet ${tokenSymbol} balance.`,
       statusCode: 500,
     };
   }
@@ -302,7 +311,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
   if (maxBalanceMicro <= 0) {
     return {
       ok: false,
-      error: 'No USDC available to withdraw.',
+      error: `No ${tokenSymbol} available to withdraw.`,
       statusCode: 400,
     };
   }
@@ -320,7 +329,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     if (withdrawMicro > maxBalanceMicro) {
       return {
         ok: false,
-        error: `Amount exceeds on-chain balance (${(maxBalanceMicro / 1e6).toFixed(6)} USDC).`,
+        error: `Amount exceeds on-chain balance (${(maxBalanceMicro / 1e6).toFixed(6)} ${tokenSymbol}).`,
         statusCode: 400,
       };
     }
@@ -379,7 +388,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
   if (!cfg.success) {
     return {
       ok: false,
-      error: 'USDC contract is misconfigured.',
+      error: `${tokenSymbol} contract is misconfigured.`,
       statusCode: 500,
     };
   }
@@ -390,6 +399,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     recipientAddress: destinationAddress as `0x${string}`,
     usdcAmount: withdrawAmount,
     usdcContractAddress: cfg.data.contract_address,
+    decimals: resolveBaseTokenDecimals(cfg.data.contract_address),
     referenceId: `sa-wd:${input.activation.id}:${Date.now().toString(36)}`,
     withdrawTelemetry: true,
   });

--- a/lib/activation/campaign-wallet-withdraw.ts
+++ b/lib/activation/campaign-wallet-withdraw.ts
@@ -2,7 +2,11 @@ import {
   parseStellarSettlementAssetConfig,
   submitStellarCampaignUsdcPayment,
 } from '@/lib/activation/stellar-settlement-submit';
-import { balanceUsdcToMicro } from '@/lib/activation/usdc-micro';
+import {
+  balanceToTokenMicro,
+  balanceUsdcToMicro,
+  tokenMicroToAmount,
+} from '@/lib/activation/usdc-micro';
 import { loadActivationReservedUsdc } from '@/lib/db/sponsored-activation-admin';
 import { supabase } from '@/lib/db/client';
 import type { SponsoredActivationRow } from '@/lib/db/sponsored-activations';
@@ -301,7 +305,19 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     };
   }
 
-  let maxBalanceMicro = balanceUsdcToMicro(balance);
+  const baseAssetConfig =
+    input.activation.settlement_rail === 'base'
+      ? baseUsdcAssetConfigSchema.safeParse(input.activation.usdc_asset_config)
+      : null;
+  const tokenDecimals =
+    baseAssetConfig?.success === true
+      ? resolveBaseTokenDecimals(baseAssetConfig.data.contract_address)
+      : 6;
+
+  let maxBalanceMicro =
+    input.activation.settlement_rail === 'base'
+      ? balanceToTokenMicro(balance, tokenDecimals)
+      : balanceUsdcToMicro(balance);
   if (input.activation.settlement_rail === 'stellar') {
     maxBalanceMicro = await computeStellarSharedWalletMaxWithdrawMicro(
       input.activation,
@@ -318,7 +334,10 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
 
   let withdrawMicro: number;
   if (input.amountUsdc != null && input.amountUsdc > 0) {
-    withdrawMicro = Math.floor(input.amountUsdc * 1e6);
+    withdrawMicro =
+      input.activation.settlement_rail === 'base'
+        ? balanceToTokenMicro(input.amountUsdc, tokenDecimals)
+        : Math.floor(input.amountUsdc * 1e6);
     if (withdrawMicro <= 0) {
       return {
         ok: false,
@@ -329,7 +348,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     if (withdrawMicro > maxBalanceMicro) {
       return {
         ok: false,
-        error: `Amount exceeds on-chain balance (${(maxBalanceMicro / 1e6).toFixed(6)} ${tokenSymbol}).`,
+        error: `Amount exceeds on-chain balance (${tokenMicroToAmount(maxBalanceMicro, tokenDecimals).toFixed(tokenDecimals)} ${tokenSymbol}).`,
         statusCode: 400,
       };
     }
@@ -337,7 +356,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     withdrawMicro = maxBalanceMicro;
   }
 
-  const withdrawAmount = withdrawMicro / 1e6;
+  const withdrawAmount = tokenMicroToAmount(withdrawMicro, tokenDecimals);
   const destinationAddress = destCheck.normalized;
 
   if (input.activation.settlement_rail === 'stellar') {
@@ -382,9 +401,9 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     };
   }
 
-  const cfg = baseUsdcAssetConfigSchema.safeParse(
-    input.activation.usdc_asset_config
-  );
+  const cfg =
+    baseAssetConfig ??
+    baseUsdcAssetConfigSchema.safeParse(input.activation.usdc_asset_config);
   if (!cfg.success) {
     return {
       ok: false,
@@ -399,7 +418,7 @@ export async function withdrawSponsoredActivationCampaignWallet(input: {
     recipientAddress: destinationAddress as `0x${string}`,
     usdcAmount: withdrawAmount,
     usdcContractAddress: cfg.data.contract_address,
-    decimals: resolveBaseTokenDecimals(cfg.data.contract_address),
+    decimals: tokenDecimals,
     referenceId: `sa-wd:${input.activation.id}:${Date.now().toString(36)}`,
     withdrawTelemetry: true,
   });

--- a/lib/activation/usdc-micro.ts
+++ b/lib/activation/usdc-micro.ts
@@ -1,4 +1,14 @@
+/** Floors a token balance to smallest-unit precision for on-chain transfers. */
+export function balanceToTokenMicro(balance: number, decimals: number): number {
+  const factor = 10 ** decimals;
+  return Math.max(0, Math.floor(balance * factor));
+}
+
+export function tokenMicroToAmount(micro: number, decimals: number): number {
+  return micro / 10 ** decimals;
+}
+
 /** Floors a USDC balance to micro-unit precision (6 decimals) for on-chain transfers. */
 export function balanceUsdcToMicro(balanceUsdc: number): number {
-  return Math.max(0, Math.floor(balanceUsdc * 1e6));
+  return balanceToTokenMicro(balanceUsdc, 6);
 }

--- a/lib/schemas/__tests__/sponsored-activation.test.ts
+++ b/lib/schemas/__tests__/sponsored-activation.test.ts
@@ -3,8 +3,13 @@ import { getAddress } from 'viem';
 import {
   adminCreateSponsoredActivationRequestSchema,
   createSponsoredActivationSchema,
+  resolveAdminBaseSponsoredActivationAssetConfig,
   updateSponsoredActivationSchema,
 } from '../sponsored-activation';
+import {
+  CADD_ADDRESS_BASE,
+  SPONSORED_ACTIVATION_BASE_TOKENS,
+} from '../sponsored-activation-tokens';
 
 /** Valid EVM-format address for schema tests (avoids repo allowlisted production contract literals). */
 const SAMPLE_EVM_CONTRACT = '0x2222222222222222222222222222222222222222';
@@ -274,6 +279,53 @@ describe('adminCreateSponsoredActivationRequestSchema', () => {
       campaign_wallet_address: '0xf39fd6e51aad88f6f4ce6ab8827279cfffb92266',
     });
     expect(r.success).toBe(false);
+  });
+
+  it('accepts payment_token=CADD on Base create', () => {
+    const r = adminCreateSponsoredActivationRequestSchema.safeParse({
+      settlement_rail: 'base',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      payment_token: 'CADD',
+    });
+    expect(r.success).toBe(true);
+    if (r.success && r.data.settlement_rail === 'base') {
+      expect(r.data.payment_token).toBe('CADD');
+    }
+  });
+
+  it('rejects an unknown payment_token', () => {
+    const r = adminCreateSponsoredActivationRequestSchema.safeParse({
+      settlement_rail: 'base',
+      title: 't',
+      sponsor_name: 's',
+      max_redemptions: 1,
+      ...validTime,
+      venue_settlement_wallet_address:
+        '0x70997970c51812dc3a010c7d01b50e0d17dc79c8',
+      payment_token: 'DOGE',
+    });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('resolveAdminBaseSponsoredActivationAssetConfig', () => {
+  it('defaults to USDC when payment_token is omitted', () => {
+    expect(resolveAdminBaseSponsoredActivationAssetConfig(undefined)).toEqual({
+      contract_address: SPONSORED_ACTIVATION_BASE_TOKENS.USDC.contract_address,
+      symbol: 'USDC',
+    });
+  });
+
+  it('resolves CADD contract and symbol', () => {
+    expect(resolveAdminBaseSponsoredActivationAssetConfig('CADD')).toEqual({
+      contract_address: CADD_ADDRESS_BASE,
+      symbol: 'CADD',
+    });
   });
 });
 

--- a/lib/schemas/sponsored-activation-tokens.test.ts
+++ b/lib/schemas/sponsored-activation-tokens.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
+import {
+  CADD_ADDRESS_BASE,
+  describeSponsoredActivationPaymentTokenSymbol,
+  getSponsoredActivationBaseTokenByContract,
+  getSponsoredActivationBaseTokenBySymbol,
+  isSponsoredActivationBaseTokenSymbol,
+  resolveBaseTokenDecimals,
+  SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS,
+} from './sponsored-activation-tokens';
+
+describe('sponsored-activation-tokens', () => {
+  it('exposes USDC and CADD symbols', () => {
+    expect(SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS.sort()).toEqual([
+      'CADD',
+      'USDC',
+    ]);
+  });
+
+  it('resolves USDC (6 decimals) and CADD (18 decimals) by symbol', () => {
+    expect(getSponsoredActivationBaseTokenBySymbol('USDC')).toMatchObject({
+      symbol: 'USDC',
+      contract_address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+      decimals: 6,
+    });
+    expect(getSponsoredActivationBaseTokenBySymbol('CADD')).toMatchObject({
+      symbol: 'CADD',
+      contract_address: CADD_ADDRESS_BASE,
+      decimals: 18,
+    });
+    expect(getSponsoredActivationBaseTokenBySymbol('ETH')).toBeNull();
+  });
+
+  it('resolves tokens by contract address case-insensitively', () => {
+    expect(
+      getSponsoredActivationBaseTokenByContract(CADD_ADDRESS_BASE.toLowerCase())
+    ).toMatchObject({ symbol: 'CADD' });
+    expect(
+      getSponsoredActivationBaseTokenByContract(
+        '0x0000000000000000000000000000000000dead'
+      )
+    ).toBeNull();
+  });
+
+  it('isSponsoredActivationBaseTokenSymbol narrows valid symbols', () => {
+    expect(isSponsoredActivationBaseTokenSymbol('CADD')).toBe(true);
+    expect(isSponsoredActivationBaseTokenSymbol('DOGE')).toBe(false);
+  });
+
+  it('resolveBaseTokenDecimals falls back to 6 for legacy/unknown contracts', () => {
+    expect(resolveBaseTokenDecimals(CADD_ADDRESS_BASE)).toBe(18);
+    expect(resolveBaseTokenDecimals(POSTER_CHECKOUT_USDC_ADDRESS_BASE)).toBe(6);
+    expect(
+      resolveBaseTokenDecimals('0x0000000000000000000000000000000000dead')
+    ).toBe(6);
+  });
+
+  describe('describeSponsoredActivationPaymentTokenSymbol', () => {
+    it('returns CADD for a Base activation configured with CADD', () => {
+      expect(
+        describeSponsoredActivationPaymentTokenSymbol({
+          settlement_rail: 'base',
+          usdc_asset_config: { contract_address: CADD_ADDRESS_BASE },
+        })
+      ).toBe('CADD');
+    });
+
+    it('defaults to USDC for legacy Base rows without a recognized contract', () => {
+      expect(
+        describeSponsoredActivationPaymentTokenSymbol({
+          settlement_rail: 'base',
+          usdc_asset_config: {
+            contract_address: '0x0000000000000000000000000000000000dead',
+          },
+        })
+      ).toBe('USDC');
+    });
+
+    it('reads the Stellar asset_code', () => {
+      expect(
+        describeSponsoredActivationPaymentTokenSymbol({
+          settlement_rail: 'stellar',
+          usdc_asset_config: { asset_code: 'USDC', issuer: 'G...' },
+        })
+      ).toBe('USDC');
+    });
+  });
+});

--- a/lib/schemas/sponsored-activation-tokens.test.ts
+++ b/lib/schemas/sponsored-activation-tokens.test.ts
@@ -66,6 +66,18 @@ describe('sponsored-activation-tokens', () => {
       ).toBe('CADD');
     });
 
+    it('reads persisted symbol before contract lookup', () => {
+      expect(
+        describeSponsoredActivationPaymentTokenSymbol({
+          settlement_rail: 'base',
+          usdc_asset_config: {
+            contract_address: CADD_ADDRESS_BASE,
+            symbol: 'CADD',
+          },
+        })
+      ).toBe('CADD');
+    });
+
     it('defaults to USDC for legacy Base rows without a recognized contract', () => {
       expect(
         describeSponsoredActivationPaymentTokenSymbol({

--- a/lib/schemas/sponsored-activation-tokens.ts
+++ b/lib/schemas/sponsored-activation-tokens.ts
@@ -1,0 +1,101 @@
+import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
+
+/**
+ * Payment tokens sponsored activations can settle in on Base. Admin picks one
+ * at create time (`payment_token`); the resolved contract + decimals are
+ * persisted in `usdc_asset_config` so settlement/withdraw/balance reads never
+ * have to re-derive them.
+ */
+export type SponsoredActivationBaseTokenSymbol = 'USDC' | 'CADD';
+
+export type SponsoredActivationBaseToken = {
+  symbol: SponsoredActivationBaseTokenSymbol;
+  label: string;
+  contract_address: `0x${string}`;
+  decimals: number;
+};
+
+/** CADD ("CAD Digital Inc") on Base mainnet. */
+export const CADD_ADDRESS_BASE =
+  '0x16F93eBC5320C89EfC8701577efe49d14A276a06' as const;
+
+export const SPONSORED_ACTIVATION_BASE_TOKENS: Record<
+  SponsoredActivationBaseTokenSymbol,
+  SponsoredActivationBaseToken
+> = {
+  USDC: {
+    symbol: 'USDC',
+    label: 'USDC',
+    contract_address: POSTER_CHECKOUT_USDC_ADDRESS_BASE,
+    decimals: 6,
+  },
+  CADD: {
+    symbol: 'CADD',
+    label: 'CADD',
+    contract_address: CADD_ADDRESS_BASE,
+    decimals: 18,
+  },
+};
+
+export const SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS = Object.keys(
+  SPONSORED_ACTIVATION_BASE_TOKENS
+) as SponsoredActivationBaseTokenSymbol[];
+
+export function isSponsoredActivationBaseTokenSymbol(
+  value: string
+): value is SponsoredActivationBaseTokenSymbol {
+  return (SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS as string[]).includes(value);
+}
+
+export function getSponsoredActivationBaseTokenBySymbol(
+  symbol: string
+): SponsoredActivationBaseToken | null {
+  return isSponsoredActivationBaseTokenSymbol(symbol)
+    ? SPONSORED_ACTIVATION_BASE_TOKENS[symbol]
+    : null;
+}
+
+export function getSponsoredActivationBaseTokenByContract(
+  contractAddress: string
+): SponsoredActivationBaseToken | null {
+  const normalized = contractAddress.trim().toLowerCase();
+  return (
+    Object.values(SPONSORED_ACTIVATION_BASE_TOKENS).find(
+      (t) => t.contract_address.toLowerCase() === normalized
+    ) ?? null
+  );
+}
+
+/**
+ * Resolves ERC-20 decimals for a Base settlement contract. Falls back to
+ * USDC's 6 decimals for legacy activations (pre-dating `symbol` on
+ * `usdc_asset_config`) and unrecognized/custom contracts, matching prior
+ * behavior where 6 decimals was hardcoded everywhere.
+ */
+export function resolveBaseTokenDecimals(contractAddress: string): number {
+  return (
+    getSponsoredActivationBaseTokenByContract(contractAddress)?.decimals ?? 6
+  );
+}
+
+/**
+ * Display symbol for a sponsored activation's settlement token (Base or
+ * Stellar). Structural typing keeps this safe to import from client
+ * components without pulling in `lib/db/sponsored-activations`.
+ */
+export function describeSponsoredActivationPaymentTokenSymbol(row: {
+  settlement_rail: string;
+  usdc_asset_config: Record<string, unknown>;
+}): string {
+  if (row.settlement_rail === 'stellar') {
+    const code = row.usdc_asset_config?.asset_code;
+    return typeof code === 'string' && code.trim() ? code.trim() : 'USDC';
+  }
+  const contract = row.usdc_asset_config?.contract_address;
+  if (typeof contract === 'string') {
+    return (
+      getSponsoredActivationBaseTokenByContract(contract)?.symbol ?? 'USDC'
+    );
+  }
+  return 'USDC';
+}

--- a/lib/schemas/sponsored-activation-tokens.ts
+++ b/lib/schemas/sponsored-activation-tokens.ts
@@ -44,7 +44,7 @@ export const SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS = Object.keys(
 export function isSponsoredActivationBaseTokenSymbol(
   value: string
 ): value is SponsoredActivationBaseTokenSymbol {
-  return (SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS as string[]).includes(value);
+  return value in SPONSORED_ACTIVATION_BASE_TOKENS;
 }
 
 export function getSponsoredActivationBaseTokenBySymbol(
@@ -90,6 +90,13 @@ export function describeSponsoredActivationPaymentTokenSymbol(row: {
   if (row.settlement_rail === 'stellar') {
     const code = row.usdc_asset_config?.asset_code;
     return typeof code === 'string' && code.trim() ? code.trim() : 'USDC';
+  }
+  const persistedSymbol = row.usdc_asset_config?.symbol;
+  if (typeof persistedSymbol === 'string') {
+    const trimmed = persistedSymbol.trim();
+    if (trimmed && isSponsoredActivationBaseTokenSymbol(trimmed)) {
+      return trimmed;
+    }
   }
   const contract = row.usdc_asset_config?.contract_address;
   if (typeof contract === 'string') {

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -7,6 +7,10 @@ import {
 import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+import {
+  getSponsoredActivationBaseTokenBySymbol,
+  SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS,
+} from '@/lib/schemas/sponsored-activation-tokens';
 
 /**
  * `sponsored_activation.settlement_rail` — matches DB CHECK
@@ -42,9 +46,20 @@ const stellarAssetCodeSchema = z
   .max(12)
   .regex(/^[a-zA-Z0-9]+$/, 'Invalid Stellar asset code');
 
+/**
+ * Base settlement payment token, chosen by the admin at create time
+ * (`payment_token`). Defaults to `USDC` when omitted for backward
+ * compatibility.
+ */
+export const sponsoredActivationBaseTokenSymbolSchema = z.enum(
+  SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS as [string, ...string[]]
+);
+
 export const baseUsdcAssetConfigSchema = z
   .object({
     contract_address: normalizedEvmAddressSchema,
+    /** Present for activations created after multi-token support (IRL CADD); absent means legacy USDC. */
+    symbol: z.string().optional(),
   })
   .strict();
 
@@ -126,6 +141,8 @@ const createSponsoredActivationBaseObject = z
     campaign_wallet_address: normalizedEvmAddressSchema,
     venue_settlement_wallet_address: normalizedEvmAddressSchema,
     usdc_asset_config: baseUsdcAssetConfigSchema,
+    /** Which Base token to settle in (admin create only; ignored once `usdc_asset_config` is explicit). */
+    payment_token: sponsoredActivationBaseTokenSymbolSchema.optional(),
   })
   .strict();
 
@@ -212,6 +229,19 @@ const adminCreateSponsoredActivationStellarObject =
 /** Canonical Base USDC contract for sponsored activations (admin create default). */
 export const DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT =
   POSTER_CHECKOUT_USDC_ADDRESS_BASE;
+
+/**
+ * Resolves the admin's `payment_token` choice (default `USDC`) to the
+ * `usdc_asset_config` persisted for a Base-rail activation.
+ */
+export function resolveAdminBaseSponsoredActivationAssetConfig(
+  paymentToken: string | undefined
+): { contract_address: `0x${string}`; symbol: string } {
+  const token =
+    getSponsoredActivationBaseTokenBySymbol(paymentToken ?? 'USDC') ??
+    getSponsoredActivationBaseTokenBySymbol('USDC')!;
+  return { contract_address: token.contract_address, symbol: token.symbol };
+}
 
 /**
  * Admin POST body: campaign wallet is provisioned server-side (Privy on Base; shared env wallet on Stellar).

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -9,7 +9,9 @@ import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 import {
   getSponsoredActivationBaseTokenBySymbol,
+  SPONSORED_ACTIVATION_BASE_TOKENS,
   SPONSORED_ACTIVATION_BASE_TOKEN_SYMBOLS,
+  type SponsoredActivationBaseTokenSymbol,
 } from '@/lib/schemas/sponsored-activation-tokens';
 
 /**
@@ -226,10 +228,6 @@ const adminCreateSponsoredActivationStellarObject =
         .default(DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG),
     });
 
-/** Canonical Base USDC contract for sponsored activations (admin create default). */
-export const DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT =
-  POSTER_CHECKOUT_USDC_ADDRESS_BASE;
-
 /**
  * Resolves the admin's `payment_token` choice (default `USDC`) to the
  * `usdc_asset_config` persisted for a Base-rail activation.
@@ -237,10 +235,13 @@ export const DEFAULT_SPONSORED_ACTIVATION_BASE_USDC_CONTRACT =
 export function resolveAdminBaseSponsoredActivationAssetConfig(
   paymentToken: string | undefined
 ): { contract_address: `0x${string}`; symbol: string } {
-  const token =
-    getSponsoredActivationBaseTokenBySymbol(paymentToken ?? 'USDC') ??
-    getSponsoredActivationBaseTokenBySymbol('USDC')!;
-  return { contract_address: token.contract_address, symbol: token.symbol };
+  const symbol: SponsoredActivationBaseTokenSymbol =
+    getSponsoredActivationBaseTokenBySymbol(paymentToken ?? 'USDC')?.symbol ??
+    'USDC';
+  return {
+    contract_address: SPONSORED_ACTIVATION_BASE_TOKENS[symbol].contract_address,
+    symbol,
+  };
 }
 
 /**

--- a/lib/schemas/sponsored-activation.ts
+++ b/lib/schemas/sponsored-activation.ts
@@ -4,7 +4,6 @@ import {
   activationEligibilityRulesConfigSchema,
   DEFAULT_SPONSORED_ACTIVATION_ELIGIBILITY_CONFIG,
 } from '@/lib/schemas/activation-eligibility-config';
-import { POSTER_CHECKOUT_USDC_ADDRESS_BASE } from '@/lib/walletconnect-poster-direct-usdc';
 import { stellarWalletAddressSchema } from '@/lib/schemas/player';
 import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 import {

--- a/lib/spend-treasury-usdc-transfer.test.ts
+++ b/lib/spend-treasury-usdc-transfer.test.ts
@@ -136,6 +136,33 @@ describe('submitTreasuryUsdcTransfer', () => {
     );
   });
 
+  it('encodes transfer calldata using custom decimals (e.g. 18 for CADD)', async () => {
+    mockSignAndSend.mockResolvedValue({
+      transactionId: 'privy-tx-2',
+      userOperationHash: null,
+      hash: '',
+    });
+    mockWaitForTransaction.mockResolvedValue({
+      transactionHash: txHash as `0x${string}`,
+      status: 'finalized',
+      userOperationHash: null,
+    });
+
+    await submitTreasuryUsdcTransfer({
+      serverWalletId: 'wallet-1',
+      serverWalletAddress: '0x1111111111111111111111111111111111111111',
+      recipientAddress: '0x2222222222222222222222222222222222222222',
+      usdcAmount: 2,
+      decimals: 18,
+    });
+
+    const data = (mockSignAndSend.mock.calls[0][0] as { data: `0x${string}` })
+      .data;
+    // transfer(address,uint256) selector + 32-byte recipient + 32-byte amount
+    const amountHex = data.slice(2 + 8 + 64);
+    expect(BigInt('0x' + amountHex)).toBe(2n * 10n ** 18n);
+  });
+
   it('rejects when Privy wallet address does not match server_wallet_address', async () => {
     mockGetWallet.mockResolvedValue({
       id: 'wallet-1',

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -111,10 +111,13 @@ async function findRecentTreasuryTransferHash(params: {
   fromBlock: bigint | null;
   /** When set (e.g. activation `usdc_asset_config.contract_address`), scan this contract instead of the spend-rail default. */
   erc20ContractAddress?: string | null;
+  /** ERC-20 decimals for `erc20ContractAddress` (default 6, i.e. USDC). */
+  decimals?: number;
 }): Promise<`0x${string}` | null> {
   const publicClient = await publicBaseClient();
   const latest = await publicClient.getBlockNumber();
-  const rawAmount = parseUnits(params.usdcAmount.toFixed(6), 6);
+  const decimals = params.decimals ?? 6;
+  const rawAmount = parseUnits(params.usdcAmount.toFixed(decimals), decimals);
   const fallbackFrom =
     latest > FALLBACK_SCAN_BLOCKS ? latest - FALLBACK_SCAN_BLOCKS : 0n;
   const scanFrom =
@@ -193,6 +196,8 @@ export function findRecentTreasuryUsdcTransfer(params: {
   recipientAddress: `0x${string}`;
   usdcAmount: number;
   erc20ContractAddress?: string | null;
+  /** ERC-20 decimals for `erc20ContractAddress` (default 6, i.e. USDC). */
+  decimals?: number;
 }): Promise<`0x${string}` | null> {
   return findRecentTreasuryTransferHash({ ...params, fromBlock: null });
 }
@@ -212,6 +217,8 @@ export async function submitTreasuryUsdcTransfer(params: {
    * When omitted, uses the spend-rail env default (`getSpendRailBaseUsdcContractAddress`).
    */
   usdcContractAddress?: string | null;
+  /** ERC-20 decimals for `usdcContractAddress` (default 6, i.e. USDC). */
+  decimals?: number;
   /** Override Privy poll (e.g. tests). */
   privyHashResolveOptions?: { timeoutMs?: number; pollIntervalMs?: number };
   /** Optional Privy `reference_id` (default: random UUID). */
@@ -261,12 +268,13 @@ export async function submitTreasuryUsdcTransfer(params: {
       };
     }
 
+    const decimals = params.decimals ?? 6;
     const transferData = encodeFunctionData({
       abi: erc20Abi,
       functionName: 'transfer',
       args: [
         params.recipientAddress,
-        parseUnits(params.usdcAmount.toFixed(6), 6),
+        parseUnits(params.usdcAmount.toFixed(decimals), decimals),
       ],
     });
 

--- a/lib/spend-treasury-usdc-transfer.ts
+++ b/lib/spend-treasury-usdc-transfer.ts
@@ -210,7 +210,7 @@ export async function submitTreasuryUsdcTransfer(params: {
   serverWalletId: string;
   serverWalletAddress: `0x${string}`;
   recipientAddress: `0x${string}`;
-  /** Human-readable USDC amount (6 decimals). */
+  /** Human-readable token amount (default 6 decimals, i.e. USDC). */
   usdcAmount: number;
   /**
    * ERC-20 contract for the transfer `to` field (USDC on Base).

--- a/lib/walletconnect-poster-direct-usdc.ts
+++ b/lib/walletconnect-poster-direct-usdc.ts
@@ -53,6 +53,8 @@ export async function fetchUsdcBalanceOnBase(
   options?: {
     rpcUrl?: string;
     usdcContract?: `0x${string}`;
+    /** ERC-20 decimals for `usdcContract` (default 6, i.e. USDC). */
+    decimals?: number;
   }
 ): Promise<number> {
   const rpcUrl =
@@ -62,11 +64,12 @@ export async function fetchUsdcBalanceOnBase(
     transport: rpcUrl ? http(rpcUrl) : http(),
   });
   const contract = options?.usdcContract ?? POSTER_CHECKOUT_USDC_ADDRESS_BASE;
+  const decimals = options?.decimals ?? 6;
   const raw = await client.readContract({
     address: contract,
     abi: erc20Abi,
     functionName: 'balanceOf',
     args: [walletAddress],
   });
-  return parseFloat(formatUnits(raw, 6));
+  return parseFloat(formatUnits(raw, decimals));
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
### Summary

Sponsored activations on Base could only settle in USDC. This adds support for CADD (`0x16F93eBC5320C89EfC8701577efe49d14A276a06`, 18 decimals) as a second option, selectable by the admin at [/admin/sponsored-activations](https://www.irl.energy/admin/sponsored-activations) when creating a Base-rail activation.

* Added a Base token registry (`lib/schemas/sponsored-activation-tokens.ts`) with USDC (6 decimals) and CADD (18 decimals) contract addresses/decimals.
* Admin create request now accepts an optional `payment_token` (`USDC` | `CADD`, defaults to `USDC`); the server resolves it to `usdc_asset_config = { contract_address, symbol }`.
* USDC's 6-decimal assumption was hardcoded in several places for on-chain transfers/balance reads. `fetchUsdcBalanceOnBase`, `submitTreasuryUsdcTransfer`, and `findRecentTreasuryUsdcTransfer` now accept an optional `decimals` param; the settlement worker and campaign wallet withdraw/balance logic resolve the correct decimals from the activation's configured contract address (falling back to 6 for legacy/unrecognized contracts, preserving prior behavior).
* Admin UI: added a "Payment token" selector (Base rail only) to the create form, and the list/launch-checklist/dashboard pages now display the activation's actual settlement token symbol instead of a hardcoded "USDC" label.

Stellar-rail activations are unaffected (CADD is Base-only, per the request).

### Testing
* ✅ `yarn test` — no new failures vs. `main` baseline (same 14 pre-existing failing files, e.g. `location-search.test.tsx`, `user-menu.test.tsx`, `admin.test.ts`, confirmed via `git stash` comparison); added/updated tests for the token registry, schema, admin create route, settlement worker, treasury transfer, and campaign wallet withdraw all pass.
* ✅ `yarn tsc --noEmit` — no new errors vs. `main` baseline (confirmed via diff).
* ✅ `yarn lint` — no new warnings/errors.
* ✅ `yarn build` — succeeds (also ran automatically via the pre-commit hook on every commit).
* ✅ Verified the Base RPC contract calls (`decimals`/`symbol`/`name`) for the CADD address to confirm it's an 18-decimal ERC-20 named "CAD Digital Inc" before wiring it in.
* ✅ Manual UI test (temporary unauthenticated preview route, deleted after testing): confirmed the "Payment token" selector shows exactly USDC/CADD, defaults to USDC, is Base-rail only, and the "Max budget" label updates dynamically when CADD is selected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2efbee82-2645-4131-b03f-77116cd9dc40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2efbee82-2645-4131-b03f-77116cd9dc40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

