### PR TITLE
Fix EVM wallet resolution for checkpoint check-ins

### DIFF
--- a/components/checkpoint/unified-checkpoint.test.tsx
+++ b/components/checkpoint/unified-checkpoint.test.tsx
@@ -25,9 +25,11 @@ vi.mock('@/components/layout/footer', () => ({
 
 // Mock Privy
 const mockUsePrivy = vi.fn();
+const mockUseWallets = vi.fn();
 const mockCreateWallet = vi.fn();
 vi.mock('@privy-io/react-auth', () => ({
   usePrivy: () => mockUsePrivy(),
+  useWallets: () => mockUseWallets(),
   useCreateWallet: () => ({ createWallet: mockCreateWallet }),
 }));
 
@@ -71,6 +73,7 @@ describe('UnifiedCheckpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     global.fetch = vi.fn();
+    mockUseWallets.mockReturnValue({ wallets: [] });
     mockUseStellarWallet.mockReturnValue({
       address: null,
       connect: vi.fn(),
@@ -372,7 +375,9 @@ describe('UnifiedCheckpoint', () => {
     it('should auto check-in when wallet is available', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -401,7 +406,52 @@ describe('UnifiedCheckpoint', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chain: 'evm',
-            walletAddress: '0x1234567890abcdef',
+            walletAddress: '0x1234567890AbcdEF1234567890aBcdef12345678',
+            email: 'test@example.com',
+            checkpoint: 'checkpoint-1',
+          }),
+        });
+      });
+    });
+
+    it('should use a linked EVM wallet when the primary wallet is non-EVM', async () => {
+      mockUsePrivy.mockReturnValue({
+        user: {
+          wallet: { address: 'SolanaWallet123' },
+          email: { address: 'test@example.com' },
+          linkedAccounts: [
+            {
+              type: 'wallet',
+              chainType: 'solana',
+              address: 'SolanaWallet123',
+            },
+            {
+              type: 'wallet',
+              chainType: 'ethereum',
+              address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+            },
+          ],
+        },
+      });
+
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true, player: { total_points: 1000 } }),
+      } as Response);
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+
+      render(<UnifiedCheckpoint checkpoint={mockEvmCheckpoint} />);
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/checkin', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            chain: 'evm',
+            walletAddress: '0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD',
             email: 'test@example.com',
             checkpoint: 'checkpoint-1',
           }),
@@ -533,7 +583,9 @@ describe('UnifiedCheckpoint', () => {
     it('should show success screen with points earned', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -565,7 +617,9 @@ describe('UnifiedCheckpoint', () => {
     it('should show Go to IRL Map button', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -593,7 +647,9 @@ describe('UnifiedCheckpoint', () => {
       const user = userEvent.setup();
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -631,7 +687,9 @@ describe('UnifiedCheckpoint', () => {
 
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -660,7 +718,9 @@ describe('UnifiedCheckpoint', () => {
     it('should show error message when check-in fails', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -686,7 +746,9 @@ describe('UnifiedCheckpoint', () => {
     it('should show daily limit message when limit is reached', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -714,7 +776,9 @@ describe('UnifiedCheckpoint', () => {
     it('should show Visit IRL.ENERGY button on error', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });
@@ -743,7 +807,9 @@ describe('UnifiedCheckpoint', () => {
     it('should show checking in message while request is in progress', async () => {
       mockUsePrivy.mockReturnValue({
         user: {
-          wallet: { address: '0x1234567890abcdef' },
+          wallet: {
+            address: '0x1234567890abcdef1234567890abcdef12345678',
+          },
           email: { address: 'test@example.com' },
         },
       });

--- a/components/checkpoint/unified-checkpoint.test.tsx
+++ b/components/checkpoint/unified-checkpoint.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { getAddress } from 'viem';
 import UnifiedCheckpoint from './unified-checkpoint';
 import type { Checkpoint } from '@/lib/types';
 
@@ -25,11 +26,10 @@ vi.mock('@/components/layout/footer', () => ({
 
 // Mock Privy
 const mockUsePrivy = vi.fn();
-const mockUseWallets = vi.fn();
 const mockCreateWallet = vi.fn();
 vi.mock('@privy-io/react-auth', () => ({
   usePrivy: () => mockUsePrivy(),
-  useWallets: () => mockUseWallets(),
+  useWallets: () => ({ wallets: [] }),
   useCreateWallet: () => ({ createWallet: mockCreateWallet }),
 }));
 
@@ -45,7 +45,25 @@ vi.mock('@/hooks/useAptosWallet', () => ({
   useAptosWallet: () => mockUseAptosWallet(),
 }));
 
+const PRIMARY_EVM_WALLET = '0x1234567890abcdef1234567890abcdef12345678';
+const LINKED_EVM_WALLET = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const CHECKSUMMED_PRIMARY_EVM_WALLET = getAddress(
+  PRIMARY_EVM_WALLET as `0x${string}`
+);
+const CHECKSUMMED_LINKED_EVM_WALLET = getAddress(
+  LINKED_EVM_WALLET as `0x${string}`
+);
+
 describe('UnifiedCheckpoint', () => {
+  const mockSignedInEvmUser = () => {
+    mockUsePrivy.mockReturnValue({
+      user: {
+        wallet: { address: PRIMARY_EVM_WALLET },
+        email: { address: 'test@example.com' },
+      },
+    });
+  };
+
   const mockEvmCheckpoint: Checkpoint = {
     id: 'checkpoint-1',
     name: 'Test Checkpoint',
@@ -73,7 +91,6 @@ describe('UnifiedCheckpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     global.fetch = vi.fn();
-    mockUseWallets.mockReturnValue({ wallets: [] });
     mockUseStellarWallet.mockReturnValue({
       address: null,
       connect: vi.fn(),
@@ -373,14 +390,7 @@ describe('UnifiedCheckpoint', () => {
 
   describe('Auto Check-in', () => {
     it('should auto check-in when wallet is available', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       // Player stats fetch
       vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -406,7 +416,7 @@ describe('UnifiedCheckpoint', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chain: 'evm',
-            walletAddress: '0x1234567890AbcdEF1234567890aBcdef12345678',
+            walletAddress: CHECKSUMMED_PRIMARY_EVM_WALLET,
             email: 'test@example.com',
             checkpoint: 'checkpoint-1',
           }),
@@ -428,7 +438,7 @@ describe('UnifiedCheckpoint', () => {
             {
               type: 'wallet',
               chainType: 'ethereum',
-              address: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
+              address: LINKED_EVM_WALLET,
             },
           ],
         },
@@ -451,7 +461,7 @@ describe('UnifiedCheckpoint', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             chain: 'evm',
-            walletAddress: '0xABcdEFABcdEFabcdEfAbCdefabcdeFABcDEFabCD',
+            walletAddress: CHECKSUMMED_LINKED_EVM_WALLET,
             email: 'test@example.com',
             checkpoint: 'checkpoint-1',
           }),
@@ -581,14 +591,7 @@ describe('UnifiedCheckpoint', () => {
 
   describe('Successful Check-in', () => {
     it('should show success screen with points earned', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -615,14 +618,7 @@ describe('UnifiedCheckpoint', () => {
     });
 
     it('should show Go to IRL Map button', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -645,14 +641,7 @@ describe('UnifiedCheckpoint', () => {
 
     it('should navigate to map when button is clicked', async () => {
       const user = userEvent.setup();
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -685,14 +674,7 @@ describe('UnifiedCheckpoint', () => {
         partner_image_url: '/images/partner.png',
       };
 
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -716,14 +698,7 @@ describe('UnifiedCheckpoint', () => {
 
   describe('Check-in Error', () => {
     it('should show error message when check-in fails', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -744,14 +719,7 @@ describe('UnifiedCheckpoint', () => {
     });
 
     it('should show daily limit message when limit is reached', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -774,14 +742,7 @@ describe('UnifiedCheckpoint', () => {
     });
 
     it('should show Visit IRL.ENERGY button on error', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,
@@ -805,14 +766,7 @@ describe('UnifiedCheckpoint', () => {
 
   describe('Checking In State', () => {
     it('should show checking in message while request is in progress', async () => {
-      mockUsePrivy.mockReturnValue({
-        user: {
-          wallet: {
-            address: '0x1234567890abcdef1234567890abcdef12345678',
-          },
-          email: { address: 'test@example.com' },
-        },
-      });
+      mockSignedInEvmUser();
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: true,

--- a/components/checkpoint/unified-checkpoint.tsx
+++ b/components/checkpoint/unified-checkpoint.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { useStellarWallet } from '@/hooks/useStellarWallet';
 import { useAptosWallet } from '@/hooks/useAptosWallet';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import SpendCheckpoint from '@/components/checkpoint/spend-checkpoint';
 import type { Checkpoint } from '@/lib/types';
 import { cn } from '@/lib/utils';
@@ -179,6 +180,7 @@ function CheckinSuccessView({
 function CheckinCheckpoint({ checkpoint }: UnifiedCheckpointProps) {
   const { user } = usePrivy();
   const { createWallet } = useCreateWallet();
+  const evmWalletAddress = useEvmWalletAddress();
   const {
     address: stellarAddress,
     connect: connectStellar,
@@ -200,7 +202,7 @@ function CheckinCheckpoint({ checkpoint }: UnifiedCheckpointProps) {
   const getWalletAddress = () => {
     switch (checkpoint.chain_type) {
       case 'evm':
-        return user?.wallet?.address;
+        return evmWalletAddress;
       case 'solana': {
         const solanaWallet = user?.linkedAccounts?.find(
           (account) =>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- resolve the signed-in user's validated EVM wallet instead of assuming Privy's primary wallet is EVM
- prevent non-EVM primary addresses from being submitted as `chain: "evm"`
- add regression coverage for users whose primary wallet is Solana but who have a linked EVM wallet

## Why
Privy can expose a non-EVM linked account as `user.wallet`. The checkpoint flow submitted that address with an EVM chain type, so API validation returned `walletAddress: Invalid EVM wallet address format`.

## Verification
- `yarn test components/checkpoint/unified-checkpoint.test.tsx --run` (26 passed)
- `yarn test lib/privy/__tests__/resolve-evm-wallet-address.test.ts --run` (3 passed)
- `yarn lint` (passes with existing warnings)
- `yarn build` (passes via pre-commit hook)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82aa762a-d10b-444a-b151-ee6e560faab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82aa762a-d10b-444a-b151-ee6e560faab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

