### PR TITLE
Resolve canonical EVM wallets across user flows

### DIFF
--- a/app/claim/login/success/page.tsx
+++ b/app/claim/login/success/page.tsx
@@ -9,9 +9,11 @@ import ClaimFooter from '@/components/claim/claim-footer';
 import { Dialog, DialogContent, DialogClose } from '@/components/ui/dialog';
 
 import { usePrivy } from '@privy-io/react-auth';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 export default function LoginSuccessPage() {
-  const { authenticated, ready, user, getAccessToken } = usePrivy();
+  const { authenticated, ready, getAccessToken } = usePrivy();
+  const walletAddress = useEvmWalletAddress();
   const router = useRouter();
   const [isMapModalOpen, setIsMapModalOpen] = useState(false);
   const [checkinPointsLine, setCheckinPointsLine] = useState<string | null>(
@@ -28,7 +30,7 @@ export default function LoginSuccessPage() {
 
   // One-time 100 IRL points for reaching this screen (server enforces idempotency)
   useEffect(() => {
-    if (!ready || !authenticated || !user?.wallet?.address) return;
+    if (!ready || !authenticated || !walletAddress) return;
     if (walletconPointsRequestedRef.current) return;
     walletconPointsRequestedRef.current = true;
 
@@ -37,8 +39,7 @@ export default function LoginSuccessPage() {
     void (async () => {
       try {
         const token = await getAccessToken();
-        const addr = user.wallet?.address;
-        if (!token || !addr) {
+        if (!token) {
           walletconPointsRequestedRef.current = false;
           return;
         }
@@ -48,7 +49,7 @@ export default function LoginSuccessPage() {
             'Content-Type': 'application/json',
             Authorization: `Bearer ${token}`,
           },
-          body: JSON.stringify({ walletAddress: addr }),
+          body: JSON.stringify({ walletAddress }),
         });
         const json = await res.json();
         if (cancelled) return;
@@ -71,7 +72,7 @@ export default function LoginSuccessPage() {
     return () => {
       cancelled = true;
     };
-  }, [ready, authenticated, user?.wallet?.address, getAccessToken]);
+  }, [ready, authenticated, walletAddress, getAccessToken]);
 
   // Show loading state while Privy is initializing
   if (!ready) {

--- a/app/claim/nft/page.tsx
+++ b/app/claim/nft/page.tsx
@@ -10,14 +10,15 @@ import MembersSection from '@/components/members-section';
 import { usePrivy } from '@privy-io/react-auth';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 export default function ClaimNFTPage() {
-  const { authenticated, user, ready, getAccessToken } = usePrivy();
+  const { authenticated, ready, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const router = useRouter();
   const [claiming, setClaiming] = useState(false);
 
-  const userAddress = user?.wallet?.address;
+  const userAddress = useEvmWalletAddress();
 
   // Redirect to login if not authenticated (only after Privy is ready)
   useEffect(() => {

--- a/app/claim/success/claim-success-content.tsx
+++ b/app/claim/success/claim-success-content.tsx
@@ -9,6 +9,7 @@ import ExportWalletButton from '@/components/claim/export-wallet-button';
 import Image from 'next/image';
 import { usePrivy } from '@privy-io/react-auth';
 import { useQuery } from '@tanstack/react-query';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 /** Styling-only success UI: any build can use `?preview=1` (no mint). */
 function isPreviewModeFromSearch(search: string): boolean {
@@ -16,7 +17,7 @@ function isPreviewModeFromSearch(search: string): boolean {
 }
 
 export function ClaimSuccessContent() {
-  const { authenticated, ready, user, getAccessToken } = usePrivy();
+  const { authenticated, ready, getAccessToken } = usePrivy();
   const router = useRouter();
 
   /** null = not yet read on client (avoid redirect using stale React Query cache from /claim/nft). */
@@ -30,7 +31,7 @@ export function ClaimSuccessContent() {
     setPreviewResolved(true);
   }, []);
 
-  const userAddress = user?.wallet?.address;
+  const userAddress = useEvmWalletAddress();
 
   // Wait for Privy — before `ready`, `authenticated` is false and would wrongly send users to /claim.
   useEffect(() => {

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -19,6 +19,7 @@ import type { Tier } from '@/lib/types';
 import LeaderboardAvatar from '@/components/leaderboard-avatar';
 import DashboardSocialLinks from '@/components/dashboard/dashboard-social-links';
 import Transactions from '@/components/dashboard/transactions';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 /** Single dashboard shell background (hero + points gutter share this) */
 const DASHBOARD_HERO_GRADIENT =
@@ -38,7 +39,7 @@ function findTierForPoints(tiers: Tier[], totalPoints: number): Tier | null {
 export default function DashboardPage() {
   const { user, ready } = usePrivy();
   const router = useRouter();
-  const currentUserAddress = user?.wallet?.address;
+  const currentUserAddress = useEvmWalletAddress();
 
   const { data: player, isLoading: isLoadingPlayer } = useCurrentPlayer();
   const { data: userProfile } = useUserProfile(currentUserAddress);

--- a/app/perks/[perkId]/page.tsx
+++ b/app/perks/[perkId]/page.tsx
@@ -23,6 +23,7 @@ import { useAnalytics } from '@/hooks/useAnalytics';
 import { ANALYTICS_EVENTS } from '@/lib/analytics';
 import { apiClient } from '@/lib/api/client';
 import type { Perk } from '@/lib/types';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 // Helper function to calculate time left
 const getTimeLeft = (endDate: string) => {
@@ -84,8 +85,8 @@ const TimeLeft = ({
 
 export default function PerkDetailPage() {
   const params = useParams();
-  const { user, login } = usePrivy();
-  const address = user?.wallet?.address;
+  const { login } = usePrivy();
+  const address = useEvmWalletAddress();
   const queryClient = useQueryClient();
   const perkId = params.perkId as string;
   const { trackEvent } = useAnalytics();

--- a/app/perks/page.tsx
+++ b/app/perks/page.tsx
@@ -2,7 +2,6 @@
 
 import type { Perk } from '@/lib/types';
 import Link from 'next/link';
-import { usePrivy } from '@privy-io/react-auth';
 import { Tag, Clock, MapPin, ExternalLink, Gift } from 'lucide-react';
 
 import { useState, useEffect } from 'react';
@@ -14,6 +13,7 @@ import {
 } from '@/hooks/usePerks';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import { useAnalytics } from '@/hooks/useAnalytics';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 // Helper function to calculate time left
 const getTimeLeft = (endDate: string) => {
@@ -85,8 +85,7 @@ const PerkCodeCount = ({ perkId }: { perkId: string }) => {
 };
 
 export default function PerksPage() {
-  const { user } = usePrivy();
-  const address = user?.wallet?.address;
+  const address = useEvmWalletAddress();
   const { trackPage } = useAnalytics();
 
   // Track page view on mount

--- a/app/rewards/page.tsx
+++ b/app/rewards/page.tsx
@@ -30,6 +30,7 @@ import { usePerks, useUserRedemptions } from '@/hooks/usePerks';
 import { useCurrentPlayer } from '@/hooks/usePlayer';
 import { useAnalytics } from '@/hooks/useAnalytics';
 import { ANALYTICS_EVENTS } from '@/lib/analytics';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 // Perks tagged with this city value apply everywhere; they yield to more
 // specific local picks when a city filter is active.
@@ -103,8 +104,8 @@ const TimeLeft = ({
 };
 
 function PerksPageInner() {
-  const { user, login } = usePrivy();
-  const address = user?.wallet?.address;
+  const { login } = usePrivy();
+  const address = useEvmWalletAddress();
   const { trackEvent, trackPage } = useAnalytics();
 
   // Track page view on mount

--- a/app/stripecommons/artwork/page.tsx
+++ b/app/stripecommons/artwork/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation';
 import { usePrivy } from '@privy-io/react-auth';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 type ClaimStatus = {
   hasClaimed: boolean;
@@ -18,12 +19,12 @@ type ClaimStatus = {
 };
 
 export default function StripeCommonsArtworkPage() {
-  const { authenticated, user, ready, getAccessToken } = usePrivy();
+  const { authenticated, ready, getAccessToken } = usePrivy();
   const queryClient = useQueryClient();
   const router = useRouter();
   const [claiming, setClaiming] = useState(false);
 
-  const userAddress = user?.wallet?.address;
+  const userAddress = useEvmWalletAddress();
 
   useEffect(() => {
     if (ready && !authenticated) {

--- a/app/walletconnect/walletconnect-page-client.test.tsx
+++ b/app/walletconnect/walletconnect-page-client.test.tsx
@@ -29,6 +29,9 @@ vi.mock("@privy-io/react-auth", () => ({
   }),
   useWallets: () => ({ wallets: [] }),
 }));
+vi.mock("@/hooks/use-evm-wallet-address", () => ({
+  useEvmWalletAddress: () => "0x4D41AABBCCDDEEFF00112233445566778899A9E3",
+}));
 
 vi.mock("@reown/walletkit", () => ({
   isPaymentLink: () => false,
@@ -52,7 +55,8 @@ vi.mock("@/lib/walletconnect-poster-direct-usdc", () => ({
     mockFetchUsdcBalanceOnBase(...args),
   isEvmAddress: () => false,
   POSTER_CHECKOUT_CHAIN_ID: 8453,
-  POSTER_CHECKOUT_USDC_ADDRESS_BASE: "0x0000000000000000000000000000000000000000",
+  POSTER_CHECKOUT_USDC_ADDRESS_BASE:
+    "0x0000000000000000000000000000000000000000",
   USDC_WARNING_THRESHOLD: 0.01,
 }));
 
@@ -77,7 +81,9 @@ describe("WalletConnectPageClient", () => {
     render(<WalletConnectPageClient />);
 
     expect(screen.getByText(/paying with/i)).toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /change/i })).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /change/i })
+    ).not.toBeInTheDocument();
   });
 
   it("shows low USDC balance warning when balance is below threshold", async () => {

--- a/app/walletconnect/walletconnect-page-client.tsx
+++ b/app/walletconnect/walletconnect-page-client.tsx
@@ -1,8 +1,8 @@
-"use client";
+'use client';
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { usePrivy, useWallets } from "@privy-io/react-auth";
-import { isPaymentLink } from "@reown/walletkit";
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { usePrivy } from '@privy-io/react-auth';
+import { isPaymentLink } from '@reown/walletkit';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -10,26 +10,26 @@ import {
   QrCode,
   Sparkles,
   Wallet,
-} from "lucide-react";
-import Image from "next/image";
-import { toast } from "sonner";
+} from 'lucide-react';
+import Image from 'next/image';
+import { toast } from 'sonner';
 
-import { Button } from "@/components/ui/button";
+import { Button } from '@/components/ui/button';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
+} from '@/components/ui/dialog';
 import {
   getWalletKitSingleton,
   isWalletConnectPayAuthErrorMessage,
   resetWalletKitSingleton,
-} from "@/lib/walletconnect-pay/walletkit-instance";
+} from '@/lib/walletconnect-pay/walletkit-instance';
 import {
   signWalletRpcAction,
   type BrowserProvider,
-} from "@/lib/walletconnect-pay/sign-wallet-rpc-action";
+} from '@/lib/walletconnect-pay/sign-wallet-rpc-action';
 import {
   encodePosterUsdcTransferData,
   fetchUsdcBalanceOnBase,
@@ -37,22 +37,23 @@ import {
   POSTER_CHECKOUT_CHAIN_ID,
   POSTER_CHECKOUT_USDC_ADDRESS_BASE,
   USDC_WARNING_THRESHOLD,
-} from "@/lib/walletconnect-poster-direct-usdc";
-import { PaymentLinkQrReaderDialog } from "@/components/walletconnect/payment-link-qr-reader-dialog";
-import { cn } from "@/lib/utils";
-import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
+} from '@/lib/walletconnect-poster-direct-usdc';
+import { PaymentLinkQrReaderDialog } from '@/components/walletconnect/payment-link-qr-reader-dialog';
+import { cn } from '@/lib/utils';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
+import { useConnectedEvmWallet } from '@/hooks/use-connected-evm-wallet';
 
-import type { PaymentOptionsResponse } from "@walletconnect/pay";
+import type { PaymentOptionsResponse } from '@walletconnect/pay';
 
-const PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? "";
+const PROJECT_ID = process.env.NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID ?? '';
 /** When set, /walletconnect can settle $1 USDC on Base without a Pay product link (plain ERC-20 transfer). */
 const POSTER_USDC_RECIPIENT =
-  process.env.NEXT_PUBLIC_POSTER_USDC_RECIPIENT_ADDRESS?.trim() ?? "";
+  process.env.NEXT_PUBLIC_POSTER_USDC_RECIPIENT_ADDRESS?.trim() ?? '';
 
 const POSTER_PRICE_USD = 1;
-const PRODUCT_NAME = "Limited edition poster";
+const PRODUCT_NAME = 'Limited edition poster';
 const PRODUCT_BLURB =
-  "Screen-printed IRL drop. Pay with USDC via WalletConnect Pay.";
+  'Screen-printed IRL drop. Pay with USDC via WalletConnect Pay.';
 
 /**
  * Build CAIP-10 accounts from the connected wallet address.
@@ -77,13 +78,13 @@ function toEvmHexAddress(value: string | undefined): `0x${string}` | null {
 }
 
 type FlowStatus =
-  | "idle"
-  | "initializing"
-  | "loading_options"
-  | "awaiting_ic"
-  | "signing"
-  | "confirming"
-  | "done";
+  | 'idle'
+  | 'initializing'
+  | 'loading_options'
+  | 'awaiting_ic'
+  | 'signing'
+  | 'confirming'
+  | 'done';
 
 const WALLET_STEP_TIMEOUT_MS = 180_000;
 
@@ -114,15 +115,15 @@ function withTimeout<T>(
 
 export function WalletConnectPageClient() {
   const { login, authenticated, ready: privyReady } = usePrivy();
-  const { wallets } = useWallets();
   const address = useEvmWalletAddress();
+  const evmWallet = useConnectedEvmWallet();
 
-  const [paymentLinkOverride, setPaymentLinkOverride] = useState("");
+  const [paymentLinkOverride, setPaymentLinkOverride] = useState('');
   const [qrReaderOpen, setQrReaderOpen] = useState(false);
   const [optionsResponse, setOptionsResponse] =
     useState<PaymentOptionsResponse | null>(null);
   const [selectedOptionId, setSelectedOptionId] = useState<string | null>(null);
-  const [flowStatus, setFlowStatus] = useState<FlowStatus>("idle");
+  const [flowStatus, setFlowStatus] = useState<FlowStatus>('idle');
   const [lastError, setLastError] = useState<string | null>(null);
   const [purchaseComplete, setPurchaseComplete] = useState(false);
 
@@ -133,12 +134,6 @@ export function WalletConnectPageClient() {
 
   const [usdcBalance, setUsdcBalance] = useState<number | null>(null);
   const [usdcBalanceLoading, setUsdcBalanceLoading] = useState(false);
-
-  const evmWallet = (() => {
-    if (!address) return null;
-    const lower = address.toLowerCase();
-    return wallets.find((w) => w.address.toLowerCase() === lower) ?? null;
-  })();
 
   /** Payment URI from QR scan only (no env-based product link). */
   const effectivePaymentLink = paymentLinkOverride.trim();
@@ -176,12 +171,12 @@ export function WalletConnectPageClient() {
     function handleMessage(event: MessageEvent) {
       try {
         const data =
-          typeof event.data === "string" ? JSON.parse(event.data) : event.data;
-        if (data?.type === "IC_COMPLETE") {
+          typeof event.data === 'string' ? JSON.parse(event.data) : event.data;
+        if (data?.type === 'IC_COMPLETE') {
           icResolveRef.current?.();
-        } else if (data?.type === "IC_ERROR") {
+        } else if (data?.type === 'IC_ERROR') {
           icRejectRef.current?.(
-            new Error(data.error || "Information collection failed")
+            new Error(data.error || 'Information collection failed')
           );
         }
       } catch {
@@ -189,12 +184,12 @@ export function WalletConnectPageClient() {
       }
     }
 
-    window.addEventListener("message", handleMessage);
-    return () => window.removeEventListener("message", handleMessage);
+    window.addEventListener('message', handleMessage);
+    return () => window.removeEventListener('message', handleMessage);
   }, [icOpen]);
 
   const handleCloseIc = useCallback(() => {
-    icRejectRef.current?.(new Error("Information collection cancelled"));
+    icRejectRef.current?.(new Error('Information collection cancelled'));
   }, []);
 
   const handleWalletKitPayError = useCallback(
@@ -220,7 +215,7 @@ export function WalletConnectPageClient() {
   const initWalletKit = useCallback(
     async (authHint: string) => {
       if (!PROJECT_ID) {
-        toast.error("App configuration incomplete");
+        toast.error('App configuration incomplete');
         return null;
       }
       try {
@@ -229,7 +224,7 @@ export function WalletConnectPageClient() {
             projectId: PROJECT_ID,
           }),
           60_000,
-          "Wallet connection setup"
+          'Wallet connection setup'
         );
       } catch (e) {
         handleWalletKitPayError(e, authHint);
@@ -243,29 +238,29 @@ export function WalletConnectPageClient() {
     useCallback(async (): Promise<PaymentOptionsResponse | null> => {
       const link = effectivePaymentLink;
       if (!link) {
-        toast.error("Scan the payment QR code first");
+        toast.error('Scan the payment QR code first');
         return null;
       }
       if (!isPaymentLink(link)) {
-        toast.error("Invalid payment link");
+        toast.error('Invalid payment link');
         return null;
       }
       if (!address) {
-        toast.error("Connect your wallet to continue");
+        toast.error('Connect your wallet to continue');
         return null;
       }
       setLastError(null);
-      setFlowStatus("initializing");
+      setFlowStatus('initializing');
       try {
         const walletkit = await initWalletKit(
-          "Pay rejected the configured project id (401). Confirm NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy."
+          'Pay rejected the configured project id (401). Confirm NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy.'
         );
         if (!walletkit) return null;
-        setFlowStatus("loading_options");
+        setFlowStatus('loading_options');
         const accounts = buildPayCaip10Accounts(address);
         if (accounts.length === 0) {
           throw new Error(
-            "Connected wallet address is invalid for EVM payments"
+            'Connected wallet address is invalid for EVM payments'
           );
         }
 
@@ -276,11 +271,11 @@ export function WalletConnectPageClient() {
             includePaymentInfo: true,
           }),
           WALLET_STEP_TIMEOUT_MS,
-          "Loading payment options"
+          'Loading payment options'
         );
         setOptionsResponse(options);
         if (options.options.length === 0) {
-          toast.error("No payment options for your wallet");
+          toast.error('No payment options for your wallet');
           return null;
         }
         const first = options.options[0]!.id;
@@ -289,65 +284,65 @@ export function WalletConnectPageClient() {
       } catch (e) {
         handleWalletKitPayError(
           e,
-          "Pay rejected the configured project id (401). Confirm NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy."
+          'Pay rejected the configured project id (401). Confirm NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy.'
         );
         return null;
       } finally {
-        setFlowStatus("idle");
+        setFlowStatus('idle');
       }
     }, [address, effectivePaymentLink, handleWalletKitPayError, initWalletKit]);
 
   const payWithSelectedOption = useCallback(
     async (response: PaymentOptionsResponse, optionId: string) => {
       if (!address || !evmWallet) {
-        toast.error("Wallet not ready");
+        toast.error('Wallet not ready');
         return;
       }
       const link = effectivePaymentLink;
       if (!link || !isPaymentLink(link)) {
-        toast.error("Invalid payment link");
+        toast.error('Invalid payment link');
         return;
       }
       setLastError(null);
 
       try {
         const walletkit = await initWalletKit(
-          "Pay rejected the configured project id (401). Check NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy after changes."
+          'Pay rejected the configured project id (401). Check NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy after changes.'
         );
         if (!walletkit) {
-          setFlowStatus("idle");
+          setFlowStatus('idle');
           return;
         }
 
         const option = response.options.find((o) => o.id === optionId);
         if (!option) {
-          throw new Error("Selected payment method not found");
+          throw new Error('Selected payment method not found');
         }
 
         const ic = option.collectData?.url;
         if (ic) {
-          setFlowStatus("awaiting_ic");
+          setFlowStatus('awaiting_ic');
           await runDataCollectionIframe(ic);
         }
 
-        setFlowStatus("signing");
+        setFlowStatus('signing');
         const actions = await withTimeout(
           walletkit.pay.getRequiredPaymentActions({
             paymentId: response.paymentId,
             optionId,
           }),
           WALLET_STEP_TIMEOUT_MS,
-          "Preparing payment in wallet"
+          'Preparing payment in wallet'
         );
 
         const provider = await evmWallet.getEthereumProvider();
         if (!provider) {
-          throw new Error("Could not connect to your wallet");
+          throw new Error('Could not connect to your wallet');
         }
 
         const accountAddress = toEvmHexAddress(address);
         if (!accountAddress) {
-          throw new Error("Connected wallet address is invalid for signing");
+          throw new Error('Connected wallet address is invalid for signing');
         }
 
         const signatures: string[] = [];
@@ -362,18 +357,18 @@ export function WalletConnectPageClient() {
                   await withTimeout(
                     evmWallet.switchChain(chainId),
                     WALLET_STEP_TIMEOUT_MS,
-                    "Switch network in your wallet"
+                    'Switch network in your wallet'
                   );
                 },
               }
             ),
             WALLET_STEP_TIMEOUT_MS,
-            "Sign or confirm in your wallet"
+            'Sign or confirm in your wallet'
           );
           signatures.push(sig);
         }
 
-        setFlowStatus("confirming");
+        setFlowStatus('confirming');
         const result = await withTimeout(
           walletkit.pay.confirmPayment({
             paymentId: response.paymentId,
@@ -381,17 +376,17 @@ export function WalletConnectPageClient() {
             signatures,
           }),
           WALLET_STEP_TIMEOUT_MS,
-          "Confirming payment"
+          'Confirming payment'
         );
 
-        setFlowStatus("done");
-        if (result.status === "succeeded") {
+        setFlowStatus('done');
+        if (result.status === 'succeeded') {
           setPurchaseComplete(true);
-          toast.success("Payment received — thank you!");
-        } else if (result.status === "processing") {
+          toast.success('Payment received — thank you!');
+        } else if (result.status === 'processing') {
           setPurchaseComplete(true);
-          toast.message("Payment is processing", {
-            description: "We will confirm shortly.",
+          toast.message('Payment is processing', {
+            description: 'We will confirm shortly.',
           });
         } else {
           toast.error(`Payment could not complete (${result.status})`);
@@ -399,11 +394,11 @@ export function WalletConnectPageClient() {
       } catch (e) {
         handleWalletKitPayError(
           e,
-          "Pay rejected the configured project id (401). Check NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy after changes."
+          'Pay rejected the configured project id (401). Check NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID and redeploy after changes.'
         );
       } finally {
         setFlowStatus((prev) =>
-          prev === "done" || prev === "idle" ? prev : "idle"
+          prev === 'done' || prev === 'idle' ? prev : 'idle'
         );
       }
     },
@@ -419,29 +414,29 @@ export function WalletConnectPageClient() {
 
   const payDirectUsdcOnBase = useCallback(async () => {
     if (!address || !evmWallet) {
-      toast.error("Wallet not ready");
+      toast.error('Wallet not ready');
       return;
     }
     if (!directUsdcReady) return;
 
     setLastError(null);
-    setFlowStatus("signing");
+    setFlowStatus('signing');
     try {
       await withTimeout(
         evmWallet.switchChain(POSTER_CHECKOUT_CHAIN_ID),
         WALLET_STEP_TIMEOUT_MS,
-        "Switching to Base in your wallet"
+        'Switching to Base in your wallet'
       );
       const provider = await evmWallet.getEthereumProvider();
       if (!provider) {
-        throw new Error("Could not connect to your wallet");
+        throw new Error('Could not connect to your wallet');
       }
       const data = encodePosterUsdcTransferData(
         POSTER_USDC_RECIPIENT as `0x${string}`
       );
       await withTimeout(
         (provider as unknown as BrowserProvider).request({
-          method: "eth_sendTransaction",
+          method: 'eth_sendTransaction',
           params: [
             {
               from: address,
@@ -451,18 +446,18 @@ export function WalletConnectPageClient() {
           ],
         }),
         WALLET_STEP_TIMEOUT_MS,
-        "Confirm the USDC payment in your wallet"
+        'Confirm the USDC payment in your wallet'
       );
-      setFlowStatus("done");
+      setFlowStatus('done');
       setPurchaseComplete(true);
-      toast.success("Payment sent — thank you!");
+      toast.success('Payment sent — thank you!');
     } catch (e) {
       const msg = e instanceof Error ? e.message : String(e);
       setLastError(msg);
       toast.error(msg);
     } finally {
       setFlowStatus((prev) =>
-        prev === "done" || prev === "idle" ? prev : "idle"
+        prev === 'done' || prev === 'idle' ? prev : 'idle'
       );
     }
   }, [address, directUsdcReady, evmWallet]);
@@ -470,7 +465,7 @@ export function WalletConnectPageClient() {
   const handlePayClick = useCallback(async () => {
     if (!checkoutReady) {
       toast.error(
-        "Scan the payment QR code, or set NEXT_PUBLIC_POSTER_USDC_RECIPIENT_ADDRESS for direct 1 USDC on Base."
+        'Scan the payment QR code, or set NEXT_PUBLIC_POSTER_USDC_RECIPIENT_ADDRESS for direct 1 USDC on Base.'
       );
       return;
     }
@@ -514,11 +509,11 @@ export function WalletConnectPageClient() {
     usdcBalance !== null &&
     usdcBalance < USDC_WARNING_THRESHOLD;
   const isBusy =
-    flowStatus === "initializing" ||
-    flowStatus === "loading_options" ||
-    flowStatus === "awaiting_ic" ||
-    flowStatus === "signing" ||
-    flowStatus === "confirming";
+    flowStatus === 'initializing' ||
+    flowStatus === 'loading_options' ||
+    flowStatus === 'awaiting_ic' ||
+    flowStatus === 'signing' ||
+    flowStatus === 'confirming';
 
   useEffect(() => {
     if (!walletReady || !wcPayLinkValid || purchaseComplete || optionsResponse)
@@ -559,10 +554,10 @@ export function WalletConnectPageClient() {
       <main className="mx-auto max-w-lg px-4 py-8 sm:max-w-xl sm:py-12">
         {!configOk ? (
           <div className="rounded-2xl border border-amber-900 bg-amber-950/40 p-4 text-sm text-amber-100">
-            This checkout is not fully configured. Add{" "}
+            This checkout is not fully configured. Add{' '}
             <code className="rounded bg-zinc-900 px-1">
               NEXT_PUBLIC_WALLETCONNECT_PROJECT_ID
-            </code>{" "}
+            </code>{' '}
             to the app environment.
           </div>
         ) : null}
@@ -637,10 +632,10 @@ export function WalletConnectPageClient() {
                           Insufficient USDC balance
                         </p>
                         <p className="text-sm text-amber-300/80">
-                          You need at least{" "}
+                          You need at least{' '}
                           <span className="font-semibold">
                             {USDC_WARNING_THRESHOLD} USDC
-                          </span>{" "}
+                          </span>{' '}
                           on Base to complete this purchase. Send USDC to your
                           wallet address before continuing:
                         </p>
@@ -682,10 +677,10 @@ export function WalletConnectPageClient() {
                               type="button"
                               onClick={() => setSelectedOptionId(opt.id)}
                               className={cn(
-                                "flex w-full items-center rounded-xl border px-4 py-3 text-left text-sm transition-colors",
+                                'flex w-full items-center rounded-xl border px-4 py-3 text-left text-sm transition-colors',
                                 active
-                                  ? "border-primary bg-primary/5 ring-1 ring-primary"
-                                  : "border-zinc-700 hover:bg-zinc-800"
+                                  ? 'border-primary bg-primary/5 ring-1 ring-primary'
+                                  : 'border-zinc-700 hover:bg-zinc-800'
                               )}
                             >
                               <span>
@@ -694,7 +689,7 @@ export function WalletConnectPageClient() {
                                 </span>
                                 {opt.amount.display.networkName ? (
                                   <span className="text-zinc-500">
-                                    {" "}
+                                    {' '}
                                     on {opt.amount.display.networkName}
                                   </span>
                                 ) : null}

--- a/app/walletconnect/walletconnect-page-client.tsx
+++ b/app/walletconnect/walletconnect-page-client.tsx
@@ -40,6 +40,7 @@ import {
 } from "@/lib/walletconnect-poster-direct-usdc";
 import { PaymentLinkQrReaderDialog } from "@/components/walletconnect/payment-link-qr-reader-dialog";
 import { cn } from "@/lib/utils";
+import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
 
 import type { PaymentOptionsResponse } from "@walletconnect/pay";
 
@@ -86,7 +87,11 @@ type FlowStatus =
 
 const WALLET_STEP_TIMEOUT_MS = 180_000;
 
-function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
+function withTimeout<T>(
+  promise: Promise<T>,
+  ms: number,
+  label: string
+): Promise<T> {
   return new Promise((resolve, reject) => {
     const id = window.setTimeout(() => {
       reject(
@@ -108,8 +113,9 @@ function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise
 }
 
 export function WalletConnectPageClient() {
-  const { login, authenticated, ready: privyReady, user } = usePrivy();
+  const { login, authenticated, ready: privyReady } = usePrivy();
   const { wallets } = useWallets();
+  const address = useEvmWalletAddress();
 
   const [paymentLinkOverride, setPaymentLinkOverride] = useState("");
   const [qrReaderOpen, setQrReaderOpen] = useState(false);
@@ -128,14 +134,10 @@ export function WalletConnectPageClient() {
   const [usdcBalance, setUsdcBalance] = useState<number | null>(null);
   const [usdcBalanceLoading, setUsdcBalanceLoading] = useState(false);
 
-  const address = user?.wallet?.address;
-
   const evmWallet = (() => {
     if (!address) return null;
     const lower = address.toLowerCase();
-    return (
-      wallets.find((w) => w.address.toLowerCase() === lower) ?? wallets[0] ?? null
-    );
+    return wallets.find((w) => w.address.toLowerCase() === lower) ?? null;
   })();
 
   /** Payment URI from QR scan only (no env-based product link). */
@@ -195,22 +197,25 @@ export function WalletConnectPageClient() {
     icRejectRef.current?.(new Error("Information collection cancelled"));
   }, []);
 
-  const handleWalletKitPayError = useCallback((err: unknown, authHint: string) => {
-    const msg = err instanceof Error ? err.message : String(err);
-    const formattedProjectId = JSON.stringify(PROJECT_ID);
-    const withProjectId = (text: string) =>
-      `${text} (projectId=${formattedProjectId})`;
-    if (isWalletConnectPayAuthErrorMessage(msg)) {
-      resetWalletKitSingleton();
-      const hint = withProjectId(authHint);
-      setLastError(hint);
-      toast.error(hint);
-      return;
-    }
-    const detail = withProjectId(msg);
-    setLastError(detail);
-    toast.error(detail);
-  }, []);
+  const handleWalletKitPayError = useCallback(
+    (err: unknown, authHint: string) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      const formattedProjectId = JSON.stringify(PROJECT_ID);
+      const withProjectId = (text: string) =>
+        `${text} (projectId=${formattedProjectId})`;
+      if (isWalletConnectPayAuthErrorMessage(msg)) {
+        resetWalletKitSingleton();
+        const hint = withProjectId(authHint);
+        setLastError(hint);
+        toast.error(hint);
+        return;
+      }
+      const detail = withProjectId(msg);
+      setLastError(detail);
+      toast.error(detail);
+    },
+    []
+  );
 
   const initWalletKit = useCallback(
     async (authHint: string) => {
@@ -259,7 +264,9 @@ export function WalletConnectPageClient() {
         setFlowStatus("loading_options");
         const accounts = buildPayCaip10Accounts(address);
         if (accounts.length === 0) {
-          throw new Error("Connected wallet address is invalid for EVM payments");
+          throw new Error(
+            "Connected wallet address is invalid for EVM payments"
+          );
         }
 
         const options = await withTimeout(
@@ -288,12 +295,7 @@ export function WalletConnectPageClient() {
       } finally {
         setFlowStatus("idle");
       }
-    }, [
-      address,
-      effectivePaymentLink,
-      handleWalletKitPayError,
-      initWalletKit,
-    ]);
+    }, [address, effectivePaymentLink, handleWalletKitPayError, initWalletKit]);
 
   const payWithSelectedOption = useCallback(
     async (response: PaymentOptionsResponse, optionId: string) => {
@@ -500,7 +502,12 @@ export function WalletConnectPageClient() {
   ]);
 
   const configOk = Boolean(PROJECT_ID);
-  const walletReady = privyReady && authenticated && Boolean(address) && configOk;
+  const walletReady =
+    privyReady &&
+    authenticated &&
+    Boolean(address) &&
+    Boolean(evmWallet) &&
+    configOk;
   const hasLowUsdcBalance =
     authenticated &&
     !usdcBalanceLoading &&
@@ -514,12 +521,7 @@ export function WalletConnectPageClient() {
     flowStatus === "confirming";
 
   useEffect(() => {
-    if (
-      !walletReady ||
-      !wcPayLinkValid ||
-      purchaseComplete ||
-      optionsResponse
-    )
+    if (!walletReady || !wcPayLinkValid || purchaseComplete || optionsResponse)
       return;
     void loadPaymentOptions();
   }, [
@@ -590,7 +592,6 @@ export function WalletConnectPageClient() {
               <p className="mt-2 text-sm leading-relaxed text-zinc-400">
                 {PRODUCT_BLURB}
               </p>
-
             </div>
 
             {purchaseComplete ? (
@@ -657,7 +658,9 @@ export function WalletConnectPageClient() {
                     variant="outline"
                     size="lg"
                     className="h-12 w-full rounded-xl text-base"
-                    disabled={!walletReady || purchaseComplete || hasLowUsdcBalance}
+                    disabled={
+                      !walletReady || purchaseComplete || hasLowUsdcBalance
+                    }
                     onClick={() => setQrReaderOpen(true)}
                   >
                     <QrCode className="size-5" />
@@ -730,8 +733,8 @@ export function WalletConnectPageClient() {
 
                 {directUsdcReady && !wcPayLinkValid ? (
                   <p className="text-center text-xs text-zinc-400">
-                    Sends 1 USDC on Base to the merchant wallet. No WalletConnect
-                    Pay link needed.
+                    Sends 1 USDC on Base to the merchant wallet. No
+                    WalletConnect Pay link needed.
                   </p>
                 ) : null}
               </div>
@@ -744,8 +747,6 @@ export function WalletConnectPageClient() {
             ) : null}
           </div>
         </div>
-
-
       </main>
 
       <PaymentLinkQrReaderDialog
@@ -764,8 +765,8 @@ export function WalletConnectPageClient() {
             <DialogTitle>Verify your details</DialogTitle>
           </DialogHeader>
           <p className="shrink-0 px-4 pb-2 text-xs text-muted-foreground">
-            Regulations require a few details for this payment. Complete the form,
-            then we will finish in your wallet.
+            Regulations require a few details for this payment. Complete the
+            form, then we will finish in your wallet.
           </p>
           {icUrl ? (
             <iframe

--- a/components/auth/auth-wrapper.test.tsx
+++ b/components/auth/auth-wrapper.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuthWrapper from './auth-wrapper';
+
+const LINKED_EVM_ADDRESS = '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd';
+const mockUsePrivy = vi.fn();
+const mockUseEvmWalletAddress = vi.fn();
+
+vi.mock('@privy-io/react-auth', () => ({
+  usePrivy: () => mockUsePrivy(),
+}));
+
+vi.mock('@/hooks/use-evm-wallet-address', () => ({
+  useEvmWalletAddress: () => mockUseEvmWalletAddress(),
+}));
+
+vi.mock('next/image', () => ({
+  default: ({ src, alt }: { src: string; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={src} alt={alt} />
+  ),
+}));
+
+describe('AuthWrapper EVM wallet resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+    mockUsePrivy.mockReturnValue({
+      user: {
+        wallet: { address: 'SolanaWallet123' },
+        email: { address: 'test@example.com' },
+      },
+      ready: true,
+      login: vi.fn(),
+      linkEmail: vi.fn(),
+    });
+    mockUseEvmWalletAddress.mockReturnValue(LINKED_EVM_ADDRESS);
+  });
+
+  it('creates the username profile with the linked EVM wallet', async () => {
+    const user = userEvent.setup();
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
+    render(
+      <AuthWrapper requireUsername authContextName="FLOW">
+        <div>Checkpoint</div>
+      </AuthWrapper>
+    );
+
+    await user.type(
+      await screen.findByPlaceholderText('Enter your username'),
+      'testuser'
+    );
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    } as Response);
+    await user.click(screen.getByRole('button', { name: /start earning/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith('/api/player', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          walletAddress: LINKED_EVM_ADDRESS,
+          email: 'test@example.com',
+          username: 'testuser',
+        }),
+      });
+    });
+  });
+});

--- a/components/auth/auth-wrapper.tsx
+++ b/components/auth/auth-wrapper.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 import { cn } from '@/lib/utils';
 import { useUsernameSignup } from '@/hooks/use-username-signup';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import { UsernameSignupForm } from '@/components/auth/username-signup-form';
 
 export interface CheckpointCustomization {
@@ -70,7 +71,7 @@ export default function AuthWrapper({
     ? `Choose your username to check in at ${authContextName.trim()}`
     : DEFAULT_USERNAME_HEADING;
   const { user, ready, linkEmail, login } = usePrivy();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
   const {
     username,
     setUsername,

--- a/components/auth/auth.test.tsx
+++ b/components/auth/auth.test.tsx
@@ -15,15 +15,20 @@ vi.mock('next/image', () => ({
 const mockLogin = vi.fn();
 const mockLinkEmail = vi.fn();
 const mockUsePrivy = vi.fn();
+const mockUseEvmWalletAddress = vi.fn();
 
 vi.mock('@privy-io/react-auth', () => ({
   usePrivy: () => mockUsePrivy(),
+}));
+vi.mock('@/hooks/use-evm-wallet-address', () => ({
+  useEvmWalletAddress: () => mockUseEvmWalletAddress(),
 }));
 
 describe('Auth', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
+    mockUseEvmWalletAddress.mockReturnValue('0x1234567890abcdef');
     // Default mock - override in specific tests
     global.fetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -341,6 +346,54 @@ describe('Auth', () => {
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({
             walletAddress: '0x1234567890abcdef',
+            email: 'test@example.com',
+            username: 'testuser',
+          }),
+        });
+      });
+    });
+
+    it('should create a player with the linked EVM wallet when the primary wallet is non-EVM', async () => {
+      const user = userEvent.setup();
+      mockUsePrivy.mockReturnValue({
+        user: {
+          wallet: { address: 'SolanaWallet123' },
+          email: { address: 'test@example.com' },
+        },
+        ready: true,
+        login: mockLogin,
+        linkEmail: mockLinkEmail,
+      });
+      mockUseEvmWalletAddress.mockReturnValue(
+        '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd'
+      );
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: false,
+        status: 404,
+      } as Response);
+
+      render(
+        <Auth>
+          <div>Children</div>
+        </Auth>
+      );
+
+      await user.type(
+        await screen.findByPlaceholderText('Enter your username'),
+        'testuser'
+      );
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ success: true }),
+      } as Response);
+      await user.click(screen.getByRole('button', { name: /start earning/i }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith('/api/player', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            walletAddress: '0xabcdefabcdefabcdefabcdefabcdefabcdefabcd',
             email: 'test@example.com',
             username: 'testuser',
           }),

--- a/components/auth/auth.tsx
+++ b/components/auth/auth.tsx
@@ -4,6 +4,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 import { useUsernameSignup } from '@/hooks/use-username-signup';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 import { UsernameSignupForm } from '@/components/auth/username-signup-form';
 
 interface AuthProps {
@@ -12,7 +13,7 @@ interface AuthProps {
 
 export default function Auth({ children }: AuthProps) {
   const { user, ready, linkEmail, login } = usePrivy();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
   const {
     username,
     setUsername,

--- a/components/claim/export-wallet-button.tsx
+++ b/components/claim/export-wallet-button.tsx
@@ -5,6 +5,7 @@ import { usePrivy } from "@privy-io/react-auth";
 import { toast } from "sonner";
 
 import { cn } from "@/lib/utils";
+import { tryNormalizeEvmAddress } from "@/lib/utils/wallets";
 
 interface ExportWalletButtonProps {
   className?: string;
@@ -17,20 +18,23 @@ export default function ExportWalletButton({
 }: ExportWalletButtonProps) {
   const { ready, authenticated, user, exportWallet } = usePrivy();
 
-  const userAddress = user?.wallet?.address;
-  const hasEmbeddedWallet = useMemo(
-    () =>
-      Boolean(
-        user?.linkedAccounts?.some(
-          (account) =>
-            account.type === "wallet" &&
-            account.walletClientType === "privy" &&
-            account.chainType === "ethereum",
-        ),
-      ),
-    [user?.linkedAccounts],
-  );
-
+  const userAddress = useMemo(() => {
+    const embeddedEvmWallet = user?.linkedAccounts?.find(
+      (account) =>
+        account.type === "wallet" &&
+        account.walletClientType === "privy" &&
+        account.chainType === "ethereum"
+    );
+    if (
+      !embeddedEvmWallet ||
+      !("address" in embeddedEvmWallet) ||
+      typeof embeddedEvmWallet.address !== "string"
+    ) {
+      return undefined;
+    }
+    return tryNormalizeEvmAddress(embeddedEvmWallet.address) ?? undefined;
+  }, [user?.linkedAccounts]);
+  const hasEmbeddedWallet = Boolean(userAddress);
   const isWalletReady = ready || Boolean(userAddress);
 
   const disabledReason = useMemo(() => {
@@ -45,7 +49,9 @@ export default function ExportWalletButton({
 
   const handleExportWallet = async () => {
     if (!isWalletReady) {
-      toast.error("Still connecting to your wallet. Please try again in a moment.");
+      toast.error(
+        "Still connecting to your wallet. Please try again in a moment."
+      );
       return;
     }
 
@@ -71,11 +77,10 @@ export default function ExportWalletButton({
       title={disabledReason ?? undefined}
       className={cn(
         "flex h-10 w-full items-center justify-center rounded-full border border-[#313131] bg-white px-4 py-2 font-grotesk text-sm text-[#313131] transition hover:bg-[#F9F9F9] disabled:cursor-not-allowed disabled:opacity-60",
-        className,
+        className
       )}
     >
       {buttonText}
     </button>
   );
 }
-

--- a/components/claim/export-wallet-button.tsx
+++ b/components/claim/export-wallet-button.tsx
@@ -1,11 +1,11 @@
-"use client";
+'use client';
 
-import { useMemo } from "react";
-import { usePrivy } from "@privy-io/react-auth";
-import { toast } from "sonner";
+import { useMemo } from 'react';
+import { usePrivy } from '@privy-io/react-auth';
+import { toast } from 'sonner';
 
-import { cn } from "@/lib/utils";
-import { tryNormalizeEvmAddress } from "@/lib/utils/wallets";
+import { cn } from '@/lib/utils';
+import { resolveEmbeddedPrivyEvmWalletAddress } from '@/lib/privy/resolve-embedded-privy-evm-wallet-address';
 
 interface ExportWalletButtonProps {
   className?: string;
@@ -14,43 +14,29 @@ interface ExportWalletButtonProps {
 
 export default function ExportWalletButton({
   className,
-  buttonText = "Export Wallet",
+  buttonText = 'Export Wallet',
 }: ExportWalletButtonProps) {
   const { ready, authenticated, user, exportWallet } = usePrivy();
 
-  const userAddress = useMemo(() => {
-    const embeddedEvmWallet = user?.linkedAccounts?.find(
-      (account) =>
-        account.type === "wallet" &&
-        account.walletClientType === "privy" &&
-        account.chainType === "ethereum"
-    );
-    if (
-      !embeddedEvmWallet ||
-      !("address" in embeddedEvmWallet) ||
-      typeof embeddedEvmWallet.address !== "string"
-    ) {
-      return undefined;
-    }
-    return tryNormalizeEvmAddress(embeddedEvmWallet.address) ?? undefined;
-  }, [user?.linkedAccounts]);
-  const hasEmbeddedWallet = Boolean(userAddress);
+  const userAddress = useMemo(
+    () => resolveEmbeddedPrivyEvmWalletAddress(user),
+    [user]
+  );
   const isWalletReady = ready || Boolean(userAddress);
 
   const disabledReason = useMemo(() => {
     if (!isWalletReady && !authenticated) {
-      return "Connecting to Privy...";
+      return 'Connecting to Privy...';
     }
-    if (!authenticated) return "Log in to export your wallet.";
-    if (!hasEmbeddedWallet || !userAddress)
-      return "No embedded Privy wallet found to export.";
+    if (!authenticated) return 'Log in to export your wallet.';
+    if (!userAddress) return 'No embedded Privy wallet found to export.';
     return null;
-  }, [isWalletReady, authenticated, hasEmbeddedWallet, userAddress]);
+  }, [isWalletReady, authenticated, userAddress]);
 
   const handleExportWallet = async () => {
     if (!isWalletReady) {
       toast.error(
-        "Still connecting to your wallet. Please try again in a moment."
+        'Still connecting to your wallet. Please try again in a moment.'
       );
       return;
     }
@@ -62,10 +48,10 @@ export default function ExportWalletButton({
 
     try {
       await exportWallet({ address: userAddress as `0x${string}` });
-      toast.success("Privy export modal opened. Copy your key securely.");
+      toast.success('Privy export modal opened. Copy your key securely.');
     } catch (error: any) {
-      console.error("Failed to export wallet:", error);
-      toast.error(error?.message || "Failed to export wallet. Please retry.");
+      console.error('Failed to export wallet:', error);
+      toast.error(error?.message || 'Failed to export wallet. Please retry.');
     }
   };
 
@@ -76,7 +62,7 @@ export default function ExportWalletButton({
       disabled={Boolean(disabledReason)}
       title={disabledReason ?? undefined}
       className={cn(
-        "flex h-10 w-full items-center justify-center rounded-full border border-[#313131] bg-white px-4 py-2 font-grotesk text-sm text-[#313131] transition hover:bg-[#F9F9F9] disabled:cursor-not-allowed disabled:opacity-60",
+        'flex h-10 w-full items-center justify-center rounded-full border border-[#313131] bg-white px-4 py-2 font-grotesk text-sm text-[#313131] transition hover:bg-[#F9F9F9] disabled:cursor-not-allowed disabled:opacity-60',
         className
       )}
     >

--- a/components/claim/transfer-tokens.tsx
+++ b/components/claim/transfer-tokens.tsx
@@ -1,17 +1,17 @@
-"use client";
+'use client';
 
-import { useState } from "react";
-import { useWallets } from "@privy-io/react-auth";
-import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { toast } from "sonner";
-import { createPublicClient, createWalletClient, custom, parseAbi } from "viem";
-import { base } from "viem/chains";
-import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
+import { useState } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { createPublicClient, createWalletClient, custom, parseAbi } from 'viem';
+import { base } from 'viem/chains';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
+import { useConnectedEvmWallet } from '@/hooks/use-connected-evm-wallet';
 
 const ERC20_ABI = parseAbi([
-  "function transfer(address to, uint256 amount) external returns (bool)",
-  "function balanceOf(address account) external view returns (uint256)",
-  "function decimals() external view returns (uint8)",
+  'function transfer(address to, uint256 amount) external returns (bool)',
+  'function balanceOf(address account) external view returns (uint256)',
+  'function decimals() external view returns (uint8)',
 ]);
 
 interface TransferTokensProps {
@@ -27,19 +27,15 @@ export default function TransferTokens({
   onTransferComplete,
   buttonClassName,
   buttonFontFamily,
-  buttonText = "Transfer Tokens",
+  buttonText = 'Transfer Tokens',
 }: TransferTokensProps) {
-  const { wallets } = useWallets();
   const userAddress = useEvmWalletAddress();
+  const evmWallet = useConnectedEvmWallet();
   const queryClient = useQueryClient();
-  const [recipientAddress, setRecipientAddress] = useState("");
-  const [amount, setAmount] = useState("");
+  const [recipientAddress, setRecipientAddress] = useState('');
+  const [amount, setAmount] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [showFundingInfo, setShowFundingInfo] = useState(false);
-
-  const evmWallet = wallets.find(
-    (wallet) => wallet.address.toLowerCase() === userAddress?.toLowerCase()
-  );
 
   // Helper function to check if wallet is on Base network (without switching)
   const isOnBaseNetwork = async (): Promise<boolean> => {
@@ -51,8 +47,8 @@ export default function TransferTokens({
       if (wallet?.chainId) {
         // Privy chainId format is "eip155:8453" or just the number
         const chainIdStr = wallet.chainId.toString();
-        const chainIdNumber = chainIdStr.includes(":")
-          ? parseInt(chainIdStr.split(":")[1], 10)
+        const chainIdNumber = chainIdStr.includes(':')
+          ? parseInt(chainIdStr.split(':')[1], 10)
           : parseInt(chainIdStr, 10);
 
         if (chainIdNumber === base.id) {
@@ -65,14 +61,14 @@ export default function TransferTokens({
       if (provider) {
         try {
           const currentChainId = await provider.request({
-            method: "eth_chainId",
+            method: 'eth_chainId',
           });
           const currentChainIdNumber = parseInt(currentChainId, 16);
           return currentChainIdNumber === base.id;
         } catch (providerError) {
           // Provider request failed, but we already checked Privy wallet
           // If we got here, Privy wallet wasn't on Base, so return false
-          console.warn("Provider request failed:", providerError);
+          console.warn('Provider request failed:', providerError);
           return false;
         }
       }
@@ -81,7 +77,7 @@ export default function TransferTokens({
       // Default to false to be safe
       return false;
     } catch (error) {
-      console.error("Error checking network:", error);
+      console.error('Error checking network:', error);
       return false;
     }
   };
@@ -103,7 +99,7 @@ export default function TransferTokens({
       // Switch to Base network
       try {
         await wallet.switchChain(base.id);
-        toast.info("Switched to Base network");
+        toast.info('Switched to Base network');
         // Wait a bit for the chain switch to complete
         await new Promise((resolve) => setTimeout(resolve, 1500));
 
@@ -114,14 +110,14 @@ export default function TransferTokens({
         if (provider) {
           try {
             const currentChainId = await provider.request({
-              method: "eth_chainId",
+              method: 'eth_chainId',
             });
             const currentChainIdNumber = parseInt(currentChainId, 16);
             if (currentChainIdNumber === base.id) {
               return true;
             }
           } catch (verifyError) {
-            console.warn("Failed to verify chain after switch:", verifyError);
+            console.warn('Failed to verify chain after switch:', verifyError);
           }
         }
 
@@ -129,25 +125,25 @@ export default function TransferTokens({
         const verified = await isOnBaseNetwork();
         return verified;
       } catch (switchError: any) {
-        console.error("Failed to switch to Base network:", switchError);
-        toast.error("Please switch to Base network in your wallet");
+        console.error('Failed to switch to Base network:', switchError);
+        toast.error('Please switch to Base network in your wallet');
         return false;
       }
     } catch (error) {
-      console.error("Error ensuring Base network:", error);
+      console.error('Error ensuring Base network:', error);
       return false;
     }
   };
 
   // Get token info
   const { data: tokenInfo } = useQuery({
-    queryKey: ["token-info", userAddress],
+    queryKey: ['token-info', userAddress],
     queryFn: async () => {
       if (!userAddress) return null;
       const response = await fetch(
         `/api/transfer-tokens?userAddress=${userAddress}`
       );
-      if (!response.ok) throw new Error("Failed to fetch token info");
+      if (!response.ok) throw new Error('Failed to fetch token info');
       return response.json();
     },
     enabled: !!userAddress,
@@ -155,7 +151,7 @@ export default function TransferTokens({
 
   // Check ETH balance for gas
   const { data: ethBalance } = useQuery({
-    queryKey: ["eth-balance", userAddress],
+    queryKey: ['eth-balance', userAddress],
     queryFn: async () => {
       if (!userAddress) return null;
 
@@ -168,7 +164,7 @@ export default function TransferTokens({
           // Log but don't return null immediately - try to get balance anyway
           // The actual balance query might work even if network check failed
           console.log(
-            "Network check suggests not on Base, but attempting balance query anyway"
+            'Network check suggests not on Base, but attempting balance query anyway'
           );
         }
 
@@ -181,7 +177,7 @@ export default function TransferTokens({
             provider = await wallet.getEthereumProvider();
           } catch (walletError) {
             console.warn(
-              "Failed to get provider from Privy wallet:",
+              'Failed to get provider from Privy wallet:',
               walletError
             );
           }
@@ -193,7 +189,7 @@ export default function TransferTokens({
         }
 
         if (!provider) {
-          console.warn("No provider available for balance check");
+          console.warn('No provider available for balance check');
           return null;
         }
 
@@ -208,12 +204,12 @@ export default function TransferTokens({
             address: userAddress as `0x${string}`,
           });
 
-          console.log("ETH Balance:", balance);
+          console.log('ETH Balance:', balance);
           return balance;
         } catch (balanceError: any) {
           // If balance query fails, it might be because we're not on the right network
           // or there's a network issue
-          console.warn("Failed to get ETH balance:", balanceError);
+          console.warn('Failed to get ETH balance:', balanceError);
 
           // If network check said we're not on Base, return null
           // Otherwise, it might be a temporary network issue
@@ -226,7 +222,7 @@ export default function TransferTokens({
           return null;
         }
       } catch (error) {
-        console.error("Error in ETH balance query:", error);
+        console.error('Error in ETH balance query:', error);
         return null;
       }
     },
@@ -239,18 +235,18 @@ export default function TransferTokens({
   // Transfer mutation
   const transferMutation = useMutation({
     mutationFn: async ({ to, amount }: { to: string; amount: string }) => {
-      if (!userAddress) throw new Error("No wallet connected");
+      if (!userAddress) throw new Error('No wallet connected');
       if (!tokenInfo?.tokenAddress)
-        throw new Error("No token address available");
+        throw new Error('No token address available');
 
       // Get the wallet from Privy first
       const wallet = evmWallet;
-      if (!wallet) throw new Error("No wallet found");
+      if (!wallet) throw new Error('No wallet found');
 
       // Ensure wallet is on Base network before performing transfer
       const isOnBase = await ensureBaseNetwork();
       if (!isOnBase) {
-        throw new Error("Please switch to Base network in your wallet");
+        throw new Error('Please switch to Base network in your wallet');
       }
 
       // Get the wallet provider from Privy (not window.ethereum)
@@ -258,17 +254,17 @@ export default function TransferTokens({
       try {
         provider = await wallet.getEthereumProvider();
       } catch (walletError) {
-        console.warn("Failed to get provider from Privy wallet:", walletError);
+        console.warn('Failed to get provider from Privy wallet:', walletError);
         // Fallback to window.ethereum if Privy provider not available
         provider = (window as any).ethereum;
       }
 
-      if (!provider) throw new Error("No wallet provider found");
+      if (!provider) throw new Error('No wallet provider found');
 
       // Double-check the chain after getting provider
       try {
         const currentChainId = await provider.request({
-          method: "eth_chainId",
+          method: 'eth_chainId',
         });
         const currentChainIdNumber = parseInt(currentChainId, 16);
         if (currentChainIdNumber !== base.id) {
@@ -277,15 +273,15 @@ export default function TransferTokens({
           await new Promise((resolve) => setTimeout(resolve, 1500));
 
           // Verify again
-          const newChainId = await provider.request({ method: "eth_chainId" });
+          const newChainId = await provider.request({ method: 'eth_chainId' });
           const newChainIdNumber = parseInt(newChainId, 16);
           if (newChainIdNumber !== base.id) {
-            throw new Error("Please switch to Base network in your wallet");
+            throw new Error('Please switch to Base network in your wallet');
           }
         }
       } catch (chainError: any) {
-        console.error("Chain verification failed:", chainError);
-        throw new Error("Please switch to Base network in your wallet");
+        console.error('Chain verification failed:', chainError);
+        throw new Error('Please switch to Base network in your wallet');
       }
 
       // Create wallet client with user's wallet
@@ -305,7 +301,7 @@ export default function TransferTokens({
       const hash = await walletClient.writeContract({
         address: tokenInfo.tokenAddress as `0x${string}`,
         abi: ERC20_ABI,
-        functionName: "transfer",
+        functionName: 'transfer',
         args: [to as `0x${string}`, amountInWei],
       });
 
@@ -317,35 +313,35 @@ export default function TransferTokens({
 
       const receipt = await publicClient.waitForTransactionReceipt({ hash });
 
-      if (receipt.status !== "success") {
-        throw new Error("Transaction failed");
+      if (receipt.status !== 'success') {
+        throw new Error('Transaction failed');
       }
 
       return { hash, receipt };
     },
     onSuccess: () => {
-      toast.success("Tokens transferred successfully!");
-      setRecipientAddress("");
-      setAmount("");
+      toast.success('Tokens transferred successfully!');
+      setRecipientAddress('');
+      setAmount('');
       setIsOpen(false);
       setShowFundingInfo(false);
       queryClient.invalidateQueries({
-        queryKey: ["claim-status", userAddress],
+        queryKey: ['claim-status', userAddress],
       });
-      queryClient.invalidateQueries({ queryKey: ["token-info", userAddress] });
+      queryClient.invalidateQueries({ queryKey: ['token-info', userAddress] });
       onTransferComplete?.();
     },
     onError: (error: any) => {
-      const errorMessage = error.message || "Failed to transfer tokens";
+      const errorMessage = error.message || 'Failed to transfer tokens';
 
       // Check for chain mismatch errors
       if (
-        errorMessage.includes("chain") ||
-        errorMessage.includes("Chain ID") ||
-        errorMessage.includes("does not match") ||
-        errorMessage.includes("target chain")
+        errorMessage.includes('chain') ||
+        errorMessage.includes('Chain ID') ||
+        errorMessage.includes('does not match') ||
+        errorMessage.includes('target chain')
       ) {
-        toast.error("Please switch to Base network in your wallet");
+        toast.error('Please switch to Base network in your wallet');
         return;
       }
 
@@ -353,9 +349,9 @@ export default function TransferTokens({
 
       // If error is about insufficient funds, show funding info
       if (
-        errorMessage.toLowerCase().includes("insufficient funds") ||
-        errorMessage.toLowerCase().includes("insufficient balance") ||
-        errorMessage.toLowerCase().includes("gas")
+        errorMessage.toLowerCase().includes('insufficient funds') ||
+        errorMessage.toLowerCase().includes('insufficient balance') ||
+        errorMessage.toLowerCase().includes('gas')
       ) {
         setShowFundingInfo(true);
       }
@@ -364,32 +360,32 @@ export default function TransferTokens({
 
   const handleTransfer = async () => {
     if (!userAddress || !evmWallet) {
-      toast.error("Your EVM wallet is still connecting");
+      toast.error('Your EVM wallet is still connecting');
       return;
     }
 
     if (!recipientAddress || !amount) {
-      toast.error("Please fill in all fields");
+      toast.error('Please fill in all fields');
       return;
     }
 
     // Basic address validation
     if (!/^0x[a-fA-F0-9]{40}$/.test(recipientAddress)) {
-      toast.error("Invalid recipient address");
+      toast.error('Invalid recipient address');
       return;
     }
 
     // Validate amount
     const transferAmount = parseFloat(amount);
     if (isNaN(transferAmount) || transferAmount <= 0) {
-      toast.error("Invalid amount");
+      toast.error('Invalid amount');
       return;
     }
 
     const balanceInTokens =
       Number(tokenBalance) / 10 ** (tokenInfo?.decimals || 18);
     if (transferAmount > balanceInTokens) {
-      toast.error("Insufficient balance");
+      toast.error('Insufficient balance');
       return;
     }
 
@@ -399,9 +395,9 @@ export default function TransferTokens({
   const copyToClipboard = async (text: string) => {
     try {
       await navigator.clipboard.writeText(text);
-      toast.success("Address copied to clipboard!");
+      toast.success('Address copied to clipboard!');
     } catch {
-      toast.error("Failed to copy address");
+      toast.error('Failed to copy address');
     }
   };
 
@@ -410,7 +406,7 @@ export default function TransferTokens({
 
   // Helper function to convert wei to ETH
   const weiToEth = (wei: bigint | null | undefined): string => {
-    if (!wei) return "0.0000";
+    if (!wei) return '0.0000';
     const eth = Number(wei) / Math.pow(10, 18);
     return eth.toFixed(4);
   };
@@ -432,7 +428,7 @@ export default function TransferTokens({
           onClick={() => setIsOpen(true)}
           className={
             buttonClassName ||
-            "flex w-full items-center justify-center gap-2 rounded-full border border-[#313131] bg-white px-4 py-2 text-sm font-grotesk text-[#313131] transition hover:bg-[#F9F9F9]"
+            'flex w-full items-center justify-center gap-2 rounded-full border border-[#313131] bg-white px-4 py-2 text-sm font-grotesk text-[#313131] transition hover:bg-[#F9F9F9]'
           }
         >
           <span
@@ -514,7 +510,7 @@ export default function TransferTokens({
                     </p>
                     <p className="mt-1 text-xs font-grotesk text-[#92400E]">
                       You need ETH on Base to pay for transaction fees. Send ETH
-                      to your wallet address below. ETH Balance:{" "}
+                      to your wallet address below. ETH Balance:{' '}
                       {formattedEthBalance} ETH
                     </p>
                   </div>
@@ -533,7 +529,7 @@ export default function TransferTokens({
                   </div>
                   <button
                     type="button"
-                    onClick={() => copyToClipboard(userAddress || "")}
+                    onClick={() => copyToClipboard(userAddress || '')}
                     className="flex-shrink-0 rounded-lg border border-[#313131] bg-white p-2 text-[#313131] transition hover:bg-[#F9F9F9]"
                     title="Copy address"
                   >
@@ -565,7 +561,7 @@ export default function TransferTokens({
               <div className="rounded-lg border border-[#EDEDED] bg-[#F9F9F9] p-3">
                 <p className="text-xs font-grotesk text-[#7D7D7D]">
                   <strong className="text-[#313131]">Note:</strong> Make sure to
-                  send ETH on the{" "}
+                  send ETH on the{' '}
                   <strong className="text-[#313131]">Base network</strong>.
                   Sending on other networks will result in loss of funds.
                 </p>
@@ -674,7 +670,7 @@ export default function TransferTokens({
                       Transferring...
                     </span>
                   ) : (
-                    "Transfer"
+                    'Transfer'
                   )}
                 </button>
               )}

--- a/components/claim/transfer-tokens.tsx
+++ b/components/claim/transfer-tokens.tsx
@@ -1,11 +1,12 @@
 "use client";
 
 import { useState } from "react";
-import { usePrivy, useWallets } from "@privy-io/react-auth";
+import { useWallets } from "@privy-io/react-auth";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { createPublicClient, createWalletClient, custom, parseAbi } from "viem";
 import { base } from "viem/chains";
+import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
 
 const ERC20_ABI = parseAbi([
   "function transfer(address to, uint256 amount) external returns (bool)",
@@ -28,15 +29,17 @@ export default function TransferTokens({
   buttonFontFamily,
   buttonText = "Transfer Tokens",
 }: TransferTokensProps) {
-  const { user } = usePrivy();
   const { wallets } = useWallets();
+  const userAddress = useEvmWalletAddress();
   const queryClient = useQueryClient();
   const [recipientAddress, setRecipientAddress] = useState("");
   const [amount, setAmount] = useState("");
   const [isOpen, setIsOpen] = useState(false);
   const [showFundingInfo, setShowFundingInfo] = useState(false);
 
-  const userAddress = user?.wallet?.address;
+  const evmWallet = wallets.find(
+    (wallet) => wallet.address.toLowerCase() === userAddress?.toLowerCase()
+  );
 
   // Helper function to check if wallet is on Base network (without switching)
   const isOnBaseNetwork = async (): Promise<boolean> => {
@@ -44,14 +47,14 @@ export default function TransferTokens({
 
     try {
       // First, try to use Privy wallet's chainId (most reliable)
-      const wallet = wallets.find((w) => w.address === userAddress) || wallets[0];
+      const wallet = evmWallet;
       if (wallet?.chainId) {
         // Privy chainId format is "eip155:8453" or just the number
         const chainIdStr = wallet.chainId.toString();
         const chainIdNumber = chainIdStr.includes(":")
           ? parseInt(chainIdStr.split(":")[1], 10)
           : parseInt(chainIdStr, 10);
-        
+
         if (chainIdNumber === base.id) {
           return true;
         }
@@ -61,7 +64,9 @@ export default function TransferTokens({
       const provider = (window as any).ethereum;
       if (provider) {
         try {
-          const currentChainId = await provider.request({ method: "eth_chainId" });
+          const currentChainId = await provider.request({
+            method: "eth_chainId",
+          });
           const currentChainIdNumber = parseInt(currentChainId, 16);
           return currentChainIdNumber === base.id;
         } catch (providerError) {
@@ -85,7 +90,7 @@ export default function TransferTokens({
   const ensureBaseNetwork = async (): Promise<boolean> => {
     if (!userAddress) return false;
 
-    const wallet = wallets.find((w) => w.address === userAddress) || wallets[0];
+    const wallet = evmWallet;
     if (!wallet) return false;
 
     try {
@@ -101,12 +106,16 @@ export default function TransferTokens({
         toast.info("Switched to Base network");
         // Wait a bit for the chain switch to complete
         await new Promise((resolve) => setTimeout(resolve, 1500));
-        
+
         // Verify the chain switch was successful
-        const provider = await wallet.getEthereumProvider().catch(() => (window as any).ethereum);
+        const provider = await wallet
+          .getEthereumProvider()
+          .catch(() => (window as any).ethereum);
         if (provider) {
           try {
-            const currentChainId = await provider.request({ method: "eth_chainId" });
+            const currentChainId = await provider.request({
+              method: "eth_chainId",
+            });
             const currentChainIdNumber = parseInt(currentChainId, 16);
             if (currentChainIdNumber === base.id) {
               return true;
@@ -115,7 +124,7 @@ export default function TransferTokens({
             console.warn("Failed to verify chain after switch:", verifyError);
           }
         }
-        
+
         // If verification failed, check again using isOnBaseNetwork
         const verified = await isOnBaseNetwork();
         return verified;
@@ -136,7 +145,7 @@ export default function TransferTokens({
     queryFn: async () => {
       if (!userAddress) return null;
       const response = await fetch(
-        `/api/transfer-tokens?userAddress=${userAddress}`,
+        `/api/transfer-tokens?userAddress=${userAddress}`
       );
       if (!response.ok) throw new Error("Failed to fetch token info");
       return response.json();
@@ -154,22 +163,27 @@ export default function TransferTokens({
         // First, try to verify wallet is on Base network
         // But don't fail completely if check fails - still try to get balance
         const onBase = await isOnBaseNetwork();
-        
+
         if (!onBase) {
           // Log but don't return null immediately - try to get balance anyway
           // The actual balance query might work even if network check failed
-          console.log("Network check suggests not on Base, but attempting balance query anyway");
+          console.log(
+            "Network check suggests not on Base, but attempting balance query anyway"
+          );
         }
 
         // Try to get provider from Privy wallet first (more reliable)
-        const wallet = wallets.find((w) => w.address === userAddress) || wallets[0];
+        const wallet = evmWallet;
         let provider: any = null;
 
         if (wallet) {
           try {
             provider = await wallet.getEthereumProvider();
           } catch (walletError) {
-            console.warn("Failed to get provider from Privy wallet:", walletError);
+            console.warn(
+              "Failed to get provider from Privy wallet:",
+              walletError
+            );
           }
         }
 
@@ -200,13 +214,13 @@ export default function TransferTokens({
           // If balance query fails, it might be because we're not on the right network
           // or there's a network issue
           console.warn("Failed to get ETH balance:", balanceError);
-          
+
           // If network check said we're not on Base, return null
           // Otherwise, it might be a temporary network issue
           if (!onBase) {
             return null;
           }
-          
+
           // If we thought we were on Base but balance query failed,
           // return null to be safe (will show as insufficient funds)
           return null;
@@ -230,7 +244,7 @@ export default function TransferTokens({
         throw new Error("No token address available");
 
       // Get the wallet from Privy first
-      const wallet = wallets.find((w) => w.address === userAddress) || wallets[0];
+      const wallet = evmWallet;
       if (!wallet) throw new Error("No wallet found");
 
       // Ensure wallet is on Base network before performing transfer
@@ -253,13 +267,15 @@ export default function TransferTokens({
 
       // Double-check the chain after getting provider
       try {
-        const currentChainId = await provider.request({ method: "eth_chainId" });
+        const currentChainId = await provider.request({
+          method: "eth_chainId",
+        });
         const currentChainIdNumber = parseInt(currentChainId, 16);
         if (currentChainIdNumber !== base.id) {
           // Try switching one more time
           await wallet.switchChain(base.id);
           await new Promise((resolve) => setTimeout(resolve, 1500));
-          
+
           // Verify again
           const newChainId = await provider.request({ method: "eth_chainId" });
           const newChainIdNumber = parseInt(newChainId, 16);
@@ -282,7 +298,7 @@ export default function TransferTokens({
       // Convert amount to wei (assuming 18 decimals)
       const decimals = tokenInfo.decimals || 18;
       const amountInWei = BigInt(
-        Math.floor(parseFloat(amount) * 10 ** decimals),
+        Math.floor(parseFloat(amount) * 10 ** decimals)
       );
 
       // Execute transfer
@@ -321,7 +337,7 @@ export default function TransferTokens({
     },
     onError: (error: any) => {
       const errorMessage = error.message || "Failed to transfer tokens";
-      
+
       // Check for chain mismatch errors
       if (
         errorMessage.includes("chain") ||
@@ -347,6 +363,11 @@ export default function TransferTokens({
   });
 
   const handleTransfer = async () => {
+    if (!userAddress || !evmWallet) {
+      toast.error("Your EVM wallet is still connecting");
+      return;
+    }
+
     if (!recipientAddress || !amount) {
       toast.error("Please fill in all fields");
       return;
@@ -493,7 +514,8 @@ export default function TransferTokens({
                     </p>
                     <p className="mt-1 text-xs font-grotesk text-[#92400E]">
                       You need ETH on Base to pay for transaction fees. Send ETH
-                      to your wallet address below. ETH Balance: {formattedEthBalance} ETH
+                      to your wallet address below. ETH Balance:{" "}
+                      {formattedEthBalance} ETH
                     </p>
                   </div>
                 </div>
@@ -624,7 +646,7 @@ export default function TransferTokens({
                 <button
                   type="button"
                   onClick={handleTransfer}
-                  disabled={transferMutation.isPending}
+                  disabled={transferMutation.isPending || !evmWallet}
                   className="flex h-10 w-full items-center justify-center rounded-full bg-[#313131] px-4 py-2 font-grotesk text-sm text-white transition hover:bg-[#313131]/80 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-black disabled:opacity-50"
                 >
                   {transferMutation.isPending ? (

--- a/components/home/home-desktop-nav.tsx
+++ b/components/home/home-desktop-nav.tsx
@@ -7,6 +7,7 @@ import { usePrivy } from '@privy-io/react-auth';
 import LocationSearch from '@/components/shared/location-search';
 import LeaderboardAvatar from '@/components/leaderboard-avatar';
 import { cn } from '@/lib/utils';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 const NAV_LINKS = [
   { label: 'MAP', href: '/interactive-map' },
@@ -49,9 +50,9 @@ const navLinkClassName =
  * Logged out, only the logo and SIGN UP show; the full nav appears after login.
  */
 export function HomeDesktopNav() {
-  const { ready, authenticated, user, login } = usePrivy();
+  const { ready, authenticated, login } = usePrivy();
   const router = useRouter();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
   const showFullNav = ready && authenticated;
 
   const handleSearchSelect = (picked: {

--- a/components/layout/user-menu.test.tsx
+++ b/components/layout/user-menu.test.tsx
@@ -23,6 +23,9 @@ const mockUsePrivy = vi.fn();
 vi.mock('@privy-io/react-auth', () => ({
   usePrivy: () => mockUsePrivy(),
 }));
+vi.mock('@/hooks/use-evm-wallet-address', () => ({
+  useEvmWalletAddress: () => mockUsePrivy()?.user?.wallet?.address,
+}));
 
 // Mock useUserStats hook
 const mockUseUserStats = vi.fn();

--- a/components/layout/user-menu.tsx
+++ b/components/layout/user-menu.tsx
@@ -8,6 +8,7 @@ import Image from 'next/image';
 import type { UserProfile } from '@/lib/types';
 import { getSocialUrl } from '@/lib/utils/social-links';
 import { useUserStats } from '@/hooks/usePlayer';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 interface UserMenuProps {
   isOpen: boolean;
@@ -22,6 +23,7 @@ export default function UserMenu({
 }: UserMenuProps) {
   const { user } = usePrivy();
   const router = useRouter();
+  const walletAddress = useEvmWalletAddress();
   const [profile, setProfile] = useState<UserProfile>({
     wallet_address: '',
     email: '',
@@ -44,9 +46,8 @@ export default function UserMenu({
   const scrollableContentRef = useRef<HTMLDivElement>(null);
 
   // Use the reusable hook for user stats
-  const { userStats, isLoading: isLoadingUserStats } = useUserStats(
-    user?.wallet?.address
-  );
+  const { userStats, isLoading: isLoadingUserStats } =
+    useUserStats(walletAddress);
 
   // Handle menu open/close with transitions
   useEffect(() => {
@@ -85,12 +86,12 @@ export default function UserMenu({
   }, [isOpen]);
 
   const fetchProfile = useCallback(async () => {
-    if (!user?.wallet?.address) return;
+    if (!user || !walletAddress) return;
 
     setIsLoadingProfile(true);
     try {
       const response = await fetch(
-        `/api/profile?wallet_address=${user.wallet.address}`
+        `/api/profile?wallet_address=${walletAddress}`
       );
 
       if (response.ok) {
@@ -99,7 +100,7 @@ export default function UserMenu({
         const data = responseData.data || responseData;
 
         setProfile({
-          wallet_address: user.wallet.address,
+          wallet_address: walletAddress,
           email: data.email || user.email?.address || '',
           name: data.name || '',
           username: data.username || '',
@@ -117,7 +118,7 @@ export default function UserMenu({
       } else {
         // If profile doesn't exist or API returns error, use defaults
         setProfile({
-          wallet_address: user.wallet.address,
+          wallet_address: walletAddress,
           email: user.email?.address || '',
           name: '',
           username: '',
@@ -137,7 +138,7 @@ export default function UserMenu({
       console.error('Error fetching profile:', error);
       // On error, use defaults
       setProfile({
-        wallet_address: user.wallet.address,
+        wallet_address: walletAddress,
         email: user.email?.address || '',
         name: '',
         username: '',
@@ -155,14 +156,14 @@ export default function UserMenu({
     } finally {
       setIsLoadingProfile(false);
     }
-  }, [user?.wallet?.address, user?.email?.address]);
+  }, [walletAddress, user]);
 
   // Fetch data when menu opens
   useEffect(() => {
-    if (isOpen && user?.wallet?.address) {
+    if (isOpen && walletAddress) {
       void fetchProfile();
     }
-  }, [isOpen, user?.wallet?.address, fetchProfile]);
+  }, [isOpen, walletAddress, fetchProfile]);
 
   if (!user || !isMenuMounted) return null;
 

--- a/components/leaderboard/leaderboard-page.tsx
+++ b/components/leaderboard/leaderboard-page.tsx
@@ -8,6 +8,7 @@ import MapNav, { MAP_NAV_MOBILE_FLUSH_X } from '@/components/map/mapnav';
 import Link from 'next/link';
 import LeaderboardAvatar from '@/components/leaderboard-avatar';
 import { useUserStats } from '@/hooks/usePlayer';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 interface LeaderboardUser {
   player_id: number;
@@ -44,7 +45,7 @@ const getOrdinalSuffix = (num: number): string => {
 
 export default function LeaderboardPage() {
   const { user } = usePrivy();
-  const currentUserAddress = user?.wallet?.address;
+  const currentUserAddress = useEvmWalletAddress();
   const currentUsername = user?.google?.name || user?.twitter?.name;
 
   // Use the reusable hook for user stats

--- a/components/leaderboard/leaderboard.test.tsx
+++ b/components/leaderboard/leaderboard.test.tsx
@@ -8,6 +8,9 @@ const mockUsePrivy = vi.fn()
 vi.mock('@privy-io/react-auth', () => ({
   usePrivy: () => mockUsePrivy(),
 }))
+vi.mock('@/hooks/use-evm-wallet-address', () => ({
+  useEvmWalletAddress: () => mockUsePrivy()?.user?.wallet?.address,
+}))
 
 // Mock lucide-react icons
 vi.mock('lucide-react', () => ({
@@ -102,33 +105,35 @@ describe('Leaderboard', () => {
     it('should display leaderboard entries', async () => {
       const user = userEvent.setup()
       // Override the default mock for this test
-      vi.mocked(global.fetch).mockReset().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            leaderboard: [
-              {
-                player_id: '1',
-                wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
-                username: 'TopPlayer',
-                total_points: 5000,
-                total_checkins: 50,
-                rank: 1,
-              },
-              {
-                player_id: '2',
-                wallet_address: '0xabcdef1234567890abcdef1234567890abcdef12',
-                username: 'SecondPlayer',
-                total_points: 4500,
-                total_checkins: 45,
-                rank: 2,
-              },
-            ],
-            pagination: { page: 1, limit: 50, total: 2, totalPages: 1 },
-          },
-        }),
-      } as Response)
+      vi.mocked(global.fetch)
+        .mockReset()
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              leaderboard: [
+                {
+                  player_id: '1',
+                  wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+                  username: 'TopPlayer',
+                  total_points: 5000,
+                  total_checkins: 50,
+                  rank: 1,
+                },
+                {
+                  player_id: '2',
+                  wallet_address: '0xabcdef1234567890abcdef1234567890abcdef12',
+                  username: 'SecondPlayer',
+                  total_points: 4500,
+                  total_checkins: 45,
+                  rank: 2,
+                },
+              ],
+              pagination: { page: 1, limit: 50, total: 2, totalPages: 1 },
+            },
+          }),
+        } as Response)
 
       render(<Leaderboard />)
 
@@ -170,11 +175,14 @@ describe('Leaderboard', () => {
     it('should fetch and display current user stats when logged in', async () => {
       const user = userEvent.setup()
       mockUsePrivy.mockReturnValue({
-        user: { wallet: { address: '0x1234567890abcdef1234567890abcdef12345678' } },
+        user: {
+          wallet: { address: '0x1234567890abcdef1234567890abcdef12345678' },
+        },
       })
 
       // Reset and set up sequential mocks
-      vi.mocked(global.fetch).mockReset()
+      vi.mocked(global.fetch)
+        .mockReset()
         // Leaderboard fetch
         .mockResolvedValueOnce({
           ok: true,
@@ -212,7 +220,9 @@ describe('Leaderboard', () => {
     it('should show prompt when user has no stats', async () => {
       const user = userEvent.setup()
       mockUsePrivy.mockReturnValue({
-        user: { wallet: { address: '0x1234567890abcdef1234567890abcdef12345678' } },
+        user: {
+          wallet: { address: '0x1234567890abcdef1234567890abcdef12345678' },
+        },
       })
 
       vi.mocked(global.fetch).mockResolvedValueOnce({
@@ -294,23 +304,25 @@ describe('Leaderboard', () => {
   describe('Pagination', () => {
     it('should show pagination controls when multiple pages exist', async () => {
       const user = userEvent.setup()
-      vi.mocked(global.fetch).mockReset().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            leaderboard: Array.from({ length: 50 }, (_, i) => ({
-              player_id: `${i + 1}`,
-              wallet_address: `0x${i.toString().padStart(40, '0')}`,
-              username: `Player${i + 1}`,
-              total_points: 1000 - i * 10,
-              total_checkins: 10,
-              rank: i + 1,
-            })),
-            pagination: { page: 1, limit: 50, total: 150, totalPages: 3 },
-          },
-        }),
-      } as Response)
+      vi.mocked(global.fetch)
+        .mockReset()
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              leaderboard: Array.from({ length: 50 }, (_, i) => ({
+                player_id: `${i + 1}`,
+                wallet_address: `0x${i.toString().padStart(40, '0')}`,
+                username: `Player${i + 1}`,
+                total_points: 1000 - i * 10,
+                total_checkins: 10,
+                rank: i + 1,
+              })),
+              pagination: { page: 1, limit: 50, total: 150, totalPages: 3 },
+            },
+          }),
+        } as Response)
 
       render(<Leaderboard />)
 
@@ -324,16 +336,18 @@ describe('Leaderboard', () => {
 
     it('should navigate to next page when right arrow is clicked', async () => {
       const user = userEvent.setup()
-      vi.mocked(global.fetch).mockReset().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            leaderboard: [],
-            pagination: { page: 1, limit: 50, total: 150, totalPages: 3 },
-          },
-        }),
-      } as Response)
+      vi.mocked(global.fetch)
+        .mockReset()
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              leaderboard: [],
+              pagination: { page: 1, limit: 50, total: 150, totalPages: 3 },
+            },
+          }),
+        } as Response)
 
       render(<Leaderboard />)
 
@@ -352,16 +366,18 @@ describe('Leaderboard', () => {
 
     it('should disable previous button on first page', async () => {
       const user = userEvent.setup()
-      vi.mocked(global.fetch).mockReset().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            leaderboard: [],
-            pagination: { page: 1, limit: 50, total: 150, totalPages: 3 },
-          },
-        }),
-      } as Response)
+      vi.mocked(global.fetch)
+        .mockReset()
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              leaderboard: [],
+              pagination: { page: 1, limit: 50, total: 150, totalPages: 3 },
+            },
+          }),
+        } as Response)
 
       render(<Leaderboard />)
 
@@ -463,20 +479,32 @@ describe('Leaderboard', () => {
     it('should show loading state initially when modal opens', async () => {
       const user = userEvent.setup()
       // Use a pending promise that we'll manually resolve
-      vi.mocked(global.fetch).mockReset().mockImplementation(
-        () => new Promise((resolve) => {
-          setTimeout(() => resolve({
-            ok: true,
-            json: async () => ({
-              success: true,
-              data: {
-                leaderboard: [],
-                pagination: { page: 1, limit: 50, total: 0, totalPages: 0 },
-              },
-            }),
-          } as Response), 100)
-        })
-      )
+      vi.mocked(global.fetch)
+        .mockReset()
+        .mockImplementation(
+          () =>
+            new Promise((resolve) => {
+              setTimeout(
+                () =>
+                  resolve({
+                    ok: true,
+                    json: async () => ({
+                      success: true,
+                      data: {
+                        leaderboard: [],
+                        pagination: {
+                          page: 1,
+                          limit: 50,
+                          total: 0,
+                          totalPages: 0,
+                        },
+                      },
+                    }),
+                  } as Response),
+                100
+              )
+            })
+        )
 
       render(<Leaderboard />)
 
@@ -492,25 +520,27 @@ describe('Leaderboard', () => {
   describe('Wallet Address Formatting', () => {
     it('should format wallet addresses for users without usernames', async () => {
       const user = userEvent.setup()
-      vi.mocked(global.fetch).mockReset().mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          success: true,
-          data: {
-            leaderboard: [
-              {
-                player_id: '1',
-                wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
-                username: null,
-                total_points: 1000,
-                total_checkins: 10,
-                rank: 1,
-              },
-            ],
-            pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
-          },
-        }),
-      } as Response)
+      vi.mocked(global.fetch)
+        .mockReset()
+        .mockResolvedValue({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              leaderboard: [
+                {
+                  player_id: '1',
+                  wallet_address: '0x1234567890abcdef1234567890abcdef12345678',
+                  username: null,
+                  total_points: 1000,
+                  total_checkins: 10,
+                  rank: 1,
+                },
+              ],
+              pagination: { page: 1, limit: 50, total: 1, totalPages: 1 },
+            },
+          }),
+        } as Response)
 
       render(<Leaderboard />)
 

--- a/components/leaderboard/leaderboard.tsx
+++ b/components/leaderboard/leaderboard.tsx
@@ -10,7 +10,7 @@ import {
   ChevronRight,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { usePrivy } from "@privy-io/react-auth";
+import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
 
 interface UserStats {
   rank: number;
@@ -34,7 +34,6 @@ export default function Leaderboard({
   onClose,
   autoOpen = false,
 }: LeaderboardProps = {}) {
-  const { user } = usePrivy();
   const [showLeaderboard, setShowLeaderboard] = useState(autoOpen);
   const [userStats, setUserStats] = useState<UserStats | null>(null);
   const [isLoadingUserStats, setIsLoadingUserStats] = useState(false);
@@ -49,7 +48,7 @@ export default function Leaderboard({
   });
   const [isLoadingLeaderboard, setIsLoadingLeaderboard] = useState(false);
 
-  const currentUserAddress = user?.wallet?.address;
+  const currentUserAddress = useEvmWalletAddress();
 
   // Fetch leaderboard data with pagination
   const fetchLeaderboardPage = useCallback(
@@ -57,7 +56,7 @@ export default function Leaderboard({
       setIsLoadingLeaderboard(true);
       try {
         const response = await fetch(
-          `/api/leaderboard?page=${page}&limit=${limit}`,
+          `/api/leaderboard?page=${page}&limit=${limit}`
         );
         const result = await response.json();
 
@@ -76,7 +75,7 @@ export default function Leaderboard({
         setIsLoadingLeaderboard(false);
       }
     },
-    [],
+    []
   );
 
   // Load leaderboard when opened - only if not already loading
@@ -121,7 +120,7 @@ export default function Leaderboard({
     setIsLoadingUserStats(true);
     try {
       const response = await fetch(
-        `/api/player?walletAddress=${encodeURIComponent(walletAddress)}`,
+        `/api/player?walletAddress=${encodeURIComponent(walletAddress)}`
       );
 
       if (response.ok) {
@@ -133,7 +132,7 @@ export default function Leaderboard({
         if (player) {
           // Get user's actual rank
           const rankResponse = await fetch(
-            `/api/player/rank?walletAddress=${encodeURIComponent(walletAddress)}`,
+            `/api/player/rank?walletAddress=${encodeURIComponent(walletAddress)}`
           );
 
           let actualRank = 0;

--- a/components/map/interactive-map.tsx
+++ b/components/map/interactive-map.tsx
@@ -47,6 +47,7 @@ import {
 import { buildDeepLinkMarkerFromQueryCoords } from '@/lib/utils/map-deep-link-marker';
 import { filterByMapBounds } from '@/lib/utils/map-bounds';
 import type { LocationCategory } from '@/lib/types';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 interface MarkerData {
   latitude: number;
@@ -209,7 +210,7 @@ export default function InteractiveMap({
     guideReturnHref ?? guideReturnPersistedRef.current;
 
   const { user, getAccessToken } = usePrivy();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
   const { data: favoritePlaceIds } = useFavoritePlaceIds(walletAddress);
   const { mutate: toggleFavorite, isPending: isFavoritePending } =
     useToggleFavorite(walletAddress);
@@ -2518,7 +2519,9 @@ export default function InteractiveMap({
                       <div
                         className={`flex w-full items-center self-stretch ${isSingleWordLocationCategory(checkInTarget.category) ? 'justify-between' : 'justify-end'}`}
                       >
-                        {isSingleWordLocationCategory(checkInTarget.category) ? (
+                        {isSingleWordLocationCategory(
+                          checkInTarget.category
+                        ) ? (
                           <p className="flex label-small items-center justify-center gap-2 border border-[#171717] px-1 py-0.5  uppercase tracking-[0.3px] text-[#171717]">
                             {formatLocationCategory(checkInTarget.category)}
                           </p>

--- a/components/map/map-desktop-nav.tsx
+++ b/components/map/map-desktop-nav.tsx
@@ -10,6 +10,7 @@ import LocationSearch, {
 } from '@/components/shared/location-search';
 import LeaderboardAvatar from '@/components/leaderboard-avatar';
 import { cn } from '@/lib/utils';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 /** Landing header mark (`irl-logo-new-white.svg`), inverted for light map chrome. */
 const MAP_DESKTOP_LOGO_SRC = '/irl-svg/irl-logo-new-white.svg';
@@ -78,7 +79,7 @@ export function MapDesktopNav({
   className,
 }: MapDesktopNavProps) {
   const { user, login } = usePrivy();
-  const walletAddress = user?.wallet?.address;
+  const walletAddress = useEvmWalletAddress();
 
   return (
     <header

--- a/components/onboarding.tsx
+++ b/components/onboarding.tsx
@@ -13,6 +13,7 @@ import {
   userManagerAddress,
 } from "@/lib/contracts/UserManager";
 import { createWalletClient, custom } from "viem";
+import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
 
 // Dev-only logger to avoid noisy logs during SSG/production
 const devLog = (...args: any[]) => {
@@ -52,18 +53,17 @@ const getWalletChainId = (wallet: any): string | undefined => {
 export default function Onboarding() {
   const { user, login, logout } = usePrivy();
   const { wallets } = useWallets();
+  const evmWalletAddress = useEvmWalletAddress();
 
   devLog("user", user);
   devLog("wallets", wallets);
 
-  // Get the primary wallet address
-  const address = (user?.wallet?.address || wallets[0]?.address) as
-    | `0x${string}`
-    | undefined;
+  const address = evmWalletAddress as `0x${string}` | undefined;
   devLog("address:", address);
 
-  // Find the wallet object
-  const wallet = wallets.find((w) => w.address === address) || wallets[0];
+  const wallet = wallets.find(
+    (candidate) => candidate.address.toLowerCase() === address?.toLowerCase()
+  );
   devLog("wallet:", wallet);
   devLog("wallet type:", wallet?.walletClientType);
   devLog("wallet chainId:", wallet?.chainId);
@@ -76,7 +76,7 @@ export default function Onboarding() {
   const [currentUsername, setCurrentUsername] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [currentChainId, setCurrentChainId] = useState<string | undefined>(
-    walletChainId,
+    walletChainId
   );
 
   // Update currentChainId when wallet changes

--- a/components/onboarding.tsx
+++ b/components/onboarding.tsx
@@ -1,23 +1,24 @@
-"use client";
+'use client';
 
-import { usePrivy, useWallets } from "@privy-io/react-auth";
-import { useState, useEffect } from "react";
-import { Input } from "@/components/ui/input";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import { toast } from "sonner";
-import { z } from "zod";
-import { publicClient, irlChain } from "@/lib/publicClient";
+import { usePrivy } from '@privy-io/react-auth';
+import { useState, useEffect } from 'react';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import { Label } from '@/components/ui/label';
+import { toast } from 'sonner';
+import { z } from 'zod';
+import { publicClient, irlChain } from '@/lib/publicClient';
 import {
   userManagerABI,
   userManagerAddress,
-} from "@/lib/contracts/UserManager";
-import { createWalletClient, custom } from "viem";
-import { useEvmWalletAddress } from "@/hooks/use-evm-wallet-address";
+} from '@/lib/contracts/UserManager';
+import { createWalletClient, custom } from 'viem';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
+import { useConnectedEvmWallet } from '@/hooks/use-connected-evm-wallet';
 
 // Dev-only logger to avoid noisy logs during SSG/production
 const devLog = (...args: any[]) => {
-  if (typeof window !== "undefined" && process.env.NODE_ENV !== "production") {
+  if (typeof window !== 'undefined' && process.env.NODE_ENV !== 'production') {
     // eslint-disable-next-line no-console
     console.log(...args);
   }
@@ -25,25 +26,25 @@ const devLog = (...args: any[]) => {
 
 const usernameSchema = z
   .string()
-  .min(1, "Username is required")
-  .regex(/^[a-zA-Z0-9_]+$/, "Invalid username");
+  .min(1, 'Username is required')
+  .regex(/^[a-zA-Z0-9_]+$/, 'Invalid username');
 
 // Helper function to safely get chain ID
 const getWalletChainId = (wallet: any): string | undefined => {
   if (!wallet) return undefined;
 
   // Check if chainId is already a string number
-  if (typeof wallet.chainId === "string" && !wallet.chainId.includes(":")) {
+  if (typeof wallet.chainId === 'string' && !wallet.chainId.includes(':')) {
     return wallet.chainId;
   }
 
   // Parse chain ID from format like "eip155:8453"
-  if (typeof wallet.chainId === "string" && wallet.chainId.includes(":")) {
-    return wallet.chainId.split(":")[1];
+  if (typeof wallet.chainId === 'string' && wallet.chainId.includes(':')) {
+    return wallet.chainId.split(':')[1];
   }
 
   // If chainId is a number
-  if (typeof wallet.chainId === "number") {
+  if (typeof wallet.chainId === 'number') {
     return wallet.chainId.toString();
   }
 
@@ -52,27 +53,22 @@ const getWalletChainId = (wallet: any): string | undefined => {
 
 export default function Onboarding() {
   const { user, login, logout } = usePrivy();
-  const { wallets } = useWallets();
   const evmWalletAddress = useEvmWalletAddress();
+  const wallet = useConnectedEvmWallet();
 
-  devLog("user", user);
-  devLog("wallets", wallets);
+  devLog('user', user);
+  devLog('wallet:', wallet);
 
   const address = evmWalletAddress as `0x${string}` | undefined;
-  devLog("address:", address);
-
-  const wallet = wallets.find(
-    (candidate) => candidate.address.toLowerCase() === address?.toLowerCase()
-  );
-  devLog("wallet:", wallet);
-  devLog("wallet type:", wallet?.walletClientType);
-  devLog("wallet chainId:", wallet?.chainId);
+  devLog('address:', address);
+  devLog('wallet type:', wallet?.walletClientType);
+  devLog('wallet chainId:', wallet?.chainId);
 
   // Parse chain ID safely
   const walletChainId = getWalletChainId(wallet);
-  devLog("walletChainId:", walletChainId);
+  devLog('walletChainId:', walletChainId);
 
-  const [usernameInput, setUsernameInput] = useState("");
+  const [usernameInput, setUsernameInput] = useState('');
   const [currentUsername, setCurrentUsername] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const [currentChainId, setCurrentChainId] = useState<string | undefined>(
@@ -85,7 +81,7 @@ export default function Onboarding() {
       const chainId = getWalletChainId(wallet);
       if (chainId) {
         setCurrentChainId(chainId);
-        devLog("Updated currentChainId:", chainId);
+        devLog('Updated currentChainId:', chainId);
       }
     }
   }, [wallet, wallet?.chainId]);
@@ -98,15 +94,15 @@ export default function Onboarding() {
         const userId = await publicClient.readContract({
           address: userManagerAddress,
           abi: userManagerABI,
-          functionName: "addressToId",
+          functionName: 'addressToId',
           args: [address],
         });
 
-        devLog("userId", userId);
+        devLog('userId', userId);
 
         // Check if userId is 0 (no user registered for this address)
         if (!userId || userId === BigInt(0)) {
-          devLog("No user ID found for address");
+          devLog('No user ID found for address');
           return;
         }
 
@@ -114,17 +110,17 @@ export default function Onboarding() {
         const name = await publicClient.readContract({
           address: userManagerAddress,
           abi: userManagerABI,
-          functionName: "getName",
+          functionName: 'getName',
           args: [userId],
         });
 
-        devLog("name", name);
+        devLog('name', name);
 
-        if (name && typeof name === "string" && name.length > 0) {
+        if (name && typeof name === 'string' && name.length > 0) {
           setCurrentUsername(name);
         }
       } catch (err) {
-        console.error("Error fetching username", err);
+        console.error('Error fetching username', err);
       }
     };
     fetchUsername();
@@ -145,34 +141,34 @@ export default function Onboarding() {
     try {
       setIsLoading(true);
 
-      devLog("currentChainId", currentChainId);
-      devLog("irlChain.id", irlChain.id);
-      devLog("wallet", wallet);
+      devLog('currentChainId', currentChainId);
+      devLog('irlChain.id', irlChain.id);
+      devLog('wallet', wallet);
 
       // Ensure we're on the correct chain before proceeding
       if (currentChainId !== irlChain.id.toString()) {
         try {
           // Try to switch chain directly first
           await wallet.switchChain(irlChain.id);
-          toast.info("Switching to IRL chain...");
+          toast.info('Switching to IRL chain...');
           setCurrentChainId(irlChain.id.toString());
 
           // Wait a bit for the chain switch to complete
           await new Promise((resolve) => setTimeout(resolve, 1000));
         } catch (switchError: any) {
-          console.error("Direct chain switch failed:", switchError);
+          console.error('Direct chain switch failed:', switchError);
 
           // If direct switch fails, try adding the chain first
           const provider = await wallet.getEthereumProvider();
 
           if (!provider) {
-            toast.error("Unable to get wallet provider");
+            toast.error('Unable to get wallet provider');
             return;
           }
 
           // Try switching again
           await wallet.switchChain(irlChain.id);
-          toast.info("Switching to IRL chain...");
+          toast.info('Switching to IRL chain...');
           setCurrentChainId(irlChain.id.toString());
           await new Promise((resolve) => setTimeout(resolve, 1000));
         }
@@ -182,7 +178,7 @@ export default function Onboarding() {
       const provider = await wallet.getEthereumProvider();
 
       if (!provider) {
-        toast.error("Unable to get wallet provider");
+        toast.error('Unable to get wallet provider');
         return;
       }
 
@@ -195,18 +191,18 @@ export default function Onboarding() {
       const { request } = await publicClient.simulateContract({
         address: userManagerAddress,
         abi: userManagerABI,
-        functionName: "createUser",
+        functionName: 'createUser',
         args: [usernameInput],
         account: address,
       });
 
       const hash = await walletClient.writeContract(request);
       await publicClient.waitForTransactionReceipt({ hash });
-      toast.success("Username created");
+      toast.success('Username created');
       setCurrentUsername(usernameInput);
     } catch (err) {
-      console.error("Error creating username", err);
-      toast.error("Failed to create username");
+      console.error('Error creating username', err);
+      toast.error('Failed to create username');
     } finally {
       setIsLoading(false);
     }
@@ -214,19 +210,19 @@ export default function Onboarding() {
 
   const handleChainSwitch = async () => {
     if (!wallet) {
-      toast.error("No wallet connected");
+      toast.error('No wallet connected');
       return;
     }
 
     try {
-      devLog("Starting chain switch...");
-      devLog("Wallet object:", wallet);
-      devLog("Current chainId:", wallet.chainId);
+      devLog('Starting chain switch...');
+      devLog('Wallet object:', wallet);
+      devLog('Current chainId:', wallet.chainId);
 
       // Try to switch chain using the wallet's switchChain method
       try {
         await wallet.switchChain(irlChain.id);
-        devLog("Chain switched successfully");
+        devLog('Chain switched successfully');
 
         // Update the current chain ID
         setCurrentChainId(irlChain.id.toString());
@@ -234,15 +230,15 @@ export default function Onboarding() {
         // Force a small delay to ensure the chain switch is reflected
         await new Promise((resolve) => setTimeout(resolve, 500));
 
-        toast.success("Switched to IRL chain");
+        toast.success('Switched to IRL chain');
       } catch (switchError: any) {
-        console.error("Error during switchChain:", switchError);
+        console.error('Error during switchChain:', switchError);
 
         // If switchChain fails, try adding the chain first
         const provider = await wallet.getEthereumProvider();
 
         if (!provider) {
-          toast.error("Unable to get wallet provider");
+          toast.error('Unable to get wallet provider');
           return;
         }
 
@@ -250,21 +246,21 @@ export default function Onboarding() {
           // Try switching again after adding
           await wallet.switchChain(irlChain.id);
           setCurrentChainId(irlChain.id.toString());
-          toast.success("Switched to IRL chain");
+          toast.success('Switched to IRL chain');
         } catch (addError: any) {
-          console.error("Error adding chain:", addError);
+          console.error('Error adding chain:', addError);
           throw addError;
         }
       }
     } catch (err: any) {
-      console.error("Error switching chain - Full error:", err);
-      console.error("Error type:", typeof err);
-      console.error("Error message:", err?.message);
-      console.error("Error stack:", err?.stack);
+      console.error('Error switching chain - Full error:', err);
+      console.error('Error type:', typeof err);
+      console.error('Error message:', err?.message);
+      console.error('Error stack:', err?.stack);
 
       const errorMessage =
         err?.message ||
-        "Failed to switch chain. Please switch manually in your wallet.";
+        'Failed to switch chain. Please switch manually in your wallet.';
       toast.error(errorMessage);
     }
   };
@@ -294,7 +290,7 @@ export default function Onboarding() {
     );
   }
 
-  devLog("wallet", wallet);
+  devLog('wallet', wallet);
 
   return (
     <>
@@ -317,7 +313,7 @@ export default function Onboarding() {
                 disabled={isLoading}
                 onClick={handleCreate}
               >
-                {isLoading ? "Creating..." : "Create Username"}
+                {isLoading ? 'Creating...' : 'Create Username'}
               </Button>
             ) : (
               <Button

--- a/components/profile-menu.tsx
+++ b/components/profile-menu.tsx
@@ -11,6 +11,7 @@ import { Textarea } from '@/components/ui/textarea';
 import type { UserProfile } from '@/lib/types';
 import { toast } from 'sonner';
 import { invalidateProfileRelatedQueries } from '@/lib/invalidate-profile-queries';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
 
 // Reusable Pencil Icon Component
 const PencilIcon = ({
@@ -174,6 +175,7 @@ export default function ProfileMenu({
 }: ProfileMenuProps) {
   const { user, logout } = usePrivy();
   const queryClient = useQueryClient();
+  const walletAddress = useEvmWalletAddress();
   const [profile, setProfile] = useState<UserProfile>({
     wallet_address: '',
     email: '',
@@ -214,19 +216,19 @@ export default function ProfileMenu({
   }, [isOpen]);
 
   const fetchProfile = useCallback(async () => {
-    if (!user?.wallet?.address) return;
+    if (!user || !walletAddress) return;
 
     setIsLoadingProfile(true);
     try {
       const response = await fetch(
-        `/api/profile?wallet_address=${user.wallet.address}`
+        `/api/profile?wallet_address=${walletAddress}`
       );
       const responseData = await response.json();
       // Unwrap the apiSuccess wrapper
       const data = responseData.data || responseData;
 
       setProfile({
-        wallet_address: user.wallet.address,
+        wallet_address: walletAddress,
         email: data.email || user.email?.address || '',
         name: data.name || '',
         username: data.username || '',
@@ -246,17 +248,17 @@ export default function ProfileMenu({
     } finally {
       setIsLoadingProfile(false);
     }
-  }, [user?.wallet?.address, user?.email?.address]);
+  }, [walletAddress, user]);
 
   // Fetch user profile on mount
   useEffect(() => {
-    if (user?.wallet?.address && isOpen) {
+    if (walletAddress && isOpen) {
       fetchProfile();
     }
-  }, [user?.wallet?.address, isOpen, fetchProfile]);
+  }, [walletAddress, isOpen, fetchProfile]);
 
   const handleSave = async (field?: string) => {
-    if (!user?.wallet?.address) return;
+    if (!walletAddress) return;
 
     isSavingRef.current = true;
     setSaving(true);
@@ -268,7 +270,7 @@ export default function ProfileMenu({
         },
         body: JSON.stringify({
           ...profile,
-          wallet_address: user.wallet.address,
+          wallet_address: walletAddress,
         }),
       });
 
@@ -303,7 +305,7 @@ export default function ProfileMenu({
 
       toast.success(successMessage);
 
-      invalidateProfileRelatedQueries(queryClient, user.wallet.address);
+      invalidateProfileRelatedQueries(queryClient, walletAddress);
 
       // Clear editing state after successful save
       if (field) {
@@ -330,7 +332,7 @@ export default function ProfileMenu({
   };
 
   const handleImageUpload = async (file: File) => {
-    if (!user?.wallet?.address) return;
+    if (!walletAddress) return;
 
     setUploadingImage(true);
     try {
@@ -372,7 +374,7 @@ export default function ProfileMenu({
         },
         body: JSON.stringify({
           ...updatedProfile,
-          wallet_address: user.wallet.address,
+          wallet_address: walletAddress,
         }),
       });
 
@@ -391,7 +393,7 @@ export default function ProfileMenu({
 
       setProfile(updatedProfile);
       toast.success('Profile picture updated successfully');
-      invalidateProfileRelatedQueries(queryClient, user.wallet.address);
+      invalidateProfileRelatedQueries(queryClient, walletAddress);
     } catch (error) {
       console.error('Error uploading image:', error);
       toast.error(

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -2,8 +2,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { usePrivy, useSendTransaction, useWallets } from '@privy-io/react-auth';
+import { usePrivy, useSendTransaction } from '@privy-io/react-auth';
 import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
+import { useConnectedEvmWallet } from '@/hooks/use-connected-evm-wallet';
 import { ExternalLink, Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { SpendPageShell } from '@/components/spend/spend-page-shell';
@@ -186,20 +187,10 @@ export function SpendExperiencePage({
 }: SpendExperiencePageProps) {
   const { user, login, getAccessToken } = usePrivy();
   const { sendTransaction } = useSendTransaction();
-  const { wallets } = useWallets();
   const queryClient = useQueryClient();
   const walletAddress = useEvmWalletAddress();
+  const evmWallet = useConnectedEvmWallet({ preferEmbeddedPrivy: true });
   const [trackedScan, setTrackedScan] = useState(false);
-
-  const evmWallet = useMemo(() => {
-    if (!walletAddress) return null;
-    const lower = walletAddress.toLowerCase();
-    const privyEmbedded = wallets.find(
-      (w) => w.walletClientType === 'privy' && w.address.toLowerCase() === lower
-    );
-    if (privyEmbedded) return privyEmbedded;
-    return wallets.find((w) => w.address.toLowerCase() === lower) ?? null;
-  }, [walletAddress, wallets]);
 
   const {
     data: sessionPayload,

--- a/components/spend/spend-experience-page.tsx
+++ b/components/spend/spend-experience-page.tsx
@@ -198,11 +198,7 @@ export function SpendExperiencePage({
       (w) => w.walletClientType === 'privy' && w.address.toLowerCase() === lower
     );
     if (privyEmbedded) return privyEmbedded;
-    return (
-      wallets.find((w) => w.address.toLowerCase() === lower) ??
-      wallets[0] ??
-      null
-    );
+    return wallets.find((w) => w.address.toLowerCase() === lower) ?? null;
   }, [walletAddress, wallets]);
 
   const {

--- a/hooks/use-connected-evm-wallet.ts
+++ b/hooks/use-connected-evm-wallet.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import { useWallets } from '@privy-io/react-auth';
+import {
+  findConnectedEvmWallet,
+  type FindConnectedEvmWalletOptions,
+} from '@/lib/privy/find-connected-evm-wallet';
+import { useEvmWalletAddress } from '@/hooks/use-evm-wallet-address';
+
+/** Connected Privy wallet object for the user's canonical EVM address. */
+export function useConnectedEvmWallet(options?: FindConnectedEvmWalletOptions) {
+  const { wallets } = useWallets();
+  const address = useEvmWalletAddress();
+  const preferEmbeddedPrivy = options?.preferEmbeddedPrivy ?? false;
+
+  return useMemo(
+    () =>
+      findConnectedEvmWallet(wallets, address, {
+        preferEmbeddedPrivy,
+      }),
+    [wallets, address, preferEmbeddedPrivy]
+  );
+}

--- a/lib/privy/__tests__/find-connected-evm-wallet.test.ts
+++ b/lib/privy/__tests__/find-connected-evm-wallet.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { findConnectedEvmWallet } from '@/lib/privy/find-connected-evm-wallet';
+
+const EVM = '0x4D418f71c531465337b65127B207aa849Fa5a9e3';
+const OTHER_EVM = '0x1234567890AbcdEF1234567890aBcdef12345678';
+
+describe('findConnectedEvmWallet', () => {
+  const wallets = [
+    { address: OTHER_EVM, walletClientType: 'metamask' },
+    { address: EVM, walletClientType: 'privy' },
+  ];
+
+  it('returns the connected wallet that matches the resolved address', () => {
+    expect(findConnectedEvmWallet(wallets, EVM)).toEqual(wallets[1]);
+  });
+
+  it('prefers the embedded Privy wallet when requested', () => {
+    const mixedWallets = [
+      { address: EVM, walletClientType: 'metamask' },
+      { address: EVM, walletClientType: 'privy' },
+    ];
+
+    expect(
+      findConnectedEvmWallet(mixedWallets, EVM, { preferEmbeddedPrivy: true })
+    ).toEqual(mixedWallets[1]);
+  });
+
+  it('returns null when no wallet matches', () => {
+    expect(findConnectedEvmWallet(wallets, undefined)).toBeNull();
+    expect(
+      findConnectedEvmWallet(
+        wallets,
+        '0x0000000000000000000000000000000000000001'
+      )
+    ).toBeNull();
+  });
+});

--- a/lib/privy/__tests__/resolve-embedded-privy-evm-wallet-address.test.ts
+++ b/lib/privy/__tests__/resolve-embedded-privy-evm-wallet-address.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEmbeddedPrivyEvmWalletAddress } from '@/lib/privy/resolve-embedded-privy-evm-wallet-address';
+
+const EVM = '0x4D418f71c531465337b65127B207aa849Fa5a9e3';
+const EXTERNAL_EVM = '0x1234567890AbcdEF1234567890aBcdef12345678';
+
+describe('resolveEmbeddedPrivyEvmWalletAddress', () => {
+  it('returns the embedded Privy EVM wallet address', () => {
+    const address = resolveEmbeddedPrivyEvmWalletAddress({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          walletClientType: 'metamask',
+          chainType: 'ethereum',
+          address: EXTERNAL_EVM,
+        },
+        {
+          type: 'wallet',
+          walletClientType: 'privy',
+          chainType: 'ethereum',
+          address: EVM,
+        },
+      ],
+    } as never);
+
+    expect(address).toBe('0x4D418f71c531465337b65127B207aa849Fa5a9e3');
+  });
+
+  it('returns undefined when no embedded Privy EVM wallet exists', () => {
+    const address = resolveEmbeddedPrivyEvmWalletAddress({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          walletClientType: 'metamask',
+          chainType: 'ethereum',
+          address: EXTERNAL_EVM,
+        },
+      ],
+    } as never);
+
+    expect(address).toBeUndefined();
+  });
+});

--- a/lib/privy/__tests__/resolve-evm-wallet-address.test.ts
+++ b/lib/privy/__tests__/resolve-evm-wallet-address.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { resolvePrivyEvmWalletAddress } from '@/lib/privy/resolve-evm-wallet-address';
 
 const EVM = '0x4D418f71c531465337b65127B207aa849Fa5a9e3';
+const OTHER_EVM = '0x1234567890AbcdEF1234567890aBcdef12345678';
 const STELLAR = 'GMATCHBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB';
 
 describe('resolvePrivyEvmWalletAddress', () => {
@@ -38,6 +39,26 @@ describe('resolvePrivyEvmWalletAddress', () => {
     } as never);
 
     expect(address).toBeUndefined();
+  });
+
+  it('preserves an active EVM wallet when multiple EVM wallets are linked', () => {
+    const address = resolvePrivyEvmWalletAddress({
+      linkedAccounts: [
+        {
+          type: 'wallet',
+          chainType: 'ethereum',
+          address: OTHER_EVM,
+        },
+        {
+          type: 'wallet',
+          chainType: 'ethereum',
+          address: EVM,
+        },
+      ],
+      wallet: { address: EVM },
+    } as never);
+
+    expect(address).toBe(EVM);
   });
 
   it('uses connected wallets as fallback', () => {

--- a/lib/privy/find-connected-evm-wallet.ts
+++ b/lib/privy/find-connected-evm-wallet.ts
@@ -1,0 +1,35 @@
+import { sameWalletAddress } from '@/lib/utils/wallets';
+
+export type WalletAddressSource = {
+  address: string;
+  walletClientType?: string;
+};
+
+export type FindConnectedEvmWalletOptions = {
+  /** Prefer the Privy embedded wallet when multiple connected wallets match. */
+  preferEmbeddedPrivy?: boolean;
+};
+
+/** Resolves the connected Privy wallet object for a canonical EVM address. */
+export function findConnectedEvmWallet<T extends WalletAddressSource>(
+  wallets: T[],
+  resolvedAddress: string | undefined,
+  options?: FindConnectedEvmWalletOptions
+): T | null {
+  if (!resolvedAddress) return null;
+
+  if (options?.preferEmbeddedPrivy) {
+    const embedded = wallets.find(
+      (wallet) =>
+        wallet.walletClientType === 'privy' &&
+        sameWalletAddress(resolvedAddress, wallet.address)
+    );
+    if (embedded) return embedded;
+  }
+
+  return (
+    wallets.find((wallet) =>
+      sameWalletAddress(resolvedAddress, wallet.address)
+    ) ?? null
+  );
+}

--- a/lib/privy/resolve-embedded-privy-evm-wallet-address.ts
+++ b/lib/privy/resolve-embedded-privy-evm-wallet-address.ts
@@ -1,0 +1,24 @@
+import type { User } from '@privy-io/react-auth';
+import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+
+/** Privy embedded EVM address for export flows (not external connected wallets). */
+export function resolveEmbeddedPrivyEvmWalletAddress(
+  user: User | null | undefined
+): string | undefined {
+  for (const account of user?.linkedAccounts ?? []) {
+    if (
+      account.type !== 'wallet' ||
+      account.walletClientType !== 'privy' ||
+      account.chainType !== 'ethereum' ||
+      !('address' in account) ||
+      typeof account.address !== 'string'
+    ) {
+      continue;
+    }
+
+    const normalized = tryNormalizeEvmAddress(account.address);
+    if (normalized) return normalized;
+  }
+
+  return undefined;
+}

--- a/lib/privy/resolve-evm-wallet-address.ts
+++ b/lib/privy/resolve-evm-wallet-address.ts
@@ -29,13 +29,11 @@ export function resolvePrivyEvmWalletAddress(
   user: User | null | undefined,
   connectedWallets?: WalletAddressSource[]
 ): string | undefined {
-  const candidates: string[] = [];
+  const seen = new Set<string>();
 
   const push = (value: string | null | undefined) => {
     const normalized = value ? tryNormalizeEvmAddress(value) : null;
-    if (normalized && !candidates.includes(normalized)) {
-      candidates.push(normalized);
-    }
+    if (normalized) seen.add(normalized);
   };
 
   // Preserve Privy's active wallet when it is already EVM. If the active
@@ -50,5 +48,5 @@ export function resolvePrivyEvmWalletAddress(
     push(wallet.address);
   }
 
-  return candidates[0];
+  return seen.values().next().value;
 }

--- a/lib/privy/resolve-evm-wallet-address.ts
+++ b/lib/privy/resolve-evm-wallet-address.ts
@@ -38,11 +38,13 @@ export function resolvePrivyEvmWalletAddress(
     }
   };
 
+  // Preserve Privy's active wallet when it is already EVM. If the active
+  // wallet is another chain, fall back to the user's linked EVM accounts.
+  push(user?.wallet?.address);
+
   for (const account of user?.linkedAccounts ?? []) {
     push(evmAddressFromLinkedAccount(account));
   }
-
-  push(user?.wallet?.address);
 
   for (const wallet of connectedWallets ?? []) {
     push(wallet.address);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix checkpoint username onboarding to submit the user's validated linked EVM wallet instead of Privy's potentially non-EVM primary wallet
- migrate EVM-keyed map, profile, dashboard, rewards, leaderboard, claim, transfer, Stripe, and WalletConnect flows to the shared resolver
- require exact EVM signer matches instead of falling back to the first connected wallet
- preserve the active wallet when it is already EVM, while falling back to a linked EVM wallet for non-EVM primary sessions
- add regressions for non-EVM primary wallets during username creation and multiple linked EVM wallets

## Audit findings
The same primary-wallet assumption affected user-facing calls to EVM-only player/profile APIs and Base signing flows. Those paths are migrated in this PR. Remaining direct primary-wallet reads are limited to admin creator attribution and admin analytics metadata, where the wallet used by the admin is intentional.

## Verification
- focused wallet regression suite: 6 files, 63 tests passed
- `yarn lint` passes with existing warnings
- `yarn build` passes
- manual Vitest UI rerun confirms the checkpoint username flow creates the profile with the linked EVM wallet

## Test-suite note
`yarn test --run` reports 1,515 passing tests and 88 failures in unrelated existing suites, primarily stale module mocks and documented component-test failures. The focused suites covering this migration pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-82aa762a-d10b-444a-b151-ee6e560faab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-82aa762a-d10b-444a-b151-ee6e560faab3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

