### PR TITLE
Fix transient sponsored activation dashboard failures

### DIFF
--- a/lib/db/__tests__/supabase-network-error.test.ts
+++ b/lib/db/__tests__/supabase-network-error.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { retrySupabaseNetworkOperation } from '../supabase-network-error';
+
+describe('retrySupabaseNetworkOperation', () => {
+  it('retries a transport failure and returns the next successful result', async () => {
+    const operation = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce('ok');
+
+    await expect(
+      retrySupabaseNetworkOperation(operation, { delayMs: 0 })
+    ).resolves.toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after transport retry attempts are exhausted', async () => {
+    const error = new TypeError('fetch failed');
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      retrySupabaseNetworkOperation(operation, {
+        maxAttempts: 3,
+        delayMs: 0,
+      })
+    ).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledTimes(3);
+  });
+
+  it('does not retry a database error', async () => {
+    const error = { code: '42501', message: 'permission denied' };
+    const operation = vi.fn().mockRejectedValue(error);
+
+    await expect(
+      retrySupabaseNetworkOperation(operation, { delayMs: 0 })
+    ).rejects.toBe(error);
+    expect(operation).toHaveBeenCalledOnce();
+  });
+});

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -398,20 +398,36 @@ async function fetchSettlementsByRedemptionIds(
   const uniq = [...new Set(redemptionIds)].filter(Boolean);
   const map = new Map<string, ActivationSettlementTransactionRow>();
   if (uniq.length === 0) return map;
-  const data = await retrySupabaseNetworkOperation(async () => {
-    const result = await supabase
-      .from('activation_settlement_transaction')
-      .select('*')
-      .in('redemption_id', uniq);
-    if (result.error) throw result.error;
-    return result.data;
-  });
-  for (const r of data ?? []) {
-    const row = normalizeActivationSettlementTransactionRow(
-      r as Record<string, unknown>
+
+  try {
+    const data = await retrySupabaseNetworkOperation(
+      async () => {
+        const result = await supabase
+          .from('activation_settlement_transaction')
+          .select('*')
+          .in('redemption_id', uniq);
+        if (result.error) {
+          console.error('fetchSettlementsByRedemptionIds:', result.error);
+          throw new Error(result.error.message || 'Failed to load settlements');
+        }
+        return result.data ?? [];
+      },
+      { delayMs: 0 }
     );
-    map.set(row.redemption_id, row);
+    for (const r of data) {
+      const row = normalizeActivationSettlementTransactionRow(
+        r as Record<string, unknown>
+      );
+      map.set(row.redemption_id, row);
+    }
+  } catch (error) {
+    if (!isSupabaseNetworkError(error)) throw error;
+    console.error(
+      'fetchSettlementsByRedemptionIds: transport failed after retry; returning dashboard without settlement enrichment',
+      error
+    );
   }
+
   return map;
 }
 
@@ -551,14 +567,7 @@ export async function loadSponsoredActivationAdminDashboard(
       fetchPlayersByIds(userIds),
       fetchRewardItemsByIds(rewardIds),
       fetchEligibilityEventsByIds(eligIds),
-      fetchSettlementsByRedemptionIds(redIds).catch((error) => {
-        if (!isSupabaseNetworkError(error)) throw error;
-        console.error(
-          'fetchSettlementsByRedemptionIds: transport failed after retry; returning dashboard without settlement enrichment',
-          error
-        );
-        return new Map<string, ActivationSettlementTransactionRow>();
-      }),
+      fetchSettlementsByRedemptionIds(redIds),
     ]);
 
   const redemptions: SponsoredActivationAdminRedemptionRow[] =

--- a/lib/db/sponsored-activation-admin.ts
+++ b/lib/db/sponsored-activation-admin.ts
@@ -9,6 +9,10 @@ import {
   normalizeActivationSettlementTransactionRow,
   type ActivationSettlementTransactionRow,
 } from '@/lib/db/activation-settlement-transactions';
+import {
+  isSupabaseNetworkError,
+  retrySupabaseNetworkOperation,
+} from '@/lib/db/supabase-network-error';
 import type { ActivationRedemptionStatus } from '@/lib/schemas/activation-redemption';
 import { formatSettlementExplorerTxUrl } from '@/lib/spend-rail-config';
 
@@ -394,14 +398,14 @@ async function fetchSettlementsByRedemptionIds(
   const uniq = [...new Set(redemptionIds)].filter(Boolean);
   const map = new Map<string, ActivationSettlementTransactionRow>();
   if (uniq.length === 0) return map;
-  const { data, error } = await supabase
-    .from('activation_settlement_transaction')
-    .select('*')
-    .in('redemption_id', uniq);
-  if (error) {
-    console.error('fetchSettlementsByRedemptionIds:', error);
-    throw new Error(error.message || 'Failed to load settlements');
-  }
+  const data = await retrySupabaseNetworkOperation(async () => {
+    const result = await supabase
+      .from('activation_settlement_transaction')
+      .select('*')
+      .in('redemption_id', uniq);
+    if (result.error) throw result.error;
+    return result.data;
+  });
   for (const r of data ?? []) {
     const row = normalizeActivationSettlementTransactionRow(
       r as Record<string, unknown>
@@ -547,7 +551,14 @@ export async function loadSponsoredActivationAdminDashboard(
       fetchPlayersByIds(userIds),
       fetchRewardItemsByIds(rewardIds),
       fetchEligibilityEventsByIds(eligIds),
-      fetchSettlementsByRedemptionIds(redIds),
+      fetchSettlementsByRedemptionIds(redIds).catch((error) => {
+        if (!isSupabaseNetworkError(error)) throw error;
+        console.error(
+          'fetchSettlementsByRedemptionIds: transport failed after retry; returning dashboard without settlement enrichment',
+          error
+        );
+        return new Map<string, ActivationSettlementTransactionRow>();
+      }),
     ]);
 
   const redemptions: SponsoredActivationAdminRedemptionRow[] =

--- a/lib/db/supabase-network-error.ts
+++ b/lib/db/supabase-network-error.ts
@@ -30,3 +30,35 @@ export function isSupabaseNetworkError(error: unknown): boolean {
     text.includes('socket')
   );
 }
+
+type SupabaseNetworkRetryOptions = {
+  maxAttempts?: number;
+  delayMs?: number;
+};
+
+/**
+ * Retries an idempotent Supabase operation only for transport failures.
+ * SQL, authorization, and validation errors are returned immediately.
+ */
+export async function retrySupabaseNetworkOperation<T>(
+  operation: () => Promise<T>,
+  options: SupabaseNetworkRetryOptions = {}
+): Promise<T> {
+  const maxAttempts = Math.max(1, options.maxAttempts ?? 2);
+  const delayMs = Math.max(0, options.delayMs ?? 50);
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await operation();
+    } catch (error) {
+      if (!isSupabaseNetworkError(error) || attempt === maxAttempts) {
+        throw error;
+      }
+      if (delayMs > 0) {
+        await new Promise((resolve) => setTimeout(resolve, delayMs));
+      }
+    }
+  }
+
+  throw new Error('Supabase operation exhausted retry attempts');
+}

--- a/lib/db/supabase-network-error.ts
+++ b/lib/db/supabase-network-error.ts
@@ -31,18 +31,13 @@ export function isSupabaseNetworkError(error: unknown): boolean {
   );
 }
 
-type SupabaseNetworkRetryOptions = {
-  maxAttempts?: number;
-  delayMs?: number;
-};
-
 /**
  * Retries an idempotent Supabase operation only for transport failures.
  * SQL, authorization, and validation errors are returned immediately.
  */
 export async function retrySupabaseNetworkOperation<T>(
   operation: () => Promise<T>,
-  options: SupabaseNetworkRetryOptions = {}
+  options: { maxAttempts?: number; delayMs?: number } = {}
 ): Promise<T> {
   const maxAttempts = Math.max(1, options.maxAttempts ?? 2);
   const delayMs = Math.max(0, options.delayMs ?? 50);
@@ -51,7 +46,8 @@ export async function retrySupabaseNetworkOperation<T>(
     try {
       return await operation();
     } catch (error) {
-      if (!isSupabaseNetworkError(error) || attempt === maxAttempts) {
+      const isLastAttempt = attempt >= maxAttempts;
+      if (!isSupabaseNetworkError(error) || isLastAttempt) {
         throw error;
       }
       if (delayMs > 0) {
@@ -60,5 +56,5 @@ export async function retrySupabaseNetworkOperation<T>(
     }
   }
 
-  throw new Error('Supabase operation exhausted retry attempts');
+  throw new Error('Unreachable');
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- retry settlement-enrichment reads when Supabase transport temporarily fails
- return the admin dashboard without optional settlement enrichment if retries are exhausted
- preserve immediate failures for SQL, authorization, and validation errors
- add focused retry behavior tests

## Testing
- `yarn test lib/db/__tests__/supabase-network-error.test.ts lib/db/__tests__/sponsored-activation-admin.test.ts` (9 tests passed)
- `yarn lint` (passed with existing warnings)
- pre-commit `yarn build` (passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53383a6c-60ca-4d63-aeb5-a61beacec74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53383a6c-60ca-4d63-aeb5-a61beacec74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

