### PR TITLE
Recover from concurrent player wallet conflicts

### DIFF
--- a/app/api/sponsored-activations/[activationId]/eligibility/__tests__/route.test.ts
+++ b/app/api/sponsored-activations/[activationId]/eligibility/__tests__/route.test.ts
@@ -3,6 +3,7 @@ import { NextRequest } from 'next/server';
 
 const mockVerifyWallet = vi.fn();
 const mockGetPrivyUserId = vi.fn();
+const mockGetPrivyUser = vi.fn();
 const mockGetActivation = vi.fn();
 const mockFindEvent = vi.fn();
 const mockCountLifetime = vi.fn();
@@ -29,6 +30,7 @@ vi.mock('@/lib/analytics/server', () => ({
 vi.mock('@/lib/api/privy', () => ({
   verifyWalletOwnership: (...a: unknown[]) => mockVerifyWallet(...a),
   getPrivyUserIdFromRequest: (...a: unknown[]) => mockGetPrivyUserId(...a),
+  getPrivyUserFromRequest: (...a: unknown[]) => mockGetPrivyUser(...a),
 }));
 
 vi.mock('@/lib/db/sponsored-activations', () => ({
@@ -148,6 +150,7 @@ describe('POST /api/sponsored-activations/[activationId]/eligibility', () => {
       userId: 'privy-user-1',
     });
     mockGetPrivyUserId.mockResolvedValue('privy-user-1');
+    mockGetPrivyUser.mockResolvedValue(null);
     mockGetActivation.mockResolvedValue(activeActivation);
     mockFindEvent.mockResolvedValue(null);
     mockCountLifetime.mockResolvedValue(0);

--- a/lib/db/__tests__/players.test.ts
+++ b/lib/db/__tests__/players.test.ts
@@ -40,6 +40,7 @@ import {
   getPlayerBySolanaWallet,
   getPlayerByStellarWallet,
   getPlayerByEmail,
+  assignEvmWalletToPlayer,
   createOrUpdatePlayer,
   updatePlayerPoints,
 } from '../players';
@@ -357,6 +358,31 @@ describe('Players Database Module', () => {
       expect(result).toEqual(newPlayer);
     });
 
+    it('returns the concurrent winner after an insert unique violation', async () => {
+      const wallet = '0x0000000000000000000000000000000000000001';
+      const concurrentWinner: Player = {
+        id: 9,
+        wallet_address: wallet,
+        total_points: 0,
+      };
+      mockMaybeSingle
+        .mockResolvedValueOnce({ data: null, error: null })
+        .mockResolvedValueOnce({ data: concurrentWinner, error: null });
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { code: '23505', message: 'duplicate key value' },
+      });
+
+      const result = await createOrUpdatePlayer({
+        wallet_address: wallet,
+        total_points: 0,
+      });
+
+      expect(result).toEqual(concurrentWinner);
+      expect(mockInsert).toHaveBeenCalledOnce();
+      expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+    });
+
     it('should throw error on update failure', async () => {
       const existingPlayer: Player = {
         id: 1,
@@ -396,6 +422,44 @@ describe('Players Database Module', () => {
           total_points: 0,
         })
       ).rejects.toEqual({ code: 'PGRST500', message: 'Insert failed' });
+    });
+  });
+
+  describe('assignEvmWalletToPlayer', () => {
+    it('returns the wallet owner after a backfill unique violation', async () => {
+      const wallet = '0x0000000000000000000000000000000000000001';
+      const walletOwner: Player = {
+        id: 12,
+        wallet_address: wallet,
+        total_points: 25,
+      };
+      mockSingle.mockResolvedValueOnce({
+        data: null,
+        error: { code: '23505', message: 'duplicate key value' },
+      });
+      mockMaybeSingle.mockResolvedValueOnce({
+        data: walletOwner,
+        error: null,
+      });
+
+      await expect(assignEvmWalletToPlayer(42, wallet)).resolves.toEqual(
+        walletOwner
+      );
+      expect(mockUpdate).toHaveBeenCalledOnce();
+      expect(mockMaybeSingle).toHaveBeenCalledOnce();
+    });
+
+    it('preserves non-unique update errors', async () => {
+      const error = { code: '42501', message: 'permission denied' };
+      mockSingle.mockResolvedValueOnce({ data: null, error });
+
+      await expect(
+        assignEvmWalletToPlayer(
+          42,
+          '0x0000000000000000000000000000000000000001'
+        )
+      ).rejects.toBe(error);
+      expect(mockMaybeSingle).not.toHaveBeenCalled();
     });
   });
 

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -18,6 +18,14 @@ function isUniqueViolation(error: unknown): boolean {
   );
 }
 
+async function getPlayerAfterWalletUniqueViolation(
+  error: unknown,
+  wallet: string
+): Promise<Player | null> {
+  if (!isUniqueViolation(error)) return null;
+  return getPlayerByWallet(wallet);
+}
+
 // Select only the columns we need for Player type
 const PLAYER_COLUMNS = `
   id,
@@ -94,14 +102,14 @@ export const createOrUpdatePlayer = async (
     .select(PLAYER_COLUMNS)
     .single();
 
-  if (error) {
-    if (isUniqueViolation(error)) {
-      const concurrentWinner = await getPlayerByWallet(normalizedWallet);
-      if (concurrentWinner) return concurrentWinner;
-    }
-    throw error;
-  }
-  return data;
+  if (!error) return data;
+
+  const walletOwner = await getPlayerAfterWalletUniqueViolation(
+    error,
+    normalizedWallet
+  );
+  if (walletOwner) return walletOwner;
+  throw error;
 };
 
 /**
@@ -124,14 +132,11 @@ export async function assignEvmWalletToPlayer(
     .select(PLAYER_COLUMNS)
     .single();
 
-  if (error) {
-    if (isUniqueViolation(error)) {
-      const walletOwner = await getPlayerByWallet(wallet);
-      if (walletOwner) return walletOwner;
-    }
-    throw error;
-  }
-  return data;
+  if (!error) return data;
+
+  const walletOwner = await getPlayerAfterWalletUniqueViolation(error, wallet);
+  if (walletOwner) return walletOwner;
+  throw error;
 }
 
 /**

--- a/lib/db/players.ts
+++ b/lib/db/players.ts
@@ -9,6 +9,15 @@ type PlayerLookupField =
   | 'aptos_wallet_address'
   | 'email';
 
+function isUniqueViolation(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: string }).code === '23505'
+  );
+}
+
 // Select only the columns we need for Player type
 const PLAYER_COLUMNS = `
   id,
@@ -85,9 +94,45 @@ export const createOrUpdatePlayer = async (
     .select(PLAYER_COLUMNS)
     .single();
 
-  if (error) throw error;
+  if (error) {
+    if (isUniqueViolation(error)) {
+      const concurrentWinner = await getPlayerByWallet(normalizedWallet);
+      if (concurrentWinner) return concurrentWinner;
+    }
+    throw error;
+  }
   return data;
 };
+
+/**
+ * Assigns an authenticated EVM wallet to a player. If another request wins
+ * the unique-key race, returns the player that now owns that wallet.
+ */
+export async function assignEvmWalletToPlayer(
+  playerId: number,
+  walletAddress: string
+): Promise<Player> {
+  const wallet =
+    tryNormalizeEvmAddress(walletAddress.trim()) ?? walletAddress.trim();
+  const { data, error } = await supabase
+    .from('players')
+    .update({
+      wallet_address: wallet,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', playerId)
+    .select(PLAYER_COLUMNS)
+    .single();
+
+  if (error) {
+    if (isUniqueViolation(error)) {
+      const walletOwner = await getPlayerByWallet(wallet);
+      if (walletOwner) return walletOwner;
+    }
+    throw error;
+  }
+  return data;
+}
 
 /**
  * Get player by EVM wallet address

--- a/lib/privy/__tests__/resolve-player-for-privy-user.test.ts
+++ b/lib/privy/__tests__/resolve-player-for-privy-user.test.ts
@@ -10,8 +10,11 @@ const mockGetPlayerByStellarWallet = vi.fn();
 const mockGetPlayerBySolanaWallet = vi.fn();
 const mockGetPlayerByAptosWallet = vi.fn();
 const mockCreateOrUpdatePlayer = vi.fn();
+const mockAssignEvmWalletToPlayer = vi.fn();
 
 vi.mock('@/lib/db/players', () => ({
+  assignEvmWalletToPlayer: (...args: unknown[]) =>
+    mockAssignEvmWalletToPlayer(...args),
   getPlayerByWallet: (...args: unknown[]) => mockGetPlayerByWallet(...args),
   getPlayerByEmail: (...args: unknown[]) => mockGetPlayerByEmail(...args),
   getPlayerByStellarWallet: (...args: unknown[]) =>
@@ -56,7 +59,7 @@ describe('resolvePlayerForPrivyUser', () => {
       stellar_wallet_address: STELLAR,
       total_points: 200,
     });
-    mockCreateOrUpdatePlayer.mockResolvedValue({
+    mockAssignEvmWalletToPlayer.mockResolvedValue({
       id: 42,
       wallet_address: EVM,
       stellar_wallet_address: STELLAR,
@@ -75,9 +78,6 @@ describe('resolvePlayerForPrivyUser', () => {
     } as never);
 
     expect(player.id).toBe(42);
-    expect(mockCreateOrUpdatePlayer).toHaveBeenCalledWith(
-      { wallet_address: EVM },
-      expect.objectContaining({ id: 42 })
-    );
+    expect(mockAssignEvmWalletToPlayer).toHaveBeenCalledWith(42, EVM);
   });
 });

--- a/lib/privy/resolve-player-for-privy-user.ts
+++ b/lib/privy/resolve-player-for-privy-user.ts
@@ -1,5 +1,6 @@
 import type { User } from '@privy-io/server-auth';
 import {
+  assignEvmWalletToPlayer,
   createOrUpdatePlayer,
   getPlayerByAptosWallet,
   getPlayerByEmail,
@@ -7,7 +8,6 @@ import {
   getPlayerByStellarWallet,
   getPlayerByWallet,
 } from '@/lib/db/players';
-import { supabase } from '@/lib/db/client';
 import type { Player } from '@/lib/types';
 import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 
@@ -40,19 +40,7 @@ async function backfillEvmWalletOnPlayer(
       tryNormalizeEvmAddress(storedWallet) ?? storedWallet;
     if (normalizedStored === wallet) return player;
   }
-  const { data, error } = await supabase
-    .from('players')
-    .update({
-      wallet_address: wallet,
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', player.id)
-    .select(
-      'id, wallet_address, solana_wallet_address, stellar_wallet_address, stellar_wallet_id, aptos_wallet_address, aptos_wallet_id, email, username, total_points, created_at, updated_at'
-    )
-    .single();
-  if (error) throw error;
-  return data;
+  return assignEvmWalletToPlayer(player.id, wallet);
 }
 
 /**

--- a/lib/privy/resolve-player-for-privy-user.ts
+++ b/lib/privy/resolve-player-for-privy-user.ts
@@ -9,7 +9,7 @@ import {
   getPlayerByWallet,
 } from '@/lib/db/players';
 import type { Player } from '@/lib/types';
-import { tryNormalizeEvmAddress } from '@/lib/utils/wallets';
+import { sameWalletAddress, tryNormalizeEvmAddress } from '@/lib/utils/wallets';
 
 function linkedWalletAddress(
   user: User,
@@ -35,11 +35,7 @@ async function backfillEvmWalletOnPlayer(
   const wallet =
     tryNormalizeEvmAddress(evmWalletAddress.trim()) ?? evmWalletAddress.trim();
   const storedWallet = player.wallet_address?.trim();
-  if (storedWallet) {
-    const normalizedStored =
-      tryNormalizeEvmAddress(storedWallet) ?? storedWallet;
-    if (normalizedStored === wallet) return player;
-  }
+  if (storedWallet && sameWalletAddress(storedWallet, wallet)) return player;
   return assignEvmWalletToPlayer(player.id, wallet);
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- recover from `players.wallet_address` insert races by re-reading the concurrent winner
- centralize EVM wallet backfills and recover when another request already assigned the wallet
- preserve non-unique database failures
- add focused tests for insert and backfill conflict handling
- update the eligibility route test harness for its current Privy lookup

## Testing
- `yarn test lib/db/__tests__/players.test.ts lib/privy/__tests__/resolve-player-for-privy-user.test.ts app/api/sponsored-activations/[activationId]/eligibility/__tests__/route.test.ts` (40 tests passed)
- `yarn lint` (passed with existing warnings)
- pre-commit `yarn build` (passed on both commits)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-53383a6c-60ca-4d63-aeb5-a61beacec74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-53383a6c-60ca-4d63-aeb5-a61beacec74b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

